### PR TITLE
fix(release): use @axintai/compiler in release body template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,5 +48,5 @@ jobs:
             See [CHANGELOG.md](https://github.com/agenticempire/axint/blob/main/CHANGELOG.md) for details.
 
             ```bash
-            npm install -g axint
+            npm install -g @axintai/compiler
             ```


### PR DESCRIPTION
Cosmetic fix: the auto-generated GitHub Release body was installing the old unscoped package name. Now points at `@axintai/compiler`.