### PR TITLE
docs: add Axint logo asset for README

### DIFF
--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" fill="none">
+  <defs>
+    <linearGradient id="axint-grad" x1="8" y1="8" x2="88" y2="88" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F05138"/>
+      <stop offset="0.5" stop-color="#EC4899"/>
+      <stop offset="1" stop-color="#7C3AED"/>
+    </linearGradient>
+    <linearGradient id="axint-stroke" x1="20" y1="20" x2="76" y2="76" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.75"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="88" height="88" rx="22" fill="url(#axint-grad)"/>
+  <path d="M29 66 L48 26 L67 66 M37 54 L59 54" stroke="url(#axint-stroke)" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="48" cy="48" r="2.5" fill="#FFFFFF"/>
+</svg>


### PR DESCRIPTION
Fixes the broken logo image at the top of README.md. The file was referenced as docs/assets/logo.svg but had never been committed — only .gitkeep was tracked.