### PR TITLE
fix: resolve CI failures (ruff lint + sandbox test)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,6 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ["dist/", "node_modules/", "*.config.js", "*.config.ts"],
+    ignores: ["dist/", "node_modules/", "*.config.js", "*.config.ts", "tests/.tmp-*"],
   }
 );

--- a/python/axintai/cli.py
+++ b/python/axintai/cli.py
@@ -26,7 +26,7 @@ from .generator import (
     generate_swift,
 )
 from .parser import ParserError, parse_file
-from .validator import validate_intent
+from .validator import ValidatorDiagnostic, validate_intent
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -232,7 +232,7 @@ def _print_parser_diagnostics(exc: ParserError) -> None:
             print(f"    = help: {d.suggestion}", file=sys.stderr)
 
 
-def _print_validator_diagnostics(diagnostics: list) -> None:
+def _print_validator_diagnostics(diagnostics: list[ValidatorDiagnostic]) -> None:
     for d in diagnostics:
         prefix = (
             "\033[31merror\033[0m"

--- a/python/axintai/generator.py
+++ b/python/axintai/generator.py
@@ -13,8 +13,7 @@ If you change one, change the other.
 
 from __future__ import annotations
 
-from .ir import IntentIR, IntentParameter, ParamType
-
+from .ir import IntentIR, IntentParameter
 
 # ── Swift Type Mapping ──────────────────────────────────────────────
 

--- a/python/axintai/ir.py
+++ b/python/axintai/ir.py
@@ -10,7 +10,7 @@ a pile of one-off generators.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass
 from typing import Any, Literal
 
 ParamType = Literal[
@@ -96,7 +96,7 @@ class IntentIR:
         return out
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "IntentIR":
+    def from_dict(cls, data: dict[str, Any]) -> IntentIR:
         params = tuple(
             IntentParameter(
                 name=p["name"],

--- a/python/axintai/parser.py
+++ b/python/axintai/parser.py
@@ -96,13 +96,11 @@ def _is_define_intent(call: ast.Call) -> bool:
     """Detect `define_intent(...)` or `axintai.define_intent(...)` calls."""
     if isinstance(call.func, ast.Name) and call.func.id == "define_intent":
         return True
-    if (
+    return (
         isinstance(call.func, ast.Attribute)
         and call.func.attr == "define_intent"
         and isinstance(call.func.value, ast.Name)
-    ):
-        return True
-    return False
+    )
 
 
 def _ir_from_call(call: ast.Call, *, file: str | None) -> IntentIR:

--- a/python/axintai/sdk.py
+++ b/python/axintai/sdk.py
@@ -17,8 +17,9 @@ means `axintai compile` never imports user code.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Protocol
+from typing import Any, Protocol
 
 from .ir import IntentIR, IntentParameter, ParamType
 

--- a/python/axintai/sdk.py
+++ b/python/axintai/sdk.py
@@ -43,26 +43,33 @@ class IntentParameterSpec:
         )
 
 
+# Type aliases — the class below has methods named `int`, `float`, and
+# `boolean` that shadow builtins. These aliases let mypy resolve them.
+_Int = int
+_Float = float
+_Bool = bool
+
+
 class _ParamFactory:
     """Typed factories for intent parameters — mirrors the TS `param.*` API."""
 
     def string(self, description: str, *, optional: bool = False, default: str | None = None) -> IntentParameterSpec:
         return IntentParameterSpec("string", description, optional, default)
 
-    def int(self, description: str, *, optional: bool = False, default: int | None = None) -> IntentParameterSpec:
+    def int(self, description: str, *, optional: bool = False, default: _Int | None = None) -> IntentParameterSpec:
         return IntentParameterSpec("int", description, optional, default)
 
-    def double(self, description: str, *, optional: bool = False, default: float | None = None) -> IntentParameterSpec:
+    def double(self, description: str, *, optional: bool = False, default: _Float | None = None) -> IntentParameterSpec:
         return IntentParameterSpec("double", description, optional, default)
 
-    def float(self, description: str, *, optional: bool = False, default: float | None = None) -> IntentParameterSpec:
+    def float(self, description: str, *, optional: bool = False, default: _Float | None = None) -> IntentParameterSpec:
         return IntentParameterSpec("float", description, optional, default)
 
-    def number(self, description: str, *, optional: bool = False, default: int | None = None) -> IntentParameterSpec:
+    def number(self, description: str, *, optional: bool = False, default: _Int | None = None) -> IntentParameterSpec:
         """Deprecated alias for `param.int` — kept for parity with the TS SDK."""
         return IntentParameterSpec("number", description, optional, default)
 
-    def boolean(self, description: str, *, optional: bool = False, default: bool | None = None) -> IntentParameterSpec:
+    def boolean(self, description: str, *, optional: bool = False, default: _Bool | None = None) -> IntentParameterSpec:
         return IntentParameterSpec("boolean", description, optional, default)
 
     def date(self, description: str, *, optional: bool = False) -> IntentParameterSpec:

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -27,10 +27,10 @@ create_event = define_intent(
 
 
 def _write_temp(content: str, suffix: str = ".py") -> Path:
-    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False)
-    tmp.write(content)
-    tmp.flush()
-    return Path(tmp.name)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False) as tmp:
+        tmp.write(content)
+        tmp.flush()
+        return Path(tmp.name)
 
 
 def test_parse_command(capsys) -> None:

--- a/tests/core/sandbox.test.ts
+++ b/tests/core/sandbox.test.ts
@@ -11,8 +11,11 @@ function hasSwiftToolchain(): boolean {
   }
 }
 
+const IS_MACOS = process.platform === "darwin";
 const SWIFT_AVAILABLE = hasSwiftToolchain();
-const describeOnMac = SWIFT_AVAILABLE ? describe : describe.skip;
+// AppIntents framework only exists on macOS — Linux runners have Swift
+// but not the Apple frameworks, so we must check both.
+const describeOnMac = IS_MACOS && SWIFT_AVAILABLE ? describe : describe.skip;
 
 describe("sandboxCompile", () => {
   const hello = `import Foundation


### PR DESCRIPTION
Fixes ruff lint errors (unused imports, import sorting, style) and skips AppIntents sandbox test on Linux runners (Swift present but no Apple frameworks).