### PR TITLE
fix eslint-disable placement in sanitize regex

### DIFF
--- a/src/mcp/scaffold.ts
+++ b/src/mcp/scaffold.ts
@@ -113,9 +113,8 @@ function kebab(pascal: string): string {
  * from getting garbled by rogue newlines or tabs in a description.
  */
 function sanitize(s: string): string {
-  // eslint-disable-next-line no-control-regex
   return s
-    .replace(/[\x00-\x1f\x7f]+/g, " ")
+    .replace(/[\x00-\x1f\x7f]+/g, " ") // eslint-disable-line no-control-regex
     .replace(/\s+/g, " ")
     .trim();
 }


### PR DESCRIPTION
eslint-disable-next-line was covering the return statement instead of the chained .replace() with control character regex. Moved to inline eslint-disable-line.