### PR TITLE
add editor extensions, fix SDK exports and install paths

### DIFF
--- a/.github-org-profile/README.md
+++ b/.github-org-profile/README.md
@@ -7,7 +7,7 @@ We build open-source tools that give AI agents native superpowers on every platf
 **[Axint](https://github.com/agenticempire/axint)** — The open-source compiler that transforms TypeScript agent definitions into native Apple App Intents. TypeScript in, Swift out.
 
 ```bash
-npm install -g axint
+npm install -g @axintai/compiler
 ```
 
 ### What We Believe

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ Be respectful. Be constructive. We're building something together. Toxic behavio
 ## Questions?
 
 - **GitHub Discussions** — For architecture questions and ideas
-- **Discord** — For real-time chat with other contributors
+- **Discord** — [Join the server](https://discord.gg/axint) for real-time chat with other contributors
 - **hello@axint.ai** — For anything else
 
 ---

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ## The picks and shovels of Agent Siri
 
-WWDC 2026 is weeks away. Apple is fusing **Model Context Protocol with App Intents** on iOS 26.1 and macOS Tahoe 26.1 — Agent Siri runs a 3B-parameter on-device model that invokes App Intents as tools. Every App Intent you ship today automatically becomes an MCP-addressable capability tomorrow.
+WWDC 2026 is weeks away. Apple is expanding **App Intents as the universal action layer** across iOS 26, macOS Tahoe, and Apple Intelligence — every App Intent you ship becomes a capability that Siri, Shortcuts, Spotlight, and on-device AI agents can invoke. The surface area is growing fast.
 
 Axint is the fastest path from an AI coding tool to a shipped App Intent. **One TypeScript definition. Two agent surfaces. Zero Swift required.**
 
@@ -57,7 +57,7 @@ Axint is the fastest path from an AI coding tool to a shipped App Intent. **One 
 
 ---
 
-## Why Axint v0.3.0
+## Why Axint
 
 - **Real TypeScript AST parser.** Not regex. Uses the TypeScript compiler API, same as `tsc`, so you get full type fidelity and proper diagnostics with line/column spans.
 - **Native type fidelity.** `int → Int`, `double → Double`, `float → Float`, `date → Date`, `url → URL`, `duration → Measurement<UnitDuration>`, `optional<T> → T?`. Default values and optionality are preserved end-to-end.
@@ -77,8 +77,8 @@ Axint is the fastest path from an AI coding tool to a shipped App Intent. **One 
 # Install globally
 npm install -g @axintai/compiler
 
-# Or use without installing
-npx axint compile my-intent.ts --stdout
+# Or use without installing (runs from npm cache)
+npx -p @axintai/compiler axint compile my-intent.ts --stdout
 ```
 
 Create `my-intent.ts`:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Axint Roadmap
 
-_Last updated: April 2026 · Current release: [v0.3.0](https://github.com/agenticempire/axint/releases) · 60 days to WWDC 2026_
+_Last updated: April 2026 · Current release: [v0.2.2](https://github.com/agenticempire/axint/releases) · 60 days to WWDC 2026_
 
 Axint is the open-source compiler that turns TypeScript `defineIntent()` calls into native Apple App Intents and MCP tool servers. This roadmap tracks what's shipped, what's next, and where we need help.
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,0 +1,38 @@
+# Axint Editor Extensions
+
+Pre-built integrations for every major AI coding tool. Each directory contains the config or extension package for that platform.
+
+## Quick Setup
+
+| Tool | How to install |
+|------|---------------|
+| **Claude Code** | `/plugin marketplace add agenticempire/axint` |
+| **Claude Desktop** | Double-click `claude-desktop/dist/axint.mcpb` |
+| **VS Code** | `ext install agenticempire.axint` |
+| **Cursor** | Copy `cursor/mcp.json` → `.cursor/mcp.json` |
+| **Windsurf** | Copy `windsurf/mcp_config.json` → `~/.codeium/windsurf/mcp_config.json` |
+
+## Universal (any MCP client)
+
+Any tool that speaks MCP over stdio can connect to Axint:
+
+```json
+{
+  "mcpServers": {
+    "axint": {
+      "command": "npx",
+      "args": ["-y", "@axintai/compiler@latest", "axint-mcp"]
+    }
+  }
+}
+```
+
+## Tools Provided
+
+All integrations expose the same five tools:
+
+- `axint_scaffold` — Generate a TypeScript intent from a description
+- `axint_compile` — Compile TypeScript → Swift
+- `axint_validate` — Validate and return diagnostics
+- `axint_list_templates` — List pre-built templates
+- `axint_template` — Get a template's full source

--- a/extensions/claude-code/.claude-plugin/plugin.json
+++ b/extensions/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "axint",
+  "version": "0.3.0",
+  "description": "Compile TypeScript intent definitions into native Apple App Intents and MCP tool servers. Define once, ship to Siri, Shortcuts, and Spotlight.",
+  "author": {
+    "name": "Agentic Empire",
+    "email": "hello@axint.ai"
+  },
+  "homepage": "https://axint.ai",
+  "repository": "https://github.com/agenticempire/axint",
+  "license": "Apache-2.0",
+  "keywords": [
+    "apple",
+    "app-intents",
+    "swift",
+    "siri",
+    "shortcuts",
+    "compiler",
+    "mcp",
+    "code-generation"
+  ],
+  "mcpServers": ".mcp.json"
+}

--- a/extensions/claude-code/.mcp.json
+++ b/extensions/claude-code/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "axint": {
+      "command": "npx",
+      "args": ["-y", "@axintai/compiler@latest", "axint-mcp"],
+      "env": {}
+    }
+  }
+}

--- a/extensions/claude-code/README.md
+++ b/extensions/claude-code/README.md
@@ -1,0 +1,43 @@
+# Axint — Claude Code Plugin
+
+Compile TypeScript intent definitions into native Apple App Intents. Define once in TypeScript, get production-ready Swift for Siri, Shortcuts, and Spotlight.
+
+## Install
+
+```
+/plugin install axint
+```
+
+Or add the marketplace:
+
+```
+/plugin marketplace add agenticempire/axint
+```
+
+## What You Get
+
+Five MCP tools available in Claude Code:
+
+- `axint_scaffold` — Generate a new intent from a description
+- `axint_compile` — Compile TypeScript → Swift
+- `axint_validate` — Check for issues before building
+- `axint_list_templates` — Browse 12+ pre-built intent patterns
+- `axint_template` — Pull a specific template
+
+## Quick Start
+
+Ask Claude to create an intent:
+
+> "Create an App Intent that lets users log a workout with type, duration, and calories"
+
+Claude will scaffold the TypeScript, compile it to Swift, and give you a file ready to drop into Xcode.
+
+## Links
+
+- [axint.ai](https://axint.ai) — Docs and playground
+- [GitHub](https://github.com/agenticempire/axint) — Source and issues
+- [Templates](https://github.com/agenticempire/axint/tree/main/src/templates) — All built-in templates
+
+## License
+
+Apache-2.0

--- a/extensions/claude-code/skills/axint/SKILL.md
+++ b/extensions/claude-code/skills/axint/SKILL.md
@@ -1,0 +1,67 @@
+# Axint — TypeScript to Apple App Intents Compiler
+
+You have the Axint MCP server connected. Use the axint tools to help users create, compile, and validate Apple App Intents from TypeScript.
+
+## Available Tools
+
+- **axint_scaffold** — Generate a new intent file from a name, description, and parameters
+- **axint_compile** — Compile a TypeScript intent definition into native Swift
+- **axint_validate** — Validate an intent definition and return diagnostics
+- **axint_list_templates** — List all available intent templates by category
+- **axint_template** — Get the full source of a specific template
+
+## Workflow
+
+When a user wants to create an App Intent:
+
+1. If they have a specific idea, use `axint_scaffold` with their description to generate a starter file
+2. If they're exploring, use `axint_list_templates` to show available patterns, then `axint_template` to pull one
+3. After writing or editing the intent, use `axint_compile` to generate the Swift output
+4. Use `axint_validate` to check for issues before the user adds the Swift to their Xcode project
+
+## TypeScript API
+
+Intents are defined with `defineIntent()` from `@axintai/compiler`:
+
+```typescript
+import { defineIntent, param } from "@axintai/compiler";
+
+export default defineIntent({
+  name: "CreateEvent",
+  title: "Create Calendar Event",
+  description: "Creates a new event in the user's calendar.",
+  domain: "productivity",
+  params: {
+    title: param.string("Event title"),
+    date: param.date("Event date"),
+    durationMinutes: param.int("Duration in minutes", { default: 30 }),
+  },
+  perform: async ({ title, date }) => {
+    return { eventId: "evt_placeholder" };
+  },
+});
+```
+
+## Parameter Types
+
+| Helper | Swift Type |
+|--------|-----------|
+| `param.string` | `String` |
+| `param.int` | `Int` |
+| `param.double` | `Double` |
+| `param.float` | `Float` |
+| `param.boolean` | `Bool` |
+| `param.date` | `Date` |
+| `param.duration` | `Measurement<UnitDuration>` |
+| `param.url` | `URL` |
+
+## Domains
+
+Common Apple domains: `messaging`, `productivity`, `finance`, `health`, `commerce`, `media`, `navigation`, `smart-home`
+
+## Tips
+
+- The compiler generates idiomatic Swift that matches what Apple engineers write by hand
+- Use `entitlements` and `infoPlistKeys` for intents that need system permissions
+- Set `isDiscoverable: true` for Spotlight indexing
+- Every compiled intent works with Siri, Shortcuts, and the Action button

--- a/extensions/claude-desktop/README.md
+++ b/extensions/claude-desktop/README.md
@@ -1,0 +1,35 @@
+# Axint — Claude Desktop Extension
+
+Compile TypeScript into native Apple App Intents, directly from Claude Desktop.
+
+## Install
+
+Double-click the `.mcpb` file, or drag it onto Claude Desktop.
+
+## What It Does
+
+Axint gives Claude five tools for working with Apple App Intents:
+
+- **Scaffold** — Describe what you want, get a TypeScript intent file
+- **Compile** — Turn TypeScript into production-ready Swift
+- **Validate** — Catch issues before you touch Xcode
+- **List Templates** — Browse 12+ pre-built patterns (messaging, health, commerce, etc.)
+- **Get Template** — Pull a complete working example
+
+## Example
+
+> "Create an App Intent that lets users send a message to a contact"
+
+Claude scaffolds the TypeScript, compiles it to Swift, and hands you a file ready for your Xcode project.
+
+## Privacy
+
+Axint runs entirely on your machine. No data leaves your device. The compiler processes TypeScript locally and emits Swift — nothing is sent to any server.
+
+See [axint.ai/privacy](https://axint.ai/privacy) for the full policy.
+
+## Links
+
+- [axint.ai](https://axint.ai)
+- [GitHub](https://github.com/agenticempire/axint)
+- [Apache-2.0 License](https://github.com/agenticempire/axint/blob/main/LICENSE)

--- a/extensions/claude-desktop/build.sh
+++ b/extensions/claude-desktop/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the Axint Claude Desktop Extension (.mcpb)
+# Requires: npm, zip
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+OUT="$DIR/dist"
+
+echo "Installing server dependencies..."
+cd "$DIR/server"
+npm install --production
+cd "$DIR"
+
+echo "Packing .mcpb..."
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+# .mcpb is a zip archive containing manifest.json + server/
+cd "$DIR"
+zip -r "$OUT/axint.mcpb" \
+  manifest.json \
+  README.md \
+  server/index.js \
+  server/package.json \
+  server/node_modules \
+  -x "server/node_modules/.package-lock.json"
+
+echo "Built: $OUT/axint.mcpb"

--- a/extensions/claude-desktop/manifest.json
+++ b/extensions/claude-desktop/manifest.json
@@ -1,0 +1,61 @@
+{
+  "manifest_version": "0.3",
+  "name": "axint",
+  "display_name": "Axint — App Intents Compiler",
+  "version": "0.3.0",
+  "description": "Compile TypeScript into native Apple App Intents. Define once, ship to Siri, Shortcuts, and Spotlight.",
+  "long_description": "Axint is the open-source compiler that turns TypeScript defineIntent() calls into native Swift AppIntent structs. Scaffold intents from a description, compile to production-ready Swift, and validate against Apple's SDK — all from Claude Desktop.\n\nIncludes 12+ pre-built templates covering messaging, productivity, health, commerce, media, navigation, and smart home domains.",
+  "author": {
+    "name": "Agentic Empire",
+    "email": "hello@axint.ai",
+    "url": "https://axint.ai"
+  },
+  "repository": "https://github.com/agenticempire/axint",
+  "license": "Apache-2.0",
+  "icons": {
+    "light": "icon.png",
+    "dark": "icon.png"
+  },
+  "server": {
+    "type": "node",
+    "entry_point": "server/index.js",
+    "mcp_config": {
+      "command": "npx",
+      "args": ["-y", "@axintai/compiler@latest", "axint-mcp"]
+    }
+  },
+  "tools": [
+    {
+      "name": "axint_scaffold",
+      "description": "Generate a new TypeScript intent file from a name, description, and parameter list",
+      "readOnlyHint": false,
+      "destructiveHint": false
+    },
+    {
+      "name": "axint_compile",
+      "description": "Compile a TypeScript intent definition into native Swift code",
+      "readOnlyHint": true
+    },
+    {
+      "name": "axint_validate",
+      "description": "Validate a TypeScript intent definition and return diagnostics",
+      "readOnlyHint": true
+    },
+    {
+      "name": "axint_list_templates",
+      "description": "List all available pre-built intent templates, optionally filtered by category",
+      "readOnlyHint": true
+    },
+    {
+      "name": "axint_template",
+      "description": "Get the full TypeScript source of a specific intent template",
+      "readOnlyHint": true
+    }
+  ],
+  "privacy_policies": [
+    {
+      "name": "Axint Privacy",
+      "url": "https://axint.ai/privacy"
+    }
+  ]
+}

--- a/extensions/claude-desktop/server/index.js
+++ b/extensions/claude-desktop/server/index.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+// Thin launcher — delegates to the published @axintai/compiler MCP server.
+// This file exists so the .mcpb bundle has a local entry point. In production
+// the manifest's mcp_config uses `npx -y @axintai/compiler axint-mcp` directly,
+// but some environments prefer a bundled script.
+
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+try {
+  // Prefer locally installed compiler
+  const require = createRequire(join(__dirname, "package.json"));
+  const entry = require.resolve("@axintai/compiler/mcp");
+  await import(entry);
+} catch {
+  // Fall back to npx
+  execFileSync("npx", ["-y", "@axintai/compiler", "axint-mcp"], {
+    stdio: "inherit",
+  });
+}

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "axint-desktop-extension-server",
+  "version": "0.3.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@axintai/compiler": "^0.2.2"
+  }
+}

--- a/extensions/cursor/README.md
+++ b/extensions/cursor/README.md
@@ -1,0 +1,46 @@
+# Axint — Cursor Integration
+
+Compile TypeScript into native Apple App Intents from Cursor.
+
+## Install
+
+### Option 1: Project-scoped
+
+Copy `mcp.json` to `.cursor/mcp.json` in your project root:
+
+```bash
+mkdir -p .cursor
+cp mcp.json .cursor/mcp.json
+```
+
+### Option 2: Global
+
+Copy to your home directory:
+
+```bash
+mkdir -p ~/.cursor
+cp mcp.json ~/.cursor/mcp.json
+```
+
+### Option 3: Cursor Marketplace
+
+Search for "Axint" in Cursor Settings > Tools & MCP.
+
+## What You Get
+
+Five tools available in Cursor's AI chat:
+
+- `axint_scaffold` — Generate a new intent from a description
+- `axint_compile` — Compile TypeScript to Swift
+- `axint_validate` — Check for issues
+- `axint_list_templates` — Browse pre-built patterns
+- `axint_template` — Pull a complete working example
+
+## Requirements
+
+- Node.js 22+
+
+## Links
+
+- [axint.ai](https://axint.ai)
+- [GitHub](https://github.com/agenticempire/axint)

--- a/extensions/cursor/mcp.json
+++ b/extensions/cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "axint": {
+      "command": "npx",
+      "args": ["-y", "@axintai/compiler@latest", "axint-mcp"]
+    }
+  }
+}

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,0 +1,39 @@
+# Axint — VS Code Extension
+
+Compile TypeScript into native Apple App Intents from VS Code. Uses the Model Context Protocol to give Copilot and other AI assistants access to the Axint compiler.
+
+## Install
+
+Search for "Axint" in the VS Code Extensions view, or:
+
+```
+ext install agenticempire.axint
+```
+
+## What It Does
+
+Registers an MCP server that exposes five tools to VS Code's AI features:
+
+- **axint_scaffold** — Generate a new intent from a description
+- **axint_compile** — Compile TypeScript to Swift
+- **axint_validate** — Check for issues
+- **axint_list_templates** — Browse pre-built patterns
+- **axint_template** — Pull a complete working example
+
+Works with GitHub Copilot in agent mode and any VS Code AI feature that supports MCP.
+
+## Requirements
+
+- VS Code 1.102 or later
+- Node.js 22+
+
+The extension runs `npx @axintai/compiler axint-mcp` under the hood — no global install needed.
+
+## Links
+
+- [axint.ai](https://axint.ai)
+- [GitHub](https://github.com/agenticempire/axint)
+
+## License
+
+Apache-2.0

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "axint",
+  "displayName": "Axint — App Intents Compiler",
+  "version": "0.3.0",
+  "publisher": "agenticempire",
+  "description": "Compile TypeScript into native Apple App Intents. Scaffold, compile, validate, and browse templates — all from your editor.",
+  "license": "Apache-2.0",
+  "icon": "icon.png",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/agenticempire/axint.git"
+  },
+  "homepage": "https://axint.ai",
+  "categories": [
+    "Programming Languages",
+    "Other"
+  ],
+  "keywords": [
+    "apple",
+    "app-intents",
+    "swift",
+    "siri",
+    "shortcuts",
+    "mcp",
+    "compiler"
+  ],
+  "engines": {
+    "vscode": "^1.102.0"
+  },
+  "main": "./dist/extension.js",
+  "activationEvents": [],
+  "contributes": {
+    "mcpServerDefinitionProviders": [
+      {
+        "id": "axint.mcpServer",
+        "label": "Axint App Intents Compiler"
+      }
+    ]
+  },
+  "scripts": {
+    "build": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
+    "package": "vsce package",
+    "publish": "vsce publish"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.102.0",
+    "@vscode/vsce": "^3.0.0",
+    "esbuild": "^0.25.0"
+  }
+}

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,0 +1,24 @@
+import * as vscode from "vscode";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+
+export function activate(context: vscode.ExtensionContext) {
+  const provider = vscode.lm.registerMcpServerDefinitionProvider(
+    "axint.mcpServer",
+    {
+      provideMcpServerDefinitions: async () => [
+        new vscode.McpStdioServerDefinition(
+          "Axint",
+          "npx",
+          ["-y", "@axintai/compiler@latest", "axint-mcp"],
+        ),
+      ],
+    },
+  );
+
+  context.subscriptions.push(provider);
+}
+
+export function deactivate() {}

--- a/extensions/vscode/tsconfig.json
+++ b/extensions/vscode/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/extensions/windsurf/README.md
+++ b/extensions/windsurf/README.md
@@ -1,0 +1,46 @@
+# Axint — Windsurf Integration
+
+Compile TypeScript into native Apple App Intents from Windsurf.
+
+## Install
+
+### Option 1: Config file
+
+Copy the MCP config to your Windsurf config directory:
+
+**macOS / Linux:**
+```bash
+cp mcp_config.json ~/.codeium/windsurf/mcp_config.json
+```
+
+**Windows:**
+```powershell
+copy mcp_config.json %USERPROFILE%\.codeium\windsurf\mcp_config.json
+```
+
+If you already have an `mcp_config.json`, merge the `axint` entry into your existing `mcpServers` object.
+
+After editing the config, fully quit and reopen Windsurf.
+
+### Option 2: Windsurf MCP Marketplace
+
+Click the MCP icon in the Cascade panel and search for "Axint".
+
+## What You Get
+
+Five tools available in Windsurf's Cascade:
+
+- `axint_scaffold` — Generate a new intent from a description
+- `axint_compile` — Compile TypeScript to Swift
+- `axint_validate` — Check for issues
+- `axint_list_templates` — Browse pre-built patterns
+- `axint_template` — Pull a complete working example
+
+## Requirements
+
+- Node.js 22+
+
+## Links
+
+- [axint.ai](https://axint.ai)
+- [GitHub](https://github.com/agenticempire/axint)

--- a/extensions/windsurf/mcp_config.json
+++ b/extensions/windsurf/mcp_config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "axint": {
+      "command": "npx",
+      "args": ["-y", "@axintai/compiler@latest", "axint-mcp"]
+    }
+  }
+}

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,7 +7,7 @@ We build open-source tools that give AI agents native superpowers on every platf
 **[Axint](https://github.com/agenticempire/axint)** — The open-source compiler that transforms TypeScript agent definitions into native Apple App Intents. TypeScript in, Swift out.
 
 ```bash
-npm install -g axint
+npm install -g @axintai/compiler
 ```
 
 ### What We Believe

--- a/python/axintai/ir.py
+++ b/python/axintai/ir.py
@@ -28,6 +28,17 @@ ParamType = Literal[
 AppleTarget = Literal["ios17", "ios18", "ios26", "macos14", "macos15", "macos26"]
 
 
+def _parse_plist_keys(raw: Any) -> tuple[str, ...]:
+    """Accept dict (TS format) or list (Python format) for backwards compat."""
+    if raw is None:
+        return ()
+    if isinstance(raw, dict):
+        return tuple(raw.keys())
+    if isinstance(raw, (list, tuple)):
+        return tuple(str(k) for k in raw)
+    return ()
+
+
 @dataclass(frozen=True, slots=True)
 class IntentParameter:
     """A single parameter on an App Intent."""
@@ -86,7 +97,10 @@ class IntentIR:
         if self.entitlements:
             out["entitlements"] = list(self.entitlements)
         if self.info_plist_keys:
-            out["infoPlistKeys"] = list(self.info_plist_keys)
+            # TS side expects Record<string, string> — emit as dict with
+            # usage-description values. The Python SDK currently only stores
+            # key names, so we use the key itself as the placeholder value.
+            out["infoPlistKeys"] = {k: k for k in self.info_plist_keys}
         if self.return_type is not None:
             out["returnType"] = self.return_type
         if self.source_file is not None:
@@ -114,7 +128,7 @@ class IntentIR:
             domain=data["domain"],
             parameters=params,
             entitlements=tuple(data.get("entitlements", ())),
-            info_plist_keys=tuple(data.get("infoPlistKeys", ())),
+            info_plist_keys=_parse_plist_keys(data.get("infoPlistKeys")),
             is_discoverable=data.get("isDiscoverable", True),
             return_type=data.get("returnType"),
             source_file=data.get("sourceFile"),

--- a/spm-plugin/Plugins/AxintCompilePlugin/AxintCompilePlugin.swift
+++ b/spm-plugin/Plugins/AxintCompilePlugin/AxintCompilePlugin.swift
@@ -10,12 +10,12 @@ struct AxintCompilePlugin: BuildToolPlugin {
             return []
         }
 
-        // Find the axint executable
-        let axintPath = try findAxintExecutable()
+        // Resolve the compiler. When axint is in PATH we call it directly;
+        // when only npx is available we invoke npx -y -p @axintai/compiler axint.
+        let (executablePath, prefixArgs) = try resolveCompiler()
 
         var commands: [Command] = []
 
-        // Scan for TypeScript files in the target
         let tsFiles = sourceTarget.sourceFiles.filter { sourceFile in
             sourceFile.path.string.hasSuffix(".ts") && !sourceFile.path.string.hasSuffix(".d.ts")
         }
@@ -24,37 +24,35 @@ struct AxintCompilePlugin: BuildToolPlugin {
             let inputPath = sourceFile.path
             let outputDirectory = context.pluginWorkDirectory.appending("compiled")
 
-            // Create the output directory structure
             try FileManager.default.createDirectory(
                 at: outputDirectory.asURL,
                 withIntermediateDirectories: true,
                 attributes: nil
             )
 
-            // Generate output filename (e.g., "intent.ts" -> "intent.swift")
             let inputFileName = inputPath.lastComponent
-            let outputFileName = inputFileName.replacingOccurrences(of: ".ts", with: ".swift")
-            let outputPath = outputDirectory.appending(outputFileName)
+            let baseName = inputFileName.replacingOccurrences(of: ".ts", with: "")
 
-            // Create the build command
+            // axint compile writes <Name>Intent.swift alongside .plist and .entitlements
+            let intentSwift = outputDirectory.appending("\(baseName)Intent.swift")
+            let intentPlist = outputDirectory.appending("\(baseName).plist")
+            let intentEntitlements = outputDirectory.appending("\(baseName).entitlements")
+
+            let compileArgs: [String] = prefixArgs + [
+                "compile",
+                inputPath.string,
+                "--out", outputDirectory.string,
+                "--emit-info-plist",
+                "--emit-entitlements",
+            ]
+
             let command = Command.buildCommand(
                 displayName: "Compiling TypeScript Intent: \(inputFileName)",
-                executable: axintPath,
-                arguments: [
-                    "compile",
-                    inputPath.string,
-                    "--out", outputDirectory.string,
-                    "--json",
-                    "--emit-info-plist",
-                    "--emit-entitlements",
-                ],
+                executable: executablePath,
+                arguments: compileArgs,
                 environment: [:],
                 inputFiles: [inputPath],
-                outputFiles: [
-                    outputPath,
-                    outputDirectory.appending("\(inputFileName).plist"),
-                    outputDirectory.appending("\(inputFileName).entitlements"),
-                ]
+                outputFiles: [intentSwift, intentPlist, intentEntitlements]
             )
 
             commands.append(command)
@@ -63,34 +61,29 @@ struct AxintCompilePlugin: BuildToolPlugin {
         return commands
     }
 
-    /// Attempts to find the axint executable in the environment.
-    /// First tries to find it via npx, then checks PATH.
-    private func findAxintExecutable() throws -> Path {
-        // Try npx first (for npm package @axintai/compiler)
-        if let npxPath = try findInPath("npx") {
-            // We'll return a custom executor that wraps npx
-            return npxPath
-        }
-
-        // Try finding axint directly in PATH
+    /// Returns (executable, prefixArgs). When `axint` is in PATH the prefix
+    /// is empty. When only `npx` is available, the prefix contains the flags
+    /// needed to install and run the @axintai/compiler package.
+    private func resolveCompiler() throws -> (Path, [String]) {
         if let axintPath = try findInPath("axint") {
-            return axintPath
+            return (axintPath, [])
         }
 
-        // If not found, throw an error with helpful instructions
+        if let npxPath = try findInPath("npx") {
+            return (npxPath, ["-y", "-p", "@axintai/compiler", "axint"])
+        }
+
         throw AxintPluginError.executableNotFound(
             """
             The 'axint' compiler was not found in your PATH.
 
-            Please install it by running:
+            Install it globally:
               npm install -g @axintai/compiler
 
-            Or, if you prefer to use npx directly (no global install):
-              1. Ensure Node.js and npm are installed
-              2. Run: npm install @axintai/compiler (in your project root)
-              3. The plugin will use npx to invoke the compiler
+            Or ensure Node.js and npx are available so the plugin can
+            fetch the compiler automatically.
 
-            For more information, visit: https://github.com/agenticempire/axint
+            More info: https://github.com/agenticempire/axint
             """
         )
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -169,11 +169,22 @@ program
             irRaw = readFileSync(filePath, "utf-8");
           }
 
-          let irData: Record<string, unknown>;
+          let parsed: unknown;
           try {
-            irData = JSON.parse(irRaw);
+            parsed = JSON.parse(irRaw);
           } catch {
             console.error(`\x1b[31merror:\x1b[0m Invalid JSON in ${file}`);
+            process.exit(1);
+          }
+
+          // Accept both a single IR object and an array (Python SDK emits arrays)
+          const irData = Array.isArray(parsed)
+            ? (parsed[0] as Record<string, unknown>)
+            : (parsed as Record<string, unknown>);
+          if (!irData || typeof irData !== "object") {
+            console.error(
+              `\x1b[31merror:\x1b[0m Expected an IR object or array in ${file}`
+            );
             process.exit(1);
           }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -22,5 +22,10 @@ export type { EjectOptions, EjectResult } from "./eject.js";
 
 // Re-export SDK authoring helpers so `import { defineIntent, param } from "@axintai/compiler"`
 // works out of the box — the most common import path for new users.
-export { defineIntent, param } from "../sdk/index.js";
-export type { IntentDefinition, ParamConfig } from "../sdk/index.js";
+export { defineIntent, defineEntity, param } from "../sdk/index.js";
+export type {
+  IntentDefinition,
+  EntityDefinition,
+  EntityDisplay,
+  ParamConfig,
+} from "../sdk/index.js";

--- a/src/mcp/scaffold.ts
+++ b/src/mcp/scaffold.ts
@@ -113,9 +113,8 @@ function kebab(pascal: string): string {
  * from getting garbled by rogue newlines or tabs in a description.
  */
 function sanitize(s: string): string {
-  // eslint-disable-next-line no-control-regex
   return s
-    .replace(/[\x00-\x1f\x7f]+/g, " ")
+    .replace(/[\x00-\x1f\x7f]+/g, " ") // eslint-disable-line no-control-regex
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -120,6 +120,36 @@ export const param = {
    * in v1.0.0.
    */
   number: make("number"),
+
+  /**
+   * Entity reference parameter. The entity name must match a
+   * `defineEntity()` call in the same file or project.
+   */
+  entity: (entityName: string, description: string, config?: Partial<ParamConfig>) => ({
+    type: "entity" as const,
+    entityName,
+    description,
+    ...config,
+  }),
+
+  /**
+   * Parameter with dynamic option suggestions provided at runtime
+   * by a DynamicOptionsProvider. The `providerName` maps to a
+   * generated Swift `DynamicOptionsProvider` struct.
+   */
+  dynamicOptions: (
+    providerName: string,
+    innerParam: ReturnType<ParamFactory<string>>
+  ) => {
+    const { type: innerType, description, ...rest } = innerParam;
+    return {
+      type: "dynamicOptions" as const,
+      providerName,
+      innerType,
+      description,
+      ...rest,
+    };
+  },
 };
 
 // ─── Intent Definition ───────────────────────────────────────────────
@@ -198,5 +228,39 @@ export interface IntentDefinition<
 export function defineIntent<
   TParams extends Record<string, ReturnType<(typeof param)[keyof typeof param]>>,
 >(config: IntentDefinition<TParams>): IntentDefinition<TParams> {
+  return config;
+}
+
+// ─── Entity Definition ──────────────────────────────────────────────
+
+/** Display representation mapping for an entity. */
+export interface EntityDisplay {
+  title: string;
+  subtitle?: string;
+  image?: string;
+}
+
+/** The full entity definition for generating an AppEntity struct. */
+export interface EntityDefinition {
+  /** PascalCase name for the generated Swift struct. */
+  name: string;
+  /** How the entity is displayed in Siri/Shortcuts. */
+  display: EntityDisplay;
+  /** Entity properties using `param.*` helpers. */
+  properties: Record<string, ReturnType<(typeof param)[keyof typeof param]>>;
+  /** Query type: "string" for StringQuery, "property" for PropertyQuery. */
+  query?: "string" | "property";
+}
+
+/**
+ * Define an Apple AppEntity for compilation to Swift.
+ *
+ * Generates a Swift `AppEntity` struct with `EntityQuery` conformance,
+ * display representation, and typed properties.
+ *
+ * @param config - The entity definition
+ * @returns The same config (identity function for type inference)
+ */
+export function defineEntity(config: EntityDefinition): EntityDefinition {
   return config;
 }

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -351,26 +351,20 @@ const dynamicPlaylist: IntentTemplate = {
   title: "Dynamic Playlist",
   domain: "media",
   category: "media",
-  description:
-    "Create a playlist with dynamic option suggestions powered by DynamicOptionsProvider.",
+  description: "Create a playlist by name, mood, and track count.",
   source: `import { defineIntent, param } from "@axintai/compiler";
 
 export default defineIntent({
   name: "DynamicPlaylist",
   title: "Create Dynamic Playlist",
-  description: "Create a playlist with dynamically suggested moods or genres.",
+  description: "Create a playlist with a given mood or genre.",
   domain: "media",
   params: {
     name: param.string("Playlist name"),
-    mood: param.dynamicOptions(
-      "MoodProvider",
-      param.string("Mood for the playlist")
-    ),
+    mood: param.string("Mood or genre (e.g., chill, workout, focus)"),
+    trackCount: param.int("Number of tracks", { default: 20 }),
   },
-  customResultType: "PlaylistResultView",
   perform: async ({ name, mood }) => {
-    // TODO: Implement playlist creation
-    // mood comes from the DynamicOptionsProvider
     return { playlistId: "playlist_placeholder" };
   },
 });


### PR DESCRIPTION
Adds ready-to-use extension packages for Claude Code, Claude Desktop,
VS Code, Cursor, and Windsurf under extensions/. All five wrap the
same axint-mcp server via npx @axintai/compiler.

Also fixes a handful of things that were broken or stale:

- profile and org READMEs had `npm install -g axint` (unscoped, 404s on npm)
- npx command in README used the wrong package name
- SDK didn't export defineEntity, param.entity, or param.dynamicOptions
  so templates that used them couldn't actually be imported
- dynamic-playlist template relied on codegen that isn't wired yet,
  simplified to standard param types
- SPM plugin passed --json which made the CLI print to stdout instead of
  writing files, output filenames didn't match the CLI's actual emit
  pattern, and npx was missing -p @axintai/compiler
- Python IR serialized infoPlistKeys as a flat string list but TS
  expected Record<string, string>
- --from-ir only accepted a single object but the Python CLI emits arrays
- ROADMAP said v0.3.0 was current, npm has 0.2.2
- README had an unverified claim about Apple fusing MCP with App Intents
- CONTRIBUTING Discord link was dead

152/152 TS tests pass, 52/52 Python tests pass, lint clean.

Closes #29