### PR TITLE
gitignore pycache and tgz artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ __pycache__/
 *.egg-info/
 python/dist/
 python/build/
+
+python/**/__pycache__/
+*.tgz


### PR DESCRIPTION
Stops tracking bytecode and npm pack output.