### PR TITLE
run build before test in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
       - run: npm audit --audit-level=moderate || true
       - run: npm run typecheck
       - run: npm run lint
-      - run: npm test
       - run: npm run build
+      - run: npm test
 
       - name: Verify CLI works
         run: |


### PR DESCRIPTION
Watch tests spawn dist/cli/index.js as a child process. CI was running tests before the build step, so the dist directory didn't exist — causing all 3 watch tests to time out looking for a missing module.