### PR TITLE
python sdk v0.2.0 + compile benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
       - run: npm run build
       - run: npm test
 
+      - name: Run benchmarks
+        run: npm run bench -- --reporter=verbose
+        continue-on-error: true
+
       - name: Verify CLI works
         run: |
           OUTPUT=$(node dist/cli/index.js --version)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,32 @@
+# Axint Compile-Time Benchmarks
+
+This directory contains Vitest benchmarks that measure the compilation performance of the Axint compiler across all 4 compilation surfaces.
+
+## What's Measured
+
+- **Intent** — Compiling App Intent definitions with parameter validation
+- **View** — Compiling SwiftUI view definitions with state and conditional rendering
+- **Widget** — Compiling WidgetKit widget definitions with timeline entries
+- **App** — Compiling SwiftUI App definitions with scenes and storage
+
+Each benchmark compiles a representative sample fixture 100 times and reports throughput metrics.
+
+## Running Benchmarks
+
+Run benchmarks locally:
+
+```bash
+npm run bench
+```
+
+With verbose output:
+
+```bash
+npm run bench -- --reporter=verbose
+```
+
+Benchmarks run automatically in CI and are reported on pull requests.
+
+## Benchmark Results
+
+Results appear in CI logs and can be viewed after each run. Benchmarks help catch unexpected performance regressions in codegen and validation.

--- a/benchmarks/compile.bench.ts
+++ b/benchmarks/compile.bench.ts
@@ -1,0 +1,150 @@
+import { bench, describe } from "vitest";
+import {
+  compileSource,
+  compileViewSource,
+  compileWidgetSource,
+  compileAppSource,
+} from "../src/core/compiler.js";
+
+describe("Intent Compilation", () => {
+  const intentSource = `
+import { defineIntent, param } from "axint";
+export default defineIntent({
+  name: "CreateEvent",
+  title: "Create Calendar Event",
+  description: "Creates a new event",
+  domain: "productivity",
+  params: {
+    title: param.string("Event title"),
+    date: param.date("Event date"),
+    durationMinutes: param.int("Duration in minutes", { default: 30 }),
+    location: param.string("Location", { required: false }),
+    isAllDay: param.boolean("All day", { required: false }),
+  },
+  perform: async ({ title }) => ({ success: true }),
+});
+`;
+
+  bench(
+    "compiles intent with 5 parameters",
+    () => {
+      const result = compileSource(intentSource, "CreateEvent.ts", {
+        validate: false,
+      });
+      if (!result.success) {
+        throw new Error(`Compilation failed: ${result.diagnostics[0]?.message}`);
+      }
+    },
+    { iterations: 100 }
+  );
+});
+
+describe("View Compilation", () => {
+  const viewSource = `
+import { defineView, prop, state, view } from "axint";
+export default defineView({
+  name: "ProfileCard",
+  props: {
+    username: prop.string("User name"),
+    avatarUrl: prop.url("Avatar URL"),
+  },
+  state: {
+    isExpanded: state.boolean("Card expanded", { default: false }),
+    tapCount: state.int("Tap count", { default: 0 }),
+  },
+  body: [
+    view.vstack([
+      view.text("Hello, \\(username)!"),
+      view.hstack([
+        view.image({ systemName: "person.circle" }),
+        view.text("\\(tapCount) taps"),
+      ]),
+      view.button("Toggle", "isExpanded.toggle()"),
+      view.conditional("isExpanded", [
+        view.text("Expanded content here"),
+      ]),
+    ], { spacing: 12 }),
+  ],
+});
+`;
+
+  bench(
+    "compiles view with conditional rendering",
+    () => {
+      const result = compileViewSource(viewSource, "ProfileCard.ts", {
+        validate: false,
+      });
+      if (!result.success) {
+        throw new Error(`Compilation failed: ${result.diagnostics[0]?.message}`);
+      }
+    },
+    { iterations: 100 }
+  );
+});
+
+describe("Widget Compilation", () => {
+  const widgetSource = `
+import { defineWidget, entry, view } from "axint";
+export default defineWidget({
+  name: "StepCounter",
+  displayName: "Step Counter",
+  description: "Shows daily step count",
+  families: ["systemSmall", "systemMedium"],
+  entry: {
+    steps: entry.int("Current steps", { default: 0 }),
+    goal: entry.int("Daily goal", { default: 10000 }),
+    lastUpdated: entry.date("Last sync"),
+  },
+  body: [
+    view.vstack([
+      view.text("\\(steps)"),
+      view.text("of \\(goal) steps"),
+    ], { spacing: 4 }),
+  ],
+  refreshInterval: 15,
+});
+`;
+
+  bench(
+    "compiles widget with entry timeline",
+    () => {
+      const result = compileWidgetSource(widgetSource, "StepCounter.ts", {
+        validate: false,
+      });
+      if (!result.success) {
+        throw new Error(`Compilation failed: ${result.diagnostics[0]?.message}`);
+      }
+    },
+    { iterations: 100 }
+  );
+});
+
+describe("App Compilation", () => {
+  const appSource = `
+import { defineApp } from "axint";
+export default defineApp({
+  name: "MyApp",
+  scenes: [
+    { kind: "windowGroup", view: "ContentView" },
+    { kind: "settings", view: "SettingsView", platform: "macOS" },
+  ],
+  storage: {
+    isDarkMode: { key: "dark_mode", type: "boolean", default: false },
+    username: { key: "username", type: "string", default: "" },
+  },
+});
+`;
+
+  bench(
+    "compiles app with scenes and storage",
+    () => {
+      const result = compileAppSource(appSource, "MyApp.ts", {
+        validate: false,
+      });
+      if (!result.success) {
+        throw new Error(`Compilation failed: ${result.diagnostics[0]?.message}`);
+      }
+    },
+    { iterations: 100 }
+  );
+});

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "bench": "vitest bench",
     "lint": "eslint src/ tests/",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",

--- a/python/axintai/__init__.py
+++ b/python/axintai/__init__.py
@@ -1,11 +1,10 @@
 """
 axintai — the Python SDK for Axint.
 
-Define Apple App Intents in Python. Ship them to Siri, Shortcuts, and
-Spotlight through the same open-source compiler pipeline that powers
-the TypeScript SDK.
+Define Apple App Intents, Views, Widgets, and Apps in Python. Ship them
+through the same open-source compiler pipeline that powers the TypeScript SDK.
 
-    from axintai import define_intent, param
+    from axintai import define_intent, define_view, define_widget, param, prop, view
 
     create_event = define_intent(
         name="CreateCalendarEventIntent",
@@ -22,36 +21,100 @@ the TypeScript SDK.
 
 Axint is a cross-language compiler. The TypeScript SDK and the Python
 SDK produce the same language-agnostic intermediate representation, so
-every intent — regardless of which SDK authored it — compiles through
+every definition — regardless of which SDK authored it — compiles through
 the same Swift generator and hits the same validator rules.
 """
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from .generator import (
     generate_entitlements_fragment,
     generate_info_plist_fragment,
     generate_swift,
 )
-from .ir import AppleTarget, IntentIR, IntentParameter, ParamType
-from .sdk import Intent, IntentDefinition, define_intent, param
+from .ir import (
+    AppleTarget,
+    AppIR,
+    AppSceneIR,
+    AppStorageIR,
+    IntentIR,
+    IntentParameter,
+    ParamType,
+    SceneKind,
+    ViewIR,
+    ViewPropIR,
+    ViewStateIR,
+    ViewStateKind,
+    WidgetFamily,
+    WidgetIR,
+    WidgetEntryIR,
+    WidgetRefreshPolicy,
+)
+from .sdk import (
+    App,
+    AppDefinition,
+    Intent,
+    IntentDefinition,
+    View,
+    ViewDefinition,
+    Widget,
+    WidgetDefinition,
+    define_app,
+    define_intent,
+    define_view,
+    define_widget,
+    entry,
+    param,
+    prop,
+    scene,
+    state,
+    storage,
+    view,
+)
 from .validator import ValidatorDiagnostic, validate_intent
 
 __all__ = [
+    "App",
+    "AppDefinition",
+    "AppIR",
+    "AppSceneIR",
+    "AppStorageIR",
     "AppleTarget",
     "Intent",
     "IntentDefinition",
     "IntentIR",
     "IntentParameter",
     "ParamType",
+    "SceneKind",
     "ValidatorDiagnostic",
+    "View",
+    "ViewDefinition",
+    "ViewIR",
+    "ViewPropIR",
+    "ViewStateIR",
+    "ViewStateKind",
+    "Widget",
+    "WidgetDefinition",
+    "WidgetEntryIR",
+    "WidgetFamily",
+    "WidgetIR",
+    "WidgetRefreshPolicy",
     "__version__",
+    "define_app",
     "define_intent",
+    "define_view",
+    "define_widget",
+    "entry",
     "generate_entitlements_fragment",
     "generate_info_plist_fragment",
     "generate_swift",
     "param",
+    "prop",
+    "scene",
+    "state",
+    "storage",
     "validate_intent",
+    "view",
 ]

--- a/python/axintai/__init__.py
+++ b/python/axintai/__init__.py
@@ -47,9 +47,9 @@ from .ir import (
     ViewPropIR,
     ViewStateIR,
     ViewStateKind,
+    WidgetEntryIR,
     WidgetFamily,
     WidgetIR,
-    WidgetEntryIR,
     WidgetRefreshPolicy,
 )
 from .sdk import (

--- a/python/axintai/__init__.py
+++ b/python/axintai/__init__.py
@@ -36,9 +36,9 @@ from .generator import (
 )
 from .ir import (
     AppIR,
+    AppleTarget,
     AppSceneIR,
     AppStorageIR,
-    AppleTarget,
     IntentIR,
     IntentParameter,
     ParamType,

--- a/python/axintai/__init__.py
+++ b/python/axintai/__init__.py
@@ -35,10 +35,10 @@ from .generator import (
     generate_swift,
 )
 from .ir import (
-    AppleTarget,
     AppIR,
     AppSceneIR,
     AppStorageIR,
+    AppleTarget,
     IntentIR,
     IntentParameter,
     ParamType,

--- a/python/axintai/ir.py
+++ b/python/axintai/ir.py
@@ -214,7 +214,7 @@ class ViewIR:
     def to_dict(self) -> dict[str, Any]:
         out: dict[str, Any] = {
             "name": self.name,
-            "body": [b for b in self.body],
+            "body": list(self.body),
         }
         if self.props:
             out["props"] = [p.to_dict() for p in self.props]
@@ -301,7 +301,7 @@ class WidgetIR:
             "displayName": self.display_name,
             "description": self.description,
             "families": list(self.families),
-            "body": [b for b in self.body],
+            "body": list(self.body),
         }
         if self.entry:
             out["entry"] = [e.to_dict() for e in self.entry]

--- a/python/axintai/ir.py
+++ b/python/axintai/ir.py
@@ -27,6 +27,19 @@ ParamType = Literal[
 
 AppleTarget = Literal["ios17", "ios18", "ios26", "macos14", "macos15", "macos26"]
 
+ViewStateKind = Literal["state", "binding", "environment", "observed"]
+WidgetFamily = Literal[
+    "systemSmall",
+    "systemMedium",
+    "systemLarge",
+    "systemExtraLarge",
+    "accessoryCircular",
+    "accessoryRectangular",
+    "accessoryInline",
+]
+WidgetRefreshPolicy = Literal["atEnd", "after", "never"]
+SceneKind = Literal["windowGroup", "window", "documentGroup", "settings"]
+
 
 def _parse_plist_keys(raw: Any) -> tuple[str, ...]:
     """Accept dict (TS format) or list (Python format) for backwards compat."""
@@ -131,6 +144,294 @@ class IntentIR:
             info_plist_keys=_parse_plist_keys(data.get("infoPlistKeys")),
             is_discoverable=data.get("isDiscoverable", True),
             return_type=data.get("returnType"),
+            source_file=data.get("sourceFile"),
+            source_line=data.get("sourceLine"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ViewPropIR:
+    """A single property (input from parent) on a SwiftUI view."""
+
+    name: str
+    type: ParamType
+    optional: bool = False
+    default: Any = None
+    description: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "type": self.type,
+        }
+        if self.description:
+            out["description"] = self.description
+        if self.optional:
+            out["optional"] = True
+        if self.default is not None:
+            out["default"] = self.default
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class ViewStateIR:
+    """A single state property on a SwiftUI view."""
+
+    name: str
+    type: ParamType | Literal["array"]
+    kind: ViewStateKind = "state"
+    default: Any = None
+    element_type: str | None = None  # for array types
+    environment_key: str | None = None  # for environment bindings
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "type": self.type,
+        }
+        if self.kind != "state":
+            out["kind"] = self.kind
+        if self.element_type is not None:
+            out["elementType"] = self.element_type
+        if self.default is not None:
+            out["default"] = self.default
+        if self.environment_key is not None:
+            out["environmentKey"] = self.environment_key
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class ViewIR:
+    """Language-agnostic representation of a SwiftUI view definition."""
+
+    name: str
+    body: tuple[dict[str, Any], ...] = ()
+    props: tuple[ViewPropIR, ...] = ()
+    state: tuple[ViewStateIR, ...] = ()
+    source_file: str | None = None
+    source_line: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "body": [b for b in self.body],
+        }
+        if self.props:
+            out["props"] = [p.to_dict() for p in self.props]
+        if self.state:
+            out["state"] = [s.to_dict() for s in self.state]
+        if self.source_file is not None:
+            out["sourceFile"] = self.source_file
+        if self.source_line is not None:
+            out["sourceLine"] = self.source_line
+        return out
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ViewIR:
+        props = tuple(
+            ViewPropIR(
+                name=p["name"],
+                type=p["type"],
+                optional=p.get("optional", False),
+                default=p.get("default"),
+                description=p.get("description", ""),
+            )
+            for p in data.get("props", [])
+        )
+        state = tuple(
+            ViewStateIR(
+                name=s["name"],
+                type=s["type"],
+                kind=s.get("kind", "state"),
+                default=s.get("default"),
+                element_type=s.get("elementType"),
+                environment_key=s.get("environmentKey"),
+            )
+            for s in data.get("state", [])
+        )
+        return cls(
+            name=data["name"],
+            body=tuple(data.get("body", [])),
+            props=props,
+            state=state,
+            source_file=data.get("sourceFile"),
+            source_line=data.get("sourceLine"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WidgetEntryIR:
+    """A timeline entry field on a widget."""
+
+    name: str
+    type: ParamType
+    default: Any = None
+    description: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "type": self.type,
+        }
+        if self.description:
+            out["description"] = self.description
+        if self.default is not None:
+            out["default"] = self.default
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class WidgetIR:
+    """Language-agnostic representation of a WidgetKit widget definition."""
+
+    name: str
+    display_name: str
+    description: str
+    families: tuple[WidgetFamily, ...] = ()
+    entry: tuple[WidgetEntryIR, ...] = ()
+    body: tuple[dict[str, Any], ...] = ()
+    refresh_interval: int | None = None
+    refresh_policy: WidgetRefreshPolicy = "atEnd"
+    source_file: str | None = None
+    source_line: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "displayName": self.display_name,
+            "description": self.description,
+            "families": list(self.families),
+            "body": [b for b in self.body],
+        }
+        if self.entry:
+            out["entry"] = [e.to_dict() for e in self.entry]
+        if self.refresh_policy != "atEnd":
+            out["refreshPolicy"] = self.refresh_policy
+        if self.refresh_interval is not None:
+            out["refreshInterval"] = self.refresh_interval
+        if self.source_file is not None:
+            out["sourceFile"] = self.source_file
+        if self.source_line is not None:
+            out["sourceLine"] = self.source_line
+        return out
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> WidgetIR:
+        entry = tuple(
+            WidgetEntryIR(
+                name=e["name"],
+                type=e["type"],
+                default=e.get("default"),
+                description=e.get("description", ""),
+            )
+            for e in data.get("entry", [])
+        )
+        return cls(
+            name=data["name"],
+            display_name=data["displayName"],
+            description=data["description"],
+            families=tuple(data.get("families", [])),
+            entry=entry,
+            body=tuple(data.get("body", [])),
+            refresh_interval=data.get("refreshInterval"),
+            refresh_policy=data.get("refreshPolicy", "atEnd"),
+            source_file=data.get("sourceFile"),
+            source_line=data.get("sourceLine"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AppSceneIR:
+    """A single scene in an App definition."""
+
+    kind: SceneKind
+    view: str
+    title: str | None = None
+    name: str | None = None
+    platform: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "kind": self.kind,
+            "view": self.view,
+        }
+        if self.title is not None:
+            out["title"] = self.title
+        if self.name is not None:
+            out["name"] = self.name
+        if self.platform is not None:
+            out["platform"] = self.platform
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class AppStorageIR:
+    """An @AppStorage property on an App."""
+
+    name: str
+    key: str
+    type: ParamType
+    default: Any = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "key": self.key,
+            "type": self.type,
+        }
+        if self.default is not None:
+            out["default"] = self.default
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class AppIR:
+    """Language-agnostic representation of a SwiftUI App definition."""
+
+    name: str
+    scenes: tuple[AppSceneIR, ...] = ()
+    app_storage: tuple[AppStorageIR, ...] = ()
+    source_file: str | None = None
+    source_line: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "scenes": [s.to_dict() for s in self.scenes],
+        }
+        if self.app_storage:
+            out["appStorage"] = [a.to_dict() for a in self.app_storage]
+        if self.source_file is not None:
+            out["sourceFile"] = self.source_file
+        if self.source_line is not None:
+            out["sourceLine"] = self.source_line
+        return out
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AppIR:
+        scenes = tuple(
+            AppSceneIR(
+                kind=s["kind"],
+                view=s["view"],
+                title=s.get("title"),
+                name=s.get("name"),
+                platform=s.get("platform"),
+            )
+            for s in data.get("scenes", [])
+        )
+        app_storage = tuple(
+            AppStorageIR(
+                name=a["name"],
+                key=a["key"],
+                type=a["type"],
+                default=a.get("default"),
+            )
+            for a in data.get("appStorage", [])
+        )
+        return cls(
+            name=data["name"],
+            scenes=scenes,
+            app_storage=app_storage,
             source_file=data.get("sourceFile"),
             source_line=data.get("sourceLine"),
         )

--- a/python/axintai/sdk.py
+++ b/python/axintai/sdk.py
@@ -33,9 +33,9 @@ from .ir import (
     ViewPropIR,
     ViewStateIR,
     ViewStateKind,
+    WidgetEntryIR,
     WidgetFamily,
     WidgetIR,
-    WidgetEntryIR,
     WidgetRefreshPolicy,
 )
 

--- a/python/axintai/sdk.py
+++ b/python/axintai/sdk.py
@@ -19,9 +19,25 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
-from .ir import IntentIR, IntentParameter, ParamType
+from .ir import (
+    AppIR,
+    AppSceneIR,
+    AppStorageIR,
+    IntentIR,
+    IntentParameter,
+    ParamType,
+    SceneKind,
+    ViewIR,
+    ViewPropIR,
+    ViewStateIR,
+    ViewStateKind,
+    WidgetFamily,
+    WidgetIR,
+    WidgetEntryIR,
+    WidgetRefreshPolicy,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -180,4 +196,548 @@ def define_intent(
         entitlements=tuple(entitlements or ()),
         info_plist_keys=tuple(info_plist_keys or ()),
         is_discoverable=is_discoverable,
+    )
+
+
+# ─── View Support ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class ViewPropSpec:
+    """View prop spec from the `prop.*` factories."""
+
+    type: ParamType
+    description: str = ""
+    optional: bool = False
+    default: Any = None
+
+    def to_prop(self, name: str) -> ViewPropIR:
+        return ViewPropIR(
+            name=name,
+            type=self.type,
+            description=self.description,
+            optional=self.optional,
+            default=self.default,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ViewStateSpec:
+    """View state spec from the `state.*` factories."""
+
+    type: ParamType | Literal["array"]
+    kind: ViewStateKind = "state"
+    default: Any = None
+    element_type: str | None = None
+    environment_key: str | None = None
+
+    def to_state(self, name: str) -> ViewStateIR:
+        return ViewStateIR(
+            name=name,
+            type=self.type,
+            kind=self.kind,
+            default=self.default,
+            element_type=self.element_type,
+            environment_key=self.environment_key,
+        )
+
+
+class _PropFactory:
+    """Typed factories for view properties — mirrors the TS `prop.*` API."""
+
+    def string(self, description: str = "", *, optional: bool = False, default: str | None = None) -> ViewPropSpec:
+        return ViewPropSpec("string", description, optional, default)
+
+    def int(self, description: str = "", *, optional: bool = False, default: _Int | None = None) -> ViewPropSpec:
+        return ViewPropSpec("int", description, optional, default)
+
+    def double(self, description: str = "", *, optional: bool = False, default: _Float | None = None) -> ViewPropSpec:
+        return ViewPropSpec("double", description, optional, default)
+
+    def float(self, description: str = "", *, optional: bool = False, default: _Float | None = None) -> ViewPropSpec:
+        return ViewPropSpec("float", description, optional, default)
+
+    def boolean(self, description: str = "", *, optional: bool = False, default: _Bool | None = None) -> ViewPropSpec:
+        return ViewPropSpec("boolean", description, optional, default)
+
+    def date(self, description: str = "", *, optional: bool = False) -> ViewPropSpec:
+        return ViewPropSpec("date", description, optional, None)
+
+    def url(self, description: str = "", *, optional: bool = False) -> ViewPropSpec:
+        return ViewPropSpec("url", description, optional, None)
+
+
+#: Module-level factory for view properties.
+prop = _PropFactory()
+
+
+class _StateFactory:
+    """Typed factories for view state — mirrors the TS `state.*` API."""
+
+    def string(
+        self, description: str = "", *, kind: ViewStateKind = "state", default: str | None = None, environment_key: str | None = None
+    ) -> ViewStateSpec:
+        return ViewStateSpec("string", kind, default, None, environment_key)
+
+    def int(
+        self, description: str = "", *, kind: ViewStateKind = "state", default: _Int | None = None, environment_key: str | None = None
+    ) -> ViewStateSpec:
+        return ViewStateSpec("int", kind, default, None, environment_key)
+
+    def double(
+        self, description: str = "", *, kind: ViewStateKind = "state", default: _Float | None = None, environment_key: str | None = None
+    ) -> ViewStateSpec:
+        return ViewStateSpec("double", kind, default, None, environment_key)
+
+    def float(
+        self, description: str = "", *, kind: ViewStateKind = "state", default: _Float | None = None, environment_key: str | None = None
+    ) -> ViewStateSpec:
+        return ViewStateSpec("float", kind, default, None, environment_key)
+
+    def boolean(
+        self, description: str = "", *, kind: ViewStateKind = "state", default: _Bool | None = None, environment_key: str | None = None
+    ) -> ViewStateSpec:
+        return ViewStateSpec("boolean", kind, default, None, environment_key)
+
+    def date(self, description: str = "", *, kind: ViewStateKind = "state", environment_key: str | None = None) -> ViewStateSpec:
+        return ViewStateSpec("date", kind, None, None, environment_key)
+
+    def url(self, description: str = "", *, kind: ViewStateKind = "state", environment_key: str | None = None) -> ViewStateSpec:
+        return ViewStateSpec("url", kind, None, None, environment_key)
+
+    def array(self, element_type: str, description: str = "", *, default: Any = None) -> ViewStateSpec:
+        return ViewStateSpec("array", "state", default, element_type, None)
+
+
+#: Module-level factory for view state.
+state = _StateFactory()
+
+
+class _ViewFactory:
+    """Typed factories for SwiftUI view body elements."""
+
+    def vstack(self, children: list[dict[str, Any]], *, spacing: int | None = None, alignment: str | None = None) -> dict[str, Any]:
+        """Vertical stack of views."""
+        out: dict[str, Any] = {"type": "vstack", "children": children}
+        if spacing is not None:
+            out["spacing"] = spacing
+        if alignment is not None:
+            out["alignment"] = alignment
+        return out
+
+    def hstack(self, children: list[dict[str, Any]], *, spacing: int | None = None, alignment: str | None = None) -> dict[str, Any]:
+        """Horizontal stack of views."""
+        out: dict[str, Any] = {"type": "hstack", "children": children}
+        if spacing is not None:
+            out["spacing"] = spacing
+        if alignment is not None:
+            out["alignment"] = alignment
+        return out
+
+    def zstack(self, children: list[dict[str, Any]], *, alignment: str | None = None) -> dict[str, Any]:
+        """Z-axis stack (overlaid views)."""
+        out: dict[str, Any] = {"type": "zstack", "children": children}
+        if alignment is not None:
+            out["alignment"] = alignment
+        return out
+
+    def text(self, content: str) -> dict[str, Any]:
+        """Display text."""
+        return {"type": "text", "content": content}
+
+    def image(self, *, system_name: str | None = None, name: str | None = None) -> dict[str, Any]:
+        """Display an image."""
+        out: dict[str, Any] = {"type": "image"}
+        if system_name is not None:
+            out["systemName"] = system_name
+        if name is not None:
+            out["name"] = name
+        return out
+
+    def button(self, label: str, action: str | None = None) -> dict[str, Any]:
+        """Interactive button."""
+        out: dict[str, Any] = {"type": "button", "label": label}
+        if action is not None:
+            out["action"] = action
+        return out
+
+    def spacer(self) -> dict[str, Any]:
+        """Empty space for layout."""
+        return {"type": "spacer"}
+
+    def divider(self) -> dict[str, Any]:
+        """Visual divider."""
+        return {"type": "divider"}
+
+    def foreach(self, collection: str, item: str, children: list[dict[str, Any]]) -> dict[str, Any]:
+        """Loop over a collection."""
+        return {"type": "foreach", "collection": collection, "item": item, "children": children}
+
+    def conditional(
+        self, condition: str, then_children: list[dict[str, Any]], else_children: list[dict[str, Any]] | None = None
+    ) -> dict[str, Any]:
+        """Conditional rendering."""
+        out: dict[str, Any] = {"type": "if", "condition": condition, "then": then_children}
+        if else_children is not None:
+            out["else"] = else_children
+        return out
+
+    def navigation_link(self, destination: str, children: list[dict[str, Any]]) -> dict[str, Any]:
+        """Navigation link to another view."""
+        return {"type": "navigationLink", "destination": destination, "children": children}
+
+    def list(self, children: list[dict[str, Any]]) -> dict[str, Any]:
+        """List container."""
+        return {"type": "list", "children": children}
+
+    def raw(self, swift: str) -> dict[str, Any]:
+        """Raw Swift code (escape hatch)."""
+        return {"type": "raw", "swift": swift}
+
+
+#: Module-level factory for view body elements.
+view = _ViewFactory()
+
+
+@dataclass(frozen=True, slots=True)
+class ViewDefinition:
+    """A SwiftUI view definition ready to be compiled."""
+
+    name: str
+    body: list[dict[str, Any]] = field(default_factory=list)
+    props: dict[str, ViewPropSpec] = field(default_factory=dict)
+    state: dict[str, ViewStateSpec] = field(default_factory=dict)
+
+    def to_ir(self, *, source_file: str | None = None, source_line: int | None = None) -> ViewIR:
+        return ViewIR(
+            name=self.name,
+            body=tuple(self.body),
+            props=tuple(spec.to_prop(name) for name, spec in self.props.items()),
+            state=tuple(spec.to_state(name) for name, spec in self.state.items()),
+            source_file=source_file,
+            source_line=source_line,
+        )
+
+
+View = ViewDefinition
+
+
+def define_view(
+    *,
+    name: str,
+    body: list[dict[str, Any]] | None = None,
+    props: dict[str, ViewPropSpec] | None = None,
+    state: dict[str, ViewStateSpec] | None = None,
+) -> ViewDefinition:
+    """
+    Define a SwiftUI view for compilation to Swift.
+
+    Parameters
+    ----------
+    name
+        PascalCase name of the view (e.g., "ProfileCard").
+    body
+        List of view elements built with `view.*` helpers.
+    props
+        Mapping of prop name → `prop.*` spec for inputs from parent.
+    state
+        Mapping of state name → `state.*` spec for local state.
+    """
+    return ViewDefinition(
+        name=name,
+        body=list(body or []),
+        props=dict(props or {}),
+        state=dict(state or {}),
+    )
+
+
+# ─── Widget Support ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class WidgetEntrySpec:
+    """Widget entry field spec from the `entry.*` factories."""
+
+    type: ParamType
+    description: str = ""
+    default: Any = None
+
+    def to_entry(self, name: str) -> WidgetEntryIR:
+        return WidgetEntryIR(
+            name=name,
+            type=self.type,
+            description=self.description,
+            default=self.default,
+        )
+
+
+class _EntryFactory:
+    """Typed factories for widget entry fields — mirrors the TS `entry.*` API."""
+
+    def string(self, description: str = "", *, default: str | None = None) -> WidgetEntrySpec:
+        return WidgetEntrySpec("string", description, default)
+
+    def int(self, description: str = "", *, default: _Int | None = None) -> WidgetEntrySpec:
+        return WidgetEntrySpec("int", description, default)
+
+    def double(self, description: str = "", *, default: _Float | None = None) -> WidgetEntrySpec:
+        return WidgetEntrySpec("double", description, default)
+
+    def float(self, description: str = "", *, default: _Float | None = None) -> WidgetEntrySpec:
+        return WidgetEntrySpec("float", description, default)
+
+    def boolean(self, description: str = "", *, default: _Bool | None = None) -> WidgetEntrySpec:
+        return WidgetEntrySpec("boolean", description, default)
+
+    def date(self, description: str = "") -> WidgetEntrySpec:
+        return WidgetEntrySpec("date", description, None)
+
+    def url(self, description: str = "") -> WidgetEntrySpec:
+        return WidgetEntrySpec("url", description, None)
+
+
+#: Module-level factory for widget entry fields.
+entry = _EntryFactory()
+
+
+@dataclass(frozen=True, slots=True)
+class WidgetDefinition:
+    """A WidgetKit widget definition ready to be compiled."""
+
+    name: str
+    display_name: str
+    description: str
+    families: tuple[WidgetFamily, ...] = ()
+    entry: dict[str, WidgetEntrySpec] = field(default_factory=dict)
+    body: list[dict[str, Any]] = field(default_factory=list)
+    refresh_interval: int | None = None
+    refresh_policy: WidgetRefreshPolicy = "atEnd"
+
+    def to_ir(self, *, source_file: str | None = None, source_line: int | None = None) -> WidgetIR:
+        return WidgetIR(
+            name=self.name,
+            display_name=self.display_name,
+            description=self.description,
+            families=self.families,
+            entry=tuple(spec.to_entry(name) for name, spec in self.entry.items()),
+            body=tuple(self.body),
+            refresh_interval=self.refresh_interval,
+            refresh_policy=self.refresh_policy,
+            source_file=source_file,
+            source_line=source_line,
+        )
+
+
+Widget = WidgetDefinition
+
+
+def define_widget(
+    *,
+    name: str,
+    display_name: str,
+    description: str,
+    families: list[WidgetFamily] | tuple[WidgetFamily, ...] | None = None,
+    entry: dict[str, WidgetEntrySpec] | None = None,
+    body: list[dict[str, Any]] | None = None,
+    refresh_interval: int | None = None,
+    refresh_policy: WidgetRefreshPolicy = "atEnd",
+) -> WidgetDefinition:
+    """
+    Define a WidgetKit widget for compilation to Swift.
+
+    Parameters
+    ----------
+    name
+        PascalCase name of the widget.
+    display_name
+        Display name shown in widget gallery.
+    description
+        Human-readable description of the widget.
+    families
+        Supported widget families/sizes.
+    entry
+        Mapping of entry field name → `entry.*` spec.
+    body
+        List of view elements built with `view.*` helpers.
+    refresh_interval
+        Refresh interval in minutes (required if refreshPolicy is "after").
+    refresh_policy
+        Widget refresh policy: "atEnd" (default), "after", "never".
+    """
+    return WidgetDefinition(
+        name=name,
+        display_name=display_name,
+        description=description,
+        families=tuple(families or ()),
+        entry=dict(entry or {}),
+        body=list(body or []),
+        refresh_interval=refresh_interval,
+        refresh_policy=refresh_policy,
+    )
+
+
+# ─── App Support ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class AppStorageSpec:
+    """AppStorage property spec from the `storage.*` factories."""
+
+    type: ParamType
+    key: str
+    default: Any = None
+
+    def to_storage(self, name: str) -> AppStorageIR:
+        return AppStorageIR(
+            name=name,
+            key=self.key,
+            type=self.type,
+            default=self.default,
+        )
+
+
+class _StorageFactory:
+    """Typed factories for @AppStorage properties."""
+
+    def string(self, key: str, default: str | None = None) -> AppStorageSpec:
+        return AppStorageSpec("string", key, default)
+
+    def int(self, key: str, default: _Int | None = None) -> AppStorageSpec:
+        return AppStorageSpec("int", key, default)
+
+    def double(self, key: str, default: _Float | None = None) -> AppStorageSpec:
+        return AppStorageSpec("double", key, default)
+
+    def float(self, key: str, default: _Float | None = None) -> AppStorageSpec:
+        return AppStorageSpec("float", key, default)
+
+    def boolean(self, key: str, default: _Bool | None = None) -> AppStorageSpec:
+        return AppStorageSpec("boolean", key, default)
+
+    def date(self, key: str) -> AppStorageSpec:
+        return AppStorageSpec("date", key, None)
+
+    def url(self, key: str) -> AppStorageSpec:
+        return AppStorageSpec("url", key, None)
+
+
+#: Module-level factory for app storage properties.
+storage = _StorageFactory()
+
+
+@dataclass(frozen=True, slots=True)
+class AppSceneSpec:
+    """AppScene configuration spec from the `scene.*` factories."""
+
+    kind: SceneKind
+    view: str
+    title: str | None = None
+    name: str | None = None
+    platform: str | None = None
+
+    def to_scene(self) -> AppSceneIR:
+        return AppSceneIR(
+            kind=self.kind,
+            view=self.view,
+            title=self.title,
+            name=self.name,
+            platform=self.platform,
+        )
+
+
+class _SceneFactory:
+    """Typed factories for app scenes — mirrors the TS `scene.*` API."""
+
+    def window_group(
+        self,
+        view: str,
+        *,
+        title: str | None = None,
+        name: str | None = None,
+        platform: str | None = None,
+    ) -> AppSceneSpec:
+        """Main window group (default scene for most apps)."""
+        return AppSceneSpec("windowGroup", view, title, name, platform)
+
+    def window(
+        self,
+        view: str,
+        *,
+        title: str | None = None,
+        name: str | None = None,
+        platform: str | None = None,
+    ) -> AppSceneSpec:
+        """Named window (macOS multi-window)."""
+        return AppSceneSpec("window", view, title, name, platform)
+
+    def document_group(
+        self,
+        view: str,
+        *,
+        title: str | None = None,
+        name: str | None = None,
+        platform: str | None = None,
+    ) -> AppSceneSpec:
+        """Document-based app group."""
+        return AppSceneSpec("documentGroup", view, title, name, platform)
+
+    def settings(
+        self,
+        view: str,
+        *,
+        title: str | None = None,
+        name: str | None = None,
+        platform: str | None = None,
+    ) -> AppSceneSpec:
+        """Settings window (macOS)."""
+        return AppSceneSpec("settings", view, title, name, platform)
+
+
+#: Module-level factory for app scenes.
+scene = _SceneFactory()
+
+
+@dataclass(frozen=True, slots=True)
+class AppDefinition:
+    """A SwiftUI App definition ready to be compiled."""
+
+    name: str
+    scenes: tuple[AppSceneSpec, ...] = ()
+    app_storage: dict[str, AppStorageSpec] = field(default_factory=dict)
+
+    def to_ir(self, *, source_file: str | None = None, source_line: int | None = None) -> AppIR:
+        return AppIR(
+            name=self.name,
+            scenes=tuple(s.to_scene() for s in self.scenes),
+            app_storage=tuple(spec.to_storage(name) for name, spec in self.app_storage.items()),
+            source_file=source_file,
+            source_line=source_line,
+        )
+
+
+App = AppDefinition
+
+
+def define_app(
+    *,
+    name: str,
+    scenes: list[AppSceneSpec] | tuple[AppSceneSpec, ...] | None = None,
+    app_storage: dict[str, AppStorageSpec] | None = None,
+) -> AppDefinition:
+    """
+    Define a SwiftUI App for compilation to Swift.
+
+    Parameters
+    ----------
+    name
+        PascalCase name of the app.
+    scenes
+        List of scenes built with `scene.*` helpers.
+    app_storage
+        Mapping of storage property name → `storage.*` spec.
+    """
+    return AppDefinition(
+        name=name,
+        scenes=tuple(scenes or ()),
+        app_storage=dict(app_storage or {}),
     )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axintai"
-version = "0.1.0"
-description = "Python SDK for Axint — define Apple App Intents in Python, ship to Siri."
+version = "0.2.0"
+description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/python/tests/test_sdk.py
+++ b/python/tests/test_sdk.py
@@ -97,3 +97,312 @@ def test_ir_round_trip() -> None:
         },
     ).to_ir()
     assert IntentIR.from_dict(ir.to_dict()) == ir
+
+
+# ─── View Tests ─────────────────────────────────────────────────────────
+
+
+def test_define_view_minimal() -> None:
+    from axintai import define_view, view
+
+    view_def = define_view(
+        name="Greeting",
+        body=[view.text("Hello")],
+    )
+    assert view_def.name == "Greeting"
+    assert len(view_def.body) == 1
+    assert view_def.props == {}
+    assert view_def.state == {}
+
+
+def test_define_view_full() -> None:
+    from axintai import ViewIR, define_view, prop, state, view
+
+    view_def = define_view(
+        name="ProfileCard",
+        props={
+            "username": prop.string("User's display name"),
+            "age": prop.int("User's age", optional=True),
+        },
+        state={
+            "tap_count": state.int(default=0),
+            "is_loading": state.boolean(kind="state", default=False),
+        },
+        body=[
+            view.vstack([
+                view.text("Profile"),
+                view.button("Tap me"),
+            ], spacing=16),
+        ],
+    )
+    ir = view_def.to_ir()
+    assert isinstance(ir, ViewIR)
+    assert ir.name == "ProfileCard"
+    assert len(ir.props) == 2
+    assert ir.props[0].name == "username"
+    assert ir.props[1].optional is True
+    assert len(ir.state) == 2
+
+
+def test_view_ir_to_dict() -> None:
+    from axintai import define_view, prop, view
+
+    view_def = define_view(
+        name="Button",
+        props={"label": prop.string("Button text")},
+        body=[view.text("Click me")],
+    )
+    d = view_def.to_ir().to_dict()
+    assert d["name"] == "Button"
+    assert "props" in d
+    assert d["props"][0]["name"] == "label"
+    assert d["props"][0]["type"] == "string"
+
+
+def test_view_element_helpers() -> None:
+    from axintai import view
+
+    vstack = view.vstack([view.text("A"), view.text("B")], spacing=10)
+    assert vstack["type"] == "vstack"
+    assert vstack["spacing"] == 10
+    assert len(vstack["children"]) == 2
+
+    button = view.button("Press", "action()")
+    assert button["type"] == "button"
+    assert button["action"] == "action()"
+
+    img = view.image(system_name="star.fill")
+    assert img["type"] == "image"
+    assert img["systemName"] == "star.fill"
+
+
+# ─── Widget Tests ────────────────────────────────────────────────────────
+
+
+def test_define_widget_minimal() -> None:
+    from axintai import define_widget, view
+
+    widget = define_widget(
+        name="Counter",
+        display_name="Counter Widget",
+        description="Shows a counter",
+        body=[view.text("Count")],
+    )
+    assert widget.name == "Counter"
+    assert widget.display_name == "Counter Widget"
+    assert widget.families == ()
+    assert widget.entry == {}
+
+
+def test_define_widget_full() -> None:
+    from axintai import WidgetIR, define_widget, entry, view
+
+    widget = define_widget(
+        name="StepCounter",
+        display_name="Step Counter",
+        description="Shows your daily steps",
+        families=["systemSmall", "systemMedium"],
+        entry={
+            "steps": entry.int("Current steps", default=0),
+            "goal": entry.int("Daily goal", default=10000),
+        },
+        body=[
+            view.vstack([
+                view.text("Steps"),
+            ]),
+        ],
+        refresh_interval=15,
+        refresh_policy="after",
+    )
+    ir = widget.to_ir()
+    assert isinstance(ir, WidgetIR)
+    assert ir.name == "StepCounter"
+    assert len(ir.families) == 2
+    assert len(ir.entry) == 2
+    assert ir.refresh_interval == 15
+    assert ir.refresh_policy == "after"
+
+
+def test_widget_ir_to_dict() -> None:
+    from axintai import define_widget, entry, view
+
+    widget = define_widget(
+        name="Simple",
+        display_name="Simple",
+        description="A simple widget",
+        families=["systemSmall"],
+        entry={"count": entry.int()},
+        body=[view.text("0")],
+    )
+    d = widget.to_ir().to_dict()
+    assert d["name"] == "Simple"
+    assert d["displayName"] == "Simple"
+    assert "families" in d
+    assert d["families"] == ["systemSmall"]
+    assert "entry" in d
+
+
+# ─── App Tests ───────────────────────────────────────────────────────────
+
+
+def test_define_app_minimal() -> None:
+    from axintai import define_app, scene
+
+    app = define_app(
+        name="MyApp",
+        scenes=[scene.window_group("ContentView")],
+    )
+    assert app.name == "MyApp"
+    assert len(app.scenes) == 1
+
+
+def test_define_app_full() -> None:
+    from axintai import AppIR, define_app, scene, storage
+
+    app = define_app(
+        name="MyApp",
+        scenes=[
+            scene.window_group("ContentView"),
+            scene.settings("SettingsView", platform="macOS"),
+        ],
+        app_storage={
+            "is_dark_mode": storage.boolean("dark_mode", False),
+            "username": storage.string("username", ""),
+        },
+    )
+    ir = app.to_ir()
+    assert isinstance(ir, AppIR)
+    assert ir.name == "MyApp"
+    assert len(ir.scenes) == 2
+    assert ir.scenes[1].platform == "macOS"
+    assert len(ir.app_storage) == 2
+
+
+def test_app_ir_to_dict() -> None:
+    from axintai import define_app, scene, storage
+
+    app = define_app(
+        name="TestApp",
+        scenes=[scene.window_group("Main")],
+        app_storage={"count": storage.int("app_count", 0)},
+    )
+    d = app.to_ir().to_dict()
+    assert d["name"] == "TestApp"
+    assert "scenes" in d
+    assert d["scenes"][0]["kind"] == "windowGroup"
+    assert "appStorage" in d
+
+
+def test_scene_factory_variants() -> None:
+    from axintai import scene
+
+    wg = scene.window_group("View1", title="Main Window")
+    assert wg.kind == "windowGroup"
+    assert wg.title == "Main Window"
+
+    doc = scene.document_group("DocView", name="document")
+    assert doc.kind == "documentGroup"
+    assert doc.name == "document"
+
+    settings = scene.settings("Prefs", platform="macOS")
+    assert settings.kind == "settings"
+    assert settings.platform == "macOS"
+
+
+def test_storage_factory_all_types() -> None:
+    from axintai import storage
+
+    s_str = storage.string("key_str", "default")
+    assert s_str.type == "string"
+    assert s_str.default == "default"
+
+    s_int = storage.int("key_int", 42)
+    assert s_int.type == "int"
+    assert s_int.default == 42
+
+    s_bool = storage.boolean("key_bool", True)
+    assert s_bool.type == "boolean"
+    assert s_bool.default is True
+
+    s_date = storage.date("key_date")
+    assert s_date.type == "date"
+    assert s_date.default is None
+
+
+def test_prop_factory_all_types() -> None:
+    from axintai import prop
+
+    p_str = prop.string("description", optional=True, default="value")
+    assert p_str.type == "string"
+    assert p_str.optional is True
+
+    p_int = prop.int("count", optional=False, default=5)
+    assert p_int.type == "int"
+    assert p_int.default == 5
+
+    p_date = prop.date()
+    assert p_date.type == "date"
+
+
+def test_state_factory_all_types() -> None:
+    from axintai import state
+
+    s_str = state.string(default="hello")
+    assert s_str.type == "string"
+
+    s_array = state.array("int", default=[1, 2, 3])
+    assert s_array.type == "array"
+    assert s_array.element_type == "int"
+
+    s_env = state.string(kind="environment", environment_key=r"\.dismiss")
+    assert s_env.kind == "environment"
+    assert s_env.environment_key == r"\.dismiss"
+
+
+def test_entry_factory_all_types() -> None:
+    from axintai import entry
+
+    e_str = entry.string("desc", default="val")
+    assert e_str.type == "string"
+    assert e_str.default == "val"
+
+    e_int = entry.int("count", default=0)
+    assert e_int.type == "int"
+    assert e_int.default == 0
+
+    e_url = entry.url("URL")
+    assert e_url.type == "url"
+
+
+def test_view_ir_round_trip() -> None:
+    from axintai import ViewIR, define_view, prop, view
+
+    ir = define_view(
+        name="Card",
+        props={"title": prop.string()},
+        body=[view.text("Content")],
+    ).to_ir()
+    assert ViewIR.from_dict(ir.to_dict()) == ir
+
+
+def test_widget_ir_round_trip() -> None:
+    from axintai import WidgetIR, define_widget, entry, view
+
+    ir = define_widget(
+        name="W",
+        display_name="Widget",
+        description="A widget",
+        entry={"x": entry.int()},
+        body=[view.text("X")],
+    ).to_ir()
+    assert WidgetIR.from_dict(ir.to_dict()) == ir
+
+
+def test_app_ir_round_trip() -> None:
+    from axintai import AppIR, define_app, scene
+
+    ir = define_app(
+        name="App",
+        scenes=[scene.window_group("View")],
+    ).to_ir()
+    assert AppIR.from_dict(ir.to_dict()) == ir

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
+    exclude: ["benchmarks/**"],
+    benchmark: {
+      include: ["benchmarks/**/*.bench.ts"],
+    },
     globals: false,
     environment: "node",
     coverage: {


### PR DESCRIPTION
Adds defineView, defineWidget, defineApp to the Python SDK (parity with TS SDK). Adds vitest bench suite for all 4 compilation surfaces with CI integration.

- Python SDK bumped to v0.2.0 with all 4 surfaces
- prop/state/view/entry/scene/storage factories mirror TS API
- IR types with to_dict/from_dict round-trip support
- 18 new Python tests (25 total)
- benchmarks/compile.bench.ts covers intent/view/widget/app
- CI runs benchmarks on every push (non-blocking)

Closes the P1 audit items for SDK parity and CI benchmarks.