### PR TITLE
fix type safety and namespace bypass from audit

### DIFF
--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -10,6 +10,8 @@ interface Env {
   PACKAGES: R2Bucket;
   GITHUB_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET: string;
+  /** Comma-separated GitHub user IDs allowed to publish to @axintai */
+  ORG_ADMIN_IDS?: string;
 }
 
 // ─── Rate Limiter ──────────────────────────────────────────────────
@@ -265,8 +267,16 @@ route("POST", "/api/v1/publish", async (req, env) => {
   // Validate namespace matches user
   const user = await env.DB.prepare("SELECT username FROM users WHERE id = ?").bind(userId).first<{ username: string }>();
   const expectedNamespace = `@${user?.username}`;
-  if (body.namespace !== expectedNamespace && body.namespace !== "@axintai") {
-    return err(`namespace must be ${expectedNamespace} (your GitHub username)`, 403);
+  if (body.namespace !== expectedNamespace) {
+    // Only org admins can publish to @axintai
+    if (body.namespace === "@axintai") {
+      const adminIds = (env.ORG_ADMIN_IDS || "").split(",").map(s => s.trim()).filter(Boolean);
+      if (!adminIds.includes(userId)) {
+        return err("only org admins can publish to the @axintai namespace", 403);
+      }
+    } else {
+      return err(`namespace must be ${expectedNamespace} (your GitHub username)`, 403);
+    }
   }
 
   // Check if package exists

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -190,8 +190,8 @@ function findDefineEntityCalls(node: ts.Node): ts.CallExpression[] {
   return found;
 }
 
-function propertyMap(obj: ts.ObjectLiteralExpression): Map<string, ts.Expression> {
-  const map = new Map<string, ts.Expression>();
+function propertyMap(obj: ts.ObjectLiteralExpression): Map<string, ts.Node> {
+  const map = new Map<string, ts.Node>();
   for (const prop of obj.properties) {
     if (ts.isPropertyAssignment(prop)) {
       const key = propertyKeyName(prop.name);
@@ -200,7 +200,7 @@ function propertyMap(obj: ts.ObjectLiteralExpression): Map<string, ts.Expression
       map.set(prop.name.text, prop.name);
     } else if (ts.isMethodDeclaration(prop)) {
       const key = propertyKeyName(prop.name);
-      if (key) map.set(key, prop as unknown as ts.Expression);
+      if (key) map.set(key, prop);
     }
   }
   return map;
@@ -213,21 +213,21 @@ function propertyKeyName(name: ts.PropertyName): string | undefined {
   return undefined;
 }
 
-function readStringLiteral(node: ts.Expression | undefined): string | null {
+function readStringLiteral(node: ts.Node | undefined): string | null {
   if (!node) return null;
   if (ts.isStringLiteral(node)) return node.text;
   if (ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
   return null;
 }
 
-function readBooleanLiteral(node: ts.Expression | undefined): boolean | undefined {
+function readBooleanLiteral(node: ts.Node | undefined): boolean | undefined {
   if (!node) return undefined;
   if (node.kind === ts.SyntaxKind.TrueKeyword) return true;
   if (node.kind === ts.SyntaxKind.FalseKeyword) return false;
   return undefined;
 }
 
-function readStringArray(node: ts.Expression | undefined): string[] {
+function readStringArray(node: ts.Node | undefined): string[] {
   if (!node || !ts.isArrayLiteralExpression(node)) return [];
   const out: string[] = [];
   for (const el of node.elements) {
@@ -237,7 +237,7 @@ function readStringArray(node: ts.Expression | undefined): string[] {
   return out;
 }
 
-function readStringRecord(node: ts.Expression | undefined): Record<string, string> {
+function readStringRecord(node: ts.Node | undefined): Record<string, string> {
   if (!node || !ts.isObjectLiteralExpression(node)) return {};
   const rec: Record<string, string> = {};
   for (const prop of node.properties) {
@@ -325,7 +325,7 @@ function validateQueryType(
   value: string | null,
   filePath: string,
   sourceFile: ts.SourceFile,
-  node: ts.Expression | undefined
+  node: ts.Node | undefined
 ): "all" | "id" | "string" | "property" {
   if (!value) {
     throw new ParserError(
@@ -336,8 +336,8 @@ function validateQueryType(
       'Add query field: query: "string" (or "all", "id", "property")'
     );
   }
-  const valid = ["all", "id", "string", "property"] as const;
-  if (!valid.includes(value as any)) {
+  const valid = new Set(["all", "id", "string", "property"]);
+  if (!valid.has(value)) {
     throw new ParserError(
       "AX019",
       `Invalid query type: "${value}". Must be one of: all, id, string, property`,
@@ -351,7 +351,7 @@ function validateQueryType(
 // ─── Parameter Extraction ────────────────────────────────────────────
 
 function extractParameters(
-  node: ts.Expression,
+  node: ts.Node,
   filePath: string,
   sourceFile: ts.SourceFile
 ): IRParameter[] {
@@ -413,7 +413,7 @@ function extractParameters(
 interface ParamCallInfo {
   typeName: string;
   description: string;
-  configObject: Map<string, ts.Expression> | null;
+  configObject: Map<string, ts.Node> | null;
   callExpr: ts.CallExpression;
 }
 
@@ -499,7 +499,7 @@ function resolveParamType(
   callExpr?: ts.CallExpression
 ): IRType {
   // Primitive types
-  if (PARAM_TYPES.has(typeName as IRPrimitiveType)) {
+  if ((PARAM_TYPES as ReadonlySet<string>).has(typeName)) {
     return { kind: "primitive", value: typeName as IRPrimitiveType };
   }
 
@@ -597,7 +597,7 @@ function resolveParamType(
 
 // ─── Literal Evaluation ──────────────────────────────────────────────
 
-function evaluateLiteral(node: ts.Expression): unknown {
+function evaluateLiteral(node: ts.Node): unknown {
   if (ts.isStringLiteral(node)) return node.text;
   if (ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
   if (ts.isNumericLiteral(node)) return Number(node.text);
@@ -616,7 +616,7 @@ function evaluateLiteral(node: ts.Expression): unknown {
 
 // ─── Return-Type Inference ───────────────────────────────────────────
 
-function inferReturnType(performNode: ts.Expression | undefined): IRType {
+function inferReturnType(performNode: ts.Node | undefined): IRType {
   // Default when we can't infer anything.
   const defaultType: IRType = { kind: "primitive", value: "string" };
   if (!performNode) return defaultType;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -93,6 +93,27 @@ type SchemaCompileArgs = {
   }>;
 };
 
+const VALID_SCENE_KINDS = new Set<string>([
+  "windowGroup",
+  "window",
+  "documentGroup",
+  "settings",
+]);
+const VALID_PLATFORMS = new Set<string>(["macOS", "iOS", "visionOS"]);
+
+function toSceneKind(kind: string | undefined): SceneKind {
+  const k = kind || "windowGroup";
+  return VALID_SCENE_KINDS.has(k) ? (k as SceneKind) : "windowGroup";
+}
+
+function toPlatformGuard(
+  platform: string | undefined
+): "macOS" | "iOS" | "visionOS" | undefined {
+  return platform && VALID_PLATFORMS.has(platform)
+    ? (platform as "macOS" | "iOS" | "visionOS")
+    : undefined;
+}
+
 /**
  * Convert a minimal schema string type to an IRType.
  */
@@ -255,7 +276,18 @@ async function handleWidgetSchema(args: SchemaCompileArgs, inputTokens: number) 
     }
   }
 
-  const families: WidgetFamily[] = (args.families as WidgetFamily[]) || ["systemSmall"];
+  const validFamilies = new Set<string>([
+    "systemSmall",
+    "systemMedium",
+    "systemLarge",
+    "systemExtraLarge",
+    "accessoryCircular",
+    "accessoryRectangular",
+    "accessoryInline",
+  ]);
+  const families: WidgetFamily[] = (args.families || ["systemSmall"]).filter(
+    (f: string): f is WidgetFamily => validFamilies.has(f)
+  );
 
   let refreshPolicy: WidgetRefreshPolicy = "atEnd";
   if (args.refreshInterval) {
@@ -298,11 +330,11 @@ async function handleAppSchema(args: SchemaCompileArgs, inputTokens: number) {
   if (args.scenes) {
     for (const s of args.scenes) {
       scenes.push({
-        sceneKind: (s.kind || "windowGroup") as SceneKind,
+        sceneKind: toSceneKind(s.kind),
         rootView: s.view,
         title: s.title,
         name: s.name,
-        platformGuard: s.platform as "macOS" | "iOS" | "visionOS" | undefined,
+        platformGuard: toPlatformGuard(s.platform),
         isDefault: scenes.length === 0 && (s.kind || "windowGroup") === "windowGroup",
       });
     }


### PR DESCRIPTION
Validates WidgetFamily/SceneKind/Platform in MCP server instead of unchecked casts, widens parser propertyMap to ts.Node removing the double cast, and closes the @axintai namespace bypass by requiring ORG_ADMIN_IDS.