### PR TITLE
add registry.axint.ai custom domain, fix og image urls

### DIFF
--- a/registry/src/frontend.ts
+++ b/registry/src/frontend.ts
@@ -104,7 +104,7 @@ function renderBaseLayout(title: string, content: string, showNav = true): strin
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://axint.ai">
   <meta property="og:site_name" content="Axint">
-  <meta property="og:image" content="https://axint.ai/og-image.png">
+  <meta property="og:image" content="https://registry.axint.ai/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="Axint — Write an App Intent in TypeScript, ship it to Siri">
@@ -113,7 +113,7 @@ function renderBaseLayout(title: string, content: string, showNav = true): strin
   <meta name="twitter:creator" content="@agenticempire">
   <meta name="twitter:title" content="Axint — Write an App Intent in TypeScript, ship it to Siri">
   <meta name="twitter:description" content="One TypeScript defineIntent(). One Swift App Intent for Siri. One MCP tool for Claude, Cursor, and Windsurf. The picks and shovels of Agent Siri.">
-  <meta name="twitter:image" content="https://axint.ai/og-image.png">
+  <meta name="twitter:image" content="https://registry.axint.ai/og-image.png">
   <link rel="canonical" href="https://axint.ai">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/registry/wrangler.toml
+++ b/registry/wrangler.toml
@@ -13,3 +13,7 @@ database_id = "14155d9c-09d2-4020-a6c4-ce9828022c2d"
 [[r2_buckets]]
 binding = "PACKAGES"
 bucket_name = "axint-packages"
+
+[[routes]]
+pattern = "registry.axint.ai"
+custom_domain = true


### PR DESCRIPTION
Points the Worker at registry.axint.ai via custom domain. Updates OG image URLs to use registry.axint.ai instead of axint.ai.