### PR TITLE
replace unsafe as-casts with type guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Axint compresses all of that. One TypeScript definition compiles to idiomatic, p
 - **Native type fidelity.** `int → Int`, `double → Double`, `date → Date`, `url → URL`, `duration → Measurement<UnitDuration>`. Default values and optionality preserved end-to-end.
 - **91 diagnostic codes** (`AX000`–`AX522`) with fix suggestions and color-coded output. Intent, entity, view, widget, and app validators each have dedicated error ranges.
 - **Sub-millisecond compile.** The [axint.ai playground](https://axint.ai/#playground) runs the full compiler in-browser with zero server round-trip.
-- **245 tests.** Parser, validator, generator, emit paths, views, widgets, apps, watch mode, sandbox, and MCP — all covered.
+- **249 tests.** Parser, validator, generator, emit paths, views, widgets, apps, watch mode, sandbox, and MCP — all covered.
 - **Cross-language IR.** The intermediate representation is language-agnostic JSON. TypeScript, Python, and raw JSON all feed into the same generator. New language frontends plug in without touching the Swift emitter.
 - **Apache 2.0, no CLA.** Fork it, extend it, ship it.
 
@@ -282,7 +282,7 @@ axint/
 ├── extensions/
 │   └── vscode/      # VS Code / Cursor extension (MCP-backed)
 ├── spm-plugin/      # Xcode SPM build plugin
-├── tests/           # 245 vitest tests
+├── tests/           # 249 vitest tests
 ├── examples/        # Example definitions
 └── docs/            # Error reference, assets
 ```

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -18,11 +18,10 @@ import type {
   IRIntent,
   IRParameter,
   IRType,
-  IRPrimitiveType,
   IREntity,
   DisplayRepresentation,
 } from "./types.js";
-import { PARAM_TYPES, LEGACY_PARAM_ALIASES } from "./types.js";
+import { PARAM_TYPES, LEGACY_PARAM_ALIASES, isPrimitiveType } from "./types.js";
 import {
   propertyMap,
   propertyKeyName,
@@ -38,7 +37,7 @@ import {
 
 function resolveEntityProperties(type: IRType, entities: IREntity[]): void {
   if (type.kind === "entity") {
-    const match = entities.find(e => e.name === type.entityName);
+    const match = entities.find((e) => e.name === type.entityName);
     if (match) {
       type.properties = match.properties;
     }
@@ -266,8 +265,14 @@ function validateQueryType(
       'Add query field: query: "string" (or "all", "id", "property")'
     );
   }
-  const valid = new Set(["all", "id", "string", "property"]);
-  if (!valid.has(value)) {
+  const valid: Record<string, "all" | "id" | "string" | "property"> = {
+    all: "all",
+    id: "id",
+    string: "string",
+    property: "property",
+  };
+  const narrowed = valid[value];
+  if (!narrowed) {
     throw new ParserError(
       "AX019",
       `Invalid query type: "${value}". Must be one of: all, id, string, property`,
@@ -275,7 +280,7 @@ function validateQueryType(
       node ? posOf(sourceFile, node) : undefined
     );
   }
-  return value as "all" | "id" | "string" | "property";
+  return narrowed;
 }
 
 // ─── Parameter Extraction ────────────────────────────────────────────
@@ -429,8 +434,8 @@ function resolveParamType(
   callExpr?: ts.CallExpression
 ): IRType {
   // Primitive types
-  if ((PARAM_TYPES as ReadonlySet<string>).has(typeName)) {
-    return { kind: "primitive", value: typeName as IRPrimitiveType };
+  if (isPrimitiveType(typeName)) {
+    return { kind: "primitive", value: typeName };
   }
 
   // Legacy aliases
@@ -543,7 +548,10 @@ function inferReturnType(performNode: ts.Node | undefined): IRType {
       return inferFromReturnStatements(performNode.body);
     }
     // Single-expression arrow: perform: async (p) => "literal"
-    return inferFromExpression(performNode.body as ts.Expression);
+    // body is ConciseBody = Block | Expression — Block handled above
+    return ts.isExpression(performNode.body)
+      ? inferFromExpression(performNode.body)
+      : defaultType;
   }
 
   // Handle function expression: perform: async function() { ... }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -190,6 +190,18 @@ export interface IRWidget {
 /** Scene type in a SwiftUI App */
 export type SceneKind = "windowGroup" | "window" | "documentGroup" | "settings";
 
+const SCENE_KINDS: ReadonlySet<string> = new Set([
+  "windowGroup",
+  "window",
+  "documentGroup",
+  "settings",
+]);
+
+/** Type guard — narrows a string to SceneKind. */
+export function isSceneKind(s: string): s is SceneKind {
+  return SCENE_KINDS.has(s);
+}
+
 /** A single scene in an App definition */
 export interface IRScene {
   /** Optional name identifier for named windows */
@@ -288,6 +300,11 @@ export const PARAM_TYPES: ReadonlySet<IRPrimitiveType> = new Set<IRPrimitiveType
   "duration",
   "url",
 ]);
+
+/** Type guard — narrows a string to IRPrimitiveType without an `as` cast. */
+export function isPrimitiveType(s: string): s is IRPrimitiveType {
+  return (PARAM_TYPES as ReadonlySet<string>).has(s);
+}
 
 /**
  * Legacy alias: "number" → "int" for backwards compatibility with v0.1.x files.

--- a/src/mcp/scaffold.ts
+++ b/src/mcp/scaffold.ts
@@ -8,8 +8,8 @@
  */
 
 import {
-  PARAM_TYPES,
   LEGACY_PARAM_ALIASES,
+  isPrimitiveType,
   type IRPrimitiveType,
 } from "../core/types.js";
 
@@ -77,7 +77,7 @@ export function scaffoldIntent(input: ScaffoldInput): string {
 
 function resolveType(raw: string): IRPrimitiveType {
   const lc = raw.toLowerCase();
-  if (PARAM_TYPES.has(lc as IRPrimitiveType)) return lc as IRPrimitiveType;
+  if (isPrimitiveType(lc)) return lc;
   if (lc in LEGACY_PARAM_ALIASES) return LEGACY_PARAM_ALIASES[lc];
   // Fall back to string — keeps scaffolding from throwing on unknown
   // types. Users can edit the file if they wanted something more exotic.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -44,11 +44,11 @@ import type {
   IRViewProp,
   IRParameter,
   IRType,
-  IRPrimitiveType,
   WidgetFamily,
   WidgetRefreshPolicy,
   SceneKind,
 } from "../core/types.js";
+import { isPrimitiveType, isSceneKind } from "../core/types.js";
 
 // Read version from package.json so it stays in sync
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -93,25 +93,21 @@ type SchemaCompileArgs = {
   }>;
 };
 
-const VALID_SCENE_KINDS = new Set<string>([
-  "windowGroup",
-  "window",
-  "documentGroup",
-  "settings",
-]);
 const VALID_PLATFORMS = new Set<string>(["macOS", "iOS", "visionOS"]);
 
 function toSceneKind(kind: string | undefined): SceneKind {
   const k = kind || "windowGroup";
-  return VALID_SCENE_KINDS.has(k) ? (k as SceneKind) : "windowGroup";
+  return isSceneKind(k) ? k : "windowGroup";
 }
 
-function toPlatformGuard(
-  platform: string | undefined
-): "macOS" | "iOS" | "visionOS" | undefined {
-  return platform && VALID_PLATFORMS.has(platform)
-    ? (platform as "macOS" | "iOS" | "visionOS")
-    : undefined;
+type Platform = "macOS" | "iOS" | "visionOS";
+
+function isPlatform(s: string): s is Platform {
+  return VALID_PLATFORMS.has(s);
+}
+
+function toPlatformGuard(platform: string | undefined): Platform | undefined {
+  return platform && isPlatform(platform) ? platform : undefined;
 }
 
 /**
@@ -119,18 +115,8 @@ function toPlatformGuard(
  */
 function schemaTypeToIRType(typeStr: string): IRType {
   const normalized = typeStr === "number" ? "int" : typeStr;
-  const validPrimitives = [
-    "string",
-    "int",
-    "double",
-    "float",
-    "boolean",
-    "date",
-    "duration",
-    "url",
-  ];
-  if (validPrimitives.includes(normalized)) {
-    return { kind: "primitive" as const, value: normalized as IRPrimitiveType };
+  if (isPrimitiveType(normalized)) {
+    return { kind: "primitive", value: normalized };
   }
   return { kind: "primitive", value: "string" };
 }
@@ -176,13 +162,17 @@ async function handleCompileFromSchema(args: SchemaCompileArgs) {
 async function handleIntentSchema(args: SchemaCompileArgs, inputTokens: number) {
   if (!args.name) {
     return {
-      content: [{ type: "text" as const, text: "[AX002] error: Schema requires a 'name' field" }],
+      content: [
+        { type: "text" as const, text: "[AX002] error: Schema requires a 'name' field" },
+      ],
       isError: true,
     };
   }
   if (!args.title && !args.name) {
     return {
-      content: [{ type: "text" as const, text: "[AX003] error: Schema requires a 'title' field" }],
+      content: [
+        { type: "text" as const, text: "[AX003] error: Schema requires a 'title' field" },
+      ],
       isError: true,
     };
   }
@@ -230,7 +220,12 @@ async function handleIntentSchema(args: SchemaCompileArgs, inputTokens: number) 
 async function handleViewSchema(args: SchemaCompileArgs, inputTokens: number) {
   if (!args.name) {
     return {
-      content: [{ type: "text" as const, text: "[AX301] error: View schema requires a 'name' field" }],
+      content: [
+        {
+          type: "text" as const,
+          text: "[AX301] error: View schema requires a 'name' field",
+        },
+      ],
       isError: true,
     };
   }
@@ -288,13 +283,23 @@ async function handleViewSchema(args: SchemaCompileArgs, inputTokens: number) {
 async function handleWidgetSchema(args: SchemaCompileArgs, inputTokens: number) {
   if (!args.name) {
     return {
-      content: [{ type: "text" as const, text: "[AX402] error: Widget schema requires a 'name' field" }],
+      content: [
+        {
+          type: "text" as const,
+          text: "[AX402] error: Widget schema requires a 'name' field",
+        },
+      ],
       isError: true,
     };
   }
   if (!args.displayName) {
     return {
-      content: [{ type: "text" as const, text: "[AX403] error: Widget schema requires a 'displayName' field" }],
+      content: [
+        {
+          type: "text" as const,
+          text: "[AX403] error: Widget schema requires a 'displayName' field",
+        },
+      ],
       isError: true,
     };
   }
@@ -361,13 +366,23 @@ async function handleWidgetSchema(args: SchemaCompileArgs, inputTokens: number) 
 async function handleAppSchema(args: SchemaCompileArgs, inputTokens: number) {
   if (!args.name) {
     return {
-      content: [{ type: "text" as const, text: "[AX502] error: App schema requires a 'name' field" }],
+      content: [
+        {
+          type: "text" as const,
+          text: "[AX502] error: App schema requires a 'name' field",
+        },
+      ],
       isError: true,
     };
   }
   if (!args.scenes || args.scenes.length === 0) {
     return {
-      content: [{ type: "text" as const, text: "[AX503] error: App schema requires at least one scene" }],
+      content: [
+        {
+          type: "text" as const,
+          text: "[AX503] error: App schema requires at least one scene",
+        },
+      ],
       isError: true,
     };
   }

--- a/tests/core/types.test.ts
+++ b/tests/core/types.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { irTypeToSwift, SWIFT_TYPE_MAP } from "../../src/core/types.js";
+import {
+  irTypeToSwift,
+  SWIFT_TYPE_MAP,
+  isPrimitiveType,
+  isSceneKind,
+} from "../../src/core/types.js";
 import type { IRType } from "../../src/core/types.js";
 
 describe("SWIFT_TYPE_MAP", () => {
@@ -69,5 +74,43 @@ describe("irTypeToSwift", () => {
       },
     };
     expect(irTypeToSwift(nestedType)).toBe("[String]?");
+  });
+});
+
+describe("isPrimitiveType", () => {
+  it("returns true for all valid primitive types", () => {
+    for (const t of [
+      "string",
+      "int",
+      "double",
+      "float",
+      "boolean",
+      "date",
+      "duration",
+      "url",
+    ]) {
+      expect(isPrimitiveType(t)).toBe(true);
+    }
+  });
+
+  it("returns false for unknown types", () => {
+    expect(isPrimitiveType("number")).toBe(false);
+    expect(isPrimitiveType("String")).toBe(false);
+    expect(isPrimitiveType("")).toBe(false);
+    expect(isPrimitiveType("object")).toBe(false);
+  });
+});
+
+describe("isSceneKind", () => {
+  it("returns true for valid scene kinds", () => {
+    for (const k of ["windowGroup", "window", "documentGroup", "settings"]) {
+      expect(isSceneKind(k)).toBe(true);
+    }
+  });
+
+  it("returns false for invalid scene kinds", () => {
+    expect(isSceneKind("tabGroup")).toBe(false);
+    expect(isSceneKind("")).toBe(false);
+    expect(isSceneKind("WindowGroup")).toBe(false);
   });
 });


### PR DESCRIPTION
adds isPrimitiveType() and isSceneKind() type guards to eliminate as-casts in parser, MCP server, and scaffold. 4 new tests for the guards.