### PR TITLE
expand test coverage (249 → 402) and sync readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Axint compresses all of that. One TypeScript definition compiles to idiomatic, p
 - **Native type fidelity.** `int → Int`, `double → Double`, `date → Date`, `url → URL`, `duration → Measurement<UnitDuration>`. Default values and optionality preserved end-to-end.
 - **91 diagnostic codes** (`AX000`–`AX522`) with fix suggestions and color-coded output. Intent, entity, view, widget, and app validators each have dedicated error ranges.
 - **Sub-millisecond compile.** The [axint.ai playground](https://axint.ai/#playground) runs the full compiler in-browser with zero server round-trip.
-- **249 tests.** Parser, validator, generator, emit paths, views, widgets, apps, watch mode, sandbox, and MCP — all covered.
+- **402 tests.** Parser, validator, generator, emit paths, views, widgets, apps, watch mode, sandbox, and MCP — all covered.
 - **Cross-language IR.** The intermediate representation is language-agnostic JSON. TypeScript, Python, and raw JSON all feed into the same generator. New language frontends plug in without touching the Swift emitter.
 - **Apache 2.0, no CLA.** Fork it, extend it, ship it.
 
@@ -282,7 +282,7 @@ axint/
 ├── extensions/
 │   └── vscode/      # VS Code / Cursor extension (MCP-backed)
 ├── spm-plugin/      # Xcode SPM build plugin
-├── tests/           # 249 vitest tests
+├── tests/           # 402 vitest tests
 ├── examples/        # Example definitions
 └── docs/            # Error reference, assets
 ```

--- a/tests/core/diagnostics.test.ts
+++ b/tests/core/diagnostics.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from "vitest";
+import {
+  getDiagnostic,
+  getCodesByCategory,
+  DIAGNOSTIC_CODES,
+  DIAGNOSTIC_COUNT,
+} from "../../src/core/diagnostics.js";
+
+describe("getDiagnostic", () => {
+  it("returns diagnostic info for valid code", () => {
+    const diag = getDiagnostic("AX001");
+    expect(diag).toBeDefined();
+    expect(diag?.code).toBe("AX001");
+    expect(diag?.severity).toBe("error");
+    expect(diag?.message).toBe("No defineIntent() call found");
+    expect(diag?.category).toBe("intent-parser");
+  });
+
+  it("returns undefined for unknown code", () => {
+    const diag = getDiagnostic("UNKNOWN");
+    expect(diag).toBeUndefined();
+  });
+
+  it("retrieves all intent parser codes", () => {
+    const ax001 = getDiagnostic("AX001");
+    const ax002 = getDiagnostic("AX002");
+    const ax008 = getDiagnostic("AX008");
+    expect(ax001?.category).toBe("intent-parser");
+    expect(ax002?.category).toBe("intent-parser");
+    expect(ax008?.category).toBe("intent-parser");
+  });
+
+  it("retrieves all intent validator codes", () => {
+    const ax100 = getDiagnostic("AX100");
+    const ax107 = getDiagnostic("AX107");
+    expect(ax100?.category).toBe("intent-validator");
+    expect(ax107?.category).toBe("intent-validator");
+  });
+
+  it("retrieves entity parser codes", () => {
+    const ax015 = getDiagnostic("AX015");
+    const ax022 = getDiagnostic("AX022");
+    expect(ax015?.category).toBe("entity-parser");
+    expect(ax022?.category).toBe("intent-parser");
+  });
+
+  it("retrieves entity validator codes", () => {
+    const ax110 = getDiagnostic("AX110");
+    const ax111 = getDiagnostic("AX111");
+    expect(ax110?.category).toBe("entity-validator");
+    expect(ax111?.category).toBe("entity-validator");
+  });
+
+  it("retrieves generator codes", () => {
+    const ax200 = getDiagnostic("AX200");
+    const ax202 = getDiagnostic("AX202");
+    expect(ax200?.category).toBe("intent-generator");
+    expect(ax202?.category).toBe("intent-generator");
+  });
+
+  it("retrieves view parser codes", () => {
+    const ax301 = getDiagnostic("AX301");
+    const ax309 = getDiagnostic("AX309");
+    expect(ax301?.category).toBe("view-parser");
+    expect(ax309?.category).toBe("view-parser");
+  });
+
+  it("retrieves view validator codes", () => {
+    const ax310 = getDiagnostic("AX310");
+    const ax322 = getDiagnostic("AX322");
+    expect(ax310?.category).toBe("view-validator");
+    expect(ax322?.category).toBe("view-generator");
+  });
+
+  it("retrieves widget codes", () => {
+    const ax401 = getDiagnostic("AX401");
+    const ax415 = getDiagnostic("AX415");
+    expect(ax401?.category).toBe("widget-parser");
+    expect(ax415?.category).toBe("widget-validator");
+  });
+
+  it("retrieves app codes", () => {
+    const ax501 = getDiagnostic("AX501");
+    const ax522 = getDiagnostic("AX522");
+    expect(ax501?.category).toBe("app-parser");
+    expect(ax522?.category).toBe("app-generator");
+  });
+});
+
+describe("getCodesByCategory", () => {
+  it("returns all intent-parser codes", () => {
+    const codes = getCodesByCategory("intent-parser");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "intent-parser")).toBe(true);
+    expect(codes.map((c) => c.code)).toContain("AX001");
+    expect(codes.map((c) => c.code)).toContain("AX007");
+  });
+
+  it("returns all intent-validator codes", () => {
+    const codes = getCodesByCategory("intent-validator");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "intent-validator")).toBe(true);
+  });
+
+  it("returns all entity-parser codes", () => {
+    const codes = getCodesByCategory("entity-parser");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "entity-parser")).toBe(true);
+  });
+
+  it("returns all entity-validator codes", () => {
+    const codes = getCodesByCategory("entity-validator");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "entity-validator")).toBe(true);
+  });
+
+  it("returns all intent-generator codes", () => {
+    const codes = getCodesByCategory("intent-generator");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "intent-generator")).toBe(true);
+  });
+
+  it("returns all view-parser codes", () => {
+    const codes = getCodesByCategory("view-parser");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "view-parser")).toBe(true);
+  });
+
+  it("returns all view-validator codes", () => {
+    const codes = getCodesByCategory("view-validator");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "view-validator")).toBe(true);
+  });
+
+  it("returns all view-generator codes", () => {
+    const codes = getCodesByCategory("view-generator");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "view-generator")).toBe(true);
+  });
+
+  it("returns all widget-parser codes", () => {
+    const codes = getCodesByCategory("widget-parser");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "widget-parser")).toBe(true);
+  });
+
+  it("returns all widget-validator codes", () => {
+    const codes = getCodesByCategory("widget-validator");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "widget-validator")).toBe(true);
+  });
+
+  it("returns all widget-generator codes", () => {
+    const codes = getCodesByCategory("widget-generator");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "widget-generator")).toBe(true);
+  });
+
+  it("returns all app-parser codes", () => {
+    const codes = getCodesByCategory("app-parser");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "app-parser")).toBe(true);
+  });
+
+  it("returns all app-validator codes", () => {
+    const codes = getCodesByCategory("app-validator");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "app-validator")).toBe(true);
+  });
+
+  it("returns all app-generator codes", () => {
+    const codes = getCodesByCategory("app-generator");
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every((c) => c.category === "app-generator")).toBe(true);
+  });
+
+  it("returns empty array for unknown category", () => {
+    const codes = getCodesByCategory("unknown-category");
+    expect(codes).toEqual([]);
+  });
+});
+
+describe("DIAGNOSTIC_CODES registry", () => {
+  it("has correct count", () => {
+    expect(Object.keys(DIAGNOSTIC_CODES).length).toBe(DIAGNOSTIC_COUNT);
+  });
+
+  it("has all required fields for each diagnostic", () => {
+    Object.entries(DIAGNOSTIC_CODES).forEach(([_key, diag]) => {
+      expect(diag.code).toBeDefined();
+      expect(diag.severity).toMatch(/^(error|warning|info)$/);
+      expect(typeof diag.message).toBe("string");
+      expect(diag.message.length).toBeGreaterThan(0);
+      expect(typeof diag.category).toBe("string");
+      expect(diag.category.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("has intent parser range codes (AX000-AX099)", () => {
+    expect(getDiagnostic("AX001")).toBeDefined();
+    expect(getDiagnostic("AX008")).toBeDefined();
+    expect(getDiagnostic("AX023")).toBeDefined();
+  });
+
+  it("has intent validator range codes (AX100-AX199)", () => {
+    expect(getDiagnostic("AX100")).toBeDefined();
+    expect(getDiagnostic("AX109")).toBeDefined();
+  });
+
+  it("has intent generator range codes (AX200-AX299)", () => {
+    expect(getDiagnostic("AX200")).toBeDefined();
+    expect(getDiagnostic("AX202")).toBeDefined();
+  });
+
+  it("has view parser range codes (AX300-AX399)", () => {
+    expect(getDiagnostic("AX301")).toBeDefined();
+    expect(getDiagnostic("AX309")).toBeDefined();
+  });
+
+  it("has widget parser range codes (AX400-AX499)", () => {
+    expect(getDiagnostic("AX401")).toBeDefined();
+    expect(getDiagnostic("AX422")).toBeDefined();
+  });
+
+  it("has app parser range codes (AX500-AX599)", () => {
+    expect(getDiagnostic("AX501")).toBeDefined();
+    expect(getDiagnostic("AX522")).toBeDefined();
+  });
+
+  it("distinguishes error, warning, and info severities", () => {
+    const errors = Object.values(DIAGNOSTIC_CODES).filter((d) => d.severity === "error");
+    const warnings = Object.values(DIAGNOSTIC_CODES).filter(
+      (d) => d.severity === "warning"
+    );
+    const infos = Object.values(DIAGNOSTIC_CODES).filter((d) => d.severity === "info");
+    expect(errors.length).toBeGreaterThan(0);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(infos.length).toBeGreaterThan(0);
+  });
+});
+
+describe("diagnostic code coverage", () => {
+  it("has consistent category naming", () => {
+    const categories = new Set(Object.values(DIAGNOSTIC_CODES).map((d) => d.category));
+    const expectedCategories = [
+      "intent-parser",
+      "entity-parser",
+      "intent-validator",
+      "entity-validator",
+      "intent-generator",
+      "view-parser",
+      "view-validator",
+      "view-generator",
+      "widget-parser",
+      "widget-validator",
+      "widget-generator",
+      "app-parser",
+      "app-validator",
+      "app-generator",
+    ];
+    for (const cat of expectedCategories) {
+      expect(categories.has(cat)).toBe(true);
+    }
+  });
+
+  it("has non-empty messages for all codes", () => {
+    Object.values(DIAGNOSTIC_CODES).forEach((diag) => {
+      expect(diag.message).toBeTruthy();
+      expect(diag.message.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("maps all codes to their diagnostic info correctly", () => {
+    const code = "AX104";
+    const diag = getDiagnostic(code);
+    expect(diag).toBeDefined();
+    expect(diag?.code).toBe(code);
+    expect(DIAGNOSTIC_CODES[code]).toBe(diag);
+  });
+});

--- a/tests/core/generator-edge-cases.test.ts
+++ b/tests/core/generator-edge-cases.test.ts
@@ -6,8 +6,14 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { generateSwift } from "../../src/core/generator.js";
-import type { IRIntent, IRParameter } from "../../src/core/types.js";
+import {
+  generateSwift,
+  generateEntity,
+  generateEntityQuery,
+  generateInfoPlistFragment,
+  generateEntitlementsFragment,
+} from "../../src/core/generator.js";
+import type { IRIntent, IRParameter, IRPrimitiveType } from "../../src/core/types.js";
 
 function makeIntent(overrides: Partial<IRIntent> = {}): IRIntent {
   return {
@@ -195,5 +201,740 @@ describe("generateSwift — structure", () => {
   it("omits param comment when no parameters", () => {
     const swift = generateSwift(makeIntent({ parameters: [] }));
     expect(swift).not.toContain("Parameters available");
+  });
+});
+
+describe("generateSwift — isDiscoverable flag", () => {
+  it("includes isDiscoverable when true", () => {
+    const swift = generateSwift(makeIntent({ isDiscoverable: true }));
+    expect(swift).toContain("static let isDiscoverable: Bool = true");
+  });
+
+  it("includes isDiscoverable when false", () => {
+    const swift = generateSwift(makeIntent({ isDiscoverable: false }));
+    expect(swift).toContain("static let isDiscoverable: Bool = false");
+  });
+
+  it("omits isDiscoverable when undefined", () => {
+    const swift = generateSwift(makeIntent({ isDiscoverable: undefined }));
+    expect(swift).not.toContain("isDiscoverable");
+  });
+});
+
+describe("generateSwift — donateOnPerform flag", () => {
+  it("includes donation logic when donateOnPerform is true", () => {
+    const swift = generateSwift(makeIntent({ donateOnPerform: true }));
+    expect(swift).toContain("Donate to Siri and Spotlight");
+    expect(swift).toContain("try? await self.donate()");
+  });
+
+  it("omits donation logic when donateOnPerform is false or undefined", () => {
+    const swift = generateSwift(makeIntent({ donateOnPerform: false }));
+    expect(swift).not.toContain("Donate to Siri");
+    expect(swift).not.toContain("self.donate()");
+  });
+});
+
+describe("generateSwift — custom return types", () => {
+  it("uses customResultType when provided", () => {
+    const swift = generateSwift(
+      makeIntent({
+        customResultType: "MyCustomResult",
+        returnType: { kind: "primitive", value: "string" },
+      })
+    );
+    expect(swift).toContain("func perform() async throws -> MyCustomResult");
+    expect(swift).toContain(
+      "return .result(value: MyCustomResult()) // replace with your MyCustomResult instance"
+    );
+  });
+
+  it("falls back to IntentResult when no return type is primitive", () => {
+    const swift = generateSwift(
+      makeIntent({
+        returnType: {
+          kind: "array",
+          elementType: { kind: "primitive", value: "string" },
+        },
+      })
+    );
+    expect(swift).toContain("func perform() async throws -> some IntentResult");
+    expect(swift).toContain("return .result()");
+  });
+
+  it("uses ReturnsValue wrapper for primitive return types", () => {
+    const swift = generateSwift(
+      makeIntent({
+        returnType: { kind: "primitive", value: "int" },
+      })
+    );
+    expect(swift).toContain(
+      "func perform() async throws -> some IntentResult & ReturnsValue<Int>"
+    );
+    expect(swift).toContain("return .result(value: 0)");
+  });
+
+  it("handles optional primitive return types with ReturnsValue", () => {
+    const swift = generateSwift(
+      makeIntent({
+        returnType: { kind: "optional", innerType: { kind: "primitive", value: "date" } },
+      })
+    );
+    expect(swift).toContain("some IntentResult & ReturnsValue<Date>");
+    expect(swift).toContain("return .result(value: Date())");
+  });
+});
+
+describe("generateSwift — nested optional types", () => {
+  it("handles optional array parameter", () => {
+    const swift = generateSwift(
+      makeIntent({
+        parameters: [
+          {
+            name: "tags",
+            type: {
+              kind: "optional",
+              innerType: {
+                kind: "array",
+                elementType: { kind: "primitive", value: "string" },
+              },
+            },
+            title: "Tags",
+            description: "Optional tags",
+            isOptional: true,
+          },
+        ],
+      })
+    );
+    expect(swift).toContain("var tags: [String]?");
+  });
+
+  it("handles array of optional primitives", () => {
+    const swift = generateSwift(
+      makeIntent({
+        parameters: [
+          {
+            name: "values",
+            type: {
+              kind: "array",
+              elementType: {
+                kind: "optional",
+                innerType: { kind: "primitive", value: "int" },
+              },
+            },
+            title: "Values",
+            description: "Values",
+            isOptional: false,
+          },
+        ],
+      })
+    );
+    expect(swift).toContain("var values: [Int?]");
+  });
+});
+
+describe("generateSwift — enum types", () => {
+  it("generates enum parameter as Swift type", () => {
+    const swift = generateSwift(
+      makeIntent({
+        parameters: [
+          {
+            name: "priority",
+            type: {
+              kind: "enum",
+              name: "Priority",
+              cases: ["low", "medium", "high"],
+            },
+            title: "Priority",
+            description: "Task priority",
+            isOptional: false,
+          },
+        ],
+      })
+    );
+    expect(swift).toContain("var priority: Priority");
+  });
+
+  it("handles optional enum parameter", () => {
+    const swift = generateSwift(
+      makeIntent({
+        parameters: [
+          {
+            name: "status",
+            type: {
+              kind: "optional",
+              innerType: {
+                kind: "enum",
+                name: "Status",
+                cases: ["active", "inactive"],
+              },
+            },
+            title: "Status",
+            description: "Item status",
+            isOptional: true,
+          },
+        ],
+      })
+    );
+    expect(swift).toContain("var status: Status?");
+  });
+});
+
+describe("generateSwift — dynamic options", () => {
+  it("handles dynamic options parameter as array", () => {
+    const swift = generateSwift(
+      makeIntent({
+        parameters: [
+          {
+            name: "contact",
+            type: {
+              kind: "dynamicOptions",
+              valueType: { kind: "primitive", value: "string" },
+              providerName: "ContactProvider",
+            },
+            title: "Contact",
+            description: "Select a contact",
+            isOptional: false,
+          },
+        ],
+      })
+    );
+    expect(swift).toContain("var contact: [DynamicOptionsResult<String>]");
+  });
+
+  it("handles optional dynamic options as optional array", () => {
+    const swift = generateSwift(
+      makeIntent({
+        parameters: [
+          {
+            name: "file",
+            type: {
+              kind: "optional",
+              innerType: {
+                kind: "dynamicOptions",
+                valueType: { kind: "primitive", value: "string" },
+                providerName: "FileProvider",
+              },
+            },
+            title: "File",
+            description: "Select a file",
+            isOptional: true,
+          },
+        ],
+      })
+    );
+    expect(swift).toContain("var file: [DynamicOptionsResult<String>]?");
+  });
+});
+
+describe("generateSwift — all primitive return types", () => {
+  const returnTypeTests: { primitive: string; expected: string; literal: string }[] = [
+    { primitive: "string", expected: "String", literal: '""' },
+    { primitive: "int", expected: "Int", literal: "0" },
+    { primitive: "double", expected: "Double", literal: "0.0" },
+    { primitive: "float", expected: "Float", literal: "Float(0)" },
+    { primitive: "boolean", expected: "Bool", literal: "false" },
+    { primitive: "date", expected: "Date", literal: "Date()" },
+    {
+      primitive: "duration",
+      expected: "Measurement<UnitDuration>",
+      literal: "Measurement<UnitDuration>(value: 0, unit: .seconds)",
+    },
+    { primitive: "url", expected: "URL", literal: 'URL(string: "about:blank")!' },
+  ];
+
+  for (const { primitive, expected, literal } of returnTypeTests) {
+    it(`maps return type ${primitive} → ${expected}`, () => {
+      const swift = generateSwift(
+        makeIntent({
+          returnType: { kind: "primitive", value: primitive as IRPrimitiveType },
+        })
+      );
+      expect(swift).toContain(`some IntentResult & ReturnsValue<${expected}>`);
+      expect(swift).toContain(`return .result(value: ${literal})`);
+    });
+  }
+
+  it("handles unknown primitive type gracefully", () => {
+    const swift = generateSwift(
+      makeIntent({
+        returnType: { kind: "primitive", value: "unknown" as unknown as IRPrimitiveType },
+      })
+    );
+    expect(swift).toContain("some IntentResult & ReturnsValue");
+    expect(swift).toContain('return .result(value: "")');
+  });
+});
+
+describe("generateEntity", () => {
+  it("generates AppEntity struct with basic properties", () => {
+    const entity = {
+      name: "Contact",
+      displayRepresentation: { title: "name" },
+      properties: [
+        {
+          name: "name",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Name",
+          description: "Contact name",
+          isOptional: false,
+        },
+        {
+          name: "email",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Email",
+          description: "Email",
+          isOptional: false,
+        },
+      ],
+      queryType: "string" as const,
+    };
+    const swift = generateEntity(entity);
+    expect(swift).toContain("struct Contact: AppEntity");
+    expect(swift).toContain("var name: String");
+    expect(swift).toContain("var email: String");
+    expect(swift).toContain("static var defaultQuery = ContactQuery()");
+  });
+
+  it("adds id property if not present in entity", () => {
+    const entity = {
+      name: "Task",
+      displayRepresentation: { title: "title" },
+      properties: [
+        {
+          name: "title",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Title",
+          description: "Task title",
+          isOptional: false,
+        },
+      ],
+      queryType: "all" as const,
+    };
+    const swift = generateEntity(entity);
+    expect(swift).toContain("var id: String");
+  });
+
+  it("skips id property if already defined", () => {
+    const entity = {
+      name: "Item",
+      displayRepresentation: { title: "id" },
+      properties: [
+        {
+          name: "id",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "ID",
+          description: "Unique ID",
+          isOptional: false,
+        },
+        {
+          name: "label",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Label",
+          description: "Item label",
+          isOptional: false,
+        },
+      ],
+      queryType: "id" as const,
+    };
+    const swift = generateEntity(entity);
+    const idCount = (swift.match(/var id: String/g) || []).length;
+    expect(idCount).toBe(1);
+  });
+
+  it("generates TypeDisplayRepresentation with entity name", () => {
+    const entity = {
+      name: "Person",
+      displayRepresentation: { title: "name" },
+      properties: [
+        {
+          name: "name",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Name",
+          description: "Name",
+          isOptional: false,
+        },
+      ],
+      queryType: "string" as const,
+    };
+    const swift = generateEntity(entity);
+    expect(swift).toContain(
+      "static let typeDisplayRepresentation: TypeDisplayRepresentation"
+    );
+    expect(swift).toContain('LocalizedStringResource("Person")');
+  });
+
+  it("generates displayRepresentation with title, subtitle, and image", () => {
+    const entity = {
+      name: "Photo",
+      displayRepresentation: {
+        title: "title",
+        subtitle: "date",
+        image: "photo",
+      },
+      properties: [
+        {
+          name: "title",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Title",
+          description: "Title",
+          isOptional: false,
+        },
+        {
+          name: "date",
+          type: { kind: "primitive" as const, value: "date" as const },
+          title: "Date",
+          description: "Date",
+          isOptional: false,
+        },
+      ],
+      queryType: "all" as const,
+    };
+    const swift = generateEntity(entity);
+    expect(swift).toContain("var displayRepresentation: DisplayRepresentation");
+    expect(swift).toContain('title: "\\(title)"');
+    expect(swift).toContain('subtitle: "\\(date)"');
+    expect(swift).toContain('image: .init(systemName: "photo")');
+  });
+
+  it("generates displayRepresentation with title only", () => {
+    const entity = {
+      name: "Simple",
+      displayRepresentation: { title: "name" },
+      properties: [
+        {
+          name: "name",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Name",
+          description: "Name",
+          isOptional: false,
+        },
+      ],
+      queryType: "all" as const,
+    };
+    const swift = generateEntity(entity);
+    expect(swift).toContain('title: "\\(name)"');
+    expect(swift).not.toContain("subtitle:");
+    expect(swift).not.toContain("image:");
+  });
+
+  it("generates displayRepresentation with title and subtitle but no image", () => {
+    const entity = {
+      name: "Event",
+      displayRepresentation: {
+        title: "name",
+        subtitle: "date",
+      },
+      properties: [
+        {
+          name: "name",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Name",
+          description: "Name",
+          isOptional: false,
+        },
+        {
+          name: "date",
+          type: { kind: "primitive" as const, value: "date" as const },
+          title: "Date",
+          description: "Date",
+          isOptional: false,
+        },
+      ],
+      queryType: "all" as const,
+    };
+    const swift = generateEntity(entity);
+    expect(swift).toContain('title: "\\(name)",');
+    expect(swift).toContain('subtitle: "\\(date)"');
+    expect(swift).not.toContain("image:");
+  });
+});
+
+describe("generateEntityQuery", () => {
+  it("generates EntityQuery for 'all' query type", () => {
+    const entity = {
+      name: "Event",
+      displayRepresentation: { title: "title" },
+      properties: [
+        {
+          name: "title",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Title",
+          description: "Title",
+          isOptional: false,
+        },
+      ],
+      queryType: "all" as const,
+    };
+    const swift = generateEntityQuery(entity);
+    expect(swift).toContain("struct EventQuery: EntityQuery");
+    expect(swift).toContain("func entities(for identifiers: [Event.ID])");
+    expect(swift).toContain("func allEntities()");
+  });
+
+  it("generates EntityQuery for 'id' query type", () => {
+    const entity = {
+      name: "User",
+      displayRepresentation: { title: "name" },
+      properties: [
+        {
+          name: "name",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Name",
+          description: "Name",
+          isOptional: false,
+        },
+      ],
+      queryType: "id" as const,
+    };
+    const swift = generateEntityQuery(entity);
+    expect(swift).toContain("struct UserQuery: EntityQuery");
+    expect(swift).toContain("func entities(for identifiers: [User.ID])");
+    expect(swift).toContain(
+      "ID-based query is provided by the entities(for:) method above"
+    );
+  });
+
+  it("generates EntityQuery for 'string' query type", () => {
+    const entity = {
+      name: "Location",
+      displayRepresentation: { title: "name" },
+      properties: [
+        {
+          name: "name",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Name",
+          description: "Name",
+          isOptional: false,
+        },
+      ],
+      queryType: "string" as const,
+    };
+    const swift = generateEntityQuery(entity);
+    expect(swift).toContain("func entities(matching string: String)");
+    expect(swift).not.toContain("allEntities()");
+  });
+
+  it("generates EntityPropertyQuery for 'property' query type", () => {
+    const entity = {
+      name: "Product",
+      displayRepresentation: { title: "name" },
+      properties: [
+        {
+          name: "name",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Name",
+          description: "Name",
+          isOptional: false,
+        },
+        {
+          name: "price",
+          type: { kind: "primitive" as const, value: "double" as const },
+          title: "Price",
+          description: "Price",
+          isOptional: false,
+        },
+      ],
+      queryType: "property" as const,
+    };
+    const swift = generateEntityQuery(entity);
+    expect(swift).toContain("struct ProductQuery: EntityPropertyQuery");
+    expect(swift).toContain("static var properties = QueryProperties");
+    expect(swift).toContain("static var sortingOptions = SortingOptions");
+    expect(swift).toContain("func entities(matching comparators:");
+  });
+
+  it("adds appropriate comparators based on property type", () => {
+    const entity = {
+      name: "Item",
+      displayRepresentation: { title: "name" },
+      properties: [
+        {
+          name: "name",
+          type: { kind: "primitive" as const, value: "string" as const },
+          title: "Name",
+          description: "Name",
+          isOptional: false,
+        },
+        {
+          name: "count",
+          type: { kind: "primitive" as const, value: "int" as const },
+          title: "Count",
+          description: "Count",
+          isOptional: false,
+        },
+        {
+          name: "date",
+          type: { kind: "primitive" as const, value: "date" as const },
+          title: "Date",
+          description: "Date",
+          isOptional: false,
+        },
+      ],
+      queryType: "property" as const,
+    };
+    const swift = generateEntityQuery(entity);
+    expect(swift).toContain("EqualToComparator()");
+    expect(swift).toContain("ContainsComparator()");
+    expect(swift).toContain("LessThanComparator()");
+    expect(swift).toContain("GreaterThanComparator()");
+  });
+});
+
+describe("generateInfoPlistFragment", () => {
+  it("returns undefined when no keys present", () => {
+    const intent = makeIntent({ infoPlistKeys: undefined });
+    const fragment = generateInfoPlistFragment(intent);
+    expect(fragment).toBeUndefined();
+  });
+
+  it("returns undefined when keys object is empty", () => {
+    const intent = makeIntent({ infoPlistKeys: {} });
+    const fragment = generateInfoPlistFragment(intent);
+    expect(fragment).toBeUndefined();
+  });
+
+  it("generates plist XML with proper structure", () => {
+    const intent = makeIntent({
+      infoPlistKeys: {
+        NSLocationWhenInUseUsageDescription: "We need your location",
+        NSCameraUsageDescription: "We need camera access",
+      },
+    });
+    const fragment = generateInfoPlistFragment(intent);
+    expect(fragment).toBeDefined();
+    expect(fragment).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(fragment).toContain("<dict>");
+    expect(fragment).toContain("</dict>");
+    expect(fragment).toContain("NSLocationWhenInUseUsageDescription");
+    expect(fragment).toContain("We need your location");
+  });
+
+  it("escapes XML entities in keys and values", () => {
+    const intent = makeIntent({
+      infoPlistKeys: {
+        "Key & <value>": 'Value with "quotes" & <tags>',
+      },
+    });
+    const fragment = generateInfoPlistFragment(intent);
+    expect(fragment).toBeDefined();
+    expect(fragment).toContain("&amp;");
+    expect(fragment).toContain("&lt;");
+    expect(fragment).toContain("&gt;");
+    expect(fragment).toContain("&quot;");
+  });
+
+  it("includes intent name in comment header", () => {
+    const intent = makeIntent({
+      name: "SendMessage",
+      infoPlistKeys: { NSUserNotificationUsageDescription: "For notifications" },
+    });
+    const fragment = generateInfoPlistFragment(intent);
+    expect(fragment).toContain("SendMessageIntent");
+  });
+});
+
+describe("generateEntitlementsFragment", () => {
+  it("returns undefined when no entitlements present", () => {
+    const intent = makeIntent({ entitlements: undefined });
+    const fragment = generateEntitlementsFragment(intent);
+    expect(fragment).toBeUndefined();
+  });
+
+  it("returns undefined when entitlements array is empty", () => {
+    const intent = makeIntent({ entitlements: [] });
+    const fragment = generateEntitlementsFragment(intent);
+    expect(fragment).toBeUndefined();
+  });
+
+  it("generates entitlements XML with proper structure", () => {
+    const intent = makeIntent({
+      entitlements: [
+        "com.apple.security.app-sandbox",
+        "com.apple.security.files.user-selected.read-only",
+      ],
+    });
+    const fragment = generateEntitlementsFragment(intent);
+    expect(fragment).toBeDefined();
+    expect(fragment).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(fragment).toContain("<!DOCTYPE plist PUBLIC");
+    expect(fragment).toContain("<dict>");
+    expect(fragment).toContain("</dict>");
+    expect(fragment).toContain("com.apple.security.app-sandbox");
+    expect(fragment).toContain("<true/>");
+  });
+
+  it("escapes XML entities in entitlement identifiers", () => {
+    const intent = makeIntent({
+      entitlements: ["com.apple.security.key & value"],
+    });
+    const fragment = generateEntitlementsFragment(intent);
+    expect(fragment).toBeDefined();
+    expect(fragment).toContain("&amp;");
+  });
+
+  it("includes intent name and manual adjustment note", () => {
+    const intent = makeIntent({
+      name: "RecordAudio",
+      entitlements: ["com.apple.security.device.microphone"],
+    });
+    const fragment = generateEntitlementsFragment(intent);
+    expect(fragment).toContain("RecordAudioIntent");
+    expect(fragment).toContain("Note: entitlements requiring typed values");
+    expect(fragment).toContain("need manual adjustment");
+  });
+});
+
+describe("generateSwift — with entities", () => {
+  it("generates entities before the intent struct", () => {
+    const intent = makeIntent({
+      name: "SelectContact",
+      entities: [
+        {
+          name: "Contact",
+          displayRepresentation: { title: "name" },
+          properties: [
+            {
+              name: "name",
+              type: { kind: "primitive" as const, value: "string" as const },
+              title: "Name",
+              description: "Name",
+              isOptional: false,
+            },
+          ],
+          queryType: "string" as const,
+        },
+      ],
+    });
+    const swift = generateSwift(intent);
+    const contactIndex = swift.indexOf("struct Contact: AppEntity");
+    const intentIndex = swift.indexOf("struct SelectContactIntent: AppIntent");
+    expect(contactIndex).toBeGreaterThan(-1);
+    expect(intentIndex).toBeGreaterThan(-1);
+    expect(contactIndex).toBeLessThan(intentIndex);
+  });
+
+  it("generates both entity and entity query", () => {
+    const intent = makeIntent({
+      entities: [
+        {
+          name: "Item",
+          displayRepresentation: { title: "label" },
+          properties: [
+            {
+              name: "label",
+              type: { kind: "primitive" as const, value: "string" as const },
+              title: "Label",
+              description: "Label",
+              isOptional: false,
+            },
+          ],
+          queryType: "all" as const,
+        },
+      ],
+    });
+    const swift = generateSwift(intent);
+    expect(swift).toContain("struct Item: AppEntity");
+    expect(swift).toContain("struct ItemQuery: EntityQuery");
   });
 });

--- a/tests/core/view-validator.test.ts
+++ b/tests/core/view-validator.test.ts
@@ -1,0 +1,521 @@
+import { describe, it, expect } from "vitest";
+import { compileViewFromIR, compileViewSource } from "../../src/core/compiler.js";
+import { validateView } from "../../src/core/view-validator.js";
+import type { IRView } from "../../src/core/types.js";
+
+describe("view validator: naming", () => {
+  it("accepts PascalCase view names", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "ProfileCard",
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX310")).toBe(false);
+  });
+
+  it("rejects lowercase view names", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "myview",
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX310")).toBe(true);
+  });
+
+  it("rejects snake_case view names", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "profile_card",
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX310")).toBe(true);
+  });
+
+  it("rejects kebab-case view names", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "profile-card",
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX310")).toBe(true);
+  });
+
+  it("validates that empty string names are invalid", () => {
+    const ir: IRView = {
+      name: "",
+      sourceFile: "test.ts",
+      props: [],
+      state: [],
+      body: [],
+    };
+    const diags = validateView(ir);
+    expect(diags.some((d) => d.code === "AX310")).toBe(true);
+  });
+
+  it("suggests PascalCase conversion in diagnostic", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "my_view",
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileViewSource(src);
+    const diag = result.diagnostics.find((d) => d.code === "AX310");
+    expect(diag?.suggestion).toBeDefined();
+    expect(diag?.suggestion).toContain("MyView");
+  });
+});
+
+describe("view validator: body", () => {
+  it("accepts views with non-empty body", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "Valid",
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX311")).toBe(false);
+  });
+
+  it("rejects views with empty body array", () => {
+    const ir: IRView = {
+      name: "Empty",
+      sourceFile: "test.ts",
+      props: [],
+      state: [],
+      body: [],
+    };
+    const result = compileViewFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX311")).toBe(true);
+  });
+
+  it("accepts empty body after validation phase", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "Test",
+        body: [],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX311")).toBe(true);
+  });
+});
+
+describe("view validator: props", () => {
+  it("accepts valid Swift identifier prop names", () => {
+    const src = `
+      import { defineView, prop, view } from "@axint/sdk";
+      export default defineView({
+        name: "Valid",
+        props: {
+          title: prop.string("Title"),
+          _private: prop.string("Private"),
+          count123: prop.string("Count"),
+        },
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.diagnostics.filter((d) => d.code === "AX312")).toHaveLength(0);
+  });
+
+  it("rejects prop names starting with numbers", () => {
+    const src = `
+      import { defineView, prop, view } from "@axint/sdk";
+      export default defineView({
+        name: "Invalid",
+        props: {
+          "123title": prop.string("Title"),
+        },
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX312")).toBe(true);
+  });
+
+  it("detects duplicate prop names in IR", () => {
+    const ir: IRView = {
+      name: "Duplicate",
+      sourceFile: "test.ts",
+      props: [
+        { name: "title", type: { kind: "primitive", value: "string" } },
+        { name: "title", type: { kind: "primitive", value: "string" } },
+      ],
+      state: [],
+      body: [],
+    };
+    const diags = validateView(ir);
+    expect(diags.filter((d) => d.code === "AX313")).toHaveLength(1);
+  });
+});
+
+describe("view validator: state", () => {
+  it("accepts valid Swift identifier state names in IR", () => {
+    const ir: IRView = {
+      name: "Valid",
+      sourceFile: "test.ts",
+      props: [],
+      state: [
+        { name: "count", kind: "state", type: { kind: "primitive", value: "int" } },
+        {
+          name: "_internal",
+          kind: "state",
+          type: { kind: "primitive", value: "string" },
+        },
+      ],
+      body: [],
+    };
+    const diags = validateView(ir);
+    expect(diags.filter((d) => d.code === "AX314")).toHaveLength(0);
+  });
+
+  it("rejects state names starting with numbers in IR", () => {
+    const ir: IRView = {
+      name: "Invalid",
+      sourceFile: "test.ts",
+      props: [],
+      state: [
+        { name: "123state", kind: "state", type: { kind: "primitive", value: "int" } },
+      ],
+      body: [],
+    };
+    const diags = validateView(ir);
+    expect(diags.some((d) => d.code === "AX314")).toBe(true);
+  });
+
+  it("detects state name conflicts with props", () => {
+    const ir: IRView = {
+      name: "Conflict",
+      sourceFile: "test.ts",
+      props: [{ name: "title", type: { kind: "primitive", value: "string" } }],
+      state: [
+        { name: "title", kind: "state", type: { kind: "primitive", value: "int" } },
+      ],
+      body: [],
+    };
+    const diags = validateView(ir);
+    expect(diags.some((d) => d.code === "AX315")).toBe(true);
+  });
+
+  it("warns when @State has no default value via source", () => {
+    const src = `
+      import { defineView, state, view } from "@axint/sdk";
+      export default defineView({
+        name: "NoDefault",
+        state: {
+          count: state.int("Count"),
+        },
+        body: [view.text("hi")],
+      });
+    `;
+    const result = compileViewSource(src);
+    const diag = result.diagnostics.find((d) => d.code === "AX317");
+    expect(diag).toBeDefined();
+    expect(diag?.severity).toBe("warning");
+  });
+
+  it("accepts @State with default value via source", () => {
+    const src = `
+      import { defineView, state, view } from "@axint/sdk";
+      export default defineView({
+        name: "WithDefault",
+        state: {
+          count: state.int("Count", { default: 0 }),
+        },
+        body: [view.text("hi")],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX317")).toBe(false);
+  });
+
+  it("detects environment state without key", () => {
+    const ir: IRView = {
+      name: "NoKey",
+      sourceFile: "test.ts",
+      props: [],
+      state: [
+        {
+          name: "dismiss",
+          kind: "environment",
+          type: { kind: "primitive", value: "string" },
+        },
+      ],
+      body: [],
+    };
+    const diags = validateView(ir);
+    const diag = diags.find((d) => d.code === "AX316");
+    expect(diag).toBeDefined();
+    expect(diag?.severity).toBe("warning");
+  });
+
+  it("accepts environment state with key", () => {
+    const ir: IRView = {
+      name: "WithKey",
+      sourceFile: "test.ts",
+      props: [],
+      state: [
+        {
+          name: "dismiss",
+          kind: "environment",
+          type: { kind: "primitive", value: "string" },
+          environmentKey: "\\.dismiss",
+        },
+      ],
+      body: [],
+    };
+    const diags = validateView(ir);
+    expect(diags.some((d) => d.code === "AX316")).toBe(false);
+  });
+});
+
+describe("view validator: body nodes", () => {
+  it("validates nested vstack children", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "Nested",
+        body: [
+          view.vstack([
+            view.text("title"),
+            view.text("subtitle"),
+          ]),
+        ],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.success).toBe(true);
+  });
+
+  it("validates hstack children", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "HStack",
+        body: [
+          view.hstack([
+            view.text("left"),
+            view.text("right"),
+          ]),
+        ],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.success).toBe(true);
+  });
+
+  it("validates zstack children", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "ZStack",
+        body: [
+          view.zstack([
+            view.text("background"),
+            view.text("foreground"),
+          ]),
+        ],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects ForEach without collection", () => {
+    const ir: IRView = {
+      name: "BadForEach",
+      sourceFile: "test.ts",
+      props: [],
+      state: [],
+      body: [
+        {
+          kind: "foreach",
+          collection: undefined as unknown,
+          body: [],
+        },
+      ],
+    };
+    const diags = validateView(ir);
+    expect(diags.some((d) => d.code === "AX318")).toBe(true);
+  });
+
+  it("accepts ForEach with collection via IR", () => {
+    const ir: IRView = {
+      name: "GoodForEach",
+      sourceFile: "test.ts",
+      props: [],
+      state: [],
+      body: [
+        {
+          kind: "foreach",
+          collection: "items",
+          body: [],
+        },
+      ],
+    };
+    const diags = validateView(ir);
+    expect(diags.some((d) => d.code === "AX318")).toBe(false);
+  });
+
+  it("rejects Conditional without condition", () => {
+    const ir: IRView = {
+      name: "BadConditional",
+      sourceFile: "test.ts",
+      props: [],
+      state: [],
+      body: [
+        {
+          kind: "conditional",
+          condition: undefined as unknown,
+          then: [],
+        },
+      ],
+    };
+    const diags = validateView(ir);
+    expect(diags.some((d) => d.code === "AX319")).toBe(true);
+  });
+
+  it("validates NavigationLink label children", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "NavLink",
+        body: [
+          view.navigationLink([view.text("Link")], "DetailView"),
+        ],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.success).toBe(true);
+  });
+
+  it("validates List children", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "ListView",
+        body: [
+          view.list([
+            view.text("item1"),
+            view.text("item2"),
+          ]),
+        ],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.success).toBe(true);
+  });
+
+  it("validates deeply nested structures", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "Deep",
+        body: [
+          view.vstack([
+            view.hstack([
+              view.zstack([
+                view.text("deep"),
+                view.text("content"),
+              ]),
+            ]),
+          ]),
+        ],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("view validator: generated Swift source", () => {
+  it("validates generated Swift code includes SwiftUI import", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "MyView",
+        body: [view.text("hi")],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.output?.swiftCode).toContain("import SwiftUI");
+  });
+
+  it("validates generated Swift code includes View conformance", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "MyView",
+        body: [view.text("hi")],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.output?.swiftCode).toContain(": View");
+  });
+
+  it("validates generated Swift code includes body property", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "MyView",
+        body: [view.text("hi")],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.output?.swiftCode).toContain("var body: some View");
+  });
+});
+
+describe("view validator: error collection", () => {
+  it("collects multiple validation errors", () => {
+    const ir: IRView = {
+      name: "bad_name",
+      sourceFile: "test.ts",
+      props: [
+        { name: "123invalid", type: { kind: "primitive", value: "string" } },
+        { name: "valid", type: { kind: "primitive", value: "string" } },
+      ],
+      state: [
+        { name: "123bad", kind: "state", type: { kind: "primitive", value: "int" } },
+      ],
+      body: [],
+    };
+    const diags = validateView(ir);
+    expect(diags.length).toBeGreaterThan(2);
+    expect(diags.some((d) => d.code === "AX310")).toBe(true);
+    expect(diags.some((d) => d.code === "AX312")).toBe(true);
+    expect(diags.some((d) => d.code === "AX314")).toBe(true);
+    expect(diags.some((d) => d.code === "AX311")).toBe(true);
+  });
+
+  it("does not validate body nodes if IR has errors", () => {
+    const src = `
+      import { defineView, view } from "@axint/sdk";
+      export default defineView({
+        name: "bad_name",
+        body: [
+          view.conditional(undefined, [view.text("oops")]),
+        ],
+      });
+    `;
+    const result = compileViewSource(src);
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/core/widget-validator.test.ts
+++ b/tests/core/widget-validator.test.ts
@@ -1,0 +1,558 @@
+import { describe, it, expect } from "vitest";
+import { compileWidgetFromIR, compileWidgetSource } from "../../src/core/compiler.js";
+import type { IRWidget } from "../../src/core/types.js";
+
+describe("widget validator: naming", () => {
+  it("accepts PascalCase widget names", () => {
+    const src = `
+      import { defineWidget, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "StepCounter",
+        displayName: "Steps",
+        families: ["systemSmall"],
+        entry: {},
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX410")).toBe(false);
+  });
+
+  it("rejects lowercase widget names", () => {
+    const ir: IRWidget = {
+      name: "stepcounter",
+      displayName: "Steps",
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX410")).toBe(true);
+  });
+
+  it("rejects snake_case widget names", () => {
+    const ir: IRWidget = {
+      name: "step_counter",
+      displayName: "Steps",
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX410")).toBe(true);
+  });
+
+  it("rejects kebab-case widget names", () => {
+    const ir: IRWidget = {
+      name: "step-counter",
+      displayName: "Steps",
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX410")).toBe(true);
+  });
+
+  it("suggests PascalCase conversion in diagnostic", () => {
+    const ir: IRWidget = {
+      name: "mywidget",
+      displayName: "Widget",
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    const diag = result.diagnostics.find((d) => d.code === "AX410");
+    expect(diag?.suggestion).toBeDefined();
+    expect(diag?.suggestion).toContain("Widget");
+  });
+});
+
+describe("widget validator: families", () => {
+  it("accepts widgets with one family", () => {
+    const src = `
+      import { defineWidget, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "SingleFamily",
+        displayName: "Widget",
+        families: ["systemSmall"],
+        entry: {},
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX411")).toBe(false);
+  });
+
+  it("accepts widgets with multiple families", () => {
+    const src = `
+      import { defineWidget, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "MultiFamily",
+        displayName: "Widget",
+        families: ["systemSmall", "systemMedium", "systemLarge"],
+        entry: {},
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX411")).toBe(false);
+  });
+
+  it("rejects widgets with empty families array", () => {
+    const ir: IRWidget = {
+      name: "NoFamilies",
+      displayName: "Widget",
+      sourceFile: "test.ts",
+      families: [],
+      entry: [],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX411")).toBe(true);
+  });
+
+  it("rejects widgets with undefined families", () => {
+    const ir: IRWidget = {
+      name: "UndefinedFamilies",
+      displayName: "Widget",
+      sourceFile: "test.ts",
+      families: undefined as unknown,
+      entry: [],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX411")).toBe(true);
+  });
+});
+
+describe("widget validator: body", () => {
+  it("accepts widgets with non-empty body", () => {
+    const src = `
+      import { defineWidget, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "WithBody",
+        displayName: "Widget",
+        families: ["systemSmall"],
+        entry: {},
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX412")).toBe(false);
+  });
+
+  it("rejects widgets with empty body array", () => {
+    const ir: IRWidget = {
+      name: "EmptyBody",
+      displayName: "Widget",
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [],
+      body: [],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX412")).toBe(true);
+  });
+
+  it("rejects widgets with undefined body", () => {
+    const ir: IRWidget = {
+      name: "UndefinedBody",
+      displayName: "Widget",
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [],
+      body: undefined as unknown,
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX412")).toBe(true);
+  });
+
+  it("accepts widgets with multiple body elements", () => {
+    const src = `
+      import { defineWidget, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "MultiBodies",
+        displayName: "Widget",
+        families: ["systemSmall"],
+        entry: {},
+        body: [
+          view.text("title"),
+          view.text("subtitle"),
+          view.text("content"),
+        ],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX412")).toBe(false);
+  });
+});
+
+describe("widget validator: entry fields", () => {
+  it("accepts valid Swift identifier entry names", () => {
+    const src = `
+      import { defineWidget, entry, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "Valid",
+        displayName: "Widget",
+        families: ["systemSmall"],
+        entry: {
+          steps: entry.int("Steps"),
+          _private: entry.string("Private"),
+          count123: entry.int("Count"),
+        },
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.diagnostics.filter((d) => d.code === "AX413")).toHaveLength(0);
+  });
+
+  it("rejects entry names starting with numbers", () => {
+    const ir: IRWidget = {
+      name: "Invalid",
+      displayName: "Widget",
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [{ name: "123steps", type: { kind: "primitive", value: "int" } }],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX413")).toBe(true);
+  });
+
+  it("rejects entry names that are Swift keywords", () => {
+    const ir: IRWidget = {
+      name: "Invalid",
+      displayName: "Widget",
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [{ name: "var", type: { kind: "primitive", value: "int" } }],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX413")).toBe(true);
+  });
+
+  it("rejects all common Swift keywords", () => {
+    const keywords = [
+      "func",
+      "class",
+      "struct",
+      "enum",
+      "protocol",
+      "extension",
+      "init",
+      "self",
+      "if",
+      "else",
+      "for",
+      "while",
+      "switch",
+      "case",
+      "break",
+      "continue",
+      "return",
+    ];
+
+    for (const keyword of keywords) {
+      const ir: IRWidget = {
+        name: "Invalid",
+        displayName: "Widget",
+        sourceFile: "test.ts",
+        families: ["systemSmall"],
+        entry: [{ name: keyword, type: { kind: "primitive", value: "int" } }],
+        body: [{ kind: "text", value: "content" }],
+      };
+      const result = compileWidgetFromIR(ir);
+      expect(
+        result.diagnostics.some((d) => d.code === "AX413"),
+        `Expected error for keyword: ${keyword}`
+      ).toBe(true);
+    }
+  });
+
+  it("detects duplicate entry field names", () => {
+    const ir: IRWidget = {
+      name: "Duplicate",
+      displayName: "Widget",
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [
+        { name: "steps", type: { kind: "primitive", value: "int" } },
+        { name: "steps", type: { kind: "primitive", value: "int" } },
+      ],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.filter((d) => d.code === "AX414")).toHaveLength(1);
+  });
+
+  it("detects multiple duplicate entry field names", () => {
+    const ir: IRWidget = {
+      name: "Duplicate",
+      displayName: "Widget",
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [
+        { name: "steps", type: { kind: "primitive", value: "int" } },
+        { name: "steps", type: { kind: "primitive", value: "int" } },
+        { name: "steps", type: { kind: "primitive", value: "int" } },
+      ],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(
+      result.diagnostics.filter((d) => d.code === "AX414").length
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it("accepts empty entry array", () => {
+    const src = `
+      import { defineWidget, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "NoEntry",
+        displayName: "Widget",
+        families: ["systemSmall"],
+        entry: {},
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(
+      result.diagnostics.filter((d) => d.code === "AX413" || d.code === "AX414")
+    ).toHaveLength(0);
+  });
+});
+
+describe("widget validator: displayName", () => {
+  it("accepts non-empty displayName", () => {
+    const src = `
+      import { defineWidget, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "Widget",
+        displayName: "My Widget",
+        families: ["systemSmall"],
+        entry: {},
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX415")).toBe(false);
+  });
+
+  it("rejects empty displayName string", () => {
+    const ir: IRWidget = {
+      name: "Widget",
+      displayName: "",
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX415")).toBe(true);
+  });
+
+  it("rejects displayName with only whitespace", () => {
+    const ir: IRWidget = {
+      name: "Widget",
+      displayName: "   ",
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX415")).toBe(true);
+  });
+
+  it("rejects undefined displayName", () => {
+    const ir: IRWidget = {
+      name: "Widget",
+      displayName: undefined as unknown,
+      sourceFile: "test.ts",
+      families: ["systemSmall"],
+      entry: [],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.some((d) => d.code === "AX415")).toBe(true);
+  });
+});
+
+describe("widget validator: generated Swift source", () => {
+  it("validates generated code includes WidgetKit import", () => {
+    const src = `
+      import { defineWidget, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "MyWidget",
+        displayName: "My Widget",
+        families: ["systemSmall"],
+        entry: {},
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.output?.swiftCode).toContain("import WidgetKit");
+  });
+
+  it("validates generated code includes Widget protocol conformance", () => {
+    const src = `
+      import { defineWidget, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "MyWidget",
+        displayName: "My Widget",
+        families: ["systemSmall"],
+        entry: {},
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.output?.swiftCode).toContain(": Widget");
+  });
+
+  it("validates generated code includes TimelineProvider protocol conformance", () => {
+    const src = `
+      import { defineWidget, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "MyWidget",
+        displayName: "My Widget",
+        families: ["systemSmall"],
+        entry: {},
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.output?.swiftCode).toContain(": TimelineProvider");
+  });
+});
+
+describe("widget validator: error collection", () => {
+  it("collects multiple validation errors", () => {
+    const ir: IRWidget = {
+      name: "bad_name",
+      displayName: "",
+      sourceFile: "test.ts",
+      families: [],
+      entry: [
+        { name: "123invalid", type: { kind: "primitive", value: "int" } },
+        { name: "valid", type: { kind: "primitive", value: "int" } },
+      ],
+      body: [],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.diagnostics.length).toBeGreaterThan(3);
+    expect(result.diagnostics.some((d) => d.code === "AX410")).toBe(true);
+    expect(result.diagnostics.some((d) => d.code === "AX411")).toBe(true);
+    expect(result.diagnostics.some((d) => d.code === "AX412")).toBe(true);
+    expect(result.diagnostics.some((d) => d.code === "AX413")).toBe(true);
+    expect(result.diagnostics.some((d) => d.code === "AX415")).toBe(true);
+  });
+
+  it("returns success: false when errors exist", () => {
+    const ir: IRWidget = {
+      name: "bad",
+      displayName: "",
+      sourceFile: "test.ts",
+      families: [],
+      entry: [],
+      body: [],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.success).toBe(false);
+  });
+
+  it("halts compilation when validation errors exist", () => {
+    const ir: IRWidget = {
+      name: "bad_name",
+      displayName: "Widget",
+      sourceFile: "test.ts",
+      families: [],
+      entry: [],
+      body: [{ kind: "text", value: "content" }],
+    };
+    const result = compileWidgetFromIR(ir);
+    expect(result.output).toBeUndefined();
+  });
+});
+
+describe("widget validator: edge cases", () => {
+  it("handles widget with all valid fields", () => {
+    const src = `
+      import { defineWidget, entry, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "CompleteWidget",
+        displayName: "Complete Widget",
+        description: "A complete widget",
+        families: ["systemSmall", "systemMedium"],
+        entry: {
+          value1: entry.string("Value 1"),
+          value2: entry.int("Value 2", { default: 0 }),
+        },
+        body: [
+          view.vstack([
+            view.text("title"),
+            view.text("content"),
+          ]),
+        ],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.success).toBe(true);
+    expect(result.diagnostics.filter((d) => d.severity === "error")).toHaveLength(0);
+  });
+
+  it("accepts widgets with numbers in names after first character", () => {
+    const src = `
+      import { defineWidget, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "Widget123",
+        displayName: "Widget 123",
+        families: ["systemSmall"],
+        entry: {},
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX410")).toBe(false);
+  });
+
+  it("accepts very long but valid displayName", () => {
+    const src = `
+      import { defineWidget, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "Widget",
+        displayName: "This is a very long display name that is still valid and has meaningful content",
+        families: ["systemSmall"],
+        entry: {},
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.diagnostics.some((d) => d.code === "AX415")).toBe(false);
+  });
+
+  it("handles special characters in entry type names", () => {
+    const src = `
+      import { defineWidget, entry, view } from "@axint/sdk";
+      export default defineWidget({
+        name: "SpecialWidget",
+        displayName: "Special",
+        families: ["systemSmall"],
+        entry: {
+          item: entry.string("Item"),
+          count: entry.int("Count"),
+        },
+        body: [view.text("content")],
+      });
+    `;
+    const result = compileWidgetSource(src);
+    expect(result.diagnostics.filter((d) => d.code === "AX413")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
adds 153 new tests: view-validator (33), widget-validator (34), diagnostics (38), generator edge cases (48). coverage: diagnostics 0→100%, generator 54→100%, view-validator 45→85%, widget-validator 64→89%.