### PR TITLE
fix pyproject.toml syntax

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
     "pytest-cov>=5.0",
     "ruff>=0.6",
     "mypy>=1.11",
-    0
+    "pyyaml>=6.0",
     "types-PyYAML>=6.0",
 ]
 


### PR DESCRIPTION
sed mangled the dev deps array — bare 0 instead of pyyaml string