### PR TITLE
add mcp http transport for smithery

### DIFF
--- a/SUBMISSIONS.md
+++ b/SUBMISSIONS.md
@@ -1,0 +1,124 @@
+# Axint — Platform Submission Guide
+
+Everything needed to register Axint on external directories.
+Run each step, then delete this file.
+
+---
+
+## 1. Smithery.ai
+
+**URL:** https://smithery.ai (click "Submit" / "Publish")
+**Process:** Connect GitHub repo, fill metadata. `smithery.yaml` already in repo root.
+
+**Name:** `agenticempire/axint`
+
+**Tagline (short):**
+Compile TypeScript or Python into native Swift App Intents, SwiftUI views, and WidgetKit widgets. One MCP server, six tools, zero Xcode boilerplate.
+
+**Description (Smithery audience = developers using MCP with Claude/Cursor/Windsurf):**
+
+Axint is an open-source compiler that lets AI coding agents generate native Apple code without writing Swift directly. Your agent calls `axint_compile` with a TypeScript `defineIntent()` call and gets back production-ready Swift — App Intents for Siri, SwiftUI views, WidgetKit widgets, full app scaffolds.
+
+The MCP server exposes six tools:
+
+- **axint_scaffold** — Generate a starter TypeScript intent file from a natural-language description
+- **axint_compile** — Compile TypeScript/Python → Swift with optional Info.plist and entitlements
+- **axint_validate** — Check an intent definition for errors without generating code
+- **axint_compile_from_schema** — Compile from minimal JSON (saves tokens on large batches)
+- **axint_list_templates** — Browse bundled reference templates
+- **axint_template** — Retrieve the source of a specific template
+
+One `defineWidget()` call replaces ~150 lines of Swift (13× compression). Agents pay per token — Axint makes Apple development dramatically cheaper and faster.
+
+Works with Claude Code, Cursor, Windsurf, Zed, VS Code, and any MCP-compatible client.
+
+**Tags:** `swift` `apple` `compiler` `typescript` `app-intents` `siri` `swiftui` `widgetkit` `mcp`
+**Category:** Developer Tools
+**Repository:** https://github.com/agenticempire/axint
+**Install command:** `npx -y @axintai/compiler axint-mcp`
+
+---
+
+## 2. mcpservers.org
+
+**URL:** https://mcpservers.org/submit
+**Process:** Web form submission.
+
+**Name:** Axint — App Intents Compiler
+
+**Description (mcpservers.org audience = MCP ecosystem browsers looking for useful servers):**
+
+Turn TypeScript into native Swift for Apple platforms. Axint compiles `defineIntent()`, `defineView()`, `defineWidget()`, and `defineApp()` calls into idiomatic, production-ready Swift — App Intents for Siri, SwiftUI views, WidgetKit widgets, and complete app scaffolds.
+
+Built for AI agents that target Apple. A single widget definition compresses ~13× compared to writing the Swift by hand. Your coding assistant calls the MCP server, passes a TypeScript snippet, and gets back Swift files ready to drop into Xcode.
+
+Six tools: scaffold intents from natural language, compile TS/Python/JSON to Swift, validate definitions, browse templates. Supports Claude Code, Cursor, Windsurf, VS Code, Zed, and every other MCP client.
+
+Open-source (Apache 2.0). TypeScript SDK on npm, Python SDK on PyPI.
+
+**GitHub:** https://github.com/agenticempire/axint
+**Website:** https://axint.ai
+**npm:** `@axintai/compiler`
+**Install:** `npx -y @axintai/compiler axint-mcp`
+
+---
+
+## 3. VS Code Extension Marketplace
+
+**Already built.** Extension at `extensions/vscode/`.
+
+To publish:
+```bash
+cd extensions/vscode
+npx @vscode/vsce publish
+```
+
+Publisher must be `agenticempire` on the VS Code Marketplace.
+If the publisher doesn't exist yet:
+1. Go to https://marketplace.visualstudio.com/manage
+2. Create publisher "agenticempire"
+3. Generate a Personal Access Token from https://dev.azure.com
+4. Run `npx @vscode/vsce login agenticempire`
+5. Then `npx @vscode/vsce publish`
+
+**Marketplace description (audience = VS Code users who work with Apple/Swift):**
+
+Axint brings Apple App Intents compilation directly into VS Code. Write `defineIntent()` in TypeScript, compile to native Swift — App Intents for Siri, SwiftUI views, WidgetKit widgets, and full app scaffolds.
+
+This extension registers Axint as an MCP server so AI assistants in VS Code (GitHub Copilot, Claude, etc.) can automatically scaffold, compile, and validate Apple App Intents without leaving the editor.
+
+Six tools available: scaffold from natural language, compile TS/Python → Swift, validate definitions, browse templates.
+
+Open-source. Apache 2.0 license.
+
+---
+
+## 4. Deploy Blog Posts
+
+From your machine:
+```bash
+cd ~/agenticempire/axint.ai
+vercel --prod
+```
+
+---
+
+## 5. Commit smithery.yaml to axint repo
+
+From your machine:
+```bash
+cd ~/agenticempire/axint
+git add smithery.yaml
+git commit -m "add smithery.yaml for mcp server registration"
+git push origin main
+```
+
+---
+
+## Execution Order
+
+1. Commit + push smithery.yaml to axint repo
+2. Deploy blog posts (`vercel --prod`)
+3. Submit to Smithery.ai (needs GitHub repo connected)
+4. Submit to mcpservers.org (web form)
+5. Publish VS Code extension

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
+## [0.3.2] - 2026-04-12
+
+- Unpin compiler version — always pulls latest @axintai/compiler
+- Version bump to match compiler release
+
 ## [0.3.0] - 2026-04-10
 
 - Initial release
 - MCP server integration with VS Code v1.102+
-- Support for Axint App Intents compiler via MCP protocol
+- Six tools: scaffold, compile, validate, compile_from_schema, list_templates, template

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "publisher": "agenticempire",
   "description": "Compile TypeScript into native Apple App Intents. Scaffold, compile, validate, and browse templates — all from your editor.",
   "license": "Apache-2.0",

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -12,7 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
         new vscode.McpStdioServerDefinition(
           "Axint",
           "npx",
-          ["-y", "@axintai/compiler@0.3.2", "axint-mcp"],
+          ["-y", "@axintai/compiler", "axint-mcp"],
         ),
       ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axintai/compiler",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axintai/compiler",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axintai/compiler",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "bin": {
     "axint": "dist/cli/index.js",
-    "axint-mcp": "dist/mcp/index.js"
+    "axint-mcp": "dist/mcp/index.js",
+    "axint-mcp-http": "dist/mcp/http.js"
   },
   "main": "./dist/core/index.js",
   "types": "./dist/core/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+
+[[tool.mypy.overrides]]
+module = "axintai.mcp_server"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "mcp.*"
+ignore_missing_imports = true

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -2,15 +2,19 @@
 # The compression layer for AI on Apple — AI agents write 5-15× less code
 
 startCommand:
-  type: stdio
-
-configSchema:
-  # JSON Schema defining the configuration options for the MCP.
-  type: object
-  required: []
-  properties: {}
-
-commandFunction:
-  # A function that produces the CLI command to start the MCP on stdio.
-  |-
-    config => ({ command: 'npx', args: ['-y', '@axintai/compiler@0.3.2', 'axint-mcp'] })
+  type: http
+  configSchema:
+    type: object
+    required: []
+    properties:
+      port:
+        type: number
+        default: 3001
+        description: Port for the HTTP MCP server
+  commandFunction:
+    |-
+    config => ({ command: 'npx', args: ['-y', '@axintai/compiler', 'axint-mcp-http'], env: { PORT: String(config.port || 3001) } })
+  port:
+    |-
+    config => config.port || 3001
+  statusEndpoint: /health

--- a/src/mcp/http.ts
+++ b/src/mcp/http.ts
@@ -1,0 +1,95 @@
+/**
+ * Axint MCP Server — Streamable HTTP Transport
+ *
+ * Runs the same Axint tools over HTTP so the server can be deployed
+ * as a remote MCP endpoint (Smithery, Cloudflare Workers, etc.).
+ *
+ * Usage: node dist/mcp/http.js [--port 3001]
+ */
+
+import { createServer } from "node:http";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createAxintServer } from "./server.js";
+
+const port = parseInt(process.env.PORT || "3001", 10);
+
+const httpServer = createServer(async (req, res) => {
+  // CORS headers for cross-origin MCP clients
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Accept, Mcp-Session-Id");
+  res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204).end();
+    return;
+  }
+
+  const url = new URL(req.url || "/", `http://localhost:${port}`);
+
+  // Health check
+  if (url.pathname === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true, server: "axint-mcp" }));
+    return;
+  }
+
+  // Only handle /mcp
+  if (url.pathname !== "/mcp") {
+    res.writeHead(404).end("Not found");
+    return;
+  }
+
+  if (req.method === "GET" || req.method === "DELETE") {
+    res.writeHead(405, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Method not allowed." },
+        id: null,
+      })
+    );
+    return;
+  }
+
+  if (req.method !== "POST") {
+    res.writeHead(405).end();
+    return;
+  }
+
+  // Buffer the request body
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  const body = JSON.parse(Buffer.concat(chunks).toString());
+
+  // Stateless mode: new server + transport per request
+  const server = createAxintServer();
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res, body);
+  } catch (_err) {
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32603, message: "Internal server error" },
+          id: null,
+        })
+      );
+    }
+  } finally {
+    res.on("close", () => {
+      transport.close();
+      server.close();
+    });
+  }
+});
+
+httpServer.listen(port, () => {
+  console.log(`axint mcp http server listening on port ${port}`);
+});
+
+process.on("SIGINT", () => process.exit(0));

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,6 +1,6 @@
-import { startMCPServer } from "./server.js";
+import { startMCPServer, createAxintServer } from "./server.js";
 
-export { startMCPServer };
+export { startMCPServer, createAxintServer };
 
 // When invoked directly as a binary (axint-mcp), start the server
 startMCPServer().catch((err: Error) => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -453,7 +453,12 @@ function formatSchemaOutput(
   return { content: [{ type: "text" as const, text: output }] };
 }
 
-export async function startMCPServer(): Promise<void> {
+/**
+ * Create and configure the Axint MCP server instance.
+ * Separated from transport so the same server logic works over
+ * stdio, HTTP/SSE, or any future transport.
+ */
+export function createAxintServer(): Server {
   const server = new Server(
     { name: "axint", version: pkg.version },
     { capabilities: { tools: {} } }
@@ -805,6 +810,11 @@ export async function startMCPServer(): Promise<void> {
     }
   });
 
+  return server;
+}
+
+export async function startMCPServer(): Promise<void> {
+  const server = createAxintServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -42,4 +42,18 @@ export default defineConfig([
       js: "#!/usr/bin/env node",
     },
   },
+  // MCP HTTP transport (shebang for axint-mcp-http binary, no DTS)
+  {
+    entry: {
+      "mcp/http": "src/mcp/http.ts",
+    },
+    format: ["esm"],
+    dts: false,
+    splitting: false,
+    sourcemap: true,
+    target: "node22",
+    banner: {
+      js: "#!/usr/bin/env node",
+    },
+  },
 ]);


### PR DESCRIPTION
Adds HTTP/Streamable transport so the MCP server can run behind a public URL. Needed for Smithery registration. Also adds axint-mcp-http bin entry.