### PR TITLE
add server.json and registry verification markers

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "nimatime"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@axintai/compiler",
   "version": "0.3.3",
+  "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"
   },

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,7 @@
 # axintai — Python SDK for Axint
 
+<!-- mcp-name: io.github.agenticempire/axint -->
+
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.agenticempire/axint",
+  "title": "Axint",
+  "description": "Open-source compiler for Apple platforms — generate App Intents, SwiftUI views, WidgetKit widgets, and full apps from TypeScript or Python. Tools for scaffolding Xcode projects, compiling definitions to Swift, managing the Axint package registry, and building native Apple experiences with AI agents.",
+  "repository": {
+    "url": "https://github.com/agenticempire/axint",
+    "source": "github"
+  },
+  "version": "0.3.3",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.axint.ai/mcp"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@axintai/compiler",
+      "version": "0.3.3",
+      "transport": {
+        "type": "stdio"
+      }
+    },
+    {
+      "registryType": "pypi",
+      "identifier": "axintai",
+      "version": "0.3.2",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -51,8 +51,13 @@ import type {
 import { isPrimitiveType, isSceneKind } from "../core/types.js";
 
 // Read version from package.json so it stays in sync
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const pkg = JSON.parse(readFileSync(resolve(__dirname, "../../package.json"), "utf-8"));
+let pkg = { version: "0.3.3" };
+try {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  pkg = JSON.parse(readFileSync(resolve(__dirname, "../../package.json"), "utf-8"));
+} catch {
+  // fallback version used when bundled outside repo (e.g. Smithery scan)
+}
 
 type CompileArgs = {
   source: string;
@@ -811,6 +816,14 @@ export function createAxintServer(): Server {
   });
 
   return server;
+}
+
+/**
+ * Sandbox server for Smithery scanning — returns a configured server
+ * without connecting a transport, so Smithery can discover tools.
+ */
+export function createSandboxServer(): Server {
+  return createAxintServer();
 }
 
 export async function startMCPServer(): Promise<void> {


### PR DESCRIPTION
Adds server.json for the Official MCP Registry, mcpName to package.json for npm verification, mcp-name marker to Python README for PyPI verification, sandbox server export for Smithery scanning, and glama.json for Glama claiming.