### PR TITLE
add dockerfile for mcp server inspection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+.git
+.github
+.vscode
+*.md
+!README.md
+examples
+python
+coverage
+.env*
+*.swift

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json tsup.config.ts ./
+COPY src/ src/
+RUN npm run build
+
+FROM node:22-slim
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY --from=build /app/dist dist/
+ENTRYPOINT ["node", "dist/mcp/index.js"]


### PR DESCRIPTION
Adds a multi-stage Dockerfile so registries like Glama can spin up the MCP server in a sandbox and run tool inspection. Also adds .dockerignore to keep the build context small.