### PR TITLE
sync docs and metadata to v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+## [0.3.4] — 2026-04-13
+
+MCP registry hardening and remote transport support.
+
+### Added
+
+- **Remote MCP endpoint** — Cloudflare Worker serving the Axint MCP server over HTTP transport for Smithery and other hosted MCP clients.
+- **`server.json` and registry markers** — machine-readable MCP server metadata for automated registry verification (Glama, Smithery, Pulsemcp).
+- **Dockerfile** for MCP server inspection and containerized deployments.
+- **Glama quality badge** in README.
+- **Dot-notation MCP tools** (`axint.compile`, `axint.validate`, etc.) alongside the existing `axint_compile` names, with enriched parameter descriptions and tool annotations.
+
+### Fixed
+
+- **`server.json` description** trimmed to fit registry character limits.
+- **MCP tool descriptions** rewritten for better indexing on Glama and Smithery quality scores.
+
+## [0.3.3] — 2026-04-12
+
+Massive internal hardening pass: test coverage jump (249 → 402), Python SDK parity, and Smithery listing.
+
+### Added
+
+- **Python MCP server** — full CLI parity with the TypeScript MCP server. `axintai-mcp` serves all six tools over stdio.
+- **MCP HTTP transport** for Smithery registry listing.
+- **153 new tests** (249 → 402) covering validator edge cases, diagnostics, generator corner cases, and type guard paths.
+- **Type guard replacements** — all unsafe `as` casts in the parser and generator replaced with narrowing type guards.
+- **Shared parser utilities** extracted from surface-specific parsers into `src/core/parser-utils.ts`.
+- **Architecture docs** (`ARCHITECTURE.md`) — full compiler pipeline walkthrough.
+- **Xcode SPM build plugin support** documentation and integration.
+- **defineView(), defineWidget(), defineApp()** — three new compilation surfaces with parsers, validators, generators, and schema mode support.
+- **MCP server test suite** — 30 tests covering all 6 tools.
+
+### Fixed
+
+- **Entity resolution and serialization bugs** in the parser utils layer.
+- **Type safety holes** in the MCP server and parser — closed a namespace bypass.
+- **Codegen bugs** for entity queries and dynamic options.
+- **CLI test assertions** aligned to new output format.
+- **Python SDK** — fixed mypy errors across the package, fixed broken TOML (`bare 0` replaced with `pyyaml` dep).
+- **Registry references** removed from the public repo and added to `.gitignore`.
+
 ## [0.3.2] — 2026-04-10
 
 Security hardening, compiler fixes, and the first PyPI publish.
@@ -156,7 +198,10 @@ The "it's a real compiler now" release. Everything the v0.1.x vision pointed at,
 - tsup for builds with separate CLI/MCP/library entry points
 - Vitest with snapshot testing and V8 coverage
 
-[Unreleased]: https://github.com/agenticempire/axint/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/agenticempire/axint/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/agenticempire/axint/compare/v0.3.3...v0.3.4
+[0.3.3]: https://github.com/agenticempire/axint/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/agenticempire/axint/compare/v0.3.0...v0.3.2
 [0.3.0]: https://github.com/agenticempire/axint/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/agenticempire/axint/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/agenticempire/axint/compare/v0.2.0...v0.2.1

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Axint Roadmap
 
-_Last updated: April 2026 · Current release: [v0.3.2](https://github.com/agenticempire/axint/releases) · 58 days to WWDC 2026_
+_Last updated: April 2026 · Current release: [v0.3.4](https://github.com/agenticempire/axint/releases) · 56 days to WWDC 2026_
 
 Axint is the open-source compiler that turns TypeScript definitions into native Apple platform code — App Intents, SwiftUI views, WidgetKit widgets, and full app scaffolds. This roadmap tracks what's shipped, what's next, and where we need help.
 
@@ -9,6 +9,20 @@ We ship small, tight releases. Everything on this page is open for contribution 
 ---
 
 ## Shipped
+
+### v0.3.4
+
+- **Remote MCP endpoint** — Cloudflare Worker serving the compiler over HTTP for Smithery and hosted MCP clients.
+- **MCP registry metadata** — `server.json`, Dockerfile, tool annotations, and dot-notation tool names for Glama/Smithery/Pulsemcp quality scores.
+
+### v0.3.3
+
+- **Python MCP server** (`axintai-mcp`) — full parity with the TS MCP server, all six tools over stdio.
+- **Smithery listing** — MCP HTTP transport for the Smithery registry.
+- **402 tests** — jumped from 249 to 402 with validator, diagnostics, and generator edge case coverage.
+- **Type safety overhaul** — replaced all unsafe `as` casts with narrowing type guards across the parser and generator.
+- **defineView() + defineWidget() + defineApp()** — three new compilation surfaces shipped end-to-end.
+- **Architecture docs** (`ARCHITECTURE.md`) and shared parser utilities extraction.
 
 ### v0.3.0
 
@@ -101,6 +115,12 @@ _Status: shipped · v0.3.2_
 Python parity for all four surfaces with a dataclass-based IR, decorator API, and cross-language compilation via `compileFromIR()`. Python and TypeScript produce byte-identical Swift output.
 
 _Status: shipped · v0.3.2_
+
+### MCP registry presence
+
+Remote MCP endpoint on Cloudflare Workers, `server.json` metadata, Dockerfile for inspection, tool annotations, and dot-notation tool names. Listed on Smithery, Glama, and Pulsemcp.
+
+_Status: shipped · v0.3.4_
 
 ### Audience positioning refresh
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,11 @@
 
 ## Supported Versions
 
-| Version | Supported           |
-|---------|----------------------|
-| 0.2.x   | Yes                 |
-| 0.1.x   | No (deprecated)     |
+| Version | Supported              |
+|---------|------------------------|
+| 0.3.x   | Yes                    |
+| 0.2.x   | Security fixes only    |
+| 0.1.x   | No (deprecated)        |
 
 ## Reporting a Vulnerability
 

--- a/examples/smart-home.ts
+++ b/examples/smart-home.ts
@@ -1,7 +1,7 @@
 /**
  * Smart Home Intent — Control lights
  *
- * Demonstrates: number defaults, boolean params, multiple param types
+ * Demonstrates: int defaults, boolean params, multiple param types
  */
 import { defineIntent, param } from "@axintai/compiler";
 
@@ -12,7 +12,7 @@ export default defineIntent({
   domain: "smart-home",
   params: {
     room: param.string("Which room to control"),
-    brightness: param.number("Brightness percentage (0-100)", { default: 100 }),
+    brightness: param.int("Brightness percentage (0-100)", { default: 100 }),
     on: param.boolean("Turn lights on or off", { default: true }),
   },
   perform: async ({ room, brightness, on }) => {

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -26,7 +26,7 @@ Any tool that speaks MCP over stdio can connect to Axint:
   "mcpServers": {
     "axint": {
       "command": "npx",
-      "args": ["-y", "@axintai/compiler@0.3.2", "axint-mcp"]
+      "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
     }
   }
 }

--- a/extensions/claude-code/.mcp.json
+++ b/extensions/claude-code/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "axint": {
       "command": "npx",
-      "args": ["-y", "@axintai/compiler@0.3.2", "axint-mcp"],
+      "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"],
       "env": {}
     }
   }

--- a/extensions/claude-desktop/manifest.json
+++ b/extensions/claude-desktop/manifest.json
@@ -21,7 +21,7 @@
     "entry_point": "server/index.js",
     "mcp_config": {
       "command": "npx",
-      "args": ["-y", "@axintai/compiler@0.3.2", "axint-mcp"]
+      "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
     }
   },
   "tools": [

--- a/extensions/codex/README.md
+++ b/extensions/codex/README.md
@@ -11,7 +11,7 @@ Add to your Codex MCP configuration:
   "mcpServers": {
     "axint": {
       "command": "npx",
-      "args": ["-y", "@axintai/compiler@0.3.2", "axint-mcp"]
+      "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
     }
   }
 }

--- a/extensions/codex/mcp.json
+++ b/extensions/codex/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "axint": {
       "command": "npx",
-      "args": ["-y", "@axintai/compiler@0.3.2", "axint-mcp"]
+      "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
     }
   }
 }

--- a/extensions/cursor/mcp.json
+++ b/extensions/cursor/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "axint": {
       "command": "npx",
-      "args": ["-y", "@axintai/compiler@0.3.2", "axint-mcp"]
+      "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
     }
   }
 }

--- a/extensions/jetbrains/README.md
+++ b/extensions/jetbrains/README.md
@@ -12,7 +12,7 @@ Use Axint inside WebStorm, IntelliJ IDEA, or any JetBrains IDE with AI Assistant
   "mcpServers": {
     "axint": {
       "command": "npx",
-      "args": ["-y", "@axintai/compiler@0.3.2", "axint-mcp"]
+      "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
     }
   }
 }

--- a/extensions/jetbrains/mcp.json
+++ b/extensions/jetbrains/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "axint": {
       "command": "npx",
-      "args": ["-y", "@axintai/compiler@0.3.2", "axint-mcp"]
+      "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
     }
   }
 }

--- a/extensions/neovim/README.md
+++ b/extensions/neovim/README.md
@@ -10,7 +10,7 @@ require("avante").setup({
     servers = {
       axint = {
         command = "npx",
-        args = { "-y", "@axintai/compiler@0.3.2", "axint-mcp" },
+        args = { "-y", "@axintai/compiler@0.3.4", "axint-mcp" },
       },
     },
   },
@@ -26,7 +26,7 @@ require("codecompanion").setup({
       servers = {
         axint = {
           command = "npx",
-          args = { "-y", "@axintai/compiler@0.3.2", "axint-mcp" },
+          args = { "-y", "@axintai/compiler@0.3.4", "axint-mcp" },
         },
       },
     },
@@ -39,5 +39,5 @@ require("codecompanion").setup({
 Any Neovim plugin that spawns an MCP server over stdio can connect using:
 
 ```
-npx -y @axintai/compiler@0.3.2 axint-mcp
+npx -y @axintai/compiler@0.3.4 axint-mcp
 ```

--- a/extensions/windsurf/mcp_config.json
+++ b/extensions/windsurf/mcp_config.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "axint": {
       "command": "npx",
-      "args": ["-y", "@axintai/compiler@0.3.2", "axint-mcp"]
+      "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
     }
   }
 }

--- a/extensions/xcode/README.md
+++ b/extensions/xcode/README.md
@@ -29,7 +29,7 @@ If your Xcode version supports MCP tool servers, add this to your MCP config:
   "mcpServers": {
     "axint": {
       "command": "npx",
-      "args": ["-y", "@axintai/compiler@0.3.2", "axint-mcp"]
+      "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
     }
   }
 }

--- a/extensions/zed/README.md
+++ b/extensions/zed/README.md
@@ -12,7 +12,7 @@ Add to your Zed settings (`~/.config/zed/settings.json`):
     "axint": {
       "command": {
         "path": "npx",
-        "args": ["-y", "@axintai/compiler@0.3.2", "axint-mcp"]
+        "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
       }
     }
   }

--- a/extensions/zed/settings.json
+++ b/extensions/zed/settings.json
@@ -3,7 +3,7 @@
     "axint": {
       "command": {
         "path": "npx",
-        "args": ["-y", "@axintai/compiler@0.3.2", "axint-mcp"]
+        "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
       }
     }
   }

--- a/launch/checklist.md
+++ b/launch/checklist.md
@@ -1,4 +1,6 @@
-# v0.3.0 Launch Checklist
+# v0.3.0 Launch Checklist (Archived)
+
+> **Note:** This checklist was drafted for the v0.3.0 launch cycle. Current release is v0.3.4. Keeping for reference — see [ROADMAP.md](../ROADMAP.md) for active planning.
 
 ## Pre-Launch (Week 5)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axintai"
-version = "0.3.2"
+version = "0.3.4"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
changelog was stuck at 0.3.2. adds entries for 0.3.3 and 0.3.4, bumps version refs across 13 extension configs, roadmap, security policy, python sdk. replaces deprecated param.number() in the smart-home example. archives the stale launch checklist.