### PR TITLE
axint.feature + xcode agentic coding support

### DIFF
--- a/extensions/xcode/README.md
+++ b/extensions/xcode/README.md
@@ -1,6 +1,83 @@
 # Axint for Xcode
 
-Axint integrates with Xcode in two ways: as an SPM build plugin for compile-time generation, and via MCP for AI-assisted coding with Xcode's AI features.
+Axint integrates with Xcode in three ways: as an MCP server for agentic coding, as an SPM build plugin for compile-time generation, and via the `axint xcode setup` command for one-step configuration.
+
+## Quick Setup (recommended)
+
+```bash
+npx @axintai/compiler axint xcode setup
+```
+
+This detects your Xcode version, configures Claude Code and Codex to use Axint as an MCP server, and verifies the connection. Run `axint xcode verify` afterward to confirm everything works.
+
+## MCP for Xcode Agentic Coding
+
+Xcode 26.3+ supports agentic coding with external agents via MCP. Axint adds specialized Apple-native feature generation on top of Xcode's built-in workspace/build/test tools.
+
+**What Xcode's MCP gives agents:** file ops, build, test, preview, diagnostics.
+**What Axint adds:** validated App Intent, SwiftUI view, WidgetKit widget generation with entitlements, Info.plist fragments, and XCTest scaffolds.
+
+### For Claude Code
+
+```bash
+claude mcp add --transport stdio axint -- npx -y @axintai/compiler axint-mcp
+```
+
+### For Codex CLI
+
+```bash
+codex mcp add axint -- npx -y @axintai/compiler axint-mcp
+```
+
+### Remote MCP (no local Node.js required)
+
+```json
+{
+  "mcpServers": {
+    "axint": {
+      "url": "https://mcp.axint.ai/mcp"
+    }
+  }
+}
+```
+
+### For any MCP-compatible agent
+
+```json
+{
+  "mcpServers": {
+    "axint": {
+      "command": "npx",
+      "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
+    }
+  }
+}
+```
+
+## Tools Available
+
+Once connected, agents gain 8 specialized tools:
+
+| Tool | What it does |
+|------|-------------|
+| `axint.feature` | Generate a complete Apple-native feature package from a description |
+| `axint.suggest` | Suggest Apple-native features for an app domain |
+| `axint.scaffold` | Generate a starter TypeScript intent file |
+| `axint.compile` | Compile TypeScript → validated Swift |
+| `axint.validate` | Validate without code generation |
+| `axint.schema.compile` | Compile minimal JSON → Swift (token-optimized) |
+| `axint.templates.list` | List bundled reference templates |
+| `axint.templates.get` | Get a specific template's source |
+
+### Composition with Xcode MCP
+
+The recommended workflow for agents:
+
+1. Call `axint.suggest` to discover what features to add
+2. Call `axint.feature` to generate the complete feature package
+3. Use Xcode's `XcodeWrite` to place each file in the project
+4. Use Xcode's `BuildProject` to verify the build passes
+5. Use Xcode's `RenderPreview` to check the UI
 
 ## SPM Build Plugin (compile-time)
 
@@ -20,19 +97,11 @@ targets: [
 
 Place `.ts` intent files in your target's source directory. Xcode runs the Axint compiler at build time and generates Swift files automatically.
 
-## MCP for Xcode AI
+## Example Prompts
 
-If your Xcode version supports MCP tool servers, add this to your MCP config:
+Once Axint is connected to your Xcode agent workflow, try:
 
-```json
-{
-  "mcpServers": {
-    "axint": {
-      "command": "npx",
-      "args": ["-y", "@axintai/compiler@0.3.4", "axint-mcp"]
-    }
-  }
-}
-```
-
-This enables Xcode's AI assistant to scaffold, compile, and validate intents directly.
+- "Use axint.suggest to recommend Apple-native features for this app"
+- "Use axint.feature to add a Siri action for logging water intake"
+- "Use axint.feature to create a home screen widget showing daily step count"
+- "Use axint.feature to add Spotlight search for saved recipes"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,8 @@
  *   axint search [query]          Search the Axint Registry for intent templates
  *   axint watch <file|dir>         Watch intent files and recompile on change
  *   axint mcp                     Start the MCP server (stdio)
+ *   axint xcode setup             Configure Axint for Xcode agentic coding
+ *   axint xcode verify            Verify the MCP connection is working
  *   axint --version               Show version
  */
 
@@ -131,6 +133,30 @@ program
   .action(async () => {
     const { startMCPServer } = await import("../mcp/server.js");
     await startMCPServer();
+  });
+
+// ─── xcode ──────────────────────────────────────────────────────────
+
+const xcode = program
+  .command("xcode")
+  .description("Xcode integration setup and management");
+
+xcode
+  .command("setup")
+  .description("Configure Axint as an MCP server for Xcode's agentic coding workflow")
+  .option("--agent <agent>", "Which agent to configure (claude, codex, all)", "all")
+  .option("--remote", "Use the hosted remote MCP endpoint instead of local stdio")
+  .action(async (options: { agent: string; remote: boolean }) => {
+    const { setupXcode } = await import("./xcode-setup.js");
+    await setupXcode(options);
+  });
+
+xcode
+  .command("verify")
+  .description("Verify Axint MCP connection is working in Xcode")
+  .action(async () => {
+    const { verifyXcode } = await import("./xcode-setup.js");
+    await verifyXcode();
   });
 
 // Helper used by scaffold to avoid a circular import

--- a/src/cli/xcode-setup.ts
+++ b/src/cli/xcode-setup.ts
@@ -1,0 +1,250 @@
+/**
+ * axint xcode setup — Configure Axint for Xcode's agentic coding workflow.
+ *
+ * Detects Xcode 26.3+, configures Claude Code and/or Codex to use
+ * Axint as an additional MCP server, and verifies the connection.
+ */
+
+import { execSync } from "node:child_process";
+
+const ORANGE = "\x1b[38;5;208m";
+const GREEN = "\x1b[38;5;82m";
+const RED = "\x1b[38;5;196m";
+const DIM = "\x1b[2m";
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+
+const REMOTE_URL = "https://mcp.axint.ai/mcp";
+
+interface SetupOptions {
+  agent: string;
+  remote: boolean;
+}
+
+export async function setupXcode(options: SetupOptions): Promise<void> {
+  console.log();
+  console.log(`  ${ORANGE}◆${RESET} ${BOLD}Axint${RESET} · Xcode Setup`);
+  console.log();
+
+  // 1. Check Xcode
+  const xcodeVersion = detectXcode();
+  if (!xcodeVersion) {
+    console.log(
+      `  ${RED}✗${RESET} Xcode not found. Install Xcode 26.3+ from the App Store.`
+    );
+    console.log();
+    return;
+  }
+  console.log(`  ${GREEN}✓${RESET} Xcode detected: ${xcodeVersion}`);
+
+  // 2. Check mcpbridge
+  const hasMcpBridge = detectMcpBridge();
+  if (hasMcpBridge) {
+    console.log(`  ${GREEN}✓${RESET} mcpbridge available`);
+  } else {
+    console.log(
+      `  ${DIM}ℹ${RESET} mcpbridge not found — Xcode 26.3+ command line tools may need updating`
+    );
+  }
+
+  // 3. Check if axint/npx is available
+  const axintPath = detectAxint();
+  if (axintPath) {
+    console.log(`  ${GREEN}✓${RESET} axint compiler: ${axintPath}`);
+  } else {
+    console.log(
+      `  ${DIM}ℹ${RESET} axint not in PATH — will use npx for on-demand install`
+    );
+  }
+
+  console.log();
+
+  // 4. Configure agents
+  const agents = options.agent === "all" ? ["claude", "codex"] : [options.agent];
+
+  for (const agent of agents) {
+    if (agent === "claude") {
+      await setupClaude(options.remote);
+    } else if (agent === "codex") {
+      await setupCodex(options.remote);
+    }
+  }
+
+  // 5. Print verification instructions
+  console.log();
+  console.log(`  ${ORANGE}◆${RESET} ${BOLD}Setup complete${RESET}`);
+  console.log();
+  console.log(`  Try it out — open a project in Xcode and ask the agent:`);
+  console.log();
+  console.log(
+    `    ${DIM}"Use axint.suggest to recommend Apple-native features for this app"${RESET}`
+  );
+  console.log(
+    `    ${DIM}"Use axint.feature to add a Siri action for logging water intake"${RESET}`
+  );
+  console.log();
+  console.log(`  Run ${BOLD}axint xcode verify${RESET} to test the connection.`);
+  console.log();
+}
+
+export async function verifyXcode(): Promise<void> {
+  console.log();
+  console.log(`  ${ORANGE}◆${RESET} ${BOLD}Axint${RESET} · Verify Xcode MCP Connection`);
+  console.log();
+
+  // test that the MCP server starts and can list tools
+  try {
+    const output = execSync(
+      'echo \'{"jsonrpc":"2.0","method":"tools/list","id":1}\' | timeout 5 npx -y @axintai/compiler axint-mcp 2>/dev/null',
+      { encoding: "utf-8", timeout: 15000 }
+    );
+
+    if (output.includes("axint.feature")) {
+      console.log(`  ${GREEN}✓${RESET} MCP server responds`);
+      console.log(`  ${GREEN}✓${RESET} axint.feature tool available`);
+
+      const toolCount = (output.match(/"name":\s*"axint\./g) || []).length;
+      console.log(`  ${GREEN}✓${RESET} ${toolCount} tools registered`);
+      console.log();
+      console.log(`  ${GREEN}All checks passed.${RESET} Axint is ready for Xcode.`);
+    } else {
+      console.log(`  ${RED}✗${RESET} Server responded but axint.feature not found`);
+      console.log(`  ${DIM}  Try updating: npm install -g @axintai/compiler${RESET}`);
+    }
+  } catch {
+    console.log(`  ${RED}✗${RESET} Could not start MCP server`);
+    console.log(`  ${DIM}  Make sure Node.js 22+ and npx are installed${RESET}`);
+  }
+
+  console.log();
+}
+
+// ─── Agent configurators ────────────────────────────────────────────
+
+async function setupClaude(remote: boolean): Promise<void> {
+  console.log(`  ${BOLD}Configuring Claude Code...${RESET}`);
+
+  if (remote) {
+    // remote mode: use the hosted endpoint
+    const cmd = `claude mcp add axint --transport http ${REMOTE_URL}`;
+    console.log(`  ${DIM}$ ${cmd}${RESET}`);
+    try {
+      execSync(cmd, { stdio: "inherit", timeout: 10000 });
+      console.log(`  ${GREEN}✓${RESET} Claude Code configured (remote: ${REMOTE_URL})`);
+    } catch {
+      console.log(`  ${DIM}ℹ${RESET} Auto-config failed. Add manually:`);
+      printManualClaude(remote);
+    }
+  } else {
+    // local stdio mode
+    const cmd = `claude mcp add --transport stdio axint -- npx -y @axintai/compiler axint-mcp`;
+    console.log(`  ${DIM}$ ${cmd}${RESET}`);
+    try {
+      execSync(cmd, { stdio: "inherit", timeout: 10000 });
+      console.log(`  ${GREEN}✓${RESET} Claude Code configured (local stdio)`);
+    } catch {
+      console.log(`  ${DIM}ℹ${RESET} Auto-config failed. Add manually:`);
+      printManualClaude(remote);
+    }
+  }
+}
+
+async function setupCodex(remote: boolean): Promise<void> {
+  console.log(`  ${BOLD}Configuring Codex CLI...${RESET}`);
+
+  if (remote) {
+    const cmd = `codex mcp add axint --transport http ${REMOTE_URL}`;
+    console.log(`  ${DIM}$ ${cmd}${RESET}`);
+    try {
+      execSync(cmd, { stdio: "inherit", timeout: 10000 });
+      console.log(`  ${GREEN}✓${RESET} Codex configured (remote: ${REMOTE_URL})`);
+    } catch {
+      console.log(`  ${DIM}ℹ${RESET} Auto-config failed. Add manually:`);
+      printManualCodex(remote);
+    }
+  } else {
+    const cmd = `codex mcp add axint -- npx -y @axintai/compiler axint-mcp`;
+    console.log(`  ${DIM}$ ${cmd}${RESET}`);
+    try {
+      execSync(cmd, { stdio: "inherit", timeout: 10000 });
+      console.log(`  ${GREEN}✓${RESET} Codex configured (local stdio)`);
+    } catch {
+      console.log(`  ${DIM}ℹ${RESET} Auto-config failed. Add manually:`);
+      printManualCodex(remote);
+    }
+  }
+}
+
+// ─── Detection helpers ──────────────────────────────────────────────
+
+function detectXcode(): string | null {
+  try {
+    const output = execSync("xcodebuild -version 2>/dev/null", {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    const match = output.match(/Xcode\s+([\d.]+)/);
+    return match ? match[1] : output.trim().split("\n")[0];
+  } catch {
+    return null;
+  }
+}
+
+function detectMcpBridge(): boolean {
+  try {
+    execSync("xcrun mcpbridge --help 2>/dev/null", { timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function detectAxint(): string | null {
+  try {
+    const output = execSync("which axint 2>/dev/null", {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    return output.trim();
+  } catch {
+    return null;
+  }
+}
+
+// ─── Manual instructions ────────────────────────────────────────────
+
+function printManualClaude(remote: boolean): void {
+  console.log();
+  if (remote) {
+    console.log(`  Add to your Claude Code MCP config:`);
+    console.log(`  ${DIM}{${RESET}`);
+    console.log(`  ${DIM}  "mcpServers": {${RESET}`);
+    console.log(`  ${DIM}    "axint": { "url": "${REMOTE_URL}" }${RESET}`);
+    console.log(`  ${DIM}  }${RESET}`);
+    console.log(`  ${DIM}}${RESET}`);
+  } else {
+    console.log(`  Run this command:`);
+    console.log(
+      `  ${DIM}claude mcp add --transport stdio axint -- npx -y @axintai/compiler axint-mcp${RESET}`
+    );
+  }
+  console.log();
+}
+
+function printManualCodex(remote: boolean): void {
+  console.log();
+  if (remote) {
+    console.log(`  Add to your Codex MCP config:`);
+    console.log(`  ${DIM}{${RESET}`);
+    console.log(`  ${DIM}  "mcpServers": {${RESET}`);
+    console.log(`  ${DIM}    "axint": { "url": "${REMOTE_URL}" }${RESET}`);
+    console.log(`  ${DIM}  }${RESET}`);
+    console.log(`  ${DIM}}${RESET}`);
+  } else {
+    console.log(`  Run this command:`);
+    console.log(
+      `  ${DIM}codex mcp add axint -- npx -y @axintai/compiler axint-mcp${RESET}`
+    );
+  }
+  console.log();
+}

--- a/src/mcp/feature.ts
+++ b/src/mcp/feature.ts
@@ -1,0 +1,614 @@
+/**
+ * axint.feature — High-level Apple-native feature generator.
+ *
+ * Takes a feature description and optional surface list, then orchestrates
+ * the compiler to produce a complete, file-by-file feature package:
+ * Swift sources, Info.plist fragments, entitlements, and XCTest scaffolds.
+ *
+ * Designed for composition with Xcode's MCP tools — the agent calls
+ * axint.feature to generate the package, then uses XcodeWrite to place
+ * each file in the project.
+ */
+
+import {
+  compileFromIR,
+  compileViewFromIR,
+  compileWidgetFromIR,
+} from "../core/compiler.js";
+import type {
+  IRIntent,
+  IRView,
+  IRWidget,
+  IRWidgetEntry,
+  IRParameter,
+  IRType,
+  IRViewState,
+  WidgetFamily,
+} from "../core/types.js";
+import { isPrimitiveType, type IRPrimitiveType } from "../core/types.js";
+
+export type Surface = "intent" | "view" | "widget";
+
+export interface FeatureInput {
+  description: string;
+  surfaces?: Surface[];
+  name?: string;
+  appName?: string;
+  domain?: string;
+  params?: Record<string, string>;
+}
+
+export interface FeatureFile {
+  path: string;
+  content: string;
+  type: "swift" | "plist" | "entitlements" | "test";
+}
+
+export interface FeatureResult {
+  success: boolean;
+  name: string;
+  files: FeatureFile[];
+  summary: string;
+  diagnostics: string[];
+}
+
+const DOMAIN_ENTITLEMENTS: Record<string, string[]> = {
+  health: ["com.apple.developer.healthkit"],
+  messaging: ["com.apple.developer.siri"],
+  "smart-home": ["com.apple.developer.homekit"],
+  navigation: ["com.apple.developer.siri"],
+  productivity: ["com.apple.developer.siri"],
+};
+
+const DOMAIN_PLIST_KEYS: Record<string, Record<string, string>> = {
+  health: {
+    NSHealthShareUsageDescription: "Read health data to provide insights.",
+    NSHealthUpdateUsageDescription: "Save health data you log.",
+  },
+};
+
+/**
+ * Generate a complete Apple-native feature package from a description.
+ */
+export function generateFeature(input: FeatureInput): FeatureResult {
+  const name = input.name || inferName(input.description);
+  const surfaces = input.surfaces?.length ? input.surfaces : (["intent"] as Surface[]);
+  const domain = input.domain || inferDomain(input.description);
+  const params = input.params || inferParams(input.description);
+  const diagnostics: string[] = [];
+  const files: FeatureFile[] = [];
+
+  // --- Intent surface ---
+  if (surfaces.includes("intent")) {
+    const intentResult = buildIntent(name, input.description, domain, params);
+    if (intentResult.swift) {
+      files.push({
+        path: `Sources/Intents/${name}Intent.swift`,
+        content: intentResult.swift,
+        type: "swift",
+      });
+    }
+    if (intentResult.plist) {
+      files.push({
+        path: `Sources/Supporting/Info.plist.fragment.xml`,
+        content: intentResult.plist,
+        type: "plist",
+      });
+    }
+    if (intentResult.entitlements) {
+      files.push({
+        path: `Sources/Supporting/${name}.entitlements.fragment.xml`,
+        content: intentResult.entitlements,
+        type: "entitlements",
+      });
+    }
+    files.push({
+      path: `Tests/${name}IntentTests.swift`,
+      content: generateIntentTest(name, params),
+      type: "test",
+    });
+    diagnostics.push(...intentResult.diagnostics);
+  }
+
+  // --- Widget surface ---
+  if (surfaces.includes("widget")) {
+    const widgetResult = buildWidget(name, input.description, domain, params);
+    if (widgetResult.swift) {
+      files.push({
+        path: `Sources/Widgets/${name}Widget.swift`,
+        content: widgetResult.swift,
+        type: "swift",
+      });
+    }
+    files.push({
+      path: `Tests/${name}WidgetTests.swift`,
+      content: generateWidgetTest(name),
+      type: "test",
+    });
+    diagnostics.push(...widgetResult.diagnostics);
+  }
+
+  // --- View surface ---
+  if (surfaces.includes("view")) {
+    const viewResult = buildView(name, input.description, params);
+    if (viewResult.swift) {
+      files.push({
+        path: `Sources/Views/${name}View.swift`,
+        content: viewResult.swift,
+        type: "swift",
+      });
+    }
+    diagnostics.push(...viewResult.diagnostics);
+  }
+
+  // --- Domain-level entitlements ---
+  if (
+    domain &&
+    DOMAIN_ENTITLEMENTS[domain] &&
+    !files.some((f) => f.type === "entitlements")
+  ) {
+    files.push({
+      path: `Sources/Supporting/${name}.entitlements.fragment.xml`,
+      content: buildEntitlementsXml(DOMAIN_ENTITLEMENTS[domain]),
+      type: "entitlements",
+    });
+  }
+
+  // --- Domain-level plist ---
+  if (domain && DOMAIN_PLIST_KEYS[domain] && !files.some((f) => f.type === "plist")) {
+    files.push({
+      path: `Sources/Supporting/Info.plist.fragment.xml`,
+      content: buildPlistXml(DOMAIN_PLIST_KEYS[domain]),
+      type: "plist",
+    });
+  }
+
+  const success = diagnostics.every((d) => !d.startsWith("[AX") || d.includes("warning"));
+  const surfaceList = surfaces.join(", ");
+  const fileCount = files.filter((f) => f.type === "swift").length;
+  const testCount = files.filter((f) => f.type === "test").length;
+
+  const summary = [
+    `Generated ${fileCount} Swift file${fileCount !== 1 ? "s" : ""} + ${testCount} test${testCount !== 1 ? "s" : ""} for "${name}"`,
+    `Surfaces: ${surfaceList}`,
+    domain ? `Domain: ${domain}` : null,
+    `Files:`,
+    ...files.map((f) => `  ${f.path} (${f.type})`),
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return { success, name, files, summary, diagnostics };
+}
+
+// ─── Surface builders ───────────────────────────────────────────────
+
+interface SurfaceOutput {
+  swift: string | null;
+  plist: string | null;
+  entitlements: string | null;
+  diagnostics: string[];
+}
+
+function buildIntent(
+  name: string,
+  description: string,
+  domain: string | undefined,
+  params: Record<string, string>
+): SurfaceOutput {
+  const irParams = paramsToIR(params);
+  const entitlements = domain ? DOMAIN_ENTITLEMENTS[domain] : undefined;
+  const plistKeys = domain ? DOMAIN_PLIST_KEYS[domain] : undefined;
+
+  const ir: IRIntent = {
+    name,
+    title: humanize(name),
+    description,
+    domain,
+    parameters: irParams,
+    returnType: { kind: "primitive", value: "string" },
+    sourceFile: "<feature>",
+    entitlements,
+    infoPlistKeys: plistKeys,
+  };
+
+  const result = compileFromIR(ir, {
+    emitInfoPlist: !!plistKeys,
+    emitEntitlements: !!entitlements,
+  });
+
+  if (!result.success || !result.output) {
+    return {
+      swift: null,
+      plist: null,
+      entitlements: null,
+      diagnostics: result.diagnostics.map(
+        (d) => `[${d.code}] ${d.severity}: ${d.message}`
+      ),
+    };
+  }
+
+  return {
+    swift: result.output.swiftCode,
+    plist: result.output.infoPlistFragment || null,
+    entitlements: result.output.entitlementsFragment || null,
+    diagnostics: result.diagnostics.map((d) => `[${d.code}] ${d.severity}: ${d.message}`),
+  };
+}
+
+function buildWidget(
+  name: string,
+  description: string,
+  domain: string | undefined,
+  params: Record<string, string>
+): SurfaceOutput {
+  const entries: IRWidgetEntry[] = Object.entries(params)
+    .slice(0, 4) // widgets get a subset of params as timeline entries
+    .map(([entryName, typeStr]) => ({
+      name: entryName,
+      type: toIRType(typeStr),
+    }));
+
+  // always include date for timeline
+  if (!entries.some((e) => e.name === "date")) {
+    entries.unshift({
+      name: "date",
+      type: { kind: "primitive", value: "date" },
+    });
+  }
+
+  const families: WidgetFamily[] = ["systemSmall", "systemMedium"];
+
+  const ir: IRWidget = {
+    name: `${name}Widget`,
+    displayName: humanize(name),
+    description,
+    families,
+    entry: entries,
+    body: [
+      {
+        kind: "raw",
+        swift: buildWidgetBody(name, entries),
+      },
+    ],
+    refreshPolicy: "atEnd",
+    sourceFile: "<feature>",
+  };
+
+  const result = compileWidgetFromIR(ir);
+
+  if (!result.success || !result.output) {
+    return {
+      swift: null,
+      plist: null,
+      entitlements: null,
+      diagnostics: result.diagnostics.map(
+        (d) => `[${d.code}] ${d.severity}: ${d.message}`
+      ),
+    };
+  }
+
+  return {
+    swift: result.output.swiftCode,
+    plist: null,
+    entitlements: null,
+    diagnostics: result.diagnostics.map((d) => `[${d.code}] ${d.severity}: ${d.message}`),
+  };
+}
+
+function buildView(
+  name: string,
+  _description: string,
+  params: Record<string, string>
+): SurfaceOutput {
+  const state: IRViewState[] = Object.entries(params).map(([propName, typeStr]) => ({
+    name: propName,
+    type: toIRType(typeStr),
+    kind: "state" as const,
+    defaultValue: defaultForType(typeStr),
+  }));
+
+  const ir: IRView = {
+    name: `${name}View`,
+    props: [],
+    state,
+    body: [
+      {
+        kind: "raw",
+        swift: buildViewBody(name, state),
+      },
+    ],
+    sourceFile: "<feature>",
+  };
+
+  const result = compileViewFromIR(ir);
+
+  if (!result.success || !result.output) {
+    return {
+      swift: null,
+      plist: null,
+      entitlements: null,
+      diagnostics: result.diagnostics.map(
+        (d) => `[${d.code}] ${d.severity}: ${d.message}`
+      ),
+    };
+  }
+
+  return {
+    swift: result.output.swiftCode,
+    plist: null,
+    entitlements: null,
+    diagnostics: result.diagnostics.map((d) => `[${d.code}] ${d.severity}: ${d.message}`),
+  };
+}
+
+// ─── Test generators ────────────────────────────────────────────────
+
+function generateIntentTest(name: string, params: Record<string, string>): string {
+  const paramSetup = Object.entries(params)
+    .map(([p, t]) => `        intent.${p} = ${testValueForType(t)}`)
+    .join("\n");
+
+  return `import XCTest
+import AppIntents
+
+final class ${name}IntentTests: XCTestCase {
+    func test${name}IntentConformance() {
+        let intent = ${name}Intent()
+        XCTAssertNotNil(intent)
+    }
+
+    func test${name}IntentTitle() {
+        let intent = ${name}Intent()
+        XCTAssertFalse(intent.title.description.isEmpty)
+    }
+
+    func test${name}IntentPerform() async throws {
+        var intent = ${name}Intent()
+${paramSetup}
+        let result = try await intent.perform()
+        XCTAssertNotNil(result)
+    }
+}
+`;
+}
+
+function generateWidgetTest(name: string): string {
+  return `import XCTest
+import WidgetKit
+
+final class ${name}WidgetTests: XCTestCase {
+    func test${name}WidgetConfiguration() {
+        // Verify widget can be instantiated
+        let widget = ${name}Widget()
+        XCTAssertNotNil(widget)
+    }
+}
+`;
+}
+
+// ─── Inference helpers ──────────────────────────────────────────────
+
+const DOMAIN_KEYWORDS: Record<string, string[]> = {
+  health: [
+    "health",
+    "fitness",
+    "workout",
+    "step",
+    "calorie",
+    "heart",
+    "sleep",
+    "water",
+    "hydration",
+    "weight",
+    "medication",
+    "vitamin",
+  ],
+  messaging: ["message", "chat", "send", "text", "email", "sms", "contact"],
+  "smart-home": [
+    "thermostat",
+    "light",
+    "lock",
+    "garage",
+    "home",
+    "smart",
+    "device",
+    "temperature",
+  ],
+  navigation: ["direction", "navigate", "map", "location", "route", "drive", "walk"],
+  productivity: [
+    "note",
+    "task",
+    "reminder",
+    "calendar",
+    "event",
+    "todo",
+    "schedule",
+    "appointment",
+    "bookmark",
+  ],
+  finance: [
+    "expense",
+    "budget",
+    "payment",
+    "transaction",
+    "money",
+    "cost",
+    "invoice",
+    "bill",
+  ],
+  commerce: ["order", "cart", "buy", "purchase", "shop", "product", "checkout"],
+  media: ["play", "music", "song", "podcast", "video", "playlist", "track", "stream"],
+};
+
+function inferDomain(description: string): string | undefined {
+  const lower = description.toLowerCase();
+  let bestDomain: string | undefined;
+  let bestScore = 0;
+
+  for (const [domain, keywords] of Object.entries(DOMAIN_KEYWORDS)) {
+    const score = keywords.filter((kw) => lower.includes(kw)).length;
+    if (score > bestScore) {
+      bestScore = score;
+      bestDomain = domain;
+    }
+  }
+
+  return bestScore > 0 ? bestDomain : undefined;
+}
+
+function inferName(description: string): string {
+  // extract the core action verb + noun from the description
+  const cleaned = description
+    .replace(/^(let users?|allow users? to|add|create|enable|implement|build)\s+/i, "")
+    .replace(
+      /\s+(via siri|through shortcuts|in spotlight|for the app|to the app)\s*\.?$/i,
+      ""
+    )
+    .replace(/[^a-zA-Z0-9\s]/g, "")
+    .trim();
+
+  const words = cleaned.split(/\s+/).slice(0, 3);
+  if (words.length === 0) return "CustomFeature";
+
+  return words.map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join("");
+}
+
+const PARAM_PATTERNS: Record<string, Record<string, string>> = {
+  health: { type: "string", duration: "duration", calories: "int" },
+  messaging: { recipient: "string", body: "string" },
+  navigation: { destination: "string", mode: "string" },
+  finance: { amount: "double", category: "string", currency: "string" },
+  commerce: { productId: "string", quantity: "int" },
+  media: { query: "string", shuffle: "boolean" },
+  productivity: { title: "string", date: "date", notes: "string" },
+  "smart-home": { device: "string", value: "string" },
+};
+
+function inferParams(description: string): Record<string, string> {
+  const domain = inferDomain(description);
+  if (domain && PARAM_PATTERNS[domain]) {
+    return { ...PARAM_PATTERNS[domain] };
+  }
+  // generic fallback
+  return { input: "string" };
+}
+
+// ─── IR / codegen helpers ───────────────────────────────────────────
+
+function paramsToIR(params: Record<string, string>): IRParameter[] {
+  return Object.entries(params).map(([name, typeStr]) => ({
+    name,
+    type: toIRType(typeStr),
+    title: humanize(name),
+    description: "",
+    isOptional: false,
+  }));
+}
+
+function toIRType(typeStr: string): IRType {
+  const normalized = typeStr === "number" ? "int" : typeStr;
+  if (isPrimitiveType(normalized)) {
+    return { kind: "primitive", value: normalized as IRPrimitiveType };
+  }
+  return { kind: "primitive", value: "string" };
+}
+
+function humanize(pascal: string): string {
+  return pascal.replace(/([A-Z])/g, " $1").trim();
+}
+
+function defaultForType(typeStr: string): unknown {
+  switch (typeStr) {
+    case "string":
+      return "";
+    case "int":
+      return 0;
+    case "double":
+    case "float":
+      return 0.0;
+    case "boolean":
+      return false;
+    default:
+      return "";
+  }
+}
+
+function testValueForType(typeStr: string): string {
+  switch (typeStr) {
+    case "string":
+      return '"test"';
+    case "int":
+      return "1";
+    case "double":
+    case "float":
+      return "1.0";
+    case "boolean":
+      return "true";
+    case "date":
+      return "Date()";
+    case "duration":
+      return "Duration.seconds(60)";
+    case "url":
+      return 'URL(string: "https://example.com")!';
+    default:
+      return '"test"';
+  }
+}
+
+function buildWidgetBody(name: string, entries: IRWidgetEntry[]): string {
+  const fields = entries
+    .filter((e) => e.name !== "date")
+    .map((e) => `                Text("\\(entry.${e.name})")`)
+    .join("\n");
+
+  return `VStack(alignment: .leading, spacing: 8) {
+            Text("${humanize(name)}")
+                .font(.headline)
+${fields || '            Text("—")'}
+        }
+        .padding()`;
+}
+
+function buildViewBody(name: string, state: IRViewState[]): string {
+  const fields = state
+    .map((s) => {
+      if (s.type.kind === "primitive" && s.type.value === "boolean") {
+        return `            Toggle("${humanize(s.name)}", isOn: $${s.name})`;
+      }
+      return `            Text("${humanize(s.name)}: \\(${s.name})")`;
+    })
+    .join("\n");
+
+  return `NavigationStack {
+            VStack(spacing: 16) {
+${fields || '                Text("Hello")'}
+            }
+            .padding()
+            .navigationTitle("${humanize(name)}")
+        }`;
+}
+
+function buildEntitlementsXml(entitlements: string[]): string {
+  const entries = entitlements.map((e) => `\t<key>${e}</key>\n\t<true/>`).join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+${entries}
+</dict>
+</plist>`;
+}
+
+function buildPlistXml(keys: Record<string, string>): string {
+  const entries = Object.entries(keys)
+    .map(([k, v]) => `\t<key>${k}</key>\n\t<string>${v}</string>`)
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+${entries}
+</dict>
+</plist>`;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -6,6 +6,8 @@
  * automatically.
  *
  * Tools:
+ *   - axint.feature:          Generate a complete Apple-native feature package
+ *   - axint.suggest:          Suggest Apple-native features for an app domain
  *   - axint.scaffold:         Generate a starter TypeScript intent file
  *   - axint.compile:          Compile TypeScript intent → Swift App Intent
  *   - axint.validate:         Validate an intent definition without codegen
@@ -33,6 +35,8 @@ import {
   compileAppFromIR,
 } from "../core/compiler.js";
 import { scaffoldIntent } from "./scaffold.js";
+import { generateFeature, type FeatureInput, type Surface } from "./feature.js";
+import { suggestFeatures, type SuggestInput } from "./suggest.js";
 import { TEMPLATES, getTemplate } from "../templates/index.js";
 import type {
   IRIntent,
@@ -474,6 +478,127 @@ export function createAxintServer(): Server {
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: [
       {
+        name: "axint.feature",
+        description:
+          "Generate a complete Apple-native feature package from a description. " +
+          "Returns multiple files: validated Swift source, companion widget/view, " +
+          "Info.plist fragments, entitlements, and XCTest scaffolds — all structured " +
+          "file-by-file so an Xcode agent can write each file directly into the " +
+          "project. Designed for composition with Xcode MCP tools: call " +
+          "axint.feature to generate the package, then use XcodeWrite to place " +
+          "each file. No files written, no network requests, no side effects.",
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            description: {
+              type: "string",
+              description:
+                "What the feature does, in natural language. E.g., " +
+                "'Let users log water intake via Siri' or " +
+                "'Add a Spotlight-searchable recipe entity'. The description " +
+                "is used to infer the feature name, domain, and parameters.",
+            },
+            surfaces: {
+              type: "array",
+              items: {
+                type: "string",
+                enum: ["intent", "view", "widget"],
+              },
+              description:
+                "Which Apple surfaces to generate. 'intent' produces an App Intent " +
+                "struct for Siri/Shortcuts/Spotlight. 'widget' produces a WidgetKit " +
+                "widget with timeline provider. 'view' produces a SwiftUI view. " +
+                "Defaults to ['intent'] if omitted. Combine surfaces to generate " +
+                "a complete feature: ['intent', 'widget'] for a Siri action + " +
+                "home screen widget.",
+            },
+            name: {
+              type: "string",
+              description:
+                "PascalCase feature name, e.g., 'LogWaterIntake'. If omitted, " +
+                "inferred from the description. Used as the base name for all " +
+                "generated Swift structs.",
+            },
+            appName: {
+              type: "string",
+              description:
+                "The target app name, used in generated comments and test " +
+                "references. E.g., 'HealthTracker'. Optional.",
+            },
+            domain: {
+              type: "string",
+              description:
+                "Apple App Intent domain. One of: messaging, productivity, health, " +
+                "finance, commerce, media, navigation, smart-home. If omitted, " +
+                "inferred from the description. Determines default entitlements, " +
+                "Info.plist keys, and parameter suggestions.",
+            },
+            params: {
+              type: "object",
+              description:
+                "Explicit parameter definitions as { fieldName: typeString }. " +
+                "E.g., { amount: 'double', unit: 'string' }. If omitted, " +
+                "inferred from the domain and description. Types: string, int, " +
+                "double, float, boolean, date, duration, url.",
+              additionalProperties: {
+                type: "string",
+                description: "Swift type for this parameter",
+              },
+            },
+          },
+          required: ["description"],
+        },
+      },
+      {
+        name: "axint.suggest",
+        description:
+          "Suggest Apple-native features for an app based on its domain or " +
+          "description. Returns a ranked list of features with recommended " +
+          "surfaces (intent, widget, view), estimated complexity, and a " +
+          "one-line description for each. Use this to discover what Axint " +
+          "can generate for an app before calling axint.feature. No files " +
+          "written, no network requests, no side effects.",
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            appDescription: {
+              type: "string",
+              description:
+                "What the app does, in natural language. E.g., " +
+                "'A fitness tracking app that logs workouts and counts steps' or " +
+                "'A recipe app for discovering and saving meals'. Used to " +
+                "suggest relevant Apple-native features.",
+            },
+            domain: {
+              type: "string",
+              description:
+                "Primary app domain. One of: messaging, productivity, health, " +
+                "finance, commerce, media, navigation, smart-home. If provided, " +
+                "suggestions are tailored to this domain.",
+            },
+            limit: {
+              type: "number",
+              description:
+                "Maximum number of suggestions to return. Defaults to 5. " +
+                "Suggestions are ordered by estimated user impact.",
+            },
+          },
+          required: ["appDescription"],
+        },
+      },
+      {
         name: "axint.scaffold",
         description:
           "Generate a starter TypeScript intent file from a name and description. " +
@@ -519,10 +644,26 @@ export function createAxintServer(): Server {
                 "description: 'Contact to message' }.",
               items: {
                 type: "object",
+                description: "Parameter definition with name, type, and description",
                 properties: {
-                  name: { type: "string" },
-                  type: { type: "string" },
-                  description: { type: "string" },
+                  name: {
+                    type: "string",
+                    description:
+                      "camelCase parameter name, e.g., 'recipient' or 'messageBody'. " +
+                      "Used as the Swift property name in the generated AppIntent struct.",
+                  },
+                  type: {
+                    type: "string",
+                    description:
+                      "Parameter type. One of: string, int, double, float, boolean, " +
+                      "date, duration, url. Maps to the corresponding Swift type.",
+                  },
+                  description: {
+                    type: "string",
+                    description:
+                      "Human-readable description shown in Shortcuts and Spotlight " +
+                      "when users configure the intent parameter.",
+                  },
                 },
                 required: ["name", "type", "description"],
               },
@@ -672,14 +813,22 @@ export function createAxintServer(): Server {
                 "Intent only. Parameter definitions as { fieldName: typeString }. " +
                 "E.g., { recipient: 'string', amount: 'double' }. Supported types: " +
                 "string, int, double, float, boolean, date, duration, url.",
-              additionalProperties: { type: "string" },
+              additionalProperties: {
+                type: "string",
+                description:
+                  "Swift type for this parameter: string, int, double, float, boolean, date, duration, or url",
+              },
             },
             props: {
               type: "object",
               description:
                 "View only. Prop definitions as { fieldName: typeString }. " +
                 "E.g., { title: 'string', count: 'int' }. Same type set as params.",
-              additionalProperties: { type: "string" },
+              additionalProperties: {
+                type: "string",
+                description:
+                  "Swift type for this prop: string, int, double, float, boolean, date, duration, or url",
+              },
             },
             state: {
               type: "object",
@@ -687,6 +836,22 @@ export function createAxintServer(): Server {
                 "View only. State variable definitions as " +
                 "{ fieldName: { type: 'string', default?: value } }. " +
                 "Generates @State properties in the SwiftUI view.",
+              additionalProperties: {
+                type: "object",
+                description: "State variable config with type and optional default value",
+                properties: {
+                  type: {
+                    type: "string",
+                    description:
+                      "Swift type: string, int, double, float, boolean, date, duration, or url",
+                  },
+                  default: {
+                    type: "string",
+                    description: "Optional default value for the @State property",
+                  },
+                },
+                required: ["type"],
+              },
             },
             body: {
               type: "string",
@@ -703,7 +868,11 @@ export function createAxintServer(): Server {
             },
             families: {
               type: "array",
-              items: { type: "string" },
+              items: {
+                type: "string",
+                description:
+                  "Widget family: systemSmall, systemMedium, systemLarge, systemExtraLarge, accessoryCircular, accessoryRectangular, or accessoryInline",
+              },
               description:
                 "Widget only. Supported widget sizes: systemSmall, systemMedium, " +
                 "systemLarge, systemExtraLarge, accessoryCircular, " +
@@ -714,7 +883,11 @@ export function createAxintServer(): Server {
               description:
                 "Widget only. Timeline entry fields as { fieldName: typeString }. " +
                 "E.g., { steps: 'int', date: 'date' }. Available in the body template.",
-              additionalProperties: { type: "string" },
+              additionalProperties: {
+                type: "string",
+                description:
+                  "Swift type for this entry field: string, int, double, float, boolean, date, duration, or url",
+              },
             },
             refreshInterval: {
               type: "number",
@@ -726,6 +899,8 @@ export function createAxintServer(): Server {
               type: "array",
               items: {
                 type: "object",
+                description:
+                  "Scene definition with kind, view, and optional title/platform",
                 properties: {
                   kind: {
                     type: "string",
@@ -781,7 +956,6 @@ export function createAxintServer(): Server {
         },
         inputSchema: {
           type: "object" as const,
-          properties: {},
         },
       },
       {
@@ -821,6 +995,81 @@ export function createAxintServer(): Server {
     const { name, arguments: args } = request.params;
 
     try {
+      if (name === "axint.feature") {
+        const a = args as unknown as FeatureInput;
+        if (!a.description) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Error: 'description' is required for axint.feature",
+              },
+            ],
+            isError: true,
+          };
+        }
+        const result = generateFeature({
+          description: a.description,
+          surfaces: a.surfaces as Surface[] | undefined,
+          name: a.name,
+          appName: a.appName,
+          domain: a.domain,
+          params: a.params,
+        });
+
+        const output: string[] = [result.summary, ""];
+
+        for (const file of result.files) {
+          output.push(`// ─── ${file.path} ───`);
+          output.push(file.content);
+          output.push("");
+        }
+
+        if (result.diagnostics.length > 0) {
+          output.push("// ─── Diagnostics ───");
+          output.push(result.diagnostics.join("\n"));
+        }
+
+        return {
+          content: [{ type: "text" as const, text: output.join("\n") }],
+          isError: !result.success,
+        };
+      }
+
+      if (name === "axint.suggest") {
+        const a = args as unknown as SuggestInput;
+        if (!a.appDescription) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Error: 'appDescription' is required for axint.suggest",
+              },
+            ],
+            isError: true,
+          };
+        }
+        const suggestions = suggestFeatures(a);
+        const output = suggestions
+          .map((s, i) => {
+            const surfaces = s.surfaces.join(", ");
+            return `${i + 1}. ${s.name}\n   ${s.description}\n   Surfaces: ${surfaces} | Complexity: ${s.complexity}\n   Prompt: "${s.featurePrompt}"`;
+          })
+          .join("\n\n");
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text:
+                suggestions.length > 0
+                  ? `Suggested Apple-native features:\n\n${output}\n\nUse axint.feature with any prompt above to generate the full feature package.`
+                  : "No specific suggestions for this app description. Try providing more detail about the app's purpose.",
+            },
+          ],
+        };
+      }
+
       if (name === "axint.scaffold") {
         const a = args as unknown as ScaffoldArgs;
         const source = scaffoldIntent({

--- a/src/mcp/suggest.ts
+++ b/src/mcp/suggest.ts
@@ -1,0 +1,474 @@
+/**
+ * axint.suggest — Apple-native feature advisor.
+ *
+ * Takes an app description or domain and returns a ranked list of
+ * Apple-native features the app should expose. Each suggestion includes
+ * the recommended surfaces, complexity estimate, and a ready-to-use
+ * prompt for axint.feature.
+ */
+
+export interface SuggestInput {
+  appDescription: string;
+  domain?: string;
+  limit?: number;
+}
+
+export interface FeatureSuggestion {
+  name: string;
+  description: string;
+  surfaces: Array<"intent" | "view" | "widget">;
+  complexity: "low" | "medium" | "high";
+  featurePrompt: string;
+  domain: string;
+}
+
+interface DomainFeatureSet {
+  domain: string;
+  keywords: string[];
+  features: Omit<FeatureSuggestion, "domain">[];
+}
+
+const FEATURE_CATALOG: DomainFeatureSet[] = [
+  {
+    domain: "health",
+    keywords: [
+      "health",
+      "fitness",
+      "workout",
+      "step",
+      "calorie",
+      "sleep",
+      "water",
+      "weight",
+      "medication",
+      "vitamin",
+      "heart",
+      "hydration",
+      "exercise",
+      "running",
+      "gym",
+      "track",
+    ],
+    features: [
+      {
+        name: "Log Workout via Siri",
+        description:
+          "Let users log workouts with type, duration, and calories through Siri and Shortcuts.",
+        surfaces: ["intent", "widget"],
+        complexity: "low",
+        featurePrompt:
+          "Let users log workouts with type, duration, and calories via Siri",
+      },
+      {
+        name: "Daily Step Count Widget",
+        description:
+          "Home screen widget showing today's step count with a progress ring.",
+        surfaces: ["widget"],
+        complexity: "low",
+        featurePrompt: "Show daily step count with progress on a home screen widget",
+      },
+      {
+        name: "Log Water Intake",
+        description:
+          "Quick Siri action to log glasses of water with a companion Lock Screen widget.",
+        surfaces: ["intent", "widget"],
+        complexity: "low",
+        featurePrompt:
+          "Let users log water intake via Siri with a hydration tracking widget",
+      },
+      {
+        name: "Health Summary View",
+        description: "SwiftUI view showing key health metrics in a dashboard layout.",
+        surfaces: ["view"],
+        complexity: "medium",
+        featurePrompt: "Create a health summary dashboard view with key metrics",
+      },
+      {
+        name: "Log Medication Reminder",
+        description:
+          "Siri action to log that a medication was taken, with optional reminder scheduling.",
+        surfaces: ["intent"],
+        complexity: "medium",
+        featurePrompt: "Let users log medication intake via Siri with name and dosage",
+      },
+      {
+        name: "Sleep Tracking Widget",
+        description: "Widget displaying last night's sleep duration and quality score.",
+        surfaces: ["widget"],
+        complexity: "medium",
+        featurePrompt:
+          "Show last night's sleep duration and quality on a home screen widget",
+      },
+    ],
+  },
+  {
+    domain: "productivity",
+    keywords: [
+      "task",
+      "note",
+      "todo",
+      "reminder",
+      "calendar",
+      "event",
+      "schedule",
+      "project",
+      "bookmark",
+      "document",
+      "organize",
+    ],
+    features: [
+      {
+        name: "Create Task via Siri",
+        description:
+          "Add tasks with title, due date, and priority through Siri and Shortcuts.",
+        surfaces: ["intent"],
+        complexity: "low",
+        featurePrompt:
+          "Let users create tasks with title, due date, and priority via Siri",
+      },
+      {
+        name: "Quick Note from Siri",
+        description:
+          "Capture a note with title and body through voice, searchable in Spotlight.",
+        surfaces: ["intent"],
+        complexity: "low",
+        featurePrompt: "Let users create quick notes via Siri searchable in Spotlight",
+      },
+      {
+        name: "Upcoming Tasks Widget",
+        description: "Home screen widget showing the next 3-5 tasks with due dates.",
+        surfaces: ["widget"],
+        complexity: "low",
+        featurePrompt: "Show upcoming tasks with due dates on a home screen widget",
+      },
+      {
+        name: "Create Calendar Event",
+        description:
+          "Schedule events with title, date, duration, and location through Siri.",
+        surfaces: ["intent"],
+        complexity: "medium",
+        featurePrompt:
+          "Let users create calendar events with title, date, and duration via Siri",
+      },
+      {
+        name: "Task Dashboard View",
+        description: "SwiftUI view organizing tasks by status with progress indicators.",
+        surfaces: ["view"],
+        complexity: "medium",
+        featurePrompt: "Create a task dashboard view organized by status with progress",
+      },
+      {
+        name: "Daily Agenda Widget",
+        description: "Medium widget combining today's tasks and calendar events.",
+        surfaces: ["widget"],
+        complexity: "medium",
+        featurePrompt:
+          "Show today's agenda combining tasks and events on a home screen widget",
+      },
+    ],
+  },
+  {
+    domain: "finance",
+    keywords: [
+      "expense",
+      "budget",
+      "money",
+      "payment",
+      "transaction",
+      "invoice",
+      "bill",
+      "finance",
+      "bank",
+      "savings",
+      "investment",
+      "portfolio",
+      "stock",
+      "crypto",
+    ],
+    features: [
+      {
+        name: "Log Expense via Siri",
+        description:
+          "Quickly log expenses with amount, category, and note through voice.",
+        surfaces: ["intent"],
+        complexity: "low",
+        featurePrompt: "Let users log expenses with amount, category, and note via Siri",
+      },
+      {
+        name: "Budget Overview Widget",
+        description:
+          "Widget showing remaining budget and spending breakdown for the month.",
+        surfaces: ["widget"],
+        complexity: "medium",
+        featurePrompt: "Show monthly budget remaining and spending breakdown on a widget",
+      },
+      {
+        name: "Quick Transfer",
+        description:
+          "Initiate a transfer between accounts with amount and description via Siri.",
+        surfaces: ["intent"],
+        complexity: "medium",
+        featurePrompt: "Let users initiate transfers between accounts via Siri",
+      },
+      {
+        name: "Spending Summary View",
+        description: "SwiftUI view with charts breaking down spending by category.",
+        surfaces: ["view"],
+        complexity: "high",
+        featurePrompt: "Create a spending summary view with category breakdown charts",
+      },
+    ],
+  },
+  {
+    domain: "commerce",
+    keywords: [
+      "shop",
+      "order",
+      "cart",
+      "product",
+      "buy",
+      "purchase",
+      "checkout",
+      "store",
+      "retail",
+      "ecommerce",
+      "delivery",
+    ],
+    features: [
+      {
+        name: "Reorder Last Purchase",
+        description: "One-tap reorder of a previous purchase through Siri.",
+        surfaces: ["intent"],
+        complexity: "low",
+        featurePrompt: "Let users reorder their last purchase via Siri",
+      },
+      {
+        name: "Order Status Widget",
+        description: "Widget showing current order status and estimated delivery.",
+        surfaces: ["widget"],
+        complexity: "low",
+        featurePrompt: "Show current order status and delivery estimate on a widget",
+      },
+      {
+        name: "Add to Cart via Siri",
+        description: "Add products to cart by name or ID through voice commands.",
+        surfaces: ["intent"],
+        complexity: "medium",
+        featurePrompt: "Let users add products to their cart by name via Siri",
+      },
+      {
+        name: "Product Search in Spotlight",
+        description: "Make products searchable through Spotlight with indexed entities.",
+        surfaces: ["intent"],
+        complexity: "medium",
+        featurePrompt: "Make products searchable in Spotlight with name and price",
+      },
+    ],
+  },
+  {
+    domain: "media",
+    keywords: [
+      "music",
+      "song",
+      "podcast",
+      "video",
+      "playlist",
+      "stream",
+      "play",
+      "track",
+      "album",
+      "artist",
+      "audio",
+      "media",
+    ],
+    features: [
+      {
+        name: "Play Content via Siri",
+        description: "Play music, podcasts, or videos by name through Siri.",
+        surfaces: ["intent"],
+        complexity: "low",
+        featurePrompt: "Let users play content by name via Siri",
+      },
+      {
+        name: "Now Playing Widget",
+        description: "Widget showing currently playing track with controls.",
+        surfaces: ["widget"],
+        complexity: "medium",
+        featurePrompt: "Show now-playing track info on a home screen widget",
+      },
+      {
+        name: "Create Playlist via Siri",
+        description: "Generate a playlist by mood or genre through voice.",
+        surfaces: ["intent"],
+        complexity: "medium",
+        featurePrompt: "Let users create a playlist by mood or genre via Siri",
+      },
+    ],
+  },
+  {
+    domain: "messaging",
+    keywords: [
+      "message",
+      "chat",
+      "send",
+      "text",
+      "email",
+      "sms",
+      "contact",
+      "conversation",
+      "communication",
+    ],
+    features: [
+      {
+        name: "Send Message via Siri",
+        description: "Send messages to contacts through Siri and Shortcuts.",
+        surfaces: ["intent"],
+        complexity: "low",
+        featurePrompt: "Let users send messages to contacts via Siri",
+      },
+      {
+        name: "Unread Messages Widget",
+        description: "Widget showing unread message count and latest sender.",
+        surfaces: ["widget"],
+        complexity: "low",
+        featurePrompt: "Show unread message count and latest messages on a widget",
+      },
+      {
+        name: "Quick Reply from Siri",
+        description: "Reply to the most recent message from a contact through voice.",
+        surfaces: ["intent"],
+        complexity: "medium",
+        featurePrompt: "Let users reply to recent messages via Siri",
+      },
+    ],
+  },
+  {
+    domain: "smart-home",
+    keywords: [
+      "thermostat",
+      "light",
+      "lock",
+      "garage",
+      "home",
+      "smart",
+      "device",
+      "temperature",
+      "sensor",
+      "automation",
+      "room",
+      "scene",
+    ],
+    features: [
+      {
+        name: "Control Device via Siri",
+        description: "Turn devices on/off or adjust settings through Siri.",
+        surfaces: ["intent"],
+        complexity: "low",
+        featurePrompt: "Let users control smart home devices via Siri",
+      },
+      {
+        name: "Room Status Widget",
+        description:
+          "Widget showing temperature, humidity, and device states for a room.",
+        surfaces: ["widget"],
+        complexity: "medium",
+        featurePrompt: "Show room temperature and device status on a home screen widget",
+      },
+      {
+        name: "Set Scene via Siri",
+        description:
+          "Activate a smart home scene (movie night, bedtime, away) through voice.",
+        surfaces: ["intent"],
+        complexity: "low",
+        featurePrompt: "Let users activate smart home scenes via Siri",
+      },
+    ],
+  },
+  {
+    domain: "navigation",
+    keywords: [
+      "map",
+      "direction",
+      "navigate",
+      "location",
+      "route",
+      "drive",
+      "walk",
+      "transit",
+      "travel",
+      "destination",
+      "gps",
+      "nearby",
+    ],
+    features: [
+      {
+        name: "Navigate to Location",
+        description: "Start navigation to an address or saved place through Siri.",
+        surfaces: ["intent"],
+        complexity: "low",
+        featurePrompt: "Let users start navigation to a destination via Siri",
+      },
+      {
+        name: "Commute Widget",
+        description: "Widget showing estimated commute time and current traffic.",
+        surfaces: ["widget"],
+        complexity: "medium",
+        featurePrompt: "Show commute time and traffic conditions on a home screen widget",
+      },
+      {
+        name: "Save Location via Siri",
+        description: "Bookmark the current location or a named place for later.",
+        surfaces: ["intent"],
+        complexity: "low",
+        featurePrompt: "Let users save locations for later via Siri",
+      },
+    ],
+  },
+];
+
+/**
+ * Suggest Apple-native features for an app based on description and domain.
+ */
+export function suggestFeatures(input: SuggestInput): FeatureSuggestion[] {
+  const limit = input.limit || 5;
+  const lower = input.appDescription.toLowerCase();
+  const explicitDomain = input.domain?.toLowerCase();
+
+  // score each domain by keyword matches
+  const domainScores = FEATURE_CATALOG.map((ds) => {
+    let score = 0;
+    if (explicitDomain === ds.domain) score += 10;
+    for (const kw of ds.keywords) {
+      if (lower.includes(kw)) score += 1;
+    }
+    return { ...ds, score };
+  })
+    .filter((ds) => ds.score > 0)
+    .sort((a, b) => b.score - a.score);
+
+  if (domainScores.length === 0) {
+    // fallback: return generic productivity suggestions
+    const fallback = FEATURE_CATALOG.find((ds) => ds.domain === "productivity");
+    if (!fallback) return [];
+    return fallback.features.slice(0, limit).map((f) => ({
+      ...f,
+      domain: "productivity",
+    }));
+  }
+
+  // collect features from matching domains, prioritizing higher-scored domains
+  const suggestions: FeatureSuggestion[] = [];
+  const seen = new Set<string>();
+
+  for (const ds of domainScores) {
+    for (const feature of ds.features) {
+      if (seen.has(feature.name)) continue;
+      seen.add(feature.name);
+      suggestions.push({ ...feature, domain: ds.domain });
+      if (suggestions.length >= limit) break;
+    }
+    if (suggestions.length >= limit) break;
+  }
+
+  return suggestions;
+}

--- a/tests/mcp/feature.test.ts
+++ b/tests/mcp/feature.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import { generateFeature } from "../../src/mcp/feature.js";
+import { suggestFeatures } from "../../src/mcp/suggest.js";
+
+describe("axint.feature", () => {
+  it("generates intent from natural language description", () => {
+    const result = generateFeature({
+      description: "Let users log water intake via Siri",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.files.length).toBeGreaterThan(0);
+
+    const intentFile = result.files.find(
+      (f) => f.type === "swift" && f.path.includes("Intent")
+    );
+    expect(intentFile).toBeDefined();
+    expect(intentFile!.content).toContain("AppIntent");
+
+    const testFile = result.files.find((f) => f.type === "test");
+    expect(testFile).toBeDefined();
+    expect(testFile!.content).toContain("XCTestCase");
+  });
+
+  it("generates intent + widget when both surfaces requested", () => {
+    const result = generateFeature({
+      description: "Track daily step count",
+      surfaces: ["intent", "widget"],
+    });
+
+    expect(result.success).toBe(true);
+
+    const swiftFiles = result.files.filter((f) => f.type === "swift");
+    expect(swiftFiles.length).toBe(2);
+
+    const widgetFile = swiftFiles.find((f) => f.path.includes("Widget"));
+    expect(widgetFile).toBeDefined();
+    expect(widgetFile!.content).toContain("Widget");
+  });
+
+  it("generates all three surfaces", () => {
+    const result = generateFeature({
+      description: "Log workouts with type and duration",
+      surfaces: ["intent", "widget", "view"],
+    });
+
+    expect(result.success).toBe(true);
+
+    const swiftFiles = result.files.filter((f) => f.type === "swift");
+    expect(swiftFiles.length).toBe(3);
+  });
+
+  it("infers health domain from description", () => {
+    const result = generateFeature({
+      description: "Let users log calories burned during exercise",
+    });
+
+    expect(result.success).toBe(true);
+    // health domain should add HealthKit entitlements
+    const entFile = result.files.find((f) => f.type === "entitlements");
+    expect(entFile).toBeDefined();
+    expect(entFile!.content).toContain("healthkit");
+  });
+
+  it("uses explicit params when provided", () => {
+    const result = generateFeature({
+      description: "Log a custom metric",
+      params: { value: "double", label: "string", timestamp: "date" },
+    });
+
+    expect(result.success).toBe(true);
+    const intentFile = result.files.find(
+      (f) => f.type === "swift" && f.path.includes("Intent")
+    );
+    expect(intentFile).toBeDefined();
+    expect(intentFile!.content).toContain("value");
+    expect(intentFile!.content).toContain("label");
+    expect(intentFile!.content).toContain("timestamp");
+  });
+
+  it("uses explicit name when provided", () => {
+    const result = generateFeature({
+      description: "Track water intake",
+      name: "HydrateNow",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.name).toBe("HydrateNow");
+    const intentFile = result.files.find((f) => f.path.includes("Intent"));
+    expect(intentFile!.path).toContain("HydrateNow");
+  });
+
+  it("includes structured file paths for Xcode agent composition", () => {
+    const result = generateFeature({
+      description: "Send a message to a contact",
+      surfaces: ["intent"],
+    });
+
+    expect(result.success).toBe(true);
+    const paths = result.files.map((f) => f.path);
+    expect(paths.some((p) => p.startsWith("Sources/"))).toBe(true);
+    expect(paths.some((p) => p.startsWith("Tests/"))).toBe(true);
+  });
+
+  it("generates summary with file listing", () => {
+    const result = generateFeature({
+      description: "Create a reminder",
+      surfaces: ["intent", "widget"],
+    });
+
+    expect(result.summary).toContain("Generated");
+    expect(result.summary).toContain("Swift file");
+    expect(result.summary).toContain("test");
+    expect(result.summary).toContain("Files:");
+  });
+});
+
+describe("axint.suggest", () => {
+  it("suggests health features for a fitness app", () => {
+    const suggestions = suggestFeatures({
+      appDescription: "A fitness tracking app that logs workouts and counts steps",
+    });
+
+    expect(suggestions.length).toBeGreaterThan(0);
+    expect(suggestions[0].domain).toBe("health");
+    expect(suggestions[0].surfaces.length).toBeGreaterThan(0);
+    expect(suggestions[0].featurePrompt).toBeTruthy();
+  });
+
+  it("suggests finance features for a budget app", () => {
+    const suggestions = suggestFeatures({
+      appDescription: "An app for tracking expenses and managing budgets",
+    });
+
+    expect(suggestions.length).toBeGreaterThan(0);
+    expect(suggestions[0].domain).toBe("finance");
+  });
+
+  it("respects explicit domain", () => {
+    const suggestions = suggestFeatures({
+      appDescription: "A general utility app",
+      domain: "smart-home",
+    });
+
+    expect(suggestions.length).toBeGreaterThan(0);
+    expect(suggestions[0].domain).toBe("smart-home");
+  });
+
+  it("respects limit", () => {
+    const suggestions = suggestFeatures({
+      appDescription: "A fitness and health tracking app",
+      limit: 3,
+    });
+
+    expect(suggestions.length).toBeLessThanOrEqual(3);
+  });
+
+  it("falls back to productivity for vague descriptions", () => {
+    const suggestions = suggestFeatures({
+      appDescription: "An app that helps users be more organized",
+    });
+
+    expect(suggestions.length).toBeGreaterThan(0);
+  });
+
+  it("each suggestion has all required fields", () => {
+    const suggestions = suggestFeatures({
+      appDescription: "A recipe and cooking app",
+    });
+
+    for (const s of suggestions) {
+      expect(s.name).toBeTruthy();
+      expect(s.description).toBeTruthy();
+      expect(s.surfaces.length).toBeGreaterThan(0);
+      expect(["low", "medium", "high"]).toContain(s.complexity);
+      expect(s.featurePrompt).toBeTruthy();
+      expect(s.domain).toBeTruthy();
+    }
+  });
+});

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -9,12 +9,22 @@
  * back to the IR-based tools. The FromIR tools and scaffold/templates work
  * natively since generators and validators are pure functions.
  *
+ * Tools:
+ *   - axint.feature:          Generate a complete Apple-native feature package
+ *   - axint.suggest:          Suggest Apple-native features for an app domain
+ *   - axint.scaffold:         Generate a starter TypeScript intent file
+ *   - axint.compile:          Compile TypeScript intent → Swift (local only)
+ *   - axint.validate:         Validate intent definition (local only)
+ *   - axint.schema.compile:   Compile JSON schema → Swift (recommended)
+ *   - axint.templates.list:   List bundled reference templates
+ *   - axint.templates.get:    Return template source by id
+ *
  * Endpoint: POST /mcp
  * Health:   GET /health
  */
 
 // Import generators + validators directly — avoids pulling in the TS parser
-import { generateSwift, generateInfoPlistFragment, generateEntitlementsFragment } from "../../../src/core/generator.js";
+import { generateSwift } from "../../../src/core/generator.js";
 import { generateSwiftUIView } from "../../../src/core/view-generator.js";
 import { generateSwiftWidget } from "../../../src/core/widget-generator.js";
 import { generateSwiftApp } from "../../../src/core/app-generator.js";
@@ -23,15 +33,30 @@ import { validateView } from "../../../src/core/view-validator.js";
 import { validateWidget } from "../../../src/core/widget-validator.js";
 import { validateApp } from "../../../src/core/app-validator.js";
 import { scaffoldIntent } from "../../../src/mcp/scaffold.js";
+import { generateFeature } from "../../../src/mcp/feature.js";
+import { suggestFeatures } from "../../../src/mcp/suggest.js";
+import type { FeatureInput, Surface } from "../../../src/mcp/feature.js";
+import type { SuggestInput } from "../../../src/mcp/suggest.js";
 import { TEMPLATES, getTemplate } from "../../../src/templates/index.js";
 import type {
-  IRIntent, IRView, IRWidget, IRWidgetEntry, IRApp, IRScene,
-  IRViewState, IRViewProp, IRParameter, IRType,
-  WidgetFamily, WidgetRefreshPolicy, SceneKind, Diagnostic,
+  IRIntent,
+  IRView,
+  IRWidget,
+  IRWidgetEntry,
+  IRApp,
+  IRScene,
+  IRViewState,
+  IRViewProp,
+  IRParameter,
+  IRType,
+  WidgetFamily,
+  WidgetRefreshPolicy,
+  SceneKind,
+  Diagnostic,
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.3.3";
+const VERSION = "0.3.7";
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",
@@ -84,7 +109,14 @@ function formatOutput(swift: string, inputTokens: number) {
   const out = Math.ceil(swift.length / 4);
   const ratio = inputTokens > 0 ? (out / inputTokens).toFixed(2) : "0.00";
   const saved = inputTokens - out;
-  return { content: [{ type: "text", text: `// In: ~${inputTokens}  Out: ~${out}  Ratio: ${ratio}x  Saved: ${saved > 0 ? `+${saved}` : saved}\n\n${swift}` }] };
+  return {
+    content: [
+      {
+        type: "text",
+        text: `// In: ~${inputTokens}  Out: ~${out}  Ratio: ${ratio}x  Saved: ${saved > 0 ? `+${saved}` : saved}\n\n${swift}`,
+      },
+    ],
+  };
 }
 
 function textResult(text: string, isError = false) {
@@ -97,91 +129,644 @@ function textResult(text: string, isError = false) {
 
 const TOOLS = [
   {
-    name: "axint_scaffold",
-    description: "Generate a starter TypeScript intent file. Pass PascalCase name, description, optional domain and params.",
+    name: "axint.feature",
+    description:
+      "Generate a complete Apple-native feature package from a description. " +
+      "Returns multiple files: validated Swift source, companion widget/view, " +
+      "Info.plist fragments, entitlements, and XCTest scaffolds — all structured " +
+      "file-by-file so an Xcode agent can write each file directly into the " +
+      "project. Designed for composition with Xcode MCP tools: call " +
+      "axint.feature to generate the package, then use XcodeWrite to place " +
+      "each file. No files written, no network requests, no side effects.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     inputSchema: {
       type: "object" as const,
       properties: {
-        name: { type: "string", description: "PascalCase intent name" },
-        description: { type: "string", description: "What the intent does" },
-        domain: { type: "string", description: "Apple App Intent domain" },
-        params: { type: "array", description: "Parameters: { name, type, description }", items: { type: "object", properties: { name: { type: "string" }, type: { type: "string" }, description: { type: "string" } }, required: ["name", "type", "description"] } },
+        description: {
+          type: "string",
+          description:
+            "What the feature does, in natural language. E.g., " +
+            "'Let users log water intake via Siri' or " +
+            "'Add a Spotlight-searchable recipe entity'. The description " +
+            "is used to infer the feature name, domain, and parameters.",
+        },
+        surfaces: {
+          type: "array",
+          items: { type: "string", enum: ["intent", "view", "widget"] },
+          description:
+            "Which Apple surfaces to generate. 'intent' produces an App Intent " +
+            "struct for Siri/Shortcuts/Spotlight. 'widget' produces a WidgetKit " +
+            "widget with timeline provider. 'view' produces a SwiftUI view. " +
+            "Defaults to ['intent'] if omitted.",
+        },
+        name: {
+          type: "string",
+          description:
+            "PascalCase feature name, e.g., 'LogWaterIntake'. If omitted, " +
+            "inferred from the description.",
+        },
+        appName: {
+          type: "string",
+          description:
+            "The target app name, used in generated comments and test " +
+            "references. E.g., 'HealthTracker'. Optional.",
+        },
+        domain: {
+          type: "string",
+          description:
+            "Apple App Intent domain. One of: messaging, productivity, health, " +
+            "finance, commerce, media, navigation, smart-home. If omitted, " +
+            "inferred from the description.",
+        },
+        params: {
+          type: "object",
+          description:
+            "Explicit parameter definitions as { fieldName: typeString }. " +
+            "E.g., { amount: 'double', unit: 'string' }. If omitted, " +
+            "inferred from the domain and description.",
+          additionalProperties: { type: "string" },
+        },
+      },
+      required: ["description"],
+    },
+  },
+  {
+    name: "axint.suggest",
+    description:
+      "Suggest Apple-native features for an app based on its domain or " +
+      "description. Returns a ranked list of features with recommended " +
+      "surfaces (intent, widget, view), estimated complexity, and a " +
+      "one-line description for each. Use this to discover what Axint " +
+      "can generate for an app before calling axint.feature. No files " +
+      "written, no network requests, no side effects.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        appDescription: {
+          type: "string",
+          description:
+            "What the app does, in natural language. E.g., " +
+            "'A fitness tracking app that logs workouts and counts steps'. " +
+            "Used to suggest relevant Apple-native features.",
+        },
+        domain: {
+          type: "string",
+          description:
+            "Primary app domain. One of: messaging, productivity, health, " +
+            "finance, commerce, media, navigation, smart-home.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of suggestions to return. Defaults to 5.",
+        },
+      },
+      required: ["appDescription"],
+    },
+  },
+  {
+    name: "axint.scaffold",
+    description:
+      "Generate a starter TypeScript intent file from a name and description. " +
+      "Returns a complete defineIntent() source string ready to save as a .ts " +
+      "file — no files are written, no network requests made. On invalid " +
+      "domain values, returns an error string. The output compiles directly " +
+      "with axint.compile. Use this when creating a new intent from scratch; " +
+      "use axint.templates.get for a working reference example, or " +
+      "axint.schema.compile to generate Swift without writing TypeScript.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description:
+            "PascalCase intent name, e.g., 'SendMessage' or 'CreateEvent'. " +
+            "Must start with an uppercase letter and contain no spaces.",
+        },
+        description: {
+          type: "string",
+          description:
+            "Human-readable description of what the intent does, shown to " +
+            "users in Shortcuts and Spotlight, e.g., 'Send a message to a contact'",
+        },
+        domain: {
+          type: "string",
+          description:
+            "Apple App Intent domain. One of: messaging, productivity, health, " +
+            "finance, commerce, media, navigation, smart-home. Omit if none apply.",
+        },
+        params: {
+          type: "array",
+          description:
+            "Initial parameters for the intent. Each item needs name (camelCase), " +
+            "type (string | int | double | float | boolean | date | duration | url), " +
+            "and description. Example: { name: 'recipient', type: 'string', " +
+            "description: 'Contact to message' }.",
+          items: {
+            type: "object",
+            description: "Parameter definition with name, type, and description",
+            properties: {
+              name: {
+                type: "string",
+                description:
+                  "camelCase parameter name, e.g., 'recipient' or 'messageBody'. " +
+                  "Used as the Swift property name in the generated AppIntent struct.",
+              },
+              type: {
+                type: "string",
+                description:
+                  "Parameter type. One of: string, int, double, float, boolean, " +
+                  "date, duration, url. Maps to the corresponding Swift type.",
+              },
+              description: {
+                type: "string",
+                description:
+                  "Human-readable description shown in Shortcuts and Spotlight " +
+                  "when users configure the intent parameter.",
+              },
+            },
+            required: ["name", "type", "description"],
+          },
+        },
       },
       required: ["name", "description"],
     },
   },
   {
-    name: "axint_compile",
-    description: "Compile TypeScript intent → Swift. Note: on this remote endpoint, use axint_compile_from_schema for best results. Full TS compilation is available via the CLI (`npx @axintai/compiler axint-mcp`).",
+    name: "axint.compile",
+    description:
+      "Compile TypeScript source (defineIntent() call) into native Swift " +
+      "App Intent code. Note: on this remote endpoint, full TS compilation " +
+      "is not available — use axint.schema.compile for best results. Full " +
+      "TS compilation is available via the CLI (npx @axintai/compiler axint-mcp).",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     inputSchema: {
       type: "object" as const,
       properties: {
-        source: { type: "string", description: "TypeScript source" },
-        fileName: { type: "string" },
-        emitInfoPlist: { type: "boolean" },
-        emitEntitlements: { type: "boolean" },
+        source: {
+          type: "string",
+          description:
+            "Full TypeScript source code containing a defineIntent() call. " +
+            "Must be a complete file starting with an axint import, not a fragment.",
+        },
+        fileName: {
+          type: "string",
+          description:
+            "Optional file name used in diagnostic messages, e.g., 'SendMessage.intent.ts'. " +
+            "Defaults to 'input.ts' if omitted.",
+        },
+        emitInfoPlist: {
+          type: "boolean",
+          description:
+            "When true, returns an Info.plist XML fragment declaring the intent's " +
+            "infoPlistKeys. Only relevant for intents that use restricted APIs. " +
+            "Defaults to false.",
+        },
+        emitEntitlements: {
+          type: "boolean",
+          description:
+            "When true, returns an .entitlements XML fragment for the intent's " +
+            "declared entitlements. Only relevant for intents requiring special " +
+            "capabilities. Defaults to false.",
+        },
       },
       required: ["source"],
     },
   },
   {
-    name: "axint_validate",
-    description: "Validate a TypeScript intent definition. Note: on this remote endpoint, use axint_compile_from_schema for validation. Full TS validation available via CLI.",
+    name: "axint.validate",
+    description:
+      "Validate a TypeScript intent definition without generating Swift " +
+      "output. Note: on this remote endpoint, use axint.schema.compile " +
+      "for validation. Full TS validation available via CLI.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     inputSchema: {
       type: "object" as const,
-      properties: { source: { type: "string" } },
+      properties: {
+        source: {
+          type: "string",
+          description:
+            "Full TypeScript source code containing a defineIntent() call. " +
+            "Must be a complete file starting with an axint import, not a " +
+            "code fragment. Same format accepted by axint.compile.",
+        },
+      },
       required: ["source"],
     },
   },
   {
-    name: "axint_compile_from_schema",
-    description: "Compile minimal JSON schema → Swift. Supports intents, views, widgets, apps. ~20 tokens input vs hundreds for full TS. Recommended for remote usage.",
+    name: "axint.schema.compile",
+    description:
+      "Compile a minimal JSON schema directly to Swift, bypassing the " +
+      "TypeScript DSL entirely. Supports intents, views, widgets, and " +
+      "full apps via the 'type' parameter. Uses ~20 input tokens vs " +
+      "hundreds for TypeScript — ideal for LLM agents optimizing token " +
+      "budgets. Returns Swift source with token usage stats; no files " +
+      "written, no network requests. On invalid input, returns an error " +
+      "message describing the issue. Use this for quick Swift generation " +
+      "without writing TypeScript; use axint.compile when you need the " +
+      "full DSL for complex intents with custom perform() logic.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     inputSchema: {
       type: "object" as const,
       properties: {
-        type: { type: "string", enum: ["intent", "view", "widget", "app"] },
-        name: { type: "string", description: "PascalCase name" },
-        title: { type: "string" },
-        description: { type: "string" },
-        domain: { type: "string" },
-        params: { type: "object", additionalProperties: { type: "string" } },
-        props: { type: "object", additionalProperties: { type: "string" } },
-        state: { type: "object" },
-        body: { type: "string" },
-        displayName: { type: "string" },
-        families: { type: "array", items: { type: "string" } },
-        entry: { type: "object", additionalProperties: { type: "string" } },
-        refreshInterval: { type: "number" },
-        scenes: { type: "array", items: { type: "object", properties: { kind: { type: "string" }, view: { type: "string" }, title: { type: "string" }, name: { type: "string" }, platform: { type: "string" } }, required: ["kind", "view"] } },
+        type: {
+          type: "string",
+          enum: ["intent", "view", "widget", "app"],
+          description:
+            "What to compile. Determines which other parameters are relevant: " +
+            "intent uses params/domain/title; view uses props/state/body; " +
+            "widget uses entry/families/body/displayName; app uses scenes.",
+        },
+        name: {
+          type: "string",
+          description:
+            "PascalCase name, e.g., 'CreateEvent' for intents, 'EventListView' " +
+            "for views, 'StepsWidget' for widgets. Used as the Swift struct name.",
+        },
+        title: {
+          type: "string",
+          description:
+            "Human-readable title shown in Shortcuts/Spotlight. Intent only. " +
+            "E.g., 'Create Event'. Defaults to a space-separated version of name.",
+        },
+        description: {
+          type: "string",
+          description:
+            "Description of what this intent/view/widget does. Shown to users " +
+            "in system UI for intents. Optional but recommended.",
+        },
+        domain: {
+          type: "string",
+          description:
+            "Apple App Intent domain. Intent only. One of: messaging, " +
+            "productivity, health, finance, commerce, media, navigation, " +
+            "smart-home. Omit if no standard domain applies.",
+        },
+        params: {
+          type: "object",
+          description:
+            "Intent only. Parameter definitions as { fieldName: typeString }. " +
+            "E.g., { recipient: 'string', amount: 'double' }. Supported types: " +
+            "string, int, double, float, boolean, date, duration, url.",
+          additionalProperties: {
+            type: "string",
+            description:
+              "Swift type for this parameter: string, int, double, float, boolean, date, duration, or url",
+          },
+        },
+        props: {
+          type: "object",
+          description:
+            "View only. Prop definitions as { fieldName: typeString }. " +
+            "E.g., { title: 'string', count: 'int' }. Same type set as params.",
+          additionalProperties: {
+            type: "string",
+            description:
+              "Swift type for this prop: string, int, double, float, boolean, date, duration, or url",
+          },
+        },
+        state: {
+          type: "object",
+          description:
+            "View only. State variable definitions as " +
+            "{ fieldName: { type: 'string', default?: value } }. " +
+            "Generates @State properties in the SwiftUI view.",
+          additionalProperties: {
+            type: "object",
+            description: "State variable config with type and optional default value",
+            properties: {
+              type: {
+                type: "string",
+                description:
+                  "Swift type: string, int, double, float, boolean, date, duration, or url",
+              },
+              default: {
+                type: "string",
+                description: "Optional default value for the @State property",
+              },
+            },
+            required: ["type"],
+          },
+        },
+        body: {
+          type: "string",
+          description:
+            "View/widget only. Raw SwiftUI code for the body, e.g., " +
+            "'VStack { Text(\"Hello\") }'. Wrapped in the struct automatically. " +
+            "Can reference props, state, and entry fields by name.",
+        },
+        displayName: {
+          type: "string",
+          description:
+            "Widget only. Human-readable name shown in the widget gallery. " +
+            "E.g., 'Daily Steps'. Defaults to a spaced version of name.",
+        },
+        families: {
+          type: "array",
+          items: {
+            type: "string",
+            description:
+              "Widget family: systemSmall, systemMedium, systemLarge, systemExtraLarge, accessoryCircular, accessoryRectangular, or accessoryInline",
+          },
+          description:
+            "Widget only. Supported widget sizes: systemSmall, systemMedium, " +
+            "systemLarge, systemExtraLarge, accessoryCircular, " +
+            "accessoryRectangular, accessoryInline. Defaults to [systemSmall].",
+        },
+        entry: {
+          type: "object",
+          description:
+            "Widget only. Timeline entry fields as { fieldName: typeString }. " +
+            "E.g., { steps: 'int', date: 'date' }. Available in the body template.",
+          additionalProperties: {
+            type: "string",
+            description:
+              "Swift type for this entry field: string, int, double, float, boolean, date, duration, or url",
+          },
+        },
+        refreshInterval: {
+          type: "number",
+          description:
+            "Widget only. Timeline refresh interval in minutes. " +
+            "E.g., 30 for half-hourly updates. Defaults to 60.",
+        },
+        scenes: {
+          type: "array",
+          items: {
+            type: "object",
+            description: "Scene definition with kind, view, and optional title/platform",
+            properties: {
+              kind: {
+                type: "string",
+                enum: ["windowGroup", "window", "documentGroup", "settings"],
+                description:
+                  "Scene type. windowGroup is most common for single-window apps.",
+              },
+              view: {
+                type: "string",
+                description:
+                  "Root SwiftUI view name, e.g., 'ContentView'. Must be defined elsewhere.",
+              },
+              title: {
+                type: "string",
+                description: "Window title shown in the title bar",
+              },
+              name: {
+                type: "string",
+                description: "Unique scene identifier for programmatic access",
+              },
+              platform: {
+                type: "string",
+                enum: ["macOS", "iOS", "visionOS"],
+                description:
+                  "Platform guard — wraps scene in #if os(...). Omit for cross-platform.",
+              },
+            },
+            required: ["kind", "view"],
+          },
+          description:
+            "App only. Scene definitions for the @main App struct. " +
+            "At least one scene with kind 'windowGroup' is typically required.",
+        },
       },
       required: ["type", "name"],
     },
   },
   {
-    name: "axint_list_templates",
-    description: "List bundled reference templates.",
-    inputSchema: { type: "object" as const, properties: {} },
-  },
-  {
-    name: "axint_template",
-    description: "Return the full source of a bundled template by id.",
+    name: "axint.templates.list",
+    description:
+      "List all bundled reference templates available in the axint SDK. " +
+      "Returns an array of { id, name, description } objects — one per " +
+      "template. No parameters, no files written, no network requests, " +
+      "no side effects. Use this to discover template ids, then call " +
+      "axint.templates.get with a specific id to retrieve the full source. " +
+      "Unlike axint.scaffold which generates from parameters, templates " +
+      "are complete working examples with perform() logic included.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     inputSchema: {
       type: "object" as const,
-      properties: { id: { type: "string" } },
+    },
+  },
+  {
+    name: "axint.templates.get",
+    description:
+      "Return the full TypeScript source code of a bundled reference " +
+      "template by id. Returns a complete defineIntent() file that " +
+      "compiles with axint.compile — no files written, no network " +
+      "requests. Returns an error message if the id is not found. " +
+      "Call axint.templates.list first to discover valid ids. Unlike " +
+      "axint.scaffold which generates a skeleton, templates include " +
+      "complete perform() logic and are ready to use as-is.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: {
+          type: "string",
+          description:
+            "Template id from axint.templates.list, e.g., 'send-message' " +
+            "or 'create-event'. Case-sensitive, kebab-case format.",
+        },
+      },
       required: ["id"],
     },
   },
 ];
 
+// --- Prompts ---
+
+const PROMPTS = [
+  {
+    name: "axint.quick-start",
+    description:
+      "Step-by-step guide to compile your first TypeScript intent into " +
+      "Swift using Axint. Walks through scaffold → compile → integrate.",
+  },
+  {
+    name: "axint.create-widget",
+    description:
+      "Generate a SwiftUI widget from a description. Produces a complete " +
+      "widget with timeline provider, entry type, and view body.",
+    arguments: [
+      {
+        name: "widgetName",
+        description: "PascalCase widget name, e.g., 'StepsWidget'",
+        required: true,
+      },
+      {
+        name: "widgetDescription",
+        description: "What the widget displays, e.g., 'daily step count from HealthKit'",
+        required: true,
+      },
+    ],
+  },
+  {
+    name: "axint.create-intent",
+    description:
+      "Generate a complete App Intent from a natural language description. " +
+      "Produces TypeScript source and compiles it to Swift in one step.",
+    arguments: [
+      {
+        name: "intentName",
+        description: "PascalCase intent name, e.g., 'SendMessage'",
+        required: true,
+      },
+      {
+        name: "intentDescription",
+        description: "What the intent does, e.g., 'Send a message to a contact'",
+        required: true,
+      },
+      {
+        name: "domain",
+        description:
+          "Apple domain: messaging, productivity, health, finance, " +
+          "commerce, media, navigation, smart-home. Omit if none apply.",
+        required: false,
+      },
+    ],
+  },
+];
+
+function getPromptMessages(name: string, args?: Record<string, string>) {
+  if (name === "axint.quick-start") {
+    return {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text:
+              "I want to create my first Apple App Intent using Axint. " +
+              "Walk me through the process step by step:\n\n" +
+              "1. First, use axint.templates.list to show me available templates\n" +
+              "2. Pick a simple one and show me its source with axint.templates.get\n" +
+              "3. Compile it to Swift with axint.compile\n" +
+              "4. Explain what each part of the Swift output does",
+          },
+        },
+      ],
+    };
+  }
+
+  if (name === "axint.create-widget") {
+    const widgetName = args?.widgetName || "MyWidget";
+    const widgetDescription = args?.widgetDescription || "a simple widget";
+    return {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text:
+              `Create a SwiftUI widget called "${widgetName}" that shows ${widgetDescription}. ` +
+              "Use axint.schema.compile with type 'widget' to generate the Swift code. " +
+              "Include appropriate families, entry fields, and a clean SwiftUI body. " +
+              "Show the final Swift output ready to drop into an Xcode project.",
+          },
+        },
+      ],
+    };
+  }
+
+  if (name === "axint.create-intent") {
+    const intentName = args?.intentName || "MyIntent";
+    const intentDescription = args?.intentDescription || "a custom action";
+    const domain = args?.domain ? ` in the ${args.domain} domain` : "";
+    return {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text:
+              `Create an App Intent called "${intentName}" that ${intentDescription}${domain}. ` +
+              "Use axint.scaffold to generate the TypeScript source with appropriate parameters, " +
+              "then compile it to Swift with axint.compile. Show both the TypeScript input and " +
+              "the Swift output so I can see the full pipeline.",
+          },
+        },
+      ],
+    };
+  }
+
+  return {
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Unknown prompt: ${name}. Use axint.quick-start, axint.create-widget, or axint.create-intent.`,
+        },
+      },
+    ],
+  };
+}
+
 // --- Tool dispatch ---
 
 type SchemaArgs = {
-  type: string; name: string; title?: string; description?: string; domain?: string;
-  params?: Record<string, string>; props?: Record<string, string>;
-  state?: Record<string, { type: string; default?: unknown }>; body?: string;
-  displayName?: string; families?: string[]; entry?: Record<string, string>;
+  type: string;
+  name: string;
+  title?: string;
+  description?: string;
+  domain?: string;
+  params?: Record<string, string>;
+  props?: Record<string, string>;
+  state?: Record<string, { type: string; default?: unknown }>;
+  body?: string;
+  displayName?: string;
+  families?: string[];
+  entry?: Record<string, string>;
   refreshInterval?: number;
-  scenes?: Array<{ kind: string; view: string; title?: string; name?: string; platform?: string }>;
+  scenes?: Array<{
+    kind: string;
+    view: string;
+    title?: string;
+    name?: string;
+    platform?: string;
+  }>;
 };
 
 function compileFromSchema(args: SchemaArgs) {
@@ -190,47 +775,122 @@ function compileFromSchema(args: SchemaArgs) {
   if (args.type === "intent") {
     if (!args.name) return textResult("[AX002] error: requires 'name'", true);
     const parameters: IRParameter[] = args.params
-      ? Object.entries(args.params).map(([name, t]) => ({ name, type: schemaTypeToIRType(t), title: name.replace(/([A-Z])/g, " $1").trim(), description: "", isOptional: false }))
+      ? Object.entries(args.params).map(([name, t]) => ({
+          name,
+          type: schemaTypeToIRType(t),
+          title: name.replace(/([A-Z])/g, " $1").trim(),
+          description: "",
+          isOptional: false,
+        }))
       : [];
-    const ir: IRIntent = { name: args.name, title: args.title || args.name.replace(/([A-Z])/g, " $1").trim(), description: args.description || "", domain: args.domain, parameters, returnType: { kind: "primitive", value: "string" }, sourceFile: "<schema>" };
+    const ir: IRIntent = {
+      name: args.name,
+      title: args.title || args.name.replace(/([A-Z])/g, " $1").trim(),
+      description: args.description || "",
+      domain: args.domain,
+      parameters,
+      returnType: { kind: "primitive", value: "string" },
+      sourceFile: "<schema>",
+    };
     const diags = validateIntent(ir);
-    if (diags.some((d) => d.severity === "error")) return textResult(diagText(diags), true);
+    if (diags.some((d) => d.severity === "error"))
+      return textResult(diagText(diags), true);
     const swift = generateSwift(ir);
     return formatOutput(swift, inputTokens);
   }
 
   if (args.type === "view") {
     if (!args.name) return textResult("[AX301] error: requires 'name'", true);
-    const props: IRViewProp[] = args.props ? Object.entries(args.props).map(([name, t]) => ({ name, type: schemaTypeToIRType(t), isOptional: false })) : [];
-    const state: IRViewState[] = args.state ? Object.entries(args.state).map(([name, cfg]) => ({ name, type: schemaTypeToIRType(cfg.type || "string"), kind: "state" as const, defaultValue: cfg.default })) : [];
-    const ir: IRView = { name: args.name, props, state, body: args.body ? [{ kind: "raw", swift: args.body }] : [{ kind: "text", content: "VStack {}" }], sourceFile: "<schema>" };
+    const props: IRViewProp[] = args.props
+      ? Object.entries(args.props).map(([name, t]) => ({
+          name,
+          type: schemaTypeToIRType(t),
+          isOptional: false,
+        }))
+      : [];
+    const state: IRViewState[] = args.state
+      ? Object.entries(args.state).map(([name, cfg]) => ({
+          name,
+          type: schemaTypeToIRType(cfg.type || "string"),
+          kind: "state" as const,
+          defaultValue: cfg.default,
+        }))
+      : [];
+    const ir: IRView = {
+      name: args.name,
+      props,
+      state,
+      body: args.body
+        ? [{ kind: "raw", swift: args.body }]
+        : [{ kind: "text", content: "VStack {}" }],
+      sourceFile: "<schema>",
+    };
     const diags = validateView(ir);
-    if (diags.some((d) => d.severity === "error")) return textResult(diagText(diags), true);
+    if (diags.some((d) => d.severity === "error"))
+      return textResult(diagText(diags), true);
     const swift = generateSwiftUIView(ir);
     return formatOutput(swift, inputTokens);
   }
 
   if (args.type === "widget") {
     if (!args.name) return textResult("[AX402] error: requires 'name'", true);
-    if (!args.displayName) return textResult("[AX403] error: requires 'displayName'", true);
-    const entries: IRWidgetEntry[] = args.entry ? Object.entries(args.entry).map(([name, t]) => ({ name, type: schemaTypeToIRType(t) })) : [];
-    const validFamilies = new Set(["systemSmall", "systemMedium", "systemLarge", "systemExtraLarge", "accessoryCircular", "accessoryRectangular", "accessoryInline"]);
-    const families = (args.families || ["systemSmall"]).filter((f): f is WidgetFamily => validFamilies.has(f));
+    if (!args.displayName)
+      return textResult("[AX403] error: requires 'displayName'", true);
+    const entries: IRWidgetEntry[] = args.entry
+      ? Object.entries(args.entry).map(([name, t]) => ({
+          name,
+          type: schemaTypeToIRType(t),
+        }))
+      : [];
+    const validFamilies = new Set([
+      "systemSmall",
+      "systemMedium",
+      "systemLarge",
+      "systemExtraLarge",
+      "accessoryCircular",
+      "accessoryRectangular",
+      "accessoryInline",
+    ]);
+    const families = (args.families || ["systemSmall"]).filter((f): f is WidgetFamily =>
+      validFamilies.has(f)
+    );
     const refreshPolicy: WidgetRefreshPolicy = args.refreshInterval ? "after" : "atEnd";
-    const ir: IRWidget = { name: args.name, displayName: args.displayName, description: args.description || "", families, entry: entries, body: args.body ? [{ kind: "raw", swift: args.body }] : [{ kind: "text", content: "Hello" }], refreshInterval: args.refreshInterval, refreshPolicy, sourceFile: "<schema>" };
+    const ir: IRWidget = {
+      name: args.name,
+      displayName: args.displayName,
+      description: args.description || "",
+      families,
+      entry: entries,
+      body: args.body
+        ? [{ kind: "raw", swift: args.body }]
+        : [{ kind: "text", content: "Hello" }],
+      refreshInterval: args.refreshInterval,
+      refreshPolicy,
+      sourceFile: "<schema>",
+    };
     const diags = validateWidget(ir);
-    if (diags.some((d) => d.severity === "error")) return textResult(diagText(diags), true);
+    if (diags.some((d) => d.severity === "error"))
+      return textResult(diagText(diags), true);
     const swift = generateSwiftWidget(ir);
     return formatOutput(swift, inputTokens);
   }
 
   if (args.type === "app") {
     if (!args.name) return textResult("[AX502] error: requires 'name'", true);
-    if (!args.scenes?.length) return textResult("[AX503] error: requires at least one scene", true);
-    const scenes: IRScene[] = (args.scenes || []).map((s, i) => ({ sceneKind: toSceneKind(s.kind), rootView: s.view, title: s.title, name: s.name, platformGuard: toPlatformGuard(s.platform), isDefault: i === 0 && (s.kind || "windowGroup") === "windowGroup" }));
+    if (!args.scenes?.length)
+      return textResult("[AX503] error: requires at least one scene", true);
+    const scenes: IRScene[] = (args.scenes || []).map((s, i) => ({
+      sceneKind: toSceneKind(s.kind),
+      rootView: s.view,
+      title: s.title,
+      name: s.name,
+      platformGuard: toPlatformGuard(s.platform),
+      isDefault: i === 0 && (s.kind || "windowGroup") === "windowGroup",
+    }));
     const ir: IRApp = { name: args.name, scenes, sourceFile: "<schema>" };
     const diags = validateApp(ir);
-    if (diags.some((d) => d.severity === "error")) return textResult(diagText(diags), true);
+    if (diags.some((d) => d.severity === "error"))
+      return textResult(diagText(diags), true);
     const swift = generateSwiftApp(ir);
     return formatOutput(swift, inputTokens);
   }
@@ -239,31 +899,85 @@ function compileFromSchema(args: SchemaArgs) {
 }
 
 function handleTool(name: string, args: Record<string, unknown>) {
-  if (name === "axint_scaffold") {
-    const a = args as { name: string; description: string; domain?: string; params?: Array<{ name: string; type: string; description: string }> };
+  if (name === "axint.feature") {
+    const a = args as unknown as FeatureInput;
+    if (!a.description)
+      return textResult("Error: 'description' is required for axint.feature", true);
+    const result = generateFeature({
+      description: a.description,
+      surfaces: a.surfaces as Surface[] | undefined,
+      name: a.name,
+      appName: a.appName,
+      domain: a.domain,
+      params: a.params,
+    });
+    const output: string[] = [result.summary, ""];
+    for (const file of result.files) {
+      output.push(`// ─── ${file.path} ───`);
+      output.push(file.content);
+      output.push("");
+    }
+    if (result.diagnostics.length > 0) {
+      output.push("// ─── Diagnostics ───");
+      output.push(result.diagnostics.join("\n"));
+    }
+    return {
+      content: [{ type: "text", text: output.join("\n") }],
+      isError: !result.success,
+    };
+  }
+
+  if (name === "axint.suggest") {
+    const a = args as unknown as SuggestInput;
+    if (!a.appDescription)
+      return textResult("Error: 'appDescription' is required for axint.suggest", true);
+    const suggestions = suggestFeatures(a);
+    const output = suggestions
+      .map((s, i) => {
+        const surfaces = s.surfaces.join(", ");
+        return `${i + 1}. ${s.name}\n   ${s.description}\n   Surfaces: ${surfaces} | Complexity: ${s.complexity}\n   Prompt: "${s.featurePrompt}"`;
+      })
+      .join("\n\n");
+    return textResult(
+      suggestions.length > 0
+        ? `Suggested Apple-native features:\n\n${output}\n\nUse axint.feature with any prompt above to generate the full feature package.`
+        : "No specific suggestions for this app description. Try providing more detail about the app's purpose."
+    );
+  }
+
+  if (name === "axint.scaffold") {
+    const a = args as {
+      name: string;
+      description: string;
+      domain?: string;
+      params?: Array<{ name: string; type: string; description: string }>;
+    };
     return textResult(scaffoldIntent(a));
   }
 
-  if (name === "axint_compile" || name === "axint_validate") {
+  if (name === "axint.compile" || name === "axint.validate") {
     return textResult(
       "Full TypeScript compilation requires the local MCP server (`npx @axintai/compiler axint-mcp`). " +
-      "Use axint_compile_from_schema instead — it accepts a minimal JSON schema and produces identical Swift output with fewer tokens.",
+        "Use axint.schema.compile instead — it accepts a minimal JSON schema and produces identical Swift output with fewer tokens.",
       true
     );
   }
 
-  if (name === "axint_compile_from_schema") {
+  if (name === "axint.schema.compile") {
     return compileFromSchema(args as unknown as SchemaArgs);
   }
 
-  if (name === "axint_list_templates") {
-    const list = TEMPLATES.map((t) => `${t.id}  —  ${t.title}${t.domain ? ` [${t.domain}]` : ""}`).join("\n");
+  if (name === "axint.templates.list") {
+    const list = TEMPLATES.map(
+      (t) => `${t.id}  —  ${t.title}${t.domain ? ` [${t.domain}]` : ""}`
+    ).join("\n");
     return textResult(list || "No templates registered.");
   }
 
-  if (name === "axint_template") {
+  if (name === "axint.templates.get") {
     const tpl = getTemplate((args as { id: string }).id);
-    if (!tpl) return textResult(`Unknown template id: ${(args as { id: string }).id}`, true);
+    if (!tpl)
+      return textResult(`Unknown template id: ${(args as { id: string }).id}`, true);
     return textResult(tpl.source);
   }
 
@@ -304,7 +1018,7 @@ export default {
     if (method === "initialize") {
       return jsonrpc(id, {
         protocolVersion: "2025-03-26",
-        capabilities: { tools: {} },
+        capabilities: { tools: {}, prompts: {} },
         serverInfo: { name: "axint", version: VERSION },
       });
     }
@@ -319,13 +1033,31 @@ export default {
 
     if (method === "tools/call") {
       const toolName = (params as { name?: string })?.name;
-      const toolArgs = ((params as { arguments?: Record<string, unknown> })?.arguments || {}) as Record<string, unknown>;
+      const toolArgs = ((params as { arguments?: Record<string, unknown> })?.arguments ||
+        {}) as Record<string, unknown>;
       if (!toolName) return jsonrpcError(id, -32602, "Missing tool name");
       try {
         return jsonrpc(id, handleTool(toolName, toolArgs));
       } catch (err) {
-        return jsonrpc(id, textResult(`Tool error: ${err instanceof Error ? err.message : String(err)}`, true));
+        return jsonrpc(
+          id,
+          textResult(
+            `Tool error: ${err instanceof Error ? err.message : String(err)}`,
+            true
+          )
+        );
       }
+    }
+
+    if (method === "prompts/list") {
+      return jsonrpc(id, { prompts: PROMPTS });
+    }
+
+    if (method === "prompts/get") {
+      const promptName = (params as { name?: string })?.name;
+      const promptArgs = (params as { arguments?: Record<string, string> })?.arguments;
+      if (!promptName) return jsonrpcError(id, -32602, "Missing prompt name");
+      return jsonrpc(id, getPromptMessages(promptName, promptArgs));
     }
 
     return jsonrpcError(id, -32601, `Unknown method: ${method}`);


### PR DESCRIPTION
Adds the hero tools for Xcode 26.3 agentic coding composition:

- axint.feature: complete Apple-native feature package from a description (intent + widget + view + plist + entitlements + tests)
- axint.suggest: domain-aware feature advisor with 35+ suggestions across 8 Apple domains
- axint xcode setup/verify: one-command MCP configuration for Claude Code and Codex
- 14 new tests, 416 total passing

The composition model: Axint generates validated Apple-native code, Xcode MCP writes/builds/tests it.