### PR TITLE
clean last axintai refs from spm plugins, lockfile, and cli

### DIFF
--- a/extensions/claude-desktop/server/index.js
+++ b/extensions/claude-desktop/server/index.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-// Thin launcher — delegates to the published @axintai/compiler MCP server.
+// Thin launcher — delegates to the published @axint/compiler MCP server.
 // This file exists so the .mcpb bundle has a local entry point. In production
-// the manifest's mcp_config uses `npx -y @axintai/compiler axint-mcp` directly,
+// the manifest's mcp_config uses `npx -y @axint/compiler axint-mcp` directly,
 // but some environments prefer a bundled script.
 
 import { createRequire } from "node:module";
@@ -15,11 +15,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 try {
   // Prefer locally installed compiler
   const require = createRequire(join(__dirname, "package.json"));
-  const entry = require.resolve("@axintai/compiler/mcp");
+  const entry = require.resolve("@axint/compiler/mcp");
   await import(entry);
 } catch {
   // Fall back to npx
-  execFileSync("npx", ["-y", "@axintai/compiler", "axint-mcp"], {
+  execFileSync("npx", ["-y", "@axint/compiler", "axint-mcp"], {
     stdio: "inherit",
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@axintai/compiler",
+  "name": "@axint/compiler",
   "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@axintai/compiler",
+      "name": "@axint/compiler",
       "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 
 [[tool.mypy.overrides]]
-module = "axintai.mcp_server"
+module = "axint.mcp_server"
 ignore_errors = true
 
 [[tool.mypy.overrides]]

--- a/spm-plugin/Plugins/AxintCompilePlugin/AxintCompilePlugin.swift
+++ b/spm-plugin/Plugins/AxintCompilePlugin/AxintCompilePlugin.swift
@@ -51,14 +51,14 @@ struct AxintCompilePlugin: BuildToolPlugin {
 
     /// Returns (executable, prefixArgs). When `axint` is in PATH the prefix
     /// is empty. When only `npx` is available, the prefix contains the flags
-    /// needed to install and run the @axintai/compiler package.
+    /// needed to install and run the @axint/compiler package.
     private func resolveCompiler() throws -> (Path, [String]) {
         if let axintPath = try findInPath("axint") {
             return (axintPath, [])
         }
 
         if let npxPath = try findInPath("npx") {
-            return (npxPath, ["-y", "-p", "@axintai/compiler", "axint"])
+            return (npxPath, ["-y", "-p", "@axint/compiler", "axint"])
         }
 
         throw AxintPluginError.executableNotFound(
@@ -66,7 +66,7 @@ struct AxintCompilePlugin: BuildToolPlugin {
             The 'axint' compiler was not found in your PATH.
 
             Install it globally:
-              npm install -g @axintai/compiler
+              npm install -g @axint/compiler
 
             Or ensure Node.js and npx are available so the plugin can
             fetch the compiler automatically.

--- a/spm-plugin/Plugins/AxintValidatePlugin/AxintValidatePlugin.swift
+++ b/spm-plugin/Plugins/AxintValidatePlugin/AxintValidatePlugin.swift
@@ -43,14 +43,14 @@ struct AxintValidatePlugin: BuildToolPlugin {
             return (axintPath, [])
         }
         if let npxPath = try findInPath("npx") {
-            return (npxPath, ["-y", "-p", "@axintai/compiler", "axint"])
+            return (npxPath, ["-y", "-p", "@axint/compiler", "axint"])
         }
         throw AxintValidateError.executableNotFound(
             """
             The 'axint' compiler was not found in your PATH.
 
             Install it globally:
-              npm install -g @axintai/compiler
+              npm install -g @axint/compiler
 
             Or ensure Node.js and npx are available so the plugin can
             fetch the compiler automatically.

--- a/src/cli/add.ts
+++ b/src/cli/add.ts
@@ -8,7 +8,7 @@ export function registerAdd(program: Command, version: string) {
     .description("Install a template from the Axint Registry")
     .argument(
       "<package>",
-      "Template to install (e.g., @axintai/create-event or @axintai/create-event@1.0.0)"
+      "Template to install (e.g., @axint/create-event or @axint/create-event@1.0.0)"
     )
     .option("--to <dir>", "Target directory", "intents")
     .action(async (pkg: string, options: { to: string }) => {

--- a/src/core/compiler.ts
+++ b/src/core/compiler.ts
@@ -119,7 +119,7 @@ export function compileSource(
  * Used by:
  *   - `compileSource()` after its own parse step
  *   - `axint compile --from-ir <file.json>` for cross-language pipelines
- *   - The Python SDK's `axintai compile` command
+ *   - The Python SDK's `axint-py compile` command
  */
 export function compileFromIR(
   ir: IRIntent,


### PR DESCRIPTION
Catches the remaining 7 files Codex flagged: SPM plugin Swift files, package-lock.json, claude-desktop server launcher, add.ts registry example, compiler.ts comment, and root pyproject.toml mypy override.