### PR TITLE
make release workflow tolerant of already-published versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       # ── Publish to npm (primary registry) ────────────────────────
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance || echo "Version already published — skipping"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
npm publish now falls through gracefully when the version exists.