### PR TITLE
feat: deepen vscode extension workflows

### DIFF
--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Align marketplace packaging with `@axint/compiler` v0.3.8
 - Document the current Axint MCP surface: 10 tools + 3 built-in prompts
 - Package the extension for marketplace-ready installation via `agenticempire.axint`
+- Add command-palette workflows for Swift preview, validation, template browse, docs, and registry
 
 ## [0.3.2] - 2026-04-12
 

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,6 +1,6 @@
 # Axint — VS Code Extension
 
-Compile TypeScript into native Apple capabilities from VS Code. Uses the Model Context Protocol to give Copilot and other AI assistants access to the Axint compiler.
+Compile TypeScript into native Apple capabilities from VS Code. Axint now does more than register MCP: it can preview generated Swift, validate the current file, browse bundled templates, and jump directly into the registry and docs.
 
 ## Install
 
@@ -15,6 +15,14 @@ ext install agenticempire.axint
 Registers the Axint MCP server so VS Code agents can call the same ten tools
 and three built-in prompts available in the CLI integrations.
 
+It also adds command-palette workflows for:
+
+- **Axint: Preview Swift for Current File** — compile the active Axint source and open generated Swift beside it
+- **Axint: Validate Current File** — run the compiler/validator and surface diagnostics in Problems
+- **Axint: Browse Bundled Templates** — explore built-in Axint templates from inside VS Code
+- **Axint: Open Registry** — jump straight to `registry.axint.ai`
+- **Axint: Open Docs** — open `docs.axint.ai`
+
 Key tools:
 
 - **axint.feature** — Generate a complete Apple-native feature package
@@ -27,12 +35,21 @@ Key tools:
 
 Works with GitHub Copilot in agent mode and any VS Code AI feature that supports MCP.
 
+## Editor Workflow
+
+1. Open an Axint TypeScript file.
+2. Run `Axint: Preview Swift for Current File` from the command palette.
+3. Axint compiles the file with `@axint/compiler`, shows diagnostics in Problems, and opens generated Swift in a split editor.
+4. Use `Axint: Validate Current File` for a fast validation-only pass while editing.
+
+This gives you a tighter “edit -> compile -> inspect Swift” loop without leaving VS Code.
+
 ## Requirements
 
 - VS Code 1.102 or later
 - Node.js 22+
 
-The extension runs `npx @axint/compiler axint-mcp` under the hood — no global install needed.
+The extension runs `npx @axint/compiler axint-mcp` under the hood for MCP, and `npx @axint/compiler compile ... --json` for editor commands. No global install needed.
 
 ## Links
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Axint — App Intents Compiler",
   "version": "0.3.8",
   "publisher": "agenticempire",
-  "description": "Compile TypeScript into native Apple App Intents. Scaffold, compile, validate, and browse templates — all from your editor.",
+  "description": "Preview, validate, and browse Apple-native Axint surfaces from VS Code. Compile TypeScript into Swift, register MCP, and explore templates from your editor.",
   "license": "Apache-2.0",
   "icon": "icon.png",
   "files": [
@@ -36,23 +36,94 @@
     "vscode": "^1.102.0"
   },
   "main": "./dist/extension.js",
-  "activationEvents": [],
+  "activationEvents": [
+    "onCommand:axint.previewSwift",
+    "onCommand:axint.validateCurrentFile",
+    "onCommand:axint.showTemplates",
+    "onCommand:axint.openRegistry",
+    "onCommand:axint.openDocs"
+  ],
   "contributes": {
+    "commands": [
+      {
+        "command": "axint.previewSwift",
+        "title": "Preview Swift for Current File",
+        "category": "Axint",
+        "icon": "$(preview)"
+      },
+      {
+        "command": "axint.validateCurrentFile",
+        "title": "Validate Current File",
+        "category": "Axint",
+        "icon": "$(check)"
+      },
+      {
+        "command": "axint.showTemplates",
+        "title": "Browse Bundled Templates",
+        "category": "Axint",
+        "icon": "$(library)"
+      },
+      {
+        "command": "axint.openRegistry",
+        "title": "Open Registry",
+        "category": "Axint",
+        "icon": "$(globe)"
+      },
+      {
+        "command": "axint.openDocs",
+        "title": "Open Docs",
+        "category": "Axint",
+        "icon": "$(book)"
+      }
+    ],
     "mcpServerDefinitionProviders": [
       {
         "id": "axint.mcpServer",
         "label": "Axint App Intents Compiler"
       }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "axint.previewSwift",
+          "group": "navigation@90",
+          "when": "resourceScheme == file && editorTextFocus"
+        },
+        {
+          "command": "axint.validateCurrentFile",
+          "group": "navigation@91",
+          "when": "resourceScheme == file && editorTextFocus"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "axint.previewSwift",
+          "group": "navigation@90",
+          "when": "resourceScheme == file"
+        },
+        {
+          "command": "axint.validateCurrentFile",
+          "group": "navigation@91",
+          "when": "resourceScheme == file"
+        }
+      ]
+    },
+    "keybindings": [
+      {
+        "command": "axint.previewSwift",
+        "key": "cmd+alt+enter",
+        "mac": "cmd+alt+enter",
+        "when": "editorTextFocus"
+      }
     ]
   },
   "scripts": {
-    "build": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
+    "build": "node ../../node_modules/typescript/bin/tsc -p ./tsconfig.json",
     "package": "vsce package",
     "publish": "vsce publish"
   },
   "devDependencies": {
     "@types/vscode": "^1.102.0",
-    "@vscode/vsce": "^3.0.0",
-    "esbuild": "^0.25.0"
+    "@vscode/vsce": "^3.0.0"
   }
 }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,24 +1,241 @@
-import * as vscode from "vscode";
-import { execFile } from "node:child_process";
+import * as path from "node:path";
+import { execFile, type ExecFileException } from "node:child_process";
 import { promisify } from "node:util";
+import * as vscode from "vscode";
 
 const exec = promisify(execFile);
+const AXINT_BINARY = process.platform === "win32" ? "npx.cmd" : "npx";
+const AXINT_PACKAGE = "@axint/compiler";
+const SUPPORTED_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"]);
+
+type AxintDiagnostic = {
+  code: string;
+  severity: "error" | "warning" | "info";
+  message: string;
+  file?: string | null;
+  line?: number | null;
+  suggestion?: string | null;
+};
+
+type AxintCompileResponse = {
+  success: boolean;
+  swift: string | null;
+  outputPath: string | null;
+  diagnostics: AxintDiagnostic[];
+};
+
+type AxintTemplate = {
+  id: string;
+  title: string;
+  domain: string;
+  description: string;
+  source: string;
+};
 
 export function activate(context: vscode.ExtensionContext) {
-  const provider = vscode.lm.registerMcpServerDefinitionProvider(
-    "axint.mcpServer",
-    {
-      provideMcpServerDefinitions: async () => [
-        new vscode.McpStdioServerDefinition(
-          "Axint",
-          "npx",
-          ["-y", "@axint/compiler", "axint-mcp"],
-        ),
-      ],
-    },
-  );
+  const output = vscode.window.createOutputChannel("Axint");
+  const diagnostics = vscode.languages.createDiagnosticCollection("axint");
 
-  context.subscriptions.push(provider);
+  const provider = vscode.lm.registerMcpServerDefinitionProvider("axint.mcpServer", {
+    provideMcpServerDefinitions: async () => [
+      new vscode.McpStdioServerDefinition("Axint", AXINT_BINARY, [
+        "-y",
+        AXINT_PACKAGE,
+        "axint-mcp",
+      ]),
+    ],
+  });
+
+  async function resolveActiveSourceFile(): Promise<vscode.Uri | undefined> {
+    const uri = vscode.window.activeTextEditor?.document.uri;
+    if (!uri || uri.scheme !== "file") {
+      void vscode.window.showInformationMessage(
+        "Open a TypeScript Axint source file to use Axint commands.",
+      );
+      return undefined;
+    }
+
+    const ext = path.extname(uri.fsPath).toLowerCase();
+    if (!SUPPORTED_EXTENSIONS.has(ext)) {
+      void vscode.window.showWarningMessage(
+        "Axint commands currently support .ts, .tsx, .mts, and .cts source files.",
+      );
+      return undefined;
+    }
+
+    return uri;
+  }
+
+  function diagnosticsFor(uri: vscode.Uri, items: AxintDiagnostic[]): vscode.Diagnostic[] {
+    return items
+      .filter((item) => item.severity === "error" || item.severity === "warning")
+      .map((item) => {
+        const line = Math.max((item.line ?? 1) - 1, 0);
+        const range = new vscode.Range(line, 0, line, 200);
+        const diagnostic = new vscode.Diagnostic(
+          range,
+          `${item.code}: ${item.message}${item.suggestion ? `\n${item.suggestion}` : ""}`,
+          item.severity === "error"
+            ? vscode.DiagnosticSeverity.Error
+            : vscode.DiagnosticSeverity.Warning,
+        );
+        diagnostic.code = item.code;
+        diagnostic.source = "Axint";
+        return diagnostic;
+      });
+  }
+
+  async function runAxintJson(
+    args: string[],
+    cwd: string,
+  ): Promise<{ parsed: AxintCompileResponse; stdout: string; stderr: string }> {
+    try {
+      const { stdout, stderr } = await exec(AXINT_BINARY, ["-y", AXINT_PACKAGE, ...args], {
+        cwd,
+        maxBuffer: 20 * 1024 * 1024,
+      });
+      return { parsed: JSON.parse(stdout) as AxintCompileResponse, stdout, stderr };
+    } catch (error) {
+      const execError = error as ExecFileException & { stdout?: string; stderr?: string };
+      const stdout = execError.stdout ?? "";
+      const stderr = execError.stderr ?? "";
+      if (!stdout.trim()) {
+        throw new Error(stderr || execError.message);
+      }
+      return { parsed: JSON.parse(stdout) as AxintCompileResponse, stdout, stderr };
+    }
+  }
+
+  async function compileCurrentFile(previewSwift: boolean) {
+    const uri = await resolveActiveSourceFile();
+    if (!uri) return;
+
+    await vscode.window.activeTextEditor?.document.save();
+    const filePath = uri.fsPath;
+    const cwd = path.dirname(filePath);
+
+    output.appendLine(`$ ${AXINT_BINARY} -y ${AXINT_PACKAGE} compile "${filePath}" --json --stdout`);
+
+    try {
+      const { parsed, stderr } = await runAxintJson(
+        ["compile", filePath, "--json", "--stdout"],
+        cwd,
+      );
+
+      diagnostics.set(uri, diagnosticsFor(uri, parsed.diagnostics));
+
+      if (stderr.trim()) {
+        output.appendLine(stderr.trim());
+      }
+
+      if (!parsed.success || !parsed.swift) {
+        const errorCount = parsed.diagnostics.filter((item) => item.severity === "error").length;
+        output.appendLine(`Axint compile failed with ${errorCount} error(s).`);
+        output.show(true);
+        void vscode.window.showErrorMessage(
+          `Axint compile failed with ${errorCount} error(s). See Problems or the Axint output channel.`,
+        );
+        return;
+      }
+
+      output.appendLine(`Compiled ${path.basename(filePath)} successfully.`);
+
+      if (previewSwift) {
+        const document = await vscode.workspace.openTextDocument({
+          language: "swift",
+          content: parsed.swift,
+        });
+        await vscode.window.showTextDocument(document, {
+          preview: true,
+          viewColumn: vscode.ViewColumn.Beside,
+        });
+      }
+
+      void vscode.window.showInformationMessage(
+        previewSwift
+          ? `Axint compiled ${path.basename(filePath)} and opened a Swift preview.`
+          : `Axint compiled ${path.basename(filePath)} successfully.`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      output.appendLine(message);
+      output.show(true);
+      void vscode.window.showErrorMessage(`Axint failed: ${message}`);
+    }
+  }
+
+  async function showTemplates() {
+    const workspaceDir =
+      vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd();
+
+    output.appendLine(`$ ${AXINT_BINARY} -y ${AXINT_PACKAGE} templates --json`);
+
+    try {
+      const { stdout, stderr } = await exec(
+        AXINT_BINARY,
+        ["-y", AXINT_PACKAGE, "templates", "--json"],
+        {
+          cwd: workspaceDir,
+          maxBuffer: 20 * 1024 * 1024,
+        },
+      );
+
+      if (stderr.trim()) {
+        output.appendLine(stderr.trim());
+      }
+
+      const templates = JSON.parse(stdout) as AxintTemplate[];
+      const pick = await vscode.window.showQuickPick(
+        templates.map((template) => ({
+          label: template.title,
+          description: template.domain,
+          detail: template.description,
+          template,
+        })),
+        {
+          matchOnDescription: true,
+          matchOnDetail: true,
+          placeHolder: "Browse bundled Axint templates",
+        },
+      );
+
+      if (!pick) return;
+
+      const document = await vscode.workspace.openTextDocument({
+        language: "typescript",
+        content: pick.template.source,
+      });
+      await vscode.window.showTextDocument(document, {
+        preview: true,
+        viewColumn: vscode.ViewColumn.Beside,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      output.appendLine(message);
+      output.show(true);
+      void vscode.window.showErrorMessage(`Unable to load Axint templates: ${message}`);
+    }
+  }
+
+  const commands = [
+    vscode.commands.registerCommand("axint.previewSwift", async () => {
+      await compileCurrentFile(true);
+    }),
+    vscode.commands.registerCommand("axint.validateCurrentFile", async () => {
+      await compileCurrentFile(false);
+    }),
+    vscode.commands.registerCommand("axint.showTemplates", async () => {
+      await showTemplates();
+    }),
+    vscode.commands.registerCommand("axint.openRegistry", async () => {
+      await vscode.env.openExternal(vscode.Uri.parse("https://registry.axint.ai"));
+    }),
+    vscode.commands.registerCommand("axint.openDocs", async () => {
+      await vscode.env.openExternal(vscode.Uri.parse("https://docs.axint.ai"));
+    }),
+  ];
+
+  context.subscriptions.push(provider, output, diagnostics, ...commands);
 }
 
 export function deactivate() {}

--- a/extensions/vscode/tsconfig.json
+++ b/extensions/vscode/tsconfig.json
@@ -1,15 +1,16 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "commonjs",
     "lib": ["ES2022"],
-    "outDir": "dist",
-    "rootDir": "src",
+    "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "sourceMap": true
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- turn the VS Code extension into a real editor workflow with Swift preview and validation
- add template browsing plus registry/docs entry points
- switch the extension build to a TypeScript-based pipeline and refresh packaging metadata

## Verification
- npm run build
- npm run package
- npm test
- npm run typecheck
- npm run build
- python3 -m pytest -q