### PR TITLE
feat: add cloud handoff to vscode extension

### DIFF
--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Document the current Axint MCP surface: 10 tools + 3 built-in prompts
 - Package the extension for marketplace-ready installation via `agenticempire.axint`
 - Add command-palette workflows for Swift preview, validation, template browse, docs, and registry
+- Add `Open Current File in Cloud` so the active file can jump directly into Axint Cloud with a shareable report state
 
 ## [0.3.2] - 2026-04-12
 

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -20,6 +20,7 @@ It also adds command-palette workflows for:
 - **Axint: Preview Swift for Current File** — compile the active Axint source and open generated Swift beside it
 - **Axint: Validate Current File** — run the compiler/validator and surface diagnostics in Problems
 - **Axint: Browse Bundled Templates** — explore built-in Axint templates from inside VS Code
+- **Axint: Open Current File in Cloud** — send the active TypeScript or Python source into Axint Cloud for a shareable validation report
 - **Axint: Open Registry** — jump straight to `registry.axint.ai`
 - **Axint: Open Docs** — open `docs.axint.ai`
 
@@ -41,8 +42,9 @@ Works with GitHub Copilot in agent mode and any VS Code AI feature that supports
 2. Run `Axint: Preview Swift for Current File` from the command palette.
 3. Axint compiles the file with `@axint/compiler`, shows diagnostics in Problems, and opens generated Swift in a split editor.
 4. Use `Axint: Validate Current File` for a fast validation-only pass while editing.
+5. Use `Axint: Open Current File in Cloud` when you want a shareable Cloud report, saved baseline, or a handoff into the private validation workflow.
 
-This gives you a tighter “edit -> compile -> inspect Swift” loop without leaving VS Code.
+This gives you a tighter `edit -> compile -> inspect Swift -> open Cloud report` loop without leaving VS Code.
 
 ## Requirements
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Axint — App Intents Compiler",
   "version": "0.3.8",
   "publisher": "agenticempire",
-  "description": "Preview, validate, and browse Apple-native Axint surfaces from VS Code. Compile TypeScript into Swift, register MCP, and explore templates from your editor.",
+  "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",
   "icon": "icon.png",
   "files": [
@@ -41,7 +41,8 @@
     "onCommand:axint.validateCurrentFile",
     "onCommand:axint.showTemplates",
     "onCommand:axint.openRegistry",
-    "onCommand:axint.openDocs"
+    "onCommand:axint.openDocs",
+    "onCommand:axint.openCloudReport"
   ],
   "contributes": {
     "commands": [
@@ -74,6 +75,12 @@
         "title": "Open Docs",
         "category": "Axint",
         "icon": "$(book)"
+      },
+      {
+        "command": "axint.openCloudReport",
+        "title": "Open Current File in Cloud",
+        "category": "Axint",
+        "icon": "$(cloud-upload)"
       }
     ],
     "mcpServerDefinitionProviders": [
@@ -93,6 +100,11 @@
           "command": "axint.validateCurrentFile",
           "group": "navigation@91",
           "when": "resourceScheme == file && editorTextFocus"
+        },
+        {
+          "command": "axint.openCloudReport",
+          "group": "navigation@92",
+          "when": "resourceScheme == file && editorTextFocus"
         }
       ],
       "explorer/context": [
@@ -104,6 +116,11 @@
         {
           "command": "axint.validateCurrentFile",
           "group": "navigation@91",
+          "when": "resourceScheme == file"
+        },
+        {
+          "command": "axint.openCloudReport",
+          "group": "navigation@92",
           "when": "resourceScheme == file"
         }
       ]

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -7,6 +7,7 @@ const exec = promisify(execFile);
 const AXINT_BINARY = process.platform === "win32" ? "npx.cmd" : "npx";
 const AXINT_PACKAGE = "@axint/compiler";
 const SUPPORTED_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"]);
+const CLOUD_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts", ".py"]);
 
 type AxintDiagnostic = {
   code: string;
@@ -46,7 +47,10 @@ export function activate(context: vscode.ExtensionContext) {
     ],
   });
 
-  async function resolveActiveSourceFile(): Promise<vscode.Uri | undefined> {
+  async function resolveActiveSourceFile(
+    allowedExtensions = SUPPORTED_EXTENSIONS,
+    unsupportedMessage = "Axint commands currently support .ts, .tsx, .mts, and .cts source files.",
+  ): Promise<vscode.Uri | undefined> {
     const uri = vscode.window.activeTextEditor?.document.uri;
     if (!uri || uri.scheme !== "file") {
       void vscode.window.showInformationMessage(
@@ -56,10 +60,8 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     const ext = path.extname(uri.fsPath).toLowerCase();
-    if (!SUPPORTED_EXTENSIONS.has(ext)) {
-      void vscode.window.showWarningMessage(
-        "Axint commands currently support .ts, .tsx, .mts, and .cts source files.",
-      );
+    if (!allowedExtensions.has(ext)) {
+      void vscode.window.showWarningMessage(unsupportedMessage);
       return undefined;
     }
 
@@ -217,6 +219,51 @@ export function activate(context: vscode.ExtensionContext) {
     }
   }
 
+  function inferCloudLanguage(filePath: string): "typescript" | "python" {
+    return path.extname(filePath).toLowerCase() === ".py" ? "python" : "typescript";
+  }
+
+  function inferCloudSurface(source: string): "intent" | "view" | "widget" {
+    if (/defineWidget\s*\(/.test(source)) return "widget";
+    if (/defineView\s*\(/.test(source) || /\bview\./.test(source)) return "view";
+    return "intent";
+  }
+
+  function encodeCloudState(state: Record<string, unknown>): string {
+    return Buffer.from(JSON.stringify(state), "utf8").toString("base64url");
+  }
+
+  async function openCurrentFileInCloud() {
+    const uri = await resolveActiveSourceFile(
+      CLOUD_EXTENSIONS,
+      "Open a TypeScript or Python Axint source file to send it to Axint Cloud.",
+    );
+    if (!uri) return;
+
+    const activeDocument =
+      vscode.window.activeTextEditor?.document.uri.toString() === uri.toString()
+        ? vscode.window.activeTextEditor.document
+        : await vscode.workspace.openTextDocument(uri);
+
+    const filePath = uri.fsPath;
+    const source = activeDocument.getText();
+    const language = inferCloudLanguage(filePath);
+    const surface = inferCloudSurface(source);
+    const hash = encodeCloudState({
+      v: 1,
+      mode: "upload",
+      source,
+      surface,
+      language,
+      fileName: path.basename(filePath),
+    });
+
+    await vscode.env.openExternal(vscode.Uri.parse(`https://axint.ai/cloud#report=${hash}`));
+    void vscode.window.showInformationMessage(
+      "Opened the current file in Axint Cloud.",
+    );
+  }
+
   const commands = [
     vscode.commands.registerCommand("axint.previewSwift", async () => {
       await compileCurrentFile(true);
@@ -232,6 +279,9 @@ export function activate(context: vscode.ExtensionContext) {
     }),
     vscode.commands.registerCommand("axint.openDocs", async () => {
       await vscode.env.openExternal(vscode.Uri.parse("https://docs.axint.ai"));
+    }),
+    vscode.commands.registerCommand("axint.openCloudReport", async () => {
+      await openCurrentFileInCloud();
     }),
   ];
 


### PR DESCRIPTION
## Summary\n- add a command to open the current file in Axint Cloud\n- update extension docs and marketplace copy for the Cloud handoff\n- keep the editor workflow aligned with the new Cloud report flow\n\n## Verification\n- npm run build\n- npm run package