### PR TITLE
accept bare namespace/slug in axint add, fix install response parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/src/cli/add.ts
+++ b/src/cli/add.ts
@@ -16,15 +16,18 @@ export function registerAdd(program: Command, version: string) {
       console.log(`  \x1b[38;5;208m◆\x1b[0m \x1b[1mAxint\x1b[0m · add`);
       console.log();
 
-      const match = pkg.match(/^(@[a-z0-9][a-z0-9-]*)\/([a-z0-9][a-z0-9-]*)(?:@(.+))?$/);
+      // Accept both `@namespace/slug` and `namespace/slug` (with optional `@version`).
+      // Web URLs drop the leading `@`, so users will copy either form — normalize here.
+      const match = pkg.match(/^@?([a-z0-9][a-z0-9-]*)\/([a-z0-9][a-z0-9-]*)(?:@(.+))?$/);
       if (!match) {
         console.error(
-          `  \x1b[31merror:\x1b[0m Invalid package format. Expected: @namespace/slug or @namespace/slug@version`
+          `  \x1b[31merror:\x1b[0m Invalid package format. Expected: @namespace/slug or namespace/slug (optionally @version)`
         );
         process.exit(1);
       }
 
-      const [, namespace, slug, pkgVersion] = match;
+      const [, rawNamespace, slug, pkgVersion] = match;
+      const namespace = `@${rawNamespace}`;
       const registryUrl = process.env.AXINT_REGISTRY_URL ?? "https://registry.axint.ai";
 
       console.log(
@@ -50,35 +53,32 @@ export function registerAdd(program: Command, version: string) {
         }
 
         const data = (await res.json()) as {
-          template: { name: string; full_name: string; primary_language: string };
-          version: {
-            version: string;
-            ts_source?: string;
-            py_source?: string;
-            swift_output: string;
-          };
-          bundle_sha256: string;
+          namespace: string;
+          slug: string;
+          version: string;
+          ts_source?: string;
+          py_source?: string | null;
+          swift_output: string;
         };
 
         const targetDir = resolve(options.to, slug);
         mkdirSync(targetDir, { recursive: true });
 
-        const ver = data.version;
         const filesWritten: string[] = [];
 
-        if (ver.ts_source) {
-          writeFileSync(resolve(targetDir, "intent.ts"), ver.ts_source, "utf-8");
+        if (data.ts_source) {
+          writeFileSync(resolve(targetDir, "intent.ts"), data.ts_source, "utf-8");
           filesWritten.push("intent.ts");
         }
-        if (ver.py_source) {
-          writeFileSync(resolve(targetDir, "intent.py"), ver.py_source, "utf-8");
+        if (data.py_source) {
+          writeFileSync(resolve(targetDir, "intent.py"), data.py_source, "utf-8");
           filesWritten.push("intent.py");
         }
-        writeFileSync(resolve(targetDir, "intent.swift"), ver.swift_output, "utf-8");
+        writeFileSync(resolve(targetDir, "intent.swift"), data.swift_output, "utf-8");
         filesWritten.push("intent.swift");
 
         console.log(
-          `  \x1b[32m✓\x1b[0m Installed ${data.template.full_name}@${ver.version}`
+          `  \x1b[32m✓\x1b[0m Installed ${data.namespace}/${data.slug}@${data.version}`
         );
         console.log(`    → ${targetDir}/`);
         filesWritten.forEach((f) => console.log(`      ${f}`));

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -41,7 +41,7 @@ import { PROMPT_MANIFEST, getPromptMessages } from "./prompts.js";
 import { handleCompileFromSchema, type SchemaCompileArgs } from "./schema-compile.js";
 
 // Read version from package.json so it stays in sync
-let pkg = { version: "0.3.8" };
+let pkg = { version: "0.3.9" };
 try {
   const __dirname = dirname(fileURLToPath(import.meta.url));
   pkg = JSON.parse(readFileSync(resolve(__dirname, "../../package.json"), "utf-8"));


### PR DESCRIPTION
Two contract drifts with registry.axint.ai caught from the Codex audit.

First: the web URLs drop the leading `@`, so `axint add axint/create-event` (copy-paste from the browser) was rejected with "Invalid package format." Regex now accepts both forms and normalizes `@` internally.

Second: `writeFileSync` was throwing `Received undefined` because the CLI typed the install response as nested (`data.version.swift_output`) but the API has always returned it flat (`data.swift_output`). Fixed the typing and reads.

Bumps to 0.3.9.

Smoke-tested locally against prod registry — both `@axint/create-event` and bare `axint/create-event` install intent.ts + intent.swift correctly.