### PR TITLE
compile across intent, view, widget, and app surfaces

### DIFF
--- a/src/cli/compile.ts
+++ b/src/cli/compile.ts
@@ -1,7 +1,13 @@
 import type { Command } from "commander";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
-import { compileFile, compileFromIR, irFromJSON } from "../core/compiler.js";
+import {
+  compileAnyFile,
+  compileFromIR,
+  irFromJSON,
+  type AnyCompileResult,
+} from "../core/compiler.js";
+import type { Diagnostic } from "../core/types.js";
 
 /**
  * Count non-blank lines in a source string. Blank lines (whitespace
@@ -30,22 +36,73 @@ export function compressionRatio(tsLines: number, swiftLines: number): string | 
   return `${(swiftLines / tsLines).toFixed(2)}x`;
 }
 
+interface UnifiedOutput {
+  outputPath: string;
+  swiftCode: string;
+  diagnostics: Diagnostic[];
+  irName: string;
+  infoPlistFragment?: string;
+  entitlementsFragment?: string;
+}
+
+/**
+ * Flatten the surface-specific result shape into a single output
+ * view so downstream CLI formatting doesn't have to fork on surface.
+ */
+function unifyOutput(result: AnyCompileResult): UnifiedOutput | null {
+  if (!result.success || !result.output) return null;
+
+  if (result.surface === "intent") {
+    return {
+      outputPath: result.output.outputPath,
+      swiftCode: result.output.swiftCode,
+      diagnostics: result.output.diagnostics,
+      irName: result.output.ir.name,
+      infoPlistFragment: result.output.infoPlistFragment,
+      entitlementsFragment: result.output.entitlementsFragment,
+    };
+  }
+
+  return {
+    outputPath: result.output.outputPath,
+    swiftCode: result.output.swiftCode,
+    diagnostics: result.output.diagnostics,
+    irName: result.output.ir.name,
+  };
+}
+
+function printDiagnostics(diagnostics: Diagnostic[]): void {
+  for (const d of diagnostics) {
+    const prefix =
+      d.severity === "error"
+        ? "\x1b[31merror\x1b[0m"
+        : d.severity === "warning"
+          ? "\x1b[33mwarning\x1b[0m"
+          : "\x1b[36minfo\x1b[0m";
+
+    console.error(`  ${prefix}[${d.code}]: ${d.message}`);
+    if (d.file) console.error(`    --> ${d.file}${d.line ? `:${d.line}` : ""}`);
+    if (d.suggestion) console.error(`    = help: ${d.suggestion}`);
+    console.error();
+  }
+}
+
 export function registerCompile(program: Command) {
   program
     .command("compile")
-    .description("Compile a TypeScript intent definition into Swift")
-    .argument("<file>", "Path to the TypeScript intent definition")
+    .description("Compile a TypeScript surface (intent, view, widget, or app) into Swift")
+    .argument("<file>", "Path to the TypeScript surface definition")
     .option("-o, --out <dir>", "Output directory for generated Swift", ".")
     .option("--no-validate", "Skip validation of generated Swift")
     .option("--stdout", "Print generated Swift to stdout instead of writing a file")
     .option("--json", "Output result as JSON (machine-readable)")
     .option(
       "--emit-info-plist",
-      "Emit a <Name>.plist.fragment.xml with NSAppIntentsDomains next to the Swift file"
+      "Emit a <Name>.plist.fragment.xml with NSAppIntentsDomains next to the Swift file (intents only)"
     )
     .option(
       "--emit-entitlements",
-      "Emit a <Name>.entitlements.fragment.xml next to the Swift file"
+      "Emit a <Name>.entitlements.fragment.xml next to the Swift file (intents only)"
     )
     .option(
       "--sandbox",
@@ -61,7 +118,7 @@ export function registerCompile(program: Command) {
     )
     .option(
       "--from-ir",
-      "Treat <file> as IR JSON (from Python SDK or any language) instead of TypeScript. Use - to read from stdin."
+      "Treat <file> as intent IR JSON (from Python SDK or any language) instead of TypeScript. Use - to read from stdin."
     )
     .action(
       async (
@@ -82,7 +139,10 @@ export function registerCompile(program: Command) {
         const filePath = resolve(file);
 
         try {
-          let result;
+          let surface: "intent" | "view" | "widget" | "app";
+          let output: UnifiedOutput | null;
+          let diagnostics: Diagnostic[];
+          let success: boolean;
 
           if (options.fromIr) {
             let irRaw: string;
@@ -115,31 +175,59 @@ export function registerCompile(program: Command) {
             }
 
             const ir = irFromJSON(irData);
-            result = compileFromIR(ir, {
+            const result = compileFromIR(ir, {
               outDir: options.out,
               validate: options.validate,
               emitInfoPlist: options.emitInfoPlist,
               emitEntitlements: options.emitEntitlements,
             });
+            surface = "intent";
+            diagnostics = result.diagnostics;
+            success = result.success;
+            output =
+              result.success && result.output
+                ? {
+                    outputPath: result.output.outputPath,
+                    swiftCode: result.output.swiftCode,
+                    diagnostics: result.output.diagnostics,
+                    irName: result.output.ir.name,
+                    infoPlistFragment: result.output.infoPlistFragment,
+                    entitlementsFragment: result.output.entitlementsFragment,
+                  }
+                : null;
           } else {
-            result = compileFile(filePath, {
+            const result = compileAnyFile(filePath, {
               outDir: options.out,
               validate: options.validate,
               emitInfoPlist: options.emitInfoPlist,
               emitEntitlements: options.emitEntitlements,
             });
+            surface = result.surface;
+            diagnostics = result.diagnostics;
+            success = result.success;
+            output = unifyOutput(result);
+
+            if (
+              result.surface !== "intent" &&
+              (options.emitInfoPlist || options.emitEntitlements)
+            ) {
+              console.error(
+                `\x1b[33mwarning:\x1b[0m --emit-info-plist and --emit-entitlements apply to intents only; ignored for ${result.surface}.`
+              );
+            }
           }
 
           if (options.json) {
             console.log(
               JSON.stringify(
                 {
-                  success: result.success,
-                  swift: result.output?.swiftCode ?? null,
-                  outputPath: result.output?.outputPath ?? null,
-                  infoPlistFragment: result.output?.infoPlistFragment ?? null,
-                  entitlementsFragment: result.output?.entitlementsFragment ?? null,
-                  diagnostics: result.diagnostics.map((d) => ({
+                  success,
+                  surface,
+                  swift: output?.swiftCode ?? null,
+                  outputPath: output?.outputPath ?? null,
+                  infoPlistFragment: output?.infoPlistFragment ?? null,
+                  entitlementsFragment: output?.entitlementsFragment ?? null,
+                  diagnostics: diagnostics.map((d) => ({
                     code: d.code,
                     severity: d.severity,
                     message: d.message,
@@ -152,27 +240,16 @@ export function registerCompile(program: Command) {
                 2
               )
             );
-            if (!result.success) process.exit(1);
+            if (!success) process.exit(1);
             return;
           }
 
-          for (const d of result.diagnostics) {
-            const prefix =
-              d.severity === "error"
-                ? "\x1b[31merror\x1b[0m"
-                : d.severity === "warning"
-                  ? "\x1b[33mwarning\x1b[0m"
-                  : "\x1b[36minfo\x1b[0m";
+          printDiagnostics(diagnostics);
 
-            console.error(`  ${prefix}[${d.code}]: ${d.message}`);
-            if (d.file) console.error(`    --> ${d.file}${d.line ? `:${d.line}` : ""}`);
-            if (d.suggestion) console.error(`    = help: ${d.suggestion}`);
-            console.error();
-          }
-
-          if (!result.success || !result.output) {
+          if (!success || !output) {
+            const errorCount = diagnostics.filter((d) => d.severity === "error").length;
             console.error(
-              `\x1b[31mCompilation failed with ${result.diagnostics.filter((d) => d.severity === "error").length} error(s)\x1b[0m`
+              `\x1b[31mCompilation failed with ${errorCount} error(s)\x1b[0m`
             );
             process.exit(1);
           }
@@ -180,12 +257,12 @@ export function registerCompile(program: Command) {
           if (options.format || options.strictFormat) {
             try {
               const { formatSwift } = await import("../core/format.js");
-              const fmt = await formatSwift(result.output.swiftCode, {
+              const fmt = await formatSwift(output.swiftCode, {
                 strict: options.strictFormat,
               });
               if (fmt.ran) {
-                result.output.swiftCode = fmt.formatted;
-              } else if (!options.json) {
+                output.swiftCode = fmt.formatted;
+              } else {
                 console.error(
                   `\x1b[33mwarning:\x1b[0m swift-format skipped — ${fmt.reason}`
                 );
@@ -202,13 +279,13 @@ export function registerCompile(program: Command) {
           }
 
           if (options.stdout) {
-            console.log(result.output.swiftCode);
+            console.log(output.swiftCode);
           } else {
-            const outPath = resolve(result.output.outputPath);
+            const outPath = resolve(output.outputPath);
             mkdirSync(dirname(outPath), { recursive: true });
-            writeFileSync(outPath, result.output.swiftCode, "utf-8");
+            writeFileSync(outPath, output.swiftCode, "utf-8");
             console.log(
-              `\x1b[32m✓\x1b[0m Compiled ${result.output.ir.name} → ${outPath}`
+              `\x1b[32m✓\x1b[0m Compiled ${surface} ${output.irName} → ${outPath}`
             );
 
             // Show TS-to-Swift compression so authors can eyeball whether
@@ -218,7 +295,7 @@ export function registerCompile(program: Command) {
               try {
                 const tsSource = readFileSync(filePath, "utf-8");
                 const tsLines = countNonBlankLines(tsSource);
-                const swiftLines = countNonBlankLines(result.output.swiftCode);
+                const swiftLines = countNonBlankLines(output.swiftCode);
                 const ratio = compressionRatio(tsLines, swiftLines);
                 if (ratio !== null) {
                   const label = swiftLines > tsLines ? "Expansion" : "Compression";
@@ -232,15 +309,23 @@ export function registerCompile(program: Command) {
               }
             }
 
-            if (options.emitInfoPlist && result.output.infoPlistFragment) {
+            if (
+              surface === "intent" &&
+              options.emitInfoPlist &&
+              output.infoPlistFragment
+            ) {
               const plistPath = outPath.replace(/\.swift$/, ".plist.fragment.xml");
-              writeFileSync(plistPath, result.output.infoPlistFragment, "utf-8");
+              writeFileSync(plistPath, output.infoPlistFragment, "utf-8");
               console.log(`\x1b[32m✓\x1b[0m Info.plist fragment → ${plistPath}`);
             }
 
-            if (options.emitEntitlements && result.output.entitlementsFragment) {
+            if (
+              surface === "intent" &&
+              options.emitEntitlements &&
+              output.entitlementsFragment
+            ) {
               const entPath = outPath.replace(/\.swift$/, ".entitlements.fragment.xml");
-              writeFileSync(entPath, result.output.entitlementsFragment, "utf-8");
+              writeFileSync(entPath, output.entitlementsFragment, "utf-8");
               console.log(`\x1b[32m✓\x1b[0m Entitlements fragment → ${entPath}`);
             }
           }
@@ -250,8 +335,8 @@ export function registerCompile(program: Command) {
               const { sandboxCompile } = await import("../core/sandbox.js");
               console.log();
               console.log(`\x1b[36m→\x1b[0m Stage 4: SPM sandbox compile...`);
-              const sandboxResult = await sandboxCompile(result.output.swiftCode, {
-                intentName: result.output.ir.name,
+              const sandboxResult = await sandboxCompile(output.swiftCode, {
+                intentName: output.irName,
               });
               if (sandboxResult.ok) {
                 console.log(
@@ -270,9 +355,7 @@ export function registerCompile(program: Command) {
             }
           }
 
-          const warnings = result.diagnostics.filter(
-            (d) => d.severity === "warning"
-          ).length;
+          const warnings = diagnostics.filter((d) => d.severity === "warning").length;
           if (warnings > 0) {
             console.log(`  ${warnings} warning(s)`);
           }

--- a/src/core/compiler.ts
+++ b/src/core/compiler.ts
@@ -16,6 +16,7 @@ import { parseIntentSource, ParserError } from "./parser.js";
 import { parseViewSource } from "./view-parser.js";
 import { parseWidgetSource } from "./widget-parser.js";
 import { parseAppSource } from "./app-parser.js";
+import { detectSurface, type Surface } from "./surface.js";
 import {
   generateSwift,
   generateInfoPlistFragment,
@@ -440,6 +441,97 @@ export function compileAppFromIR(
     },
     diagnostics,
   };
+}
+
+// ─── Surface Dispatcher ────────────────────────────────────────────
+
+/**
+ * Tagged result of compiling any surface. The CLI and MCP server
+ * switch on `surface` to pick the right output path, diagnostic
+ * presentation, and artifact emission.
+ */
+export type AnyCompileResult =
+  | ({ surface: "intent" } & CompileResult)
+  | ({ surface: "view" } & ViewCompileResult)
+  | ({ surface: "widget" } & WidgetCompileResult)
+  | ({ surface: "app" } & AppCompileResult);
+
+/**
+ * Compile a TypeScript source string, auto-detecting whether it
+ * defines an intent, view, widget, or app. Returns a diagnostic if
+ * no supported `define*` call is found.
+ */
+export function compileAnySource(
+  source: string,
+  fileName: string = "<stdin>",
+  options: Partial<CompilerOptions> = {}
+): AnyCompileResult {
+  const surface = detectSurface(source, fileName);
+
+  if (!surface) {
+    return {
+      surface: "intent",
+      success: false,
+      diagnostics: [
+        {
+          code: "AX001",
+          severity: "error",
+          message: `No defineIntent, defineView, defineWidget, or defineApp call found in ${fileName}`,
+          file: fileName,
+          suggestion:
+            "Add a top-level `defineIntent({ ... })`, `defineView({ ... })`, `defineWidget({ ... })`, or `defineApp({ ... })` call.",
+        },
+      ],
+    };
+  }
+
+  return dispatchCompile(surface, source, fileName, options);
+}
+
+/**
+ * Compile a TypeScript file from disk, auto-detecting the surface.
+ */
+export function compileAnyFile(
+  filePath: string,
+  options: Partial<CompilerOptions> = {}
+): AnyCompileResult {
+  let source: string;
+  try {
+    source = readFileSync(filePath, "utf-8");
+  } catch {
+    return {
+      surface: "intent",
+      success: false,
+      diagnostics: [
+        {
+          code: "AX000",
+          severity: "error",
+          message: `Cannot read file: ${filePath}`,
+          file: filePath,
+        },
+      ],
+    };
+  }
+
+  return compileAnySource(source, filePath, options);
+}
+
+function dispatchCompile(
+  surface: Surface,
+  source: string,
+  fileName: string,
+  options: Partial<CompilerOptions>
+): AnyCompileResult {
+  switch (surface) {
+    case "intent":
+      return { surface, ...compileSource(source, fileName, options) };
+    case "view":
+      return { surface, ...compileViewSource(source, fileName, options) };
+    case "widget":
+      return { surface, ...compileWidgetSource(source, fileName, options) };
+    case "app":
+      return { surface, ...compileAppSource(source, fileName, options) };
+  }
 }
 
 // ─── Cross-Language IR Bridge ───────────────────────────────────────

--- a/src/core/surface.ts
+++ b/src/core/surface.ts
@@ -1,0 +1,48 @@
+/**
+ * Detects which Apple surface a TypeScript source file targets by
+ * scanning for its top-level `define*` call. One surface per file is
+ * the documented contract — if a file accidentally mixes two, the
+ * first one encountered wins and the rest are reported separately by
+ * each parser's own diagnostics.
+ */
+
+import ts from "typescript";
+
+export type Surface = "intent" | "view" | "widget" | "app";
+
+const DEFINE_TO_SURFACE: Readonly<Record<string, Surface>> = {
+  defineIntent: "intent",
+  defineView: "view",
+  defineWidget: "widget",
+  defineApp: "app",
+};
+
+export function detectSurface(
+  source: string,
+  fileName: string = "<stdin>"
+): Surface | null {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+
+  let surface: Surface | null = null;
+
+  const visit = (node: ts.Node): void => {
+    if (surface) return;
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      const match = DEFINE_TO_SURFACE[node.expression.text];
+      if (match) {
+        surface = match;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return surface;
+}

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Conformance suite for the `axint compile` multi-surface dispatcher.
+ *
+ * Each Apple surface (intent, view, widget, app) must round-trip
+ * through `compileAnySource` without the caller having to pick the
+ * right parser. If any of these tests regress, the CLI stops being a
+ * single entry point and new users hit the onboarding break that
+ * action 04 of the 2026-04-17 sprint was written to fix.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { compileAnySource } from "../../src/core/compiler.js";
+import { detectSurface } from "../../src/core/surface.js";
+
+const INTENT_SOURCE = `
+import { defineIntent, param } from "@axint/sdk";
+
+export default defineIntent({
+  name: "SendMessage",
+  title: "Send Message",
+  description: "Sends a message to a contact",
+  params: {
+    recipient: param.string("Who to message"),
+    body: param.string("Message content"),
+  },
+  perform: async ({ recipient, body }) => {
+    return { sent: true };
+  },
+});
+`;
+
+const VIEW_SOURCE = `
+import { defineView, prop, state, view } from "@axint/sdk";
+
+export default defineView({
+  name: "Greeting",
+  props: {
+    username: prop.string("User's display name"),
+  },
+  state: {
+    tapCount: state.int("Number of taps", { default: 0 }),
+  },
+  body: [
+    view.vstack([
+      view.text("Hello, \\\\(username)!"),
+      view.button("Tap me", "tapCount += 1"),
+    ], { spacing: 16 }),
+  ],
+});
+`;
+
+const WIDGET_SOURCE = `
+import { defineWidget, entry, view } from "@axint/sdk";
+
+export default defineWidget({
+  name: "StepCounter",
+  displayName: "Step Counter",
+  description: "Shows your daily step count",
+  families: ["systemSmall", "systemMedium"],
+  entry: {
+    steps: entry.int("Current step count", { default: 0 }),
+    goal: entry.int("Daily goal", { default: 10000 }),
+    lastUpdated: entry.date("Last sync time"),
+  },
+  body: [
+    view.vstack([
+      view.text("\\\\(steps)"),
+      view.text("of \\\\(goal) steps"),
+    ], { spacing: 4 }),
+  ],
+  refreshInterval: 15,
+});
+`;
+
+const APP_SOURCE = `
+import { defineApp } from "@axint/sdk";
+
+export default defineApp({
+  name: "MyApp",
+  scenes: [
+    { kind: "windowGroup", view: "ContentView" },
+  ],
+});
+`;
+
+describe("detectSurface", () => {
+  it("recognizes defineIntent", () => {
+    expect(detectSurface(INTENT_SOURCE)).toBe("intent");
+  });
+
+  it("recognizes defineView", () => {
+    expect(detectSurface(VIEW_SOURCE)).toBe("view");
+  });
+
+  it("recognizes defineWidget", () => {
+    expect(detectSurface(WIDGET_SOURCE)).toBe("widget");
+  });
+
+  it("recognizes defineApp", () => {
+    expect(detectSurface(APP_SOURCE)).toBe("app");
+  });
+
+  it("returns null when no define call is present", () => {
+    expect(detectSurface("const x = 42;")).toBeNull();
+  });
+});
+
+describe("compileAnySource dispatches by surface", () => {
+  it("compiles an intent into an AppIntent struct", () => {
+    const result = compileAnySource(INTENT_SOURCE, "send-message.ts");
+
+    expect(result.surface).toBe("intent");
+    expect(result.success).toBe(true);
+    expect(result.output).toBeDefined();
+    expect(result.output!.swiftCode).toContain("struct SendMessageIntent: AppIntent");
+    expect(result.output!.outputPath).toBe("SendMessageIntent.swift");
+  });
+
+  it("compiles a view into a SwiftUI View struct", () => {
+    const result = compileAnySource(VIEW_SOURCE, "greeting.ts");
+
+    expect(result.surface).toBe("view");
+    expect(result.success).toBe(true);
+    expect(result.output).toBeDefined();
+    expect(result.output!.swiftCode).toContain("import SwiftUI");
+    expect(result.output!.swiftCode).toContain("struct Greeting: View");
+    expect(result.output!.outputPath).toBe("Greeting.swift");
+  });
+
+  it("compiles a widget into a TimelineProvider + Widget pair", () => {
+    const result = compileAnySource(WIDGET_SOURCE, "step-counter.ts");
+
+    expect(result.surface).toBe("widget");
+    expect(result.success).toBe(true);
+    expect(result.output).toBeDefined();
+    expect(result.output!.swiftCode).toContain("struct StepCounterEntry: TimelineEntry");
+    expect(result.output!.swiftCode).toContain(
+      "struct StepCounterProvider: TimelineProvider"
+    );
+    expect(result.output!.outputPath).toBe("StepCounterWidget.swift");
+  });
+
+  it("compiles an app into a SwiftUI @main App", () => {
+    const result = compileAnySource(APP_SOURCE, "my-app.ts");
+
+    expect(result.surface).toBe("app");
+    expect(result.success).toBe(true);
+    expect(result.output).toBeDefined();
+    expect(result.output!.swiftCode).toContain("@main");
+    expect(result.output!.swiftCode).toContain("struct MyAppApp: App");
+    expect(result.output!.outputPath).toBe("MyAppApp.swift");
+  });
+
+  it("returns AX001 when the source defines no surface", () => {
+    const result = compileAnySource("const x = 42;", "bad.ts");
+
+    expect(result.success).toBe(false);
+    expect(result.diagnostics.some((d) => d.code === "AX001")).toBe(true);
+  });
+
+  it("respects outDir for every surface", () => {
+    const intent = compileAnySource(INTENT_SOURCE, "i.ts", { outDir: "Generated" });
+    const view = compileAnySource(VIEW_SOURCE, "v.ts", { outDir: "Generated" });
+    const widget = compileAnySource(WIDGET_SOURCE, "w.ts", { outDir: "Generated" });
+    const app = compileAnySource(APP_SOURCE, "a.ts", { outDir: "Generated" });
+
+    expect(intent.output!.outputPath).toBe("Generated/SendMessageIntent.swift");
+    expect(view.output!.outputPath).toBe("Generated/Greeting.swift");
+    expect(widget.output!.outputPath).toBe("Generated/StepCounterWidget.swift");
+    expect(app.output!.outputPath).toBe("Generated/MyAppApp.swift");
+  });
+});


### PR DESCRIPTION
Single dispatcher in src/core/compiler.ts routes a TypeScript source to the right parser/generator by detecting the define* call. CLI stops silently returning an intent shell when given a view/widget/app source. Tests cover each surface plus the no-define fallback diagnostic.