### PR TITLE
verify bundle bytes at publish and install with sha256

### DIFF
--- a/src/cli/add.ts
+++ b/src/cli/add.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
+import { hashBundle } from "../core/bundle-hash.js";
 
 export function registerAdd(program: Command, version: string) {
   program
@@ -59,7 +60,33 @@ export function registerAdd(program: Command, version: string) {
           ts_source?: string;
           py_source?: string | null;
           swift_output: string;
+          plist_fragment?: string | null;
+          bundle_hash?: string | null;
         };
+
+        // Refuse to write the bundle if the registry's advertised hash doesn't
+        // match what we compute locally. Published-before-hashing bundles
+        // return `bundle_hash: null` and skip verification; anything else is a
+        // hard fail so tampered bytes never land in the user's repo.
+        if (data.bundle_hash) {
+          const localHash = await hashBundle({
+            ts_source: data.ts_source ?? "",
+            py_source: data.py_source ?? null,
+            swift_output: data.swift_output,
+            plist_fragment: data.plist_fragment ?? null,
+          });
+          if (localHash !== data.bundle_hash) {
+            console.error(
+              `  \x1b[31m✗\x1b[0m [AX600] Bundle hash mismatch for ${data.namespace}/${data.slug}@${data.version}`
+            );
+            console.error(`    expected sha256:${data.bundle_hash}`);
+            console.error(`    got      sha256:${localHash}`);
+            console.error(
+              `    No files written. The registry response does not match its recorded hash.`
+            );
+            process.exit(1);
+          }
+        }
 
         const targetDir = resolve(options.to, slug);
         mkdirSync(targetDir, { recursive: true });
@@ -82,6 +109,11 @@ export function registerAdd(program: Command, version: string) {
         );
         console.log(`    → ${targetDir}/`);
         filesWritten.forEach((f) => console.log(`      ${f}`));
+        if (data.bundle_hash) {
+          console.log(
+            `    \x1b[2mverified sha256:${data.bundle_hash.slice(0, 12)}…\x1b[0m`
+          );
+        }
         console.log();
         console.log(`  \x1b[1mNext:\x1b[0m`);
         console.log(

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { compileFile } from "../core/compiler.js";
+import { hashBundle } from "../core/bundle-hash.js";
 
 export function registerPublish(program: Command, version: string) {
   program
@@ -95,6 +96,19 @@ export function registerPublish(program: Command, version: string) {
         ? config.namespace
         : `@${config.namespace}`;
 
+      const tsSource = readFileSync(entryPath, "utf-8");
+      const plistFragment = result.output.infoPlistFragment ?? null;
+
+      // Hash the exact bytes the registry will return at install time so the
+      // server can verify we agree on what was published. `axint add` re-runs
+      // the same computation on fetch — any drift aborts before writing files.
+      const bundleHash = await hashBundle({
+        ts_source: tsSource,
+        py_source: pySource ?? null,
+        swift_output: result.output.swiftCode,
+        plist_fragment: plistFragment,
+      });
+
       const payload = {
         namespace,
         slug: config.slug,
@@ -108,12 +122,13 @@ export function registerPublish(program: Command, version: string) {
         license: config.license ?? "Apache-2.0",
         homepage: config.homepage,
         repository: config.repository,
-        ts_source: readFileSync(entryPath, "utf-8"),
+        ts_source: tsSource,
         py_source: pySource,
         swift_output: result.output.swiftCode,
-        plist_fragment: result.output.infoPlistFragment ?? null,
+        plist_fragment: plistFragment,
         ir: result.output.ir ?? {},
         compiler_version: version,
+        bundle_hash: bundleHash,
       };
 
       if (options.dryRun) {
@@ -125,6 +140,7 @@ export function registerPublish(program: Command, version: string) {
         console.log(
           `  Bundle size:   ${Buffer.from(JSON.stringify(payload)).byteLength} bytes`
         );
+        console.log(`  Bundle hash:   sha256:${bundleHash}`);
         console.log(`  Tags:          ${tags.join(", ") || "(none)"}`);
         console.log();
         return;
@@ -177,12 +193,20 @@ export function registerPublish(program: Command, version: string) {
           process.exit(1);
         }
 
-        const data = (await res.json()) as { url: string };
+        const data = (await res.json()) as { url: string; bundle_hash?: string };
+
+        if (data.bundle_hash && data.bundle_hash !== bundleHash) {
+          console.error(
+            `  \x1b[31m✗\x1b[0m Registry recorded a different bundle hash (client ${bundleHash} vs server ${data.bundle_hash}). Publish rejected for your safety.`
+          );
+          process.exit(1);
+        }
 
         console.log(`  \x1b[32m✓\x1b[0m Published!`);
         console.log();
         console.log(`    ${data.url}`);
         console.log();
+        console.log(`  \x1b[2mBundle hash: sha256:${bundleHash}\x1b[0m`);
         console.log(`  \x1b[2mInstall: axint add ${namespace}/${config.slug}\x1b[0m`);
         console.log();
       } catch (err: unknown) {

--- a/src/core/bundle-hash.ts
+++ b/src/core/bundle-hash.ts
@@ -1,0 +1,44 @@
+/**
+ * Canonical hash over the bytes that leave the registry at install time.
+ *
+ * The registry stores this hash on publish and returns it on install so
+ * `axint add` can verify the bundle wasn't altered between the two
+ * endpoints. We canonicalize on the TS side, the server side (Workers
+ * runtime), and anywhere else a bundle round-trips — if any of those
+ * three disagree on bytes, the hash diverges and we catch it before the
+ * files hit the user's disk.
+ *
+ * The contract:
+ *   • UTF-8 JSON, keys in alphabetical order, no whitespace
+ *   • Missing optional fields are explicit `null`, never `undefined`
+ *   • SHA-256, lower-case hex, 64 chars
+ */
+
+export interface BundleContents {
+  ts_source: string;
+  py_source?: string | null;
+  swift_output: string;
+  plist_fragment?: string | null;
+}
+
+export function canonicalizeBundle(bundle: BundleContents): string {
+  const normalized = {
+    plist_fragment: bundle.plist_fragment ?? null,
+    py_source: bundle.py_source ?? null,
+    swift_output: bundle.swift_output,
+    ts_source: bundle.ts_source,
+  };
+  return JSON.stringify(normalized);
+}
+
+export async function hashBundle(bundle: BundleContents): Promise<string> {
+  const canonical = canonicalizeBundle(bundle);
+  const bytes = new TextEncoder().encode(canonical);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join(
+    ""
+  );
+}
+
+export const BUNDLE_HASH_ALGORITHM = "sha256" as const;
+export const BUNDLE_HASH_HEX_LENGTH = 64;

--- a/tests/core/bundle-hash.test.ts
+++ b/tests/core/bundle-hash.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  canonicalizeBundle,
+  hashBundle,
+  BUNDLE_HASH_HEX_LENGTH,
+} from "../../src/core/bundle-hash.js";
+
+describe("canonicalizeBundle", () => {
+  it("orders keys deterministically regardless of input order", () => {
+    const a = canonicalizeBundle({
+      ts_source: "ts",
+      swift_output: "sw",
+      py_source: "py",
+      plist_fragment: "pl",
+    });
+    const b = canonicalizeBundle({
+      plist_fragment: "pl",
+      swift_output: "sw",
+      ts_source: "ts",
+      py_source: "py",
+    });
+    expect(a).toBe(b);
+    expect(a).toBe(
+      `{"plist_fragment":"pl","py_source":"py","swift_output":"sw","ts_source":"ts"}`
+    );
+  });
+
+  it("normalizes missing optional fields to explicit null", () => {
+    const noOptionals = canonicalizeBundle({
+      ts_source: "ts",
+      swift_output: "sw",
+    });
+    const undefinedOptionals = canonicalizeBundle({
+      ts_source: "ts",
+      swift_output: "sw",
+      py_source: undefined,
+      plist_fragment: undefined,
+    });
+    const nullOptionals = canonicalizeBundle({
+      ts_source: "ts",
+      swift_output: "sw",
+      py_source: null,
+      plist_fragment: null,
+    });
+    expect(noOptionals).toBe(undefinedOptionals);
+    expect(noOptionals).toBe(nullOptionals);
+    expect(noOptionals).toBe(
+      `{"plist_fragment":null,"py_source":null,"swift_output":"sw","ts_source":"ts"}`
+    );
+  });
+
+  it("distinguishes present-but-empty strings from missing fields", () => {
+    const empty = canonicalizeBundle({
+      ts_source: "ts",
+      swift_output: "sw",
+      py_source: "",
+    });
+    const missing = canonicalizeBundle({
+      ts_source: "ts",
+      swift_output: "sw",
+    });
+    expect(empty).not.toBe(missing);
+  });
+});
+
+describe("hashBundle", () => {
+  it("returns a 64-char lowercase hex SHA-256", async () => {
+    const hash = await hashBundle({
+      ts_source: "export default defineIntent({ name: 'X' });",
+      swift_output: "struct X: AppIntent {}",
+    });
+    expect(hash).toHaveLength(BUNDLE_HASH_HEX_LENGTH);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("produces the same hash for equivalent bundles", async () => {
+    const left = await hashBundle({
+      ts_source: "ts",
+      swift_output: "sw",
+      py_source: null,
+      plist_fragment: null,
+    });
+    const right = await hashBundle({
+      ts_source: "ts",
+      swift_output: "sw",
+    });
+    expect(left).toBe(right);
+  });
+
+  it("diverges when any bundle byte changes", async () => {
+    const base = await hashBundle({
+      ts_source: "alpha",
+      swift_output: "beta",
+    });
+    const altered = await hashBundle({
+      ts_source: "alphA",
+      swift_output: "beta",
+    });
+    expect(base).not.toBe(altered);
+  });
+
+  it("is stable against a known vector", async () => {
+    const hash = await hashBundle({
+      ts_source: "ts",
+      swift_output: "sw",
+      py_source: "py",
+      plist_fragment: "pl",
+    });
+    expect(hash).toBe("9f708e7e282ec5e3a578a18f1d4bc003e144265ea9bc0845337c65c96399bf04");
+  });
+});


### PR DESCRIPTION
Canonical JSON (sorted keys, null-normalized optionals) hashed with SHA-256 over the exact bytes the registry returns. Publish sends the hash and aborts if the server recomputes a different value; install re-hashes on fetch and refuses to write files on drift. Stability vector 9f708e7e… is asserted in both repos so any canonicalization drift breaks both suites at once.