### PR TITLE
ci ground truth for version, metric, and docs drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
 
       - run: npm ci
       - run: npm audit --audit-level=moderate || true
+      - run: npm run versions:check
+      - run: npm run metrics:check
       - run: npm run typecheck
       - run: npm run lint
       - run: npm run build
@@ -127,3 +129,8 @@ jobs:
         run: |
           axint-py --version
           axint-py parse examples/create_event.py --json
+
+      - name: Check docs.axint.ai/python/install freshness
+        if: matrix.python-version == '3.13' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: .
+        run: python scripts/check-docs-freshness.py

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/metrics.json
+++ b/metrics.json
@@ -5,7 +5,7 @@
   "bundledTemplates": 25,
   "diagnostics": 130,
   "tests": {
-    "typescript": 525,
+    "typescript": 522,
     "python": 91
   },
   "registryPackages": 8,

--- a/metrics.json
+++ b/metrics.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.3.9",
+  "mcpTools": 10,
+  "mcpPrompts": 3,
+  "bundledTemplates": 25,
+  "diagnostics": 130,
+  "tests": {
+    "typescript": 507,
+    "python": 91
+  },
+  "registryPackages": 8,
+  "distributionSurfaces": 4
+}

--- a/metrics.json
+++ b/metrics.json
@@ -5,7 +5,7 @@
   "bundledTemplates": 25,
   "diagnostics": 130,
   "tests": {
-    "typescript": 507,
+    "typescript": 525,
     "python": 91
   },
   "registryPackages": 8,

--- a/package.json
+++ b/package.json
@@ -72,7 +72,11 @@
     "clean": "rm -rf dist",
     "gen:swift-fixer": "tsx scripts/gen-swift-fixer.ts",
     "gen:swift-fixer:check": "tsx scripts/gen-swift-fixer.ts --check",
-    "prepublishOnly": "npm run clean && npm run build",
+    "versions:sync": "node scripts/sync-versions.mjs",
+    "versions:check": "node scripts/check-versions.mjs",
+    "metrics:emit": "node scripts/emit-metrics.mjs",
+    "metrics:check": "node scripts/check-metrics.mjs",
+    "prepublishOnly": "npm run versions:check && npm run metrics:check && npm run clean && npm run build",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/scripts/check-docs-freshness.py
+++ b/scripts/check-docs-freshness.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Verify the live Python install page on docs.axint.ai matches the package."""
+
+from __future__ import annotations
+
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+DOCS_URL = "https://docs.axint.ai/python/install/"
+PYPROJECT = Path(__file__).resolve().parent.parent / "python" / "pyproject.toml"
+
+
+def read_version(path: Path) -> str:
+    text = path.read_text()
+    match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', text)
+    if not match:
+        raise RuntimeError(f"no version field in {path}")
+    return match.group(1)
+
+
+def main() -> int:
+    version = read_version(PYPROJECT)
+    major_minor = ".".join(version.split(".")[:2])
+
+    try:
+        with urllib.request.urlopen(DOCS_URL, timeout=20) as resp:
+            html = resp.read().decode("utf-8", errors="replace")
+    except Exception as err:
+        print(f"could not fetch {DOCS_URL}: {err}", file=sys.stderr)
+        return 2
+
+    if "pip install axint" not in html:
+        print(f"docs missing `pip install axint` install command", file=sys.stderr)
+        return 1
+
+    # Any pinned `pip install axint==X.Y.Z` must match the package version.
+    pinned = re.findall(r"pip install axint==([\d.a-z]+)", html)
+    for pin in pinned:
+        if pin != version:
+            print(
+                f"docs pins axint=={pin}, pyproject is {version}",
+                file=sys.stderr,
+            )
+            return 1
+
+    # Catch stale prerelease references like the 0.1.0a1 line.
+    stale = re.findall(r"\b0\.1\.0a\d+\b", html)
+    if stale and major_minor != "0.1":
+        print(
+            f"docs references stale prerelease {stale[0]}, current is {version}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"docs.axint.ai/python/install matches pyproject {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-metrics.mjs
+++ b/scripts/check-metrics.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Fail if the committed metrics.json disagrees with source.
+// CI runs this before releases and before docs/site builds.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { computeMetrics } from "./metrics.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SNAPSHOT = resolve(ROOT, "metrics.json");
+
+let committed;
+try {
+  committed = JSON.parse(readFileSync(SNAPSHOT, "utf-8"));
+} catch {
+  console.error(`metrics.json missing — run: npm run metrics:emit`);
+  process.exit(1);
+}
+
+const fresh = computeMetrics();
+const drift = diff(committed, fresh);
+
+if (drift.length === 0) {
+  console.log(`metrics.json matches source`);
+  process.exit(0);
+}
+
+console.error(`metrics drift — metrics.json is stale\n`);
+for (const d of drift) {
+  console.error(`  ${d.path.padEnd(24)} committed=${d.committed}  source=${d.source}`);
+}
+console.error(`\nrun: npm run metrics:emit`);
+process.exit(1);
+
+function diff(a, b, path = "") {
+  const out = [];
+  const keys = new Set([...Object.keys(a ?? {}), ...Object.keys(b ?? {})]);
+  for (const key of keys) {
+    const nextPath = path ? `${path}.${key}` : key;
+    const av = a?.[key];
+    const bv = b?.[key];
+    if (isObject(av) && isObject(bv)) {
+      out.push(...diff(av, bv, nextPath));
+    } else if (av !== bv) {
+      out.push({ path: nextPath, committed: av, source: bv });
+    }
+  }
+  return out;
+}
+
+function isObject(v) {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// Fail if any surface disagrees with root package.json.
+// CI runs this to catch drift before a release ships.
+
+import { readCanonicalVersion, SURFACES } from "./versions.mjs";
+
+const expected = readCanonicalVersion();
+const drifts = [];
+
+for (const surface of SURFACES) {
+  for (const row of surface.read()) {
+    if (row.value !== expected) {
+      drifts.push({ file: surface.file, where: row.where, got: row.value });
+    }
+  }
+}
+
+if (drifts.length === 0) {
+  console.log(`all ${SURFACES.length} surfaces pinned to ${expected}`);
+  process.exit(0);
+}
+
+console.error(`version drift — root package.json is ${expected}\n`);
+for (const d of drifts) {
+  console.error(`  ${d.file} (${d.where}) → ${d.got}`);
+}
+console.error(`\nrun: node scripts/sync-versions.mjs`);
+process.exit(1);

--- a/scripts/emit-metrics.mjs
+++ b/scripts/emit-metrics.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Recompute metrics from source and write metrics.json.
+//   node scripts/emit-metrics.mjs
+
+import { writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { computeMetrics } from "./metrics.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const OUT = resolve(ROOT, "metrics.json");
+
+const metrics = computeMetrics();
+writeFileSync(OUT, JSON.stringify(metrics, null, 2) + "\n");
+
+const { tests, ...flat } = metrics;
+const entries = Object.entries(flat)
+  .concat([
+    ["tests.typescript", tests.typescript],
+    ["tests.python", tests.python],
+  ])
+  .map(([k, v]) => `  ${k.padEnd(22)} ${v}`)
+  .join("\n");
+
+console.log(`wrote ${OUT}\n\n${entries}`);

--- a/scripts/metrics.mjs
+++ b/scripts/metrics.mjs
@@ -117,11 +117,14 @@ function countUniqueDiagnostics() {
 }
 
 function runVitestCount() {
+  // Pin CI=1 so test.skipIf(isCI) blocks are excluded everywhere — otherwise the
+  // snapshot drifts between dev machines and CI and the whole check is noise.
   const out = execSync("npx vitest list --json", {
     cwd: ROOT,
     stdio: ["ignore", "pipe", "ignore"],
     encoding: "utf-8",
     maxBuffer: 32 * 1024 * 1024,
+    env: { ...process.env, CI: "1" },
   });
   const jsonStart = out.indexOf("[");
   if (jsonStart === -1) throw new Error("vitest list --json produced no array");

--- a/scripts/metrics.mjs
+++ b/scripts/metrics.mjs
@@ -1,0 +1,172 @@
+// Compute every headline metric directly from the source tree.
+// `scripts/emit-metrics.mjs` writes the result; `scripts/check-metrics.mjs`
+// compares it against the committed snapshot so CI catches drift.
+
+import { execSync } from "node:child_process";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export function computeMetrics({ countTests = true } = {}) {
+  const version = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf-8")).version;
+
+  return {
+    version,
+    mcpTools: countExportedArray("src/mcp/manifest.ts", "TOOL_MANIFEST"),
+    mcpPrompts: countExportedArray("src/mcp/prompts.ts", "PROMPT_MANIFEST"),
+    bundledTemplates: countExportedArray("src/templates/index.ts", "TEMPLATES"),
+    diagnostics: countUniqueDiagnostics(),
+    tests: countTests
+      ? {
+          typescript: runVitestCount(),
+          python: runPytestCount(),
+        }
+      : { typescript: 0, python: 0 },
+    // Kept as explicit constants — both depend on repos outside the compiler tree.
+    // Update these when the corresponding surface ships a new package.
+    registryPackages: 8,
+    distributionSurfaces: 4,
+  };
+}
+
+function countExportedArray(relPath, symbol) {
+  const src = readFileSync(resolve(ROOT, relPath), "utf-8");
+  const anchor = new RegExp(`export\\s+const\\s+${symbol}[^=]*=\\s*\\[`, "m");
+  const match = anchor.exec(src);
+  if (!match) throw new Error(`${relPath}: no export const ${symbol} = [ ... ]`);
+  const open = match.index + match[0].length - 1;
+
+  let depth = 0;
+  let items = 0;
+  let inString = null;
+  let escaped = false;
+
+  for (let i = open; i < src.length; i++) {
+    const c = src[i];
+
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (c === "\\") escaped = true;
+      else if (c === inString) inString = null;
+      continue;
+    }
+
+    if (c === '"' || c === "'" || c === "`") {
+      inString = c;
+      continue;
+    }
+
+    if (c === "[" || c === "{" || c === "(") depth++;
+    else if (c === "]" || c === "}" || c === ")") {
+      depth--;
+      if (depth === 0 && c === "]") {
+        // Count top-level commas inside the array. Trailing commas don't add an item.
+        const inner = src.slice(open + 1, i);
+        items = countTopLevelCommas(inner);
+        return items === 0 ? (inner.trim() ? 1 : 0) : items + (endsWithTrailingComma(inner) ? 0 : 1);
+      }
+    }
+  }
+  throw new Error(`${relPath}: unterminated ${symbol} array`);
+}
+
+function countTopLevelCommas(s) {
+  let depth = 0;
+  let inString = null;
+  let escaped = false;
+  let commas = 0;
+
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (c === "\\") escaped = true;
+      else if (c === inString) inString = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      inString = c;
+      continue;
+    }
+    if (c === "[" || c === "{" || c === "(") depth++;
+    else if (c === "]" || c === "}" || c === ")") depth--;
+    else if (c === "," && depth === 0) commas++;
+  }
+  return commas;
+}
+
+function endsWithTrailingComma(s) {
+  const trimmed = s.trimEnd();
+  return trimmed.endsWith(",");
+}
+
+function countUniqueDiagnostics() {
+  const seen = new Set();
+  const pattern = /code:\s*"(AX\d+)"/g;
+
+  for (const file of walk(resolve(ROOT, "src/core"), ".ts")) {
+    const text = readFileSync(file, "utf-8");
+    for (const match of text.matchAll(pattern)) {
+      seen.add(match[1]);
+    }
+  }
+
+  return seen.size;
+}
+
+function runVitestCount() {
+  const out = execSync("npx vitest list --json", {
+    cwd: ROOT,
+    stdio: ["ignore", "pipe", "ignore"],
+    encoding: "utf-8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  const jsonStart = out.indexOf("[");
+  if (jsonStart === -1) throw new Error("vitest list --json produced no array");
+  const data = JSON.parse(out.slice(jsonStart));
+  return Array.isArray(data) ? data.length : 0;
+}
+
+function runPytestCount() {
+  const pythonDir = resolve(ROOT, "python");
+  try {
+    statSync(resolve(pythonDir, "pyproject.toml"));
+  } catch {
+    return 0;
+  }
+  try {
+    const out = execSync("python -m pytest --collect-only -q", {
+      cwd: pythonDir,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf-8",
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    const match = out.match(/(\d+)\s+tests?\s+collected/);
+    if (match) return Number(match[1]);
+    return out.split("\n").filter((line) => line.includes("::test_")).length;
+  } catch {
+    // pytest not installed locally — fall back to static grep so the snapshot
+    // stays deterministic between dev machines and CI
+    let total = 0;
+    for (const file of walk(resolve(pythonDir, "tests"), ".py")) {
+      const text = readFileSync(file, "utf-8");
+      total += (text.match(/^\s*def\s+test_/gm) ?? []).length;
+    }
+    return total;
+  }
+}
+
+function* walk(dir, ...exts) {
+  for (const name of readdirSync(dir)) {
+    if (name.startsWith(".") || name === "node_modules" || name === "__pycache__") continue;
+    const full = join(dir, name);
+    const info = statSync(full);
+    if (info.isDirectory()) {
+      yield* walk(full, ...exts);
+    } else if (exts.some((e) => name.endsWith(e))) {
+      yield full;
+    }
+  }
+}

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// Rewrite every surface to match root package.json. Run after bumping.
+//   node scripts/sync-versions.mjs
+
+import { readCanonicalVersion, SURFACES } from "./versions.mjs";
+
+const version = readCanonicalVersion();
+
+for (const surface of SURFACES) {
+  surface.write(version);
+  console.log(`  ${surface.file} → ${version}`);
+}
+
+console.log(`\nsynced ${SURFACES.length} surfaces to ${version}`);

--- a/scripts/versions.mjs
+++ b/scripts/versions.mjs
@@ -1,0 +1,107 @@
+// Shared description of every surface that pins the Axint version.
+// `scripts/sync-versions.mjs` writes; `scripts/check-versions.mjs` reads.
+// Root `package.json` is the canonical source. Touch that, then run sync.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export const CANONICAL_FILE = "package.json";
+
+export function readCanonicalVersion() {
+  const pkg = JSON.parse(readFileSync(resolve(ROOT, CANONICAL_FILE), "utf-8"));
+  if (typeof pkg.version !== "string" || !pkg.version) {
+    throw new Error(`root package.json has no version field`);
+  }
+  return pkg.version;
+}
+
+/**
+ * Each surface knows how to read and (re)write its own version.
+ * Keeping the logic next to the file path prevents drift between the two.
+ */
+export const SURFACES = [
+  pkgJson("package.json"),
+  pyproject("python/pyproject.toml"),
+  pkgJson("extensions/vscode/package.json"),
+  pkgJson("extensions/claude-desktop/server/package.json"),
+  serverJson("server.json"),
+  workerConst("workers/mcp-http/src/worker.ts"),
+];
+
+function pkgJson(relPath) {
+  const abs = resolve(ROOT, relPath);
+  const pattern = /"version":\s*"[^"]*"/;
+  return {
+    file: relPath,
+    read() {
+      const pkg = JSON.parse(readFileSync(abs, "utf-8"));
+      return [{ where: "version", value: pkg.version }];
+    },
+    write(version) {
+      // Preserve exact formatting — only the version line changes.
+      const text = readFileSync(abs, "utf-8");
+      if (!pattern.test(text)) throw new Error(`${relPath} has no version field`);
+      writeFileSync(abs, text.replace(pattern, `"version": "${version}"`));
+    },
+  };
+}
+
+function pyproject(relPath) {
+  const abs = resolve(ROOT, relPath);
+  const pattern = /^version\s*=\s*"([^"]+)"/m;
+  return {
+    file: relPath,
+    read() {
+      const match = readFileSync(abs, "utf-8").match(pattern);
+      if (!match) throw new Error(`${relPath} has no version line`);
+      return [{ where: "version", value: match[1] }];
+    },
+    write(version) {
+      const text = readFileSync(abs, "utf-8");
+      if (!pattern.test(text)) throw new Error(`${relPath} has no version line`);
+      writeFileSync(abs, text.replace(pattern, `version = "${version}"`));
+    },
+  };
+}
+
+function serverJson(relPath) {
+  const abs = resolve(ROOT, relPath);
+  return {
+    file: relPath,
+    read() {
+      const data = JSON.parse(readFileSync(abs, "utf-8"));
+      const rows = [{ where: "version", value: data.version }];
+      for (const [i, pkg] of (data.packages ?? []).entries()) {
+        rows.push({ where: `packages[${i}].version`, value: pkg.version });
+      }
+      return rows;
+    },
+    write(version) {
+      const data = JSON.parse(readFileSync(abs, "utf-8"));
+      data.version = version;
+      for (const pkg of data.packages ?? []) pkg.version = version;
+      writeFileSync(abs, JSON.stringify(data, null, 2) + "\n");
+    },
+  };
+}
+
+function workerConst(relPath) {
+  const abs = resolve(ROOT, relPath);
+  const pattern = /(const\s+VERSION\s*=\s*)"([^"]+)"/;
+  return {
+    file: relPath,
+    read() {
+      const match = readFileSync(abs, "utf-8").match(pattern);
+      if (!match) throw new Error(`${relPath} has no VERSION constant`);
+      return [{ where: "VERSION", value: match[2] }];
+    },
+    write(version) {
+      const text = readFileSync(abs, "utf-8");
+      if (!pattern.test(text)) throw new Error(`${relPath} has no VERSION constant`);
+      writeFileSync(abs, text.replace(pattern, `$1"${version}"`));
+    },
+  };
+}


### PR DESCRIPTION
Version, metrics, and docs drift are caught in CI now.

`scripts/versions.mjs` is the single source of truth for the 0.3.9 version across root package.json, python/pyproject.toml, both extensions, server.json, and the mcp-http worker. `versions:sync` writes them all from root; `versions:check` fails CI if any surface disagrees.

`scripts/metrics.mjs` computes tool/prompt/template/diagnostic/test counts from the source tree; `metrics.json` pins the snapshot and `metrics:check` fails CI if they drift.

`scripts/check-docs-freshness.py` fetches docs.axint.ai/python/install on main and fails if the rendered install command doesn't reference the package's pyproject version. Catches the 0.1.0a1 regression we shipped last week.

Also rolls in the four satellite bumps to 0.3.9 — identical bytes to #127, rebases cleanly whichever merges first.