### PR TITLE
route registry base url through env module

### DIFF
--- a/src/cli/add.ts
+++ b/src/cli/add.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { hashBundle } from "../core/bundle-hash.js";
+import { registryBaseUrl } from "../core/env.js";
 
 export function registerAdd(program: Command, version: string) {
   program
@@ -29,7 +30,7 @@ export function registerAdd(program: Command, version: string) {
 
       const [, rawNamespace, slug, pkgVersion] = match;
       const namespace = `@${rawNamespace}`;
-      const registryUrl = process.env.AXINT_REGISTRY_URL ?? "https://registry.axint.ai";
+      const registryUrl = registryBaseUrl();
 
       console.log(
         `  \x1b[2m⏺\x1b[0m Fetching ${namespace}/${slug}${pkgVersion ? `@${pkgVersion}` : ""}…`

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { spawn } from "node:child_process";
+import { registryBaseUrl } from "../core/env.js";
 
 export function registerLogin(program: Command) {
   program
@@ -12,7 +13,7 @@ export function registerLogin(program: Command) {
 
       const configDir = join(homedir(), ".axint");
       const credPath = join(configDir, "credentials.json");
-      const registryUrl = process.env.AXINT_REGISTRY_URL ?? "https://registry.axint.ai";
+      const registryUrl = registryBaseUrl();
 
       console.log();
       console.log(`  \x1b[38;5;208m◆\x1b[0m \x1b[1mAxint\x1b[0m · login`);

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -3,6 +3,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { compileFile } from "../core/compiler.js";
 import { hashBundle } from "../core/bundle-hash.js";
+import { registryBaseUrl } from "../core/env.js";
 
 export function registerPublish(program: Command, version: string) {
   program
@@ -167,7 +168,7 @@ export function registerPublish(program: Command, version: string) {
         process.exit(1);
       }
 
-      const registryUrl = creds.registry ?? "https://registry.axint.ai";
+      const registryUrl = creds.registry ?? registryBaseUrl();
 
       console.log(`  \x1b[2m⏺\x1b[0m Publishing to ${registryUrl}…`);
 

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -1,0 +1,27 @@
+// Three-env setup for the CLI. AXINT_ENV picks the default endpoints; any
+// explicit AXINT_REGISTRY_URL still wins so local overrides don't need a
+// custom env value.
+
+export type AxintEnv = "dev" | "preview" | "prod";
+
+type Endpoints = {
+  registry: string;
+};
+
+const endpoints: Record<AxintEnv, Endpoints> = {
+  dev: { registry: "http://127.0.0.1:8787" },
+  preview: { registry: "https://preview.registry.axint.ai" },
+  prod: { registry: "https://registry.axint.ai" },
+};
+
+export function resolveEnv(value: string | undefined): AxintEnv {
+  const v = value?.toLowerCase();
+  if (v === "dev" || v === "preview" || v === "prod") return v;
+  return "prod";
+}
+
+export function registryBaseUrl(env = resolveEnv(process.env.AXINT_ENV)): string {
+  const override = process.env.AXINT_REGISTRY_URL;
+  if (override) return override;
+  return endpoints[env].registry;
+}


### PR DESCRIPTION
Adds a small `core/env.ts` that resolves the registry base URL from `AXINT_ENV` (dev/preview/prod) with `AXINT_REGISTRY_URL` as an explicit override. `add`, `publish`, and `login` now call `registryBaseUrl()` instead of carrying their own hardcoded prod defaults, so preview builds stop talking to production by accident.