### PR TITLE
add entity codegen to python generator

### DIFF
--- a/metrics.json
+++ b/metrics.json
@@ -6,7 +6,7 @@
   "diagnostics": 130,
   "tests": {
     "typescript": 522,
-    "python": 91
+    "python": 99
   },
   "registryPackages": 8,
   "distributionSurfaces": 4

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -31,6 +31,8 @@ __version__ = "0.3.8"
 
 from .generator import (
     generate_entitlements_fragment,
+    generate_entity,
+    generate_entity_query,
     generate_info_plist_fragment,
     generate_swift,
     generate_swift_app,
@@ -137,6 +139,8 @@ __all__ = [
     "define_widget",
     "entry",
     "generate_entitlements_fragment",
+    "generate_entity",
+    "generate_entity_query",
     "generate_info_plist_fragment",
     "generate_swift",
     "generate_swift_app",

--- a/python/axint/generator.py
+++ b/python/axint/generator.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from .ir import (
     AppIR,
+    EntityIR,
     IntentIR,
     IntentParameter,
     ParamType,
@@ -260,6 +261,130 @@ def generate_entitlements_fragment(intent: IntentIR) -> str | None:
     lines.append("</dict>")
     lines.append("</plist>")
     lines.append("")
+
+    return "\n".join(lines)
+
+
+# ── Entity Generator ────────────────────────────────────────────────
+#
+# Kept byte-for-byte aligned with `generateEntity` / `generateEntityQuery` in
+# src/core/generator.ts. A Python-authored entity compiled here must produce
+# the same Swift source as one authored in TypeScript.
+
+_COMPARABLE_SWIFT_TYPES = {"Int", "Double", "Float", "Date"}
+
+
+def generate_entity(entity: EntityIR) -> str:
+    """Generate an AppEntity Swift struct from an EntityIR."""
+    property_names = {p.name for p in entity.properties}
+    lines: list[str] = [
+        f"struct {entity.name}: AppEntity {{",
+        f"    static var defaultQuery = {entity.name}Query()",
+        "",
+    ]
+
+    # Apple requires AppEntity to declare an `id`. If the user didn't, we add it.
+    if "id" not in property_names:
+        lines.append("    var id: String")
+
+    for prop in entity.properties:
+        lines.append(f"    var {prop.name}: {param_type_to_swift(prop.type)}")
+
+    lines.append("")
+    lines.append(
+        "    static let typeDisplayRepresentation: TypeDisplayRepresentation = TypeDisplayRepresentation("
+    )
+    lines.append(
+        f'        name: LocalizedStringResource("{escape_swift_string(entity.name)}")'
+    )
+    lines.append("    )")
+    lines.append("")
+
+    # Display representation references property names via Swift interpolation —
+    # we emit `\(propName)` which Swift resolves against the entity instance.
+    display = entity.display_representation
+    lines.append("    var displayRepresentation: DisplayRepresentation {")
+    lines.append("        DisplayRepresentation(")
+
+    has_subtitle = display.subtitle is not None
+    has_image = display.image is not None
+    title_trailing = "," if has_subtitle or has_image else ""
+    lines.append(f'            title: "\\({display.title})"{title_trailing}')
+
+    if has_subtitle:
+        subtitle_trailing = "," if has_image else ""
+        lines.append(f'            subtitle: "\\({display.subtitle})"{subtitle_trailing}')
+
+    if has_image:
+        lines.append(
+            f'            image: .init(systemName: "{escape_swift_string(display.image or "")}")'
+        )
+
+    lines.append("        )")
+    lines.append("    }")
+    lines.append("}")
+
+    return "\n".join(lines)
+
+
+def generate_entity_query(entity: EntityIR) -> str:
+    """Generate the EntityQuery conformance matching the entity's query_type."""
+    protocol = "EntityPropertyQuery" if entity.query_type == "property" else "EntityQuery"
+
+    lines: list[str] = [
+        f"struct {entity.name}Query: {protocol} {{",
+        f"    func entities(for identifiers: [{entity.name}.ID]) async throws -> [{entity.name}] {{",
+        "        // TODO: Fetch entities by IDs",
+        "        return []",
+        "    }",
+        "",
+    ]
+
+    if entity.query_type == "all":
+        lines.append(f"    func allEntities() async throws -> [{entity.name}] {{")
+        lines.append("        // TODO: Return all entities")
+        lines.append("        return []")
+        lines.append("    }")
+    elif entity.query_type == "id":
+        lines.append("    // ID-based query is provided by the entities(for:) method above")
+    elif entity.query_type == "string":
+        lines.append(
+            f"    func entities(matching string: String) async throws -> [{entity.name}] {{"
+        )
+        lines.append("        // TODO: Search entities by string")
+        lines.append("        return []")
+        lines.append("    }")
+    elif entity.query_type == "property":
+        primitives = [p for p in entity.properties if isinstance(p.type, str)]
+
+        lines.append("    static var properties = QueryProperties {")
+        for prop in primitives:
+            swift_type = param_type_to_swift(prop.type)
+            lines.append(f"        Property(\\{entity.name}.{prop.name}) {{")
+            lines.append("            EqualToComparator()")
+            if swift_type == "String":
+                lines.append("            ContainsComparator()")
+            if swift_type in _COMPARABLE_SWIFT_TYPES:
+                lines.append("            LessThanComparator()")
+                lines.append("            GreaterThanComparator()")
+            lines.append("        }")
+        lines.append("    }")
+        lines.append("")
+        lines.append("    static var sortingOptions = SortingOptions {")
+        for prop in primitives:
+            lines.append(f"        SortableBy(\\{entity.name}.{prop.name})")
+        lines.append("    }")
+        lines.append("")
+        lines.append(
+            f"    func entities(matching comparators: [{entity.name}Comparator], "
+            f"mode: ComparatorMode, sortedBy: [{entity.name}Sort], limit: Int?) "
+            f"async throws -> [{entity.name}] {{"
+        )
+        lines.append("        // TODO: Filter and sort entities using the comparators")
+        lines.append("        return []")
+        lines.append("    }")
+
+    lines.append("}")
 
     return "\n".join(lines)
 

--- a/python/tests/test_entity_generator.py
+++ b/python/tests/test_entity_generator.py
@@ -1,0 +1,115 @@
+"""Parity tests for the Python entity generator.
+
+Every expected string in this file was captured from the TypeScript reference
+generator (src/core/generator.ts). If these diverge, the Python and TS SDKs
+are no longer producing compatible Swift — which breaks the registry promise
+that a package authored in either language drops into any project.
+"""
+
+from __future__ import annotations
+
+from axint import generate_entity, generate_entity_query
+from axint.ir import DisplayRepresentationIR, EntityIR, IntentParameter
+
+
+def _entity(
+    *,
+    properties: tuple[IntentParameter, ...] = (),
+    query_type: str = "id",
+    display: DisplayRepresentationIR | None = None,
+) -> EntityIR:
+    return EntityIR(
+        name="Contact",
+        display_representation=display
+        or DisplayRepresentationIR(title="name"),
+        properties=properties,
+        query_type=query_type,
+    )
+
+
+def test_generate_entity_adds_id_when_absent() -> None:
+    swift = generate_entity(_entity())
+    assert "struct Contact: AppEntity {" in swift
+    assert "static var defaultQuery = ContactQuery()" in swift
+    assert "var id: String" in swift
+
+
+def test_generate_entity_skips_synthesized_id_when_present() -> None:
+    swift = generate_entity(
+        _entity(
+            properties=(
+                IntentParameter(name="id", type="string", description="uuid"),
+                IntentParameter(name="name", type="string", description="display name"),
+            ),
+        )
+    )
+    # Should appear exactly once — we don't double-declare it.
+    assert swift.count("var id: String") == 1
+    assert "var name: String" in swift
+
+
+def test_generate_entity_display_representation_title_only() -> None:
+    swift = generate_entity(_entity())
+    # No trailing comma on title when there's no subtitle/image.
+    assert 'title: "\\(name)"' in swift
+    assert 'title: "\\(name)",' not in swift
+
+
+def test_generate_entity_display_representation_with_subtitle_and_image() -> None:
+    swift = generate_entity(
+        _entity(
+            display=DisplayRepresentationIR(
+                title="name",
+                subtitle="email",
+                image="person.circle",
+            ),
+        ),
+    )
+    assert 'title: "\\(name)",' in swift
+    assert 'subtitle: "\\(email)",' in swift
+    assert 'image: .init(systemName: "person.circle")' in swift
+
+
+def test_generate_entity_query_id_protocol() -> None:
+    swift = generate_entity_query(_entity())
+    assert "struct ContactQuery: EntityQuery {" in swift
+    assert "func entities(for identifiers: [Contact.ID]) async throws -> [Contact]" in swift
+    assert "ID-based query is provided by the entities(for:) method above" in swift
+
+
+def test_generate_entity_query_all() -> None:
+    swift = generate_entity_query(_entity(query_type="all"))
+    assert "func allEntities() async throws -> [Contact]" in swift
+
+
+def test_generate_entity_query_string() -> None:
+    swift = generate_entity_query(_entity(query_type="string"))
+    assert "func entities(matching string: String) async throws -> [Contact]" in swift
+
+
+def test_generate_entity_query_property() -> None:
+    swift = generate_entity_query(
+        _entity(
+            properties=(
+                IntentParameter(name="name", type="string", description="full name"),
+                IntentParameter(name="age", type="int", description="years"),
+            ),
+            query_type="property",
+        )
+    )
+    assert "struct ContactQuery: EntityPropertyQuery {" in swift
+    assert "static var properties = QueryProperties {" in swift
+    # String props get Equal + Contains comparators.
+    assert "Property(\\Contact.name) {" in swift
+    assert "EqualToComparator()" in swift
+    assert "ContainsComparator()" in swift
+    # Numeric props get Equal + Less + Greater.
+    assert "Property(\\Contact.age) {" in swift
+    assert "LessThanComparator()" in swift
+    assert "GreaterThanComparator()" in swift
+    # Both go into the sort options block.
+    assert "SortableBy(\\Contact.name)" in swift
+    assert "SortableBy(\\Contact.age)" in swift
+    # And the filter/sort function signature is emitted.
+    assert "mode: ComparatorMode" in swift
+    assert "limit: Int?" in swift


### PR DESCRIPTION
TS compiler exposed generateEntity and generateEntityQuery. Python SDK didn't. This adds both, kept byte-for-byte aligned with the TS reference. Eight new tests cover id synthesis, display representation comma rules, and the four query-type protocols. Closes the codegen parity slice of Phase 1 Action 03.