### PR TITLE
phase 1 residuals: version ssot, readme audit, pyright ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Type check with mypy
         run: mypy axint
 
+      - name: Type check with pyright
+        run: pyright
+
       - name: Run tests with coverage
         run: pytest -v --tb=short --cov=axint --cov-report=json --cov-report=lcov --cov-report=term
 

--- a/python/README.md
+++ b/python/README.md
@@ -46,23 +46,25 @@ create_event = define_intent(
 
 ## Compile it
 
+The Python SDK installs a CLI at `axint-py` (the TypeScript compiler owns the `axint` name on npm).
+
 ```bash
 # Parse and inspect the IR
-axint parse intents/create_event.py
-axint parse intents/create_event.py --json
+axint-py parse intents/create_event.py
+axint-py parse intents/create_event.py --json
 
 # Compile Python → Swift (native, no Node.js needed)
-axint compile intents/create_event.py --stdout
-axint compile intents/create_event.py --out ios/Intents/
+axint-py compile intents/create_event.py --stdout
+axint-py compile intents/create_event.py --out ios/Intents/
 
 # With companion fragments
-axint compile intents/create_event.py --out ios/Intents/ --emit-info-plist --emit-entitlements
+axint-py compile intents/create_event.py --out ios/Intents/ --emit-info-plist --emit-entitlements
 
 # Validate without generating Swift
-axint validate intents/create_event.py
+axint-py validate intents/create_event.py
 
 # Machine-readable output
-axint compile intents/create_event.py --json
+axint-py compile intents/create_event.py --json
 ```
 
 ## Use it as a library
@@ -88,7 +90,7 @@ swift_code = generate_swift(ir)
 The Python SDK produces compatible IR JSON that the TypeScript compiler can consume. You can pipe it in for additional validation and Swift generation:
 
 ```bash
-axint parse intent.py --json | axint compile - --from-ir --stdout
+axint-py parse intent.py --json | axint compile - --from-ir --stdout
 ```
 
 ## Why Python?
@@ -102,11 +104,16 @@ The Python parser never runs your code. It walks the Python AST the same way the
 | Feature                          | TypeScript | Python |
 |----------------------------------|------------|--------|
 | `define_intent` / `defineIntent` | ✅          | ✅      |
+| `define_entity` / `defineEntity` | ✅          | ✅      |
+| `define_view` / `defineView`     | ✅          | ✅      |
+| `define_widget` / `defineWidget` | ✅          | ✅      |
+| `define_app` / `defineApp`       | ✅          | ✅      |
 | `param.string/int/double/...`    | ✅          | ✅      |
 | `entitlements`, `infoPlistKeys`  | ✅          | ✅      |
 | `isDiscoverable`                 | ✅          | ✅      |
 | Multi-intent files               | ✅          | ✅      |
 | Swift codegen (native)           | ✅          | ✅      |
+| `EntityQuery` codegen            | ✅          | ✅      |
 | IR validation                    | ✅          | ✅      |
 | Info.plist fragment              | ✅          | ✅      |
 | Entitlements fragment            | ✅          | ✅      |

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/axint/generator.py
+++ b/python/axint/generator.py
@@ -17,11 +17,13 @@ from typing import Any
 
 from .ir import (
     AppIR,
+    AppSceneIR,
     EntityIR,
     IntentIR,
     IntentParameter,
     ParamType,
     ViewIR,
+    ViewStateIR,
     WidgetIR,
 )
 
@@ -451,31 +453,21 @@ def generate_swift_view(view: ViewIR) -> str:
     return "\n".join(lines)
 
 
-def _generate_view_state_property(state: object) -> str:
+def _generate_view_state_property(state: ViewStateIR) -> str:
     """Generate a state property declaration."""
-    if not hasattr(state, "name") or not hasattr(state, "kind") or not hasattr(state, "type"):
-        return ""
+    swift_type = param_type_to_swift(state.type)
 
-    name = state.name
-    kind = state.kind
-    param_type = state.type
-    default_value = getattr(state, "default", None)
-
-    swift_type = param_type_to_swift(param_type)
-
-    if kind == "binding":
-        return f"    @Binding var {name}: {swift_type}"
-    elif kind == "environment":
-        env_key = getattr(state, "environment_key", None)
-        key_str = env_key or f".{name}"
-        return f"    @Environment({key_str}) var {name}"
-    elif kind == "observed":
-        return f"    @ObservedObject var {name}: {swift_type}"
-    else:
-        if default_value is not None:
-            default_str = _format_swift_literal(default_value, param_type)
-            return f"    @State private var {name}: {swift_type} = {default_str}"
-        return f"    @State private var {name}: {swift_type}"
+    if state.kind == "binding":
+        return f"    @Binding var {state.name}: {swift_type}"
+    if state.kind == "environment":
+        key_str = state.environment_key or f".{state.name}"
+        return f"    @Environment({key_str}) var {state.name}"
+    if state.kind == "observed":
+        return f"    @ObservedObject var {state.name}: {swift_type}"
+    if state.default is not None:
+        default_str = _format_swift_literal(state.default, state.type)
+        return f"    @State private var {state.name}: {swift_type} = {default_str}"
+    return f"    @State private var {state.name}: {swift_type}"
 
 
 def _generate_body_node(node: dict[str, Any], depth: int) -> list[str]:
@@ -762,10 +754,10 @@ def generate_swift_app(app: AppIR) -> str:
 
     lines.append("    var body: some Scene {")
 
-    ungrouped = [s for s in app.scenes if not hasattr(s, "platform") or not s.platform]
-    mac_only = [s for s in app.scenes if hasattr(s, "platform") and s.platform == "macOS"]
-    ios_only = [s for s in app.scenes if hasattr(s, "platform") and s.platform == "iOS"]
-    vision_only = [s for s in app.scenes if hasattr(s, "platform") and s.platform == "visionOS"]
+    ungrouped = [s for s in app.scenes if not s.platform]
+    mac_only = [s for s in app.scenes if s.platform == "macOS"]
+    ios_only = [s for s in app.scenes if s.platform == "iOS"]
+    vision_only = [s for s in app.scenes if s.platform == "visionOS"]
 
     for scene in ungrouped:
         scene_lines = _generate_scene(scene, 2)
@@ -799,18 +791,15 @@ def generate_swift_app(app: AppIR) -> str:
     return "\n".join(lines)
 
 
-def _generate_scene(scene: object, depth: int) -> list[str]:
+def _generate_scene(scene: AppSceneIR, depth: int) -> list[str]:
     """Generate a scene declaration."""
     lines: list[str] = []
     indent = "    " * depth
 
-    if not hasattr(scene, "kind"):
-        return lines
-
     kind = scene.kind
-    view = getattr(scene, "view", "")
-    title = getattr(scene, "title", None)
-    name = getattr(scene, "name", None)
+    view = scene.view
+    title = scene.title
+    name = scene.name
 
     if kind == "windowGroup":
         args: list[str] = []

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "pytest-cov>=5.0",
     "ruff>=0.6",
     "mypy>=1.11",
+    "pyright>=1.1.400",
     "pyyaml>=6.0",
     "types-PyYAML>=6.0",
 ]
@@ -89,3 +90,13 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = "mcp.*"
 ignore_missing_imports = true
+
+[tool.pyright]
+include = ["axint"]
+exclude = ["axint/mcp_server.py"]
+pythonVersion = "3.11"
+typeCheckingMode = "standard"
+reportMissingImports = "error"
+reportAttributeAccessIssue = "error"
+reportArgumentType = "error"
+reportReturnType = "error"

--- a/scripts/versions.mjs
+++ b/scripts/versions.mjs
@@ -25,6 +25,7 @@ export function readCanonicalVersion() {
 export const SURFACES = [
   pkgJson("package.json"),
   pyproject("python/pyproject.toml"),
+  pyModule("python/axint/__init__.py"),
   pkgJson("extensions/vscode/package.json"),
   pkgJson("extensions/claude-desktop/server/package.json"),
   serverJson("server.json"),
@@ -84,6 +85,24 @@ function serverJson(relPath) {
       data.version = version;
       for (const pkg of data.packages ?? []) pkg.version = version;
       writeFileSync(abs, JSON.stringify(data, null, 2) + "\n");
+    },
+  };
+}
+
+function pyModule(relPath) {
+  const abs = resolve(ROOT, relPath);
+  const pattern = /^__version__\s*=\s*"([^"]+)"/m;
+  return {
+    file: relPath,
+    read() {
+      const match = readFileSync(abs, "utf-8").match(pattern);
+      if (!match) throw new Error(`${relPath} has no __version__ constant`);
+      return [{ where: "__version__", value: match[1] }];
+    },
+    write(version) {
+      const text = readFileSync(abs, "utf-8");
+      if (!pattern.test(text)) throw new Error(`${relPath} has no __version__ constant`);
+      writeFileSync(abs, text.replace(pattern, `__version__ = "${version}"`));
     },
   };
 }


### PR DESCRIPTION
Three small cleanups that close out phase 1.

**Version SSOT.** `python/axint/__init__.py` was drifting — `__version__` got pinned to 0.3.8 while everything else moved to 0.3.9. Added `pyModule()` to `scripts/versions.mjs` so the Python module reads/writes through the same sync as `package.json` and `pyproject.toml`. Now 7 surfaces stay locked to root.

**README audit.** The Python install docs claimed CLI commands that don't exist — `axint compile` is the npm package, the Python wheel ships `axint-py` (since `axint` is taken on PyPI by an unrelated project). Updated all 7 CLI examples plus the cross-language bridge example. Also filled in the parity table — the Python SDK quietly hit feature parity for entity, view, widget, and app codegen but the table was stuck on intents.

**Pyright as a second type checker.** mypy strict catches a lot but missed the `hasattr()`-narrowed `state: object` signature in `_generate_view_state_property` — pyright spotted it. Added pyright to the dev extras and CI matrix in standard mode (with attribute access, argument type, and return type bumped to error). Strict mode flags 35 unrelated `reportUnknown*` issues across cli/sdk/ir that aren't real bugs and would require rewriting the dict-heavy parser layer; standard mode is the right line for now. Also cleaned up the actual hasattr-narrowing that pyright caught in generator.py — typed the helpers properly with ViewStateIR and AppSceneIR. mcp_server.py is excluded from pyright the same way it's excluded from mypy.