### PR TITLE
hard-fail release workflow and add pipefail across ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Verify CLI works
         run: |
+          set -euo pipefail
           OUTPUT=$(node dist/cli/index.js --version)
           [ -n "$OUTPUT" ] || exit 1
           echo "CLI version: $OUTPUT"
@@ -61,7 +62,8 @@ jobs:
           AXINT_CLOUD_REPORT_TOKEN: ${{ secrets.AXINT_CLOUD_REPORT_TOKEN }}
           AXINT_CLOUD_REPORT_URL: https://registry.axint.ai/api/v1/cloud/reports/ci
         run: |
-          if [ -z "$AXINT_CLOUD_REPORT_TOKEN" ]; then
+          set -euo pipefail
+          if [ -z "${AXINT_CLOUD_REPORT_TOKEN:-}" ]; then
             echo "AXINT_CLOUD_REPORT_TOKEN not set — skipping"
             exit 0
           fi
@@ -130,6 +132,7 @@ jobs:
 
       - name: Verify CLI works
         run: |
+          set -euo pipefail
           axint-py --version
           axint-py parse examples/create_event.py --json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Type check with mypy
         run: mypy axint
 
+      - name: Type check with pyright
+        run: pyright
+
       - name: Run tests with coverage
         run: pytest -v --tb=short --cov=axint --cov-report=json --cov-report=lcov --cov-report=term
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,12 @@ jobs:
       - run: npm run typecheck
       - run: npm run lint
       - run: npm test
-      - run: npm audit --audit-level=moderate || true
+      - run: npm audit --audit-level=moderate
       - run: npm run build
 
       - name: Verify CLI works
         run: |
+          set -euo pipefail
           OUTPUT=$(node dist/cli/index.js --version)
           [ -n "$OUTPUT" ] || exit 1
           echo "CLI version: $OUTPUT"
@@ -50,6 +51,7 @@ jobs:
       - name: Run Python tests
         working-directory: python
         run: |
+          set -euo pipefail
           pip install -e '.[dev]'
           pytest -v
 
@@ -59,17 +61,25 @@ jobs:
 
       # ── Publish ──────────────────────────────────────────────────
       - name: Publish to npm
-        run: npm publish --access public --provenance || echo "Version already published — skipping"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "::notice::$NAME@$VERSION already published, skipping"
+            exit 0
+          fi
+          npm publish --access public --provenance
 
       - name: Publish to PyPI
-        if: env.TWINE_PASSWORD != ''
+        if: ${{ secrets.PYPI_TOKEN != '' }}
         working-directory: python
-        run: twine upload dist/* --skip-existing
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: twine upload dist/* --skip-existing
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      # Bridge secrets to env so step `if:` conditions can gate on their presence.
+      # `secrets` context isn't available in step-level `if` expressions.
+      HAS_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -74,7 +78,7 @@ jobs:
           npm publish --access public --provenance
 
       - name: Publish to PyPI
-        if: ${{ secrets.PYPI_TOKEN != '' }}
+        if: env.HAS_PYPI_TOKEN == 'true'
         working-directory: python
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/wwdc-nightly.yml
+++ b/.github/workflows/wwdc-nightly.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Show Xcode version
         run: |
+          set -euo pipefail
           xcodebuild -version
           xcrun --sdk macosx --show-sdk-path
           xcrun --sdk macosx --show-sdk-version

--- a/.github/workflows/xcode-extension.yml
+++ b/.github/workflows/xcode-extension.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Build (unsigned smoke test)
         if: "!startsWith(github.ref, 'refs/tags/xcode-ext-v')"
         run: |
+          set -euo pipefail
           xcodebuild -project AxintForXcode.xcodeproj \
             -scheme "$SCHEME" \
             -configuration "$CONFIG" \
@@ -73,7 +74,7 @@ jobs:
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            build | xcpretty || true
+            build | xcpretty
 
       # ── Signed + notarized release path ──────────────────────────────
       - name: Import signing certificate
@@ -83,6 +84,7 @@ jobs:
           P12_PASSWORD: ${{ secrets.AXINT_SIGNING_CERT_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.AXINT_KEYCHAIN_PASSWORD }}
         run: |
+          set -euo pipefail
           KEYCHAIN_PATH=$RUNNER_TEMP/axint.keychain-db
           CERT_PATH=$RUNNER_TEMP/axint-cert.p12
           echo -n "$P12_BASE64" | base64 --decode -o "$CERT_PATH"
@@ -98,6 +100,7 @@ jobs:
         env:
           TEAM_ID: ${{ secrets.AXINT_DEVELOPMENT_TEAM }}
         run: |
+          set -euo pipefail
           ARCHIVE_PATH="$DERIVED/AxintForXcode.xcarchive"
           EXPORT_PATH="$DERIVED/export"
 
@@ -134,6 +137,7 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.AXINT_NOTARY_PASSWORD }}
           TEAM_ID: ${{ secrets.AXINT_NOTARY_TEAM_ID }}
         run: |
+          set -euo pipefail
           APP_PATH="$DERIVED/export/AxintForXcode.app"
           ZIP_PATH="$DERIVED/AxintForXcode.zip"
           ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"

--- a/.github/workflows/xcode-extension.yml
+++ b/.github/workflows/xcode-extension.yml
@@ -39,7 +39,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     defaults:
       run:
         working-directory: extensions/xcode/source-editor-extension
@@ -52,8 +52,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.4.app
+      - name: Select latest Xcode
+        run: |
+          set -euo pipefail
+          LATEST=$(ls -d /Applications/Xcode_*.app | sort -V | tail -1)
+          sudo xcode-select -s "$LATEST"
+          xcodebuild -version
 
       - name: Install XcodeGen
         run: brew install xcodegen

--- a/python/README.md
+++ b/python/README.md
@@ -46,23 +46,25 @@ create_event = define_intent(
 
 ## Compile it
 
+The Python SDK installs a CLI at `axint-py` (the TypeScript compiler owns the `axint` name on npm).
+
 ```bash
 # Parse and inspect the IR
-axint parse intents/create_event.py
-axint parse intents/create_event.py --json
+axint-py parse intents/create_event.py
+axint-py parse intents/create_event.py --json
 
 # Compile Python → Swift (native, no Node.js needed)
-axint compile intents/create_event.py --stdout
-axint compile intents/create_event.py --out ios/Intents/
+axint-py compile intents/create_event.py --stdout
+axint-py compile intents/create_event.py --out ios/Intents/
 
 # With companion fragments
-axint compile intents/create_event.py --out ios/Intents/ --emit-info-plist --emit-entitlements
+axint-py compile intents/create_event.py --out ios/Intents/ --emit-info-plist --emit-entitlements
 
 # Validate without generating Swift
-axint validate intents/create_event.py
+axint-py validate intents/create_event.py
 
 # Machine-readable output
-axint compile intents/create_event.py --json
+axint-py compile intents/create_event.py --json
 ```
 
 ## Use it as a library
@@ -88,7 +90,7 @@ swift_code = generate_swift(ir)
 The Python SDK produces compatible IR JSON that the TypeScript compiler can consume. You can pipe it in for additional validation and Swift generation:
 
 ```bash
-axint parse intent.py --json | axint compile - --from-ir --stdout
+axint-py parse intent.py --json | axint compile - --from-ir --stdout
 ```
 
 ## Why Python?
@@ -102,11 +104,16 @@ The Python parser never runs your code. It walks the Python AST the same way the
 | Feature                          | TypeScript | Python |
 |----------------------------------|------------|--------|
 | `define_intent` / `defineIntent` | ✅          | ✅      |
+| `define_entity` / `defineEntity` | ✅          | ✅      |
+| `define_view` / `defineView`     | ✅          | ✅      |
+| `define_widget` / `defineWidget` | ✅          | ✅      |
+| `define_app` / `defineApp`       | ✅          | ✅      |
 | `param.string/int/double/...`    | ✅          | ✅      |
 | `entitlements`, `infoPlistKeys`  | ✅          | ✅      |
 | `isDiscoverable`                 | ✅          | ✅      |
 | Multi-intent files               | ✅          | ✅      |
 | Swift codegen (native)           | ✅          | ✅      |
+| `EntityQuery` codegen            | ✅          | ✅      |
 | IR validation                    | ✅          | ✅      |
 | Info.plist fragment              | ✅          | ✅      |
 | Entitlements fragment            | ✅          | ✅      |

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/axint/generator.py
+++ b/python/axint/generator.py
@@ -17,11 +17,13 @@ from typing import Any
 
 from .ir import (
     AppIR,
+    AppSceneIR,
     EntityIR,
     IntentIR,
     IntentParameter,
     ParamType,
     ViewIR,
+    ViewStateIR,
     WidgetIR,
 )
 
@@ -451,31 +453,21 @@ def generate_swift_view(view: ViewIR) -> str:
     return "\n".join(lines)
 
 
-def _generate_view_state_property(state: object) -> str:
+def _generate_view_state_property(state: ViewStateIR) -> str:
     """Generate a state property declaration."""
-    if not hasattr(state, "name") or not hasattr(state, "kind") or not hasattr(state, "type"):
-        return ""
+    swift_type = param_type_to_swift(state.type)
 
-    name = state.name
-    kind = state.kind
-    param_type = state.type
-    default_value = getattr(state, "default", None)
-
-    swift_type = param_type_to_swift(param_type)
-
-    if kind == "binding":
-        return f"    @Binding var {name}: {swift_type}"
-    elif kind == "environment":
-        env_key = getattr(state, "environment_key", None)
-        key_str = env_key or f".{name}"
-        return f"    @Environment({key_str}) var {name}"
-    elif kind == "observed":
-        return f"    @ObservedObject var {name}: {swift_type}"
-    else:
-        if default_value is not None:
-            default_str = _format_swift_literal(default_value, param_type)
-            return f"    @State private var {name}: {swift_type} = {default_str}"
-        return f"    @State private var {name}: {swift_type}"
+    if state.kind == "binding":
+        return f"    @Binding var {state.name}: {swift_type}"
+    if state.kind == "environment":
+        key_str = state.environment_key or f".{state.name}"
+        return f"    @Environment({key_str}) var {state.name}"
+    if state.kind == "observed":
+        return f"    @ObservedObject var {state.name}: {swift_type}"
+    if state.default is not None:
+        default_str = _format_swift_literal(state.default, state.type)
+        return f"    @State private var {state.name}: {swift_type} = {default_str}"
+    return f"    @State private var {state.name}: {swift_type}"
 
 
 def _generate_body_node(node: dict[str, Any], depth: int) -> list[str]:
@@ -762,10 +754,10 @@ def generate_swift_app(app: AppIR) -> str:
 
     lines.append("    var body: some Scene {")
 
-    ungrouped = [s for s in app.scenes if not hasattr(s, "platform") or not s.platform]
-    mac_only = [s for s in app.scenes if hasattr(s, "platform") and s.platform == "macOS"]
-    ios_only = [s for s in app.scenes if hasattr(s, "platform") and s.platform == "iOS"]
-    vision_only = [s for s in app.scenes if hasattr(s, "platform") and s.platform == "visionOS"]
+    ungrouped = [s for s in app.scenes if not s.platform]
+    mac_only = [s for s in app.scenes if s.platform == "macOS"]
+    ios_only = [s for s in app.scenes if s.platform == "iOS"]
+    vision_only = [s for s in app.scenes if s.platform == "visionOS"]
 
     for scene in ungrouped:
         scene_lines = _generate_scene(scene, 2)
@@ -799,18 +791,15 @@ def generate_swift_app(app: AppIR) -> str:
     return "\n".join(lines)
 
 
-def _generate_scene(scene: object, depth: int) -> list[str]:
+def _generate_scene(scene: AppSceneIR, depth: int) -> list[str]:
     """Generate a scene declaration."""
     lines: list[str] = []
     indent = "    " * depth
 
-    if not hasattr(scene, "kind"):
-        return lines
-
     kind = scene.kind
-    view = getattr(scene, "view", "")
-    title = getattr(scene, "title", None)
-    name = getattr(scene, "name", None)
+    view = scene.view
+    title = scene.title
+    name = scene.name
 
     if kind == "windowGroup":
         args: list[str] = []

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "pytest-cov>=5.0",
     "ruff>=0.6",
     "mypy>=1.11",
+    "pyright>=1.1.400",
     "pyyaml>=6.0",
     "types-PyYAML>=6.0",
 ]
@@ -89,3 +90,13 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = "mcp.*"
 ignore_missing_imports = true
+
+[tool.pyright]
+include = ["axint"]
+exclude = ["axint/mcp_server.py"]
+pythonVersion = "3.11"
+typeCheckingMode = "standard"
+reportMissingImports = "error"
+reportAttributeAccessIssue = "error"
+reportArgumentType = "error"
+reportReturnType = "error"

--- a/scripts/versions.mjs
+++ b/scripts/versions.mjs
@@ -25,6 +25,7 @@ export function readCanonicalVersion() {
 export const SURFACES = [
   pkgJson("package.json"),
   pyproject("python/pyproject.toml"),
+  pyModule("python/axint/__init__.py"),
   pkgJson("extensions/vscode/package.json"),
   pkgJson("extensions/claude-desktop/server/package.json"),
   serverJson("server.json"),
@@ -84,6 +85,24 @@ function serverJson(relPath) {
       data.version = version;
       for (const pkg of data.packages ?? []) pkg.version = version;
       writeFileSync(abs, JSON.stringify(data, null, 2) + "\n");
+    },
+  };
+}
+
+function pyModule(relPath) {
+  const abs = resolve(ROOT, relPath);
+  const pattern = /^__version__\s*=\s*"([^"]+)"/m;
+  return {
+    file: relPath,
+    read() {
+      const match = readFileSync(abs, "utf-8").match(pattern);
+      if (!match) throw new Error(`${relPath} has no __version__ constant`);
+      return [{ where: "__version__", value: match[1] }];
+    },
+    write(version) {
+      const text = readFileSync(abs, "utf-8");
+      if (!pattern.test(text)) throw new Error(`${relPath} has no __version__ constant`);
+      writeFileSync(abs, text.replace(pattern, `__version__ = "${version}"`));
     },
   };
 }


### PR DESCRIPTION
Stops the release workflow from silently shipping. npm audit is no longer || true'd, the publish step is idempotent via a real npm view check instead of swallow-and-echo, and the PyPI gate evaluates at job-definition time so a missing token doesn't wedge the step. Every multi-line run block across ci/release/xcode-extension/wwdc-nightly now leads with set -euo pipefail, and the xcode smoke build drops its || true so regressions fail loudly. CI npm audit stays soft on purpose — release is where zero-advisory is enforced.