### PR TITLE
send full publish payload from python cli

### DIFF
--- a/metrics.json
+++ b/metrics.json
@@ -5,8 +5,8 @@
   "bundledTemplates": 25,
   "diagnostics": 130,
   "tests": {
-    "typescript": 522,
-    "python": 99
+    "typescript": 523,
+    "python": 105
   },
   "registryPackages": 8,
   "distributionSurfaces": 4

--- a/python/axint/bundle_hash.py
+++ b/python/axint/bundle_hash.py
@@ -1,0 +1,55 @@
+"""
+Canonical hash over the bytes that leave the registry at install time.
+
+Mirror of axint/src/core/bundle-hash.ts and the registry Worker's
+bundle-hash.ts. Must stay byte-identical with both — anything that
+changes serialization here has to ship to the other two in the same
+release, or every install will fail bundle verification.
+
+The contract:
+  * UTF-8 JSON, keys in alphabetical order, no whitespace
+  * Missing optional fields are explicit null, never absent
+  * SHA-256, lower-case hex, 64 chars
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Optional, TypedDict
+
+
+class _SwiftOutput(TypedDict):
+    swift_output: str
+
+
+# swift_output is the only field every bundle must carry (the registry
+# uses it as the canonical compiled artifact). The other three are
+# optional for the same reason they're optional on the TS side: a
+# Python-only or TS-only package legitimately omits the other source.
+class BundleContents(_SwiftOutput, total=False):
+    ts_source: Optional[str]
+    py_source: Optional[str]
+    plist_fragment: Optional[str]
+
+
+BUNDLE_HASH_ALGORITHM = "sha256"
+BUNDLE_HASH_HEX_LENGTH = 64
+
+
+def canonicalize_bundle(bundle: BundleContents) -> str:
+    # .get() returns None for missing keys; we use it directly instead of
+    # `or None` so empty strings stay as empty strings, matching the TS
+    # `??` operator on the other side of the wire.
+    normalized = {
+        "plist_fragment": bundle.get("plist_fragment"),
+        "py_source": bundle.get("py_source"),
+        "swift_output": bundle["swift_output"],
+        "ts_source": bundle.get("ts_source"),
+    }
+    return json.dumps(normalized, separators=(",", ":"))
+
+
+def hash_bundle(bundle: BundleContents) -> str:
+    canonical = canonicalize_bundle(bundle)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/python/axint/bundle_hash.py
+++ b/python/axint/bundle_hash.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 
 class _SwiftOutput(TypedDict):
@@ -28,9 +28,9 @@ class _SwiftOutput(TypedDict):
 # optional for the same reason they're optional on the TS side: a
 # Python-only or TS-only package legitimately omits the other source.
 class BundleContents(_SwiftOutput, total=False):
-    ts_source: Optional[str]
-    py_source: Optional[str]
-    plist_fragment: Optional[str]
+    ts_source: str | None
+    py_source: str | None
+    plist_fragment: str | None
 
 
 BUNDLE_HASH_ALGORITHM = "sha256"

--- a/python/axint/cli.py
+++ b/python/axint/cli.py
@@ -807,15 +807,51 @@ def _registry_publish() -> int:
         )
         return 1
 
-    payload = {
-        "namespace": config.get("namespace", "user"),
+    # README is optional — ship it if the author has one.
+    readme: str | None = None
+    readme_path = cwd / config.get("readme", "README.md")
+    if readme_path.exists():
+        readme = readme_path.read_text(encoding="utf-8")
+
+    # Matches the TS CLI: @ prefix is the registry convention.
+    namespace = config.get("namespace", "user")
+    if not namespace.startswith("@"):
+        namespace = f"@{namespace}"
+
+    plist_fragment = generate_info_plist_fragment(ir) or None
+
+    # Same contract as axint/src/core/bundle-hash.ts. Server recomputes
+    # this on receipt and rejects the publish if the bytes disagree.
+    from .bundle_hash import hash_bundle
+
+    bundle_hash = hash_bundle(
+        {
+            "ts_source": None,
+            "py_source": source,
+            "swift_output": swift_code,
+            "plist_fragment": plist_fragment,
+        }
+    )
+
+    payload: dict[str, Any] = {
+        "namespace": namespace,
         "slug": config.get("slug", ir.name.lower()),
         "name": config.get("name", ir.name),
         "version": config.get("version", "0.0.1"),
         "description": config.get("description", ""),
+        "readme": readme,
+        "primary_language": config.get("primary_language", "python"),
+        "surface_areas": config.get("surface_areas", []),
+        "tags": config.get("tags", []),
+        "license": config.get("license", "Apache-2.0"),
+        "homepage": config.get("homepage"),
+        "repository": config.get("repository"),
         "py_source": source,
         "swift_output": swift_code,
+        "plist_fragment": plist_fragment,
+        "ir": _ir_to_dict(ir),
         "compiler_version": __version__,
+        "bundle_hash": bundle_hash,
     }
 
     print(f"  \033[2m⏺\033[0m Publishing to {registry_url}…")
@@ -834,22 +870,59 @@ def _registry_publish() -> int:
         )
         with urlopen(req, timeout=30) as resp:
             result = json.loads(resp.read().decode("utf-8"))
-            url = result.get("url", registry_url)
+
+        url = result.get("url", registry_url)
+        server_hash = result.get("bundle_hash")
+        if server_hash and server_hash != bundle_hash:
+            print(
+                f"  \033[31m✗\033[0m Registry recorded a different bundle hash "
+                f"(client {bundle_hash} vs server {server_hash}). Publish rejected for your safety.",
+                file=sys.stderr,
+            )
+            return 1
 
         print("  \033[32m✓\033[0m Published!")
         print()
         print(f"    {url}")
         print()
+        print(f"  \033[2mBundle hash: sha256:{bundle_hash}\033[0m")
+        print(f"  \033[2mInstall: axint add {namespace}/{payload['slug']}\033[0m")
+        print()
         return 0
 
     except HTTPError as e:
-        err = json.loads(e.read().decode("utf-8"))
-        detail = err.get("detail", e.reason)
-        print(f"  \033[31m✗\033[0m Publish failed: {detail}", file=sys.stderr)
+        # Server returns `{error: string}`. We also fall back to the HTTP
+        # reason for the case where the response body isn't JSON at all.
+        try:
+            err = json.loads(e.read().decode("utf-8"))
+            message = err.get("error") or e.reason
+        except Exception:
+            message = e.reason
+        print(f"  \033[31m✗\033[0m Publish failed: {message}", file=sys.stderr)
+        return 1
+    except URLError as e:
+        print(f"  \033[31merror:\033[0m Could not reach {registry_url}: {e.reason}", file=sys.stderr)
         return 1
     except Exception as e:
         print(f"\033[31merror:\033[0m {e}", file=sys.stderr)
         return 1
+
+
+def _ir_to_dict(ir: Any) -> dict[str, Any]:
+    """Serialize an IR dataclass to the shape the registry stores.
+
+    The registry accepts an opaque `ir` field — we send the same JSON
+    the TS SDK does so downstream tooling can diff both sides. Any IR
+    type that dataclasses.asdict() can walk is fine; we gracefully
+    degrade to an empty dict when the dataclass machinery can't see it.
+    """
+    import dataclasses
+
+    # is_dataclass returns True for both instances and classes — narrow
+    # to an instance before asdict() to keep the types honest.
+    if dataclasses.is_dataclass(ir) and not isinstance(ir, type):
+        return dataclasses.asdict(ir)
+    return {}
 
 
 def _registry_add(package: str, target_dir: str) -> int:

--- a/python/tests/test_bundle_hash.py
+++ b/python/tests/test_bundle_hash.py
@@ -1,0 +1,58 @@
+"""
+Cross-language parity tests for bundle hash.
+
+The two shared vectors below are asserted byte-for-byte in three places:
+  * axint/tests/core/bundle-hash.test.ts        (TS CLI)
+  * axint-registry/packages/api/src/bundle-hash.test.ts  (Worker)
+  * here                                          (Python CLI)
+
+If any one of them changes, all three must change in the same release —
+otherwise installs will fail bundle verification across language boundaries.
+"""
+
+from __future__ import annotations
+
+from axint.bundle_hash import (
+    BUNDLE_HASH_HEX_LENGTH,
+    canonicalize_bundle,
+    hash_bundle,
+)
+
+
+def test_canonicalize_sorts_keys_and_normalizes_optionals_to_null() -> None:
+    canonical = canonicalize_bundle({"ts_source": "ts", "swift_output": "sw"})
+    assert canonical == (
+        '{"plist_fragment":null,"py_source":null,"swift_output":"sw","ts_source":"ts"}'
+    )
+
+
+def test_canonicalize_treats_missing_and_explicit_none_the_same() -> None:
+    no_optionals = canonicalize_bundle({"ts_source": "ts", "swift_output": "sw"})
+    with_nones = canonicalize_bundle(
+        {"ts_source": "ts", "swift_output": "sw", "py_source": None, "plist_fragment": None}
+    )
+    assert no_optionals == with_nones
+
+
+def test_canonicalize_distinguishes_empty_string_from_missing() -> None:
+    empty = canonicalize_bundle({"ts_source": "ts", "swift_output": "sw", "py_source": ""})
+    missing = canonicalize_bundle({"ts_source": "ts", "swift_output": "sw"})
+    assert empty != missing
+
+
+def test_hash_returns_64_lowercase_hex() -> None:
+    h = hash_bundle({"ts_source": "a", "swift_output": "b"})
+    assert len(h) == BUNDLE_HASH_HEX_LENGTH
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_hash_matches_shared_vector_with_all_fields() -> None:
+    h = hash_bundle(
+        {"ts_source": "ts", "swift_output": "sw", "py_source": "py", "plist_fragment": "pl"}
+    )
+    assert h == "9f708e7e282ec5e3a578a18f1d4bc003e144265ea9bc0845337c65c96399bf04"
+
+
+def test_hash_matches_shared_vector_for_python_only_bundle() -> None:
+    h = hash_bundle({"py_source": "py", "swift_output": "sw"})
+    assert h == "7757c15e7a4abc2cb54dd27f4b37cb0752ea0f2f3975fb02b05c68a5b59f0c83"

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -184,12 +184,12 @@ export function registerPublish(program: Command, version: string) {
         });
 
         if (!res.ok) {
-          const err = (await res.json().catch(() => ({ detail: res.statusText }))) as {
-            detail?: string;
-            title?: string;
+          // Server uses `{error: string}` — see axint-registry/packages/api/src/index.ts.
+          const err = (await res.json().catch(() => ({ error: res.statusText }))) as {
+            error?: string;
           };
           console.error(
-            `  \x1b[31m✗\x1b[0m ${err.title ?? "Publish failed"}: ${err.detail ?? res.statusText}`
+            `  \x1b[31m✗\x1b[0m Publish failed: ${err.error ?? res.statusText}`
           );
           process.exit(1);
         }

--- a/src/core/bundle-hash.ts
+++ b/src/core/bundle-hash.ts
@@ -15,7 +15,7 @@
  */
 
 export interface BundleContents {
-  ts_source: string;
+  ts_source?: string | null;
   py_source?: string | null;
   swift_output: string;
   plist_fragment?: string | null;
@@ -26,7 +26,7 @@ export function canonicalizeBundle(bundle: BundleContents): string {
     plist_fragment: bundle.plist_fragment ?? null,
     py_source: bundle.py_source ?? null,
     swift_output: bundle.swift_output,
-    ts_source: bundle.ts_source,
+    ts_source: bundle.ts_source ?? null,
   };
   return JSON.stringify(normalized);
 }

--- a/tests/core/bundle-hash.test.ts
+++ b/tests/core/bundle-hash.test.ts
@@ -109,4 +109,14 @@ describe("hashBundle", () => {
     });
     expect(hash).toBe("9f708e7e282ec5e3a578a18f1d4bc003e144265ea9bc0845337c65c96399bf04");
   });
+
+  it("is stable for a python-only bundle", async () => {
+    // Same vector asserted in axint-registry/packages/api/src/bundle-hash.test.ts
+    // and in axint/python/tests/test_bundle_hash.py.
+    const hash = await hashBundle({
+      py_source: "py",
+      swift_output: "sw",
+    });
+    expect(hash).toBe("7757c15e7a4abc2cb54dd27f4b37cb0752ea0f2f3975fb02b05c68a5b59f0c83");
+  });
 });


### PR DESCRIPTION
The Python CLI's publish flow was sending a bare payload the registry couldn't accept — no README, no bundle hash, no IR, no plist fragment, and it was reading `detail` from error responses (FastAPI convention) when the Worker returns `{error}`. This brings the Python side to parity with the TypeScript CLI.

- `python/axint/bundle_hash.py` (new): SHA-256 over the same canonical JSON the TS CLI produces. Uses a `_SwiftOutput` required base + `BundleContents` TypedDict so pyright knows `swift_output` is always present.
- `python/tests/test_bundle_hash.py` (new): six cases including the two cross-language shared vectors (`9f708e7e…` for full bundles, `7757c15e…` for Python-only). Same vectors asserted in the TS and Worker suites so drift breaks all three.
- `python/axint/cli.py`: `_registry_publish` now sends the full payload (README, @-prefixed namespace, plist fragment, IR, bundle_hash, surface_areas, tags, license, etc.), reads `error` from failures, handles `URLError` separately, and verifies the server-returned hash matches the client hash before printing success.
- `src/cli/publish.ts`: matches the same `{error}` contract.
- `tests/core/bundle-hash.test.ts`: adds the python-only shared vector.

Pairs with agenticempire/axint-registry#2.