### PR TITLE
Ship phase 2 truth pass and pure MCP module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,8 @@ src/
 │   └── index.ts         # define*() APIs and helpers (exported from `@axint/compiler`)
 ├── mcp/
 │   ├── server.ts        # MCP server with axint.* tools and built-in prompts
-│   └── index.ts         # Entry point (also serves as axint-mcp binary)
+│   ├── index.ts         # Pure import surface for manifests + server helpers
+│   └── register.ts      # Side-effectful axint-mcp binary entry point
 ├── templates/
 │   └── index.ts         # Intent template registry (templates welcome!)
 └── cli/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 COPY --from=build /app/dist dist/
-ENTRYPOINT ["node", "dist/mcp/index.js"]
+ENTRYPOINT ["node", "dist/mcp/register.js"]

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Built-in prompts:
 
 ## Diagnostics
 
-150 diagnostic codes across eight validators with fix suggestions and color-coded output:
+130 diagnostic codes across the validator surface with fix suggestions and color-coded output:
 
 | Range | Domain |
 | --- | --- |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Axint Roadmap
 
-_Last updated: April 2026 · Current release: [v0.3.8](https://github.com/agenticempire/axint/releases) · 52 days to WWDC 2026_
+_Last updated: April 2026 · Current release: [v0.3.9](https://github.com/agenticempire/axint/releases) · ahead of WWDC 2026_
 
 Axint is the open-source compiler that turns TypeScript definitions into native Apple platform code — App Intents, SwiftUI views, WidgetKit widgets, and full app scaffolds. This roadmap tracks what's shipped, what's next, and where we need help.
 

--- a/docs/voice-rules.md
+++ b/docs/voice-rules.md
@@ -1,0 +1,80 @@
+# Voice rules for Axint and parent-brand copy
+
+Applies to public product and company copy across axint.ai, axint.ai/cloud, registry.axint.ai, docs.axint.ai, agenticempire.co, and the GitHub org profile. Blog posts, partner/career/privacy pages, community recruitment panels, and email templates are out of scope — those have legitimate first-person registers.
+
+## The rule
+
+Write feature-forward or second-person. Never narrate the build.
+
+The reader is a developer evaluating the product. They care about what it does, not why we shipped it.
+
+## Banned phrases
+
+These appear in AI-generated marketing copy and almost never in human-written product copy. Every one is grep-bait for the next review.
+
+- `we built this to...`
+- `we created ... to...`
+- `we designed ... so that...`
+- `we want the reader to...`
+- `the reason we ...`
+- `this section is here to...`
+- `this helps us...`
+- `positioned as...`
+- `our story`
+- `our mission`
+- `our goal`
+- `our vision`
+- `we believe...`
+- `we wanted...`
+- `we chose...`
+- `we picked...`
+- `we think...`
+
+## Allowed first-person
+
+First-person is fine in these contexts — leave them alone:
+
+- `/careers` — hiring voice (`we hire`, `we protect deep work`)
+- `/partners` — collaboration voice (`help us build`, `what we need from you`)
+- `/privacy` — legally-required data controller language (`we collect`, `we don't store`)
+- `/contribute` panels — community recruitment (`help us build`, `what we need next`)
+- Error messages — transactional (`something broke on our end`)
+- Email templates — direct correspondence (Nima's actual voice)
+- Code comments — developer commentary, not rendered
+
+## Rewrites
+
+Before:
+
+> We built Axint so that agents could ship Apple features without hand-writing Swift.
+
+After:
+
+> Axint compiles agent intent into Apple-native Swift. No hand-writing.
+
+Before:
+
+> This section is here to show you how the compiler handles validation.
+
+After:
+
+> The compiler validates Apple rules before Swift ever hits Xcode.
+
+Before:
+
+> We positioned the registry as a real package flow, not a template shelf.
+
+After:
+
+> The registry is a real package flow. Browse, install with one command, keep metadata attached.
+
+## Review check
+
+Before shipping copy:
+
+```
+npm run public-copy:check
+pnpm copy:check
+```
+
+Zero matches outside the allowed paths. If a phrase is on the edge, rewrite it feature-forward — the product copy is not the place to explain design decisions.

--- a/metrics.json
+++ b/metrics.json
@@ -5,7 +5,7 @@
   "bundledTemplates": 25,
   "diagnostics": 130,
   "tests": {
-    "typescript": 542,
+    "typescript": 543,
     "python": 105
   },
   "registryPackages": 8,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",
@@ -15,7 +15,8 @@
       },
       "bin": {
         "axint": "dist/cli/index.js",
-        "axint-mcp": "dist/mcp/index.js"
+        "axint-mcp": "dist/mcp/register.js",
+        "axint-mcp-http": "dist/mcp/http.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "bin": {
     "axint": "dist/cli/index.js",
-    "axint-mcp": "dist/mcp/index.js",
+    "axint-mcp": "dist/mcp/register.js",
     "axint-mcp-http": "dist/mcp/http.js"
   },
   "main": "./dist/core/index.js",

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,9 +1,3 @@
-import { startMCPServer, createAxintServer } from "./server.js";
-
-export { startMCPServer, createAxintServer };
-
-// When invoked directly as a binary (axint-mcp), start the server
-startMCPServer().catch((err: Error) => {
-  console.error("Failed to start MCP server:", err);
-  process.exit(1);
-});
+export { createAxintServer, startMCPServer } from "./server.js";
+export { TOOL_MANIFEST } from "./manifest.js";
+export { PROMPT_MANIFEST, getPromptMessages } from "./prompts.js";

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -255,7 +255,7 @@ export const TOOL_MANIFEST = [
     name: "axint.validate",
     description:
       "Validate a TypeScript intent definition without generating Swift. " +
-      "Runs the full Axint validation pipeline (150 diagnostic rules) and " +
+      "Runs the full Axint validation pipeline (130 diagnostic rules) and " +
       "returns a JSON array of diagnostics: { severity: 'error'|'warning', " +
       "code: 'AXnnn', line: number, column: number, message: string, " +
       "suggestion?: string }. Returns an empty array [] when validation " +

--- a/src/mcp/register.ts
+++ b/src/mcp/register.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { startMCPServer } from "./server.js";
+
+startMCPServer().catch((err: Error) => {
+  console.error("Failed to start MCP server:", err);
+  process.exit(1);
+});

--- a/tests/mcp/index.test.ts
+++ b/tests/mcp/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+describe("axint/mcp import surface", () => {
+  it("is importable without starting the stdio server", async () => {
+    const mod = await import("../../src/mcp/index.js");
+
+    expect(typeof mod.createAxintServer).toBe("function");
+    expect(typeof mod.startMCPServer).toBe("function");
+    expect(Array.isArray(mod.TOOL_MANIFEST)).toBe(true);
+    expect(Array.isArray(mod.PROMPT_MANIFEST)).toBe(true);
+    expect(mod.TOOL_MANIFEST.length).toBeGreaterThan(0);
+    expect(mod.PROMPT_MANIFEST.length).toBeGreaterThan(0);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -28,13 +28,24 @@ export default defineConfig([
       js: "#!/usr/bin/env node",
     },
   },
-  // MCP server (needs shebang for axint-mcp binary + DTS for library use)
+  // Importable MCP module (pure exports, no shebang)
   {
     entry: {
       "mcp/index": "src/mcp/index.ts",
     },
     format: ["esm"],
     dts: true,
+    splitting: false,
+    sourcemap: true,
+    target: "node22",
+  },
+  // MCP stdio binary (side-effectful axint-mcp entrypoint)
+  {
+    entry: {
+      "mcp/register": "src/mcp/register.ts",
+    },
+    format: ["esm"],
+    dts: false,
     splitting: false,
     sourcemap: true,
     target: "node22",


### PR DESCRIPTION
## Summary
- split the MCP module so  stays pure and move startup into a dedicated register entrypoint
- refresh public truth-copy across the repo to match current metrics and positioning
- add an MCP purity regression test and related packaging/docs updates

## Verification
- npm test
- npm run typecheck
- npm run build