### PR TITLE
Phase 2 OSS hardening pass

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,2 +1,48 @@
 version: 2
-updates: []
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      javascript-runtime:
+        patterns:
+          - "@modelcontextprotocol/sdk"
+          - "commander"
+          - "typescript"
+      javascript-tooling:
+        dependency-type: "development"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/python"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:15"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps"
+    groups:
+      python-sdk:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "deps"

--- a/README.md
+++ b/README.md
@@ -24,14 +24,73 @@
 
 <p align="center">
   <a href="https://axint.ai">Website</a> ·
-  <a href="https://axint.ai/#playground">Playground</a> ·
-  <a href="#quick-start">Quick Start</a> ·
-  <a href="#mcp-server">MCP Server</a> ·
+  <a href="#first-minute">First minute</a> ·
+  <a href="#sixty-second-compile-demo">Compile demo</a> ·
+  <a href="#sixty-second-mcp-demo">MCP demo</a> ·
   <a href="https://docs.axint.ai">Docs</a> ·
   <a href="https://registry.axint.ai">Registry</a>
 </p>
 
 ---
+
+## First minute
+
+If you are evaluating Axint cold, start here:
+
+- **Prereqs** — Node.js 22+ for the TypeScript toolchain. Xcode is optional for the first compile pass.
+- **What you will see** — one TypeScript file compiled to real Swift, then the same compiler surfaced over MCP.
+- **What is real already** — 648 tests, 130 diagnostics, 10 MCP tools, 3 built-in prompts, and four Apple surfaces from one compiler pipeline.
+
+### Sixty-second compile demo
+
+```bash
+npm install -g @axint/compiler
+
+cat > hello-intent.ts <<'TS'
+import { defineIntent, param } from "@axint/compiler";
+
+export default defineIntent({
+  name: "LogWater",
+  title: "Log Water",
+  description: "Track a glass of water from Siri or Shortcuts.",
+  domain: "health",
+  params: {
+    ounces: param.int("How many ounces?"),
+  },
+  perform: async ({ ounces }) => `Logged ${ounces} oz of water`,
+});
+TS
+
+axint compile hello-intent.ts --stdout
+```
+
+What success looks like:
+
+- `struct LogWaterIntent: AppIntent`
+- generated `@Parameter` properties
+- a real `perform()` signature
+- zero handwritten Swift
+
+### Sixty-second MCP demo
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | npx -y @axint/compiler axint-mcp
+```
+
+That returns the same tool surface agents use in Claude Code, Codex, Cursor, Windsurf, and Xcode-adjacent MCP setups. The fastest evaluator path is:
+
+1. `tools/list`
+2. `axint.schema.compile`
+3. `axint.scaffold`
+
+### Why this matters
+
+Apple surfaces are boilerplate-heavy enough that agents waste tokens recreating framework glue instead of shipping product logic. Axint moves that work into a compiler:
+
+- `defineIntent()` replaces 50–200 lines of Swift for Siri and Shortcuts work.
+- `defineView()`, `defineWidget()`, and `defineApp()` extend the same model across SwiftUI, WidgetKit, and app shells.
+- MCP gives coding agents a direct compiler surface instead of asking them to improvise Apple syntax from scratch.
 
 ## Why Axint
 

--- a/metrics.json
+++ b/metrics.json
@@ -5,8 +5,8 @@
   "bundledTemplates": 25,
   "diagnostics": 130,
   "tests": {
-    "typescript": 543,
-    "python": 105
+    "typescript": 551,
+    "python": 108
   },
   "registryPackages": 8,
   "distributionSurfaces": 4

--- a/package-lock.json
+++ b/package-lock.json
@@ -3189,9 +3189,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/python/README.md
+++ b/python/README.md
@@ -40,7 +40,9 @@ create_event = define_intent(
         "is_all_day": param.boolean("Whether the event is all-day", optional=True, default=False),
     },
     entitlements=["com.apple.developer.calendars"],
-    info_plist_keys=["NSCalendarsUsageDescription"],
+    info_plist_keys={
+        "NSCalendarsUsageDescription": "Create events in the user's calendar",
+    },
 )
 ```
 

--- a/python/axint/generator.py
+++ b/python/axint/generator.py
@@ -230,9 +230,12 @@ def generate_info_plist_fragment(intent: IntentIR) -> str | None:
         '<plist version="1.0">',
         "<dict>",
     ]
-    for key in intent.info_plist_keys:
+    for key, description in intent.info_plist_keys.items():
+        resolved_description = (
+            f"TODO: Add description for {key}" if not description or description == key else description
+        )
         lines.append(f"    <key>{escape_xml(key)}</key>")
-        lines.append(f"    <string>TODO: Add description for {escape_xml(key)}</string>")
+        lines.append(f"    <string>{escape_xml(resolved_description)}</string>")
     lines.append("</dict>")
     lines.append("</plist>")
     lines.append("")

--- a/python/axint/ir.py
+++ b/python/axint/ir.py
@@ -10,7 +10,7 @@ a pile of one-off generators.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal
 
 ParamType = Literal[
@@ -44,15 +44,15 @@ WidgetRefreshPolicy = Literal["atEnd", "after", "never"]
 SceneKind = Literal["windowGroup", "window", "documentGroup", "settings"]
 
 
-def _parse_plist_keys(raw: Any) -> tuple[str, ...]:
-    """Accept dict (TS format) or list (Python format) for backwards compat."""
+def _parse_plist_keys(raw: Any) -> dict[str, str]:
+    """Accept dict (preferred) or list (legacy) for backwards compat."""
     if raw is None:
-        return ()
+        return {}
     if isinstance(raw, dict):
-        return tuple(raw.keys())
+        return {str(k): str(v) for k, v in raw.items()}
     if isinstance(raw, (list, tuple)):
-        return tuple(str(k) for k in raw)
-    return ()
+        return {str(k): str(k) for k in raw}
+    return {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -177,7 +177,7 @@ class IntentIR:
     domain: str
     parameters: tuple[IntentParameter, ...] = ()
     entitlements: tuple[str, ...] = ()
-    info_plist_keys: tuple[str, ...] = ()
+    info_plist_keys: dict[str, str] = field(default_factory=dict)
     is_discoverable: bool = True
     return_type: str | None = None
     source_file: str | None = None
@@ -195,10 +195,7 @@ class IntentIR:
         if self.entitlements:
             out["entitlements"] = list(self.entitlements)
         if self.info_plist_keys:
-            # TS side expects Record<string, string> — emit as dict with
-            # usage-description values. The Python SDK currently only stores
-            # key names, so we use the key itself as the placeholder value.
-            out["infoPlistKeys"] = {k: k for k in self.info_plist_keys}
+            out["infoPlistKeys"] = dict(self.info_plist_keys)
         if self.return_type is not None:
             out["returnType"] = self.return_type
         if self.source_file is not None:

--- a/python/axint/parser.py
+++ b/python/axint/parser.py
@@ -306,7 +306,7 @@ def _ir_from_call(call: ast.Call, *, file: str | None) -> IntentIR:
     entitlements = _parse_str_list(
         kwargs.get("entitlements"), "entitlements", diagnostics, file, call.lineno
     )
-    info_plist_keys = _parse_str_list(
+    info_plist_keys = _parse_string_map_or_list(
         kwargs.get("info_plist_keys"), "info_plist_keys", diagnostics, file, call.lineno
     )
 
@@ -326,7 +326,7 @@ def _ir_from_call(call: ast.Call, *, file: str | None) -> IntentIR:
         domain=domain,
         parameters=tuple(params),
         entitlements=tuple(entitlements),
-        info_plist_keys=tuple(info_plist_keys),
+        info_plist_keys=info_plist_keys,
         is_discoverable=is_discoverable,
         source_file=file,
         source_line=call.lineno,
@@ -1355,6 +1355,67 @@ def _parse_param_call(
         optional=opt,
         default=dflt,
     )
+
+
+def _parse_string_map_or_list(
+    node: ast.expr | None,
+    field: str,
+    diagnostics: list[ParserDiagnostic],
+    file: str | None,
+    line: int,
+) -> dict[str, str]:
+    if node is None:
+        return {}
+    if isinstance(node, ast.Dict):
+        out: dict[str, str] = {}
+        for key_node, value_node in zip(node.keys, node.values, strict=True):
+            if key_node is None:
+                diagnostics.append(
+                    ParserDiagnostic(
+                        code="AXP008",
+                        severity="error",
+                        message=f"`{field}=` keys must be string literals",
+                        file=file,
+                        line=line,
+                    )
+                )
+                continue
+            key = _literal_str(key_node, field, diagnostics, file, getattr(key_node, "lineno", line))
+            value = _literal_str(
+                value_node,
+                field,
+                diagnostics,
+                file,
+                getattr(value_node, "lineno", line),
+            )
+            out[key] = value
+        return out
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        diagnostics.append(
+            ParserDiagnostic(
+                code="AXP008",
+                severity="error",
+                message=f"`{field}=` must be a list/tuple of strings or a dict of string pairs",
+                file=file,
+                line=line,
+            )
+        )
+        return {}
+    out: dict[str, str] = {}
+    for elt in node.elts:
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+            out[elt.value] = elt.value
+        else:
+            diagnostics.append(
+                ParserDiagnostic(
+                    code="AXP008",
+                    severity="error",
+                    message=f"`{field}=` entries must be string literals",
+                    file=file,
+                    line=getattr(elt, "lineno", line),
+                )
+            )
+    return out
 
 
 def _parse_str_list(

--- a/python/axint/sdk.py
+++ b/python/axint/sdk.py
@@ -74,6 +74,16 @@ _Float = float
 _Bool = bool
 
 
+def _normalize_info_plist_keys(
+    raw: dict[str, str] | list[str] | tuple[str, ...] | None,
+) -> dict[str, str]:
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return {str(key): str(value) for key, value in raw.items()}
+    return {str(key): str(key) for key in raw}
+
+
 def _infer_return_type(perform_fn: Callable[[], Any] | None) -> str | None:
     """
     Infer the return type from a perform function's type annotation.
@@ -181,7 +191,7 @@ class IntentDefinition:
     params: dict[str, IntentParameterSpec] = field(default_factory=dict)
     perform: Callable[[], Any] | None = None
     entitlements: tuple[str, ...] = ()
-    info_plist_keys: tuple[str, ...] = ()
+    info_plist_keys: dict[str, str] = field(default_factory=dict)
     is_discoverable: bool = True
 
     def to_ir(self, *, source_file: str | None = None, source_line: int | None = None) -> IntentIR:
@@ -291,7 +301,7 @@ def define_intent(
     params: dict[str, IntentParameterSpec] | None = None,
     perform: Callable[[], Any] | None = None,
     entitlements: list[str] | tuple[str, ...] | None = None,
-    info_plist_keys: list[str] | tuple[str, ...] | None = None,
+    info_plist_keys: dict[str, str] | list[str] | tuple[str, ...] | None = None,
     is_discoverable: bool = True,
 ) -> IntentDefinition:
     """
@@ -318,7 +328,9 @@ def define_intent(
     entitlements
         Apple entitlement identifiers this intent requires.
     info_plist_keys
-        Info.plist keys to emit next to the generated Swift.
+        Info.plist keys to emit next to the generated Swift. Prefer a
+        `{key: usage_description}` mapping; list/tuple input is accepted for
+        backwards compatibility and uses placeholder descriptions.
     is_discoverable
         Whether Siri can surface this intent proactively.
     """
@@ -330,7 +342,7 @@ def define_intent(
         params=dict(params or {}),
         perform=perform,
         entitlements=tuple(entitlements or ()),
-        info_plist_keys=tuple(info_plist_keys or ()),
+        info_plist_keys=_normalize_info_plist_keys(info_plist_keys),
         is_discoverable=is_discoverable,
     )
 

--- a/python/examples/create_event.py
+++ b/python/examples/create_event.py
@@ -24,5 +24,7 @@ create_event = define_intent(
         ),
     },
     entitlements=["com.apple.developer.calendars"],
-    info_plist_keys=["NSCalendarsUsageDescription"],
+    info_plist_keys={
+        "NSCalendarsUsageDescription": "Create events in the user's calendar",
+    },
 )

--- a/python/tests/test_generator.py
+++ b/python/tests/test_generator.py
@@ -150,12 +150,28 @@ def test_info_plist_fragment() -> None:
         title="Log Workout",
         description="Logs a workout",
         domain="health",
-        info_plist_keys=["NSHealthUpdateUsageDescription"],
+        info_plist_keys={
+            "NSHealthUpdateUsageDescription": "Write workout data to HealthKit",
+        },
     )
     frag = generate_info_plist_fragment(intent.to_ir())
     assert frag is not None
     assert "<key>NSHealthUpdateUsageDescription</key>" in frag
+    assert "<string>Write workout data to HealthKit</string>" in frag
     assert '<plist version="1.0">' in frag
+
+
+def test_info_plist_fragment_uses_placeholder_for_legacy_lists() -> None:
+    intent = define_intent(
+        name="LegacyIntent",
+        title="Legacy",
+        description="Legacy",
+        domain="utility",
+        info_plist_keys=["NSCalendarsUsageDescription"],
+    )
+    frag = generate_info_plist_fragment(intent.to_ir())
+    assert frag is not None
+    assert "<string>TODO: Add description for NSCalendarsUsageDescription</string>" in frag
 
 
 def test_info_plist_fragment_none_when_empty() -> None:

--- a/python/tests/test_parser.py
+++ b/python/tests/test_parser.py
@@ -76,12 +76,36 @@ intent = define_intent(
     description="Logs a workout",
     domain="health",
     entitlements=["com.apple.developer.healthkit"],
-    info_plist_keys=["NSHealthUpdateUsageDescription", "NSHealthShareUsageDescription"],
+    info_plist_keys={
+        "NSHealthUpdateUsageDescription": "Write workouts to HealthKit",
+        "NSHealthShareUsageDescription": "Read workouts from HealthKit",
+    },
 )
 '''
     ir = parse_source(src)[0]
     assert ir.entitlements == ("com.apple.developer.healthkit",)
-    assert len(ir.info_plist_keys) == 2
+    assert ir.info_plist_keys == {
+        "NSHealthUpdateUsageDescription": "Write workouts to HealthKit",
+        "NSHealthShareUsageDescription": "Read workouts from HealthKit",
+    }
+
+
+def test_parses_legacy_info_plist_key_lists() -> None:
+    src = '''
+from axint import define_intent
+
+intent = define_intent(
+    name="CalendarIntent",
+    title="Create Event",
+    description="Creates an event",
+    domain="productivity",
+    info_plist_keys=["NSCalendarsUsageDescription"],
+)
+'''
+    ir = parse_source(src)[0]
+    assert ir.info_plist_keys == {
+        "NSCalendarsUsageDescription": "NSCalendarsUsageDescription",
+    }
 
 
 def test_parses_number_alias_as_int() -> None:

--- a/python/tests/test_sdk.py
+++ b/python/tests/test_sdk.py
@@ -52,7 +52,9 @@ def test_define_intent_full() -> None:
             "is_all_day": param.boolean("Whether the event is all-day", optional=True, default=False),
         },
         entitlements=["com.apple.developer.calendars"],
-        info_plist_keys=["NSCalendarsUsageDescription"],
+        info_plist_keys={
+            "NSCalendarsUsageDescription": "Create events in the user's calendar",
+        },
         is_discoverable=True,
     )
     ir = intent.to_ir()
@@ -64,7 +66,9 @@ def test_define_intent_full() -> None:
     assert ir.parameters[3].optional is True
     assert ir.parameters[3].default is False
     assert ir.entitlements == ("com.apple.developer.calendars",)
-    assert ir.info_plist_keys == ("NSCalendarsUsageDescription",)
+    assert ir.info_plist_keys == {
+        "NSCalendarsUsageDescription": "Create events in the user's calendar",
+    }
 
 
 def test_ir_to_dict_matches_ts_schema() -> None:
@@ -83,6 +87,19 @@ def test_ir_to_dict_matches_ts_schema() -> None:
     assert d["isDiscoverable"] is True  # camelCase — not snake_case
     assert d["parameters"][0]["name"] == "light_id"
     assert d["parameters"][0]["type"] == "string"
+
+
+def test_define_intent_accepts_legacy_info_plist_key_lists() -> None:
+    intent = define_intent(
+        name="LegacyIntent",
+        title="Legacy",
+        description="Legacy",
+        domain="utility",
+        info_plist_keys=["NSCalendarsUsageDescription"],
+    )
+    assert intent.to_ir().info_plist_keys == {
+        "NSCalendarsUsageDescription": "NSCalendarsUsageDescription",
+    }
 
 
 def test_ir_round_trip() -> None:

--- a/tests/mcp/http-transport.test.ts
+++ b/tests/mcp/http-transport.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import worker from "../../workers/mcp-http/src/worker.js";
+import { TOOL_MANIFEST } from "../../src/mcp/manifest.js";
+import { PROMPT_MANIFEST } from "../../src/mcp/prompts.js";
+
+const env = {
+  ALLOWED_ORIGINS: "https://axint.ai",
+  MAX_BODY_BYTES: "4096",
+};
+
+async function request(
+  body: object | string,
+  init: {
+    method?: string;
+    url?: string;
+    headers?: Record<string, string>;
+  } = {}
+) {
+  const method = init.method ?? "POST";
+  const req = new Request(init.url ?? "https://mcp.axint.ai/mcp", {
+    method,
+    headers: {
+      "content-type": "application/json",
+      ...init.headers,
+    },
+    body:
+      method === "POST"
+        ? typeof body === "string"
+          ? body
+          : JSON.stringify(body)
+        : undefined,
+  });
+
+  return worker.fetch(req, env);
+}
+
+describe("axint HTTP MCP transport", () => {
+  it("serves a health payload", async () => {
+    const response = await request("{}", {
+      method: "GET",
+      url: "https://mcp.axint.ai/health",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      server: "axint-mcp",
+      version: "0.3.9",
+    });
+  });
+
+  it("handles CORS preflight for allowed origins", async () => {
+    const response = await request("{}", {
+      method: "OPTIONS",
+      headers: { Origin: "https://axint.ai" },
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://axint.ai");
+    expect(response.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("rejects cross-origin calls from untrusted origins", async () => {
+    const response = await request(
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      { headers: { Origin: "https://evil.example" } }
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: -32000, message: "Origin not allowed" },
+    });
+  });
+
+  it("lists the full MCP tool manifest", async () => {
+    const response = await request({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.result.tools).toHaveLength(TOOL_MANIFEST.length);
+    expect(payload.result.tools.map((tool: { name: string }) => tool.name)).toEqual(
+      TOOL_MANIFEST.map((tool) => tool.name)
+    );
+  });
+
+  it("lists built-in prompts and resolves prompt content", async () => {
+    const listResponse = await request({ jsonrpc: "2.0", id: 1, method: "prompts/list" });
+    const listPayload = await listResponse.json();
+
+    expect(listPayload.result.prompts).toHaveLength(PROMPT_MANIFEST.length);
+    expect(
+      listPayload.result.prompts.map((prompt: { name: string }) => prompt.name)
+    ).toEqual(PROMPT_MANIFEST.map((prompt) => prompt.name));
+
+    const getResponse = await request({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "prompts/get",
+      params: {
+        name: "axint.create-intent",
+        arguments: {
+          intentName: "CreateReminder",
+          intentDescription: "create a reminder from Siri",
+          domain: "productivity",
+        },
+      },
+    });
+    const getPayload = await getResponse.json();
+    const text = getPayload.result.messages[0].content.text as string;
+
+    expect(text).toContain("CreateReminder");
+    expect(text).toContain("productivity");
+    expect(text).toContain("axint.scaffold");
+  });
+
+  it("compiles schema requests over HTTP", async () => {
+    const response = await request({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: {
+        name: "axint.schema.compile",
+        arguments: {
+          type: "intent",
+          name: "CreateReminder",
+          title: "Create Reminder",
+          description: "Create a reminder",
+          domain: "productivity",
+          params: {
+            text: "string",
+          },
+        },
+      },
+    });
+    const payload = await response.json();
+    const text = payload.result.content[0].text as string;
+
+    expect(text).toContain("struct CreateReminderIntent");
+    expect(text).toContain("AppIntent");
+  });
+
+  it("returns protocol errors for malformed and invalid payloads", async () => {
+    const parseError = await request("{");
+    await expect(parseError.json()).resolves.toMatchObject({
+      error: { code: -32700, message: "Parse error" },
+    });
+
+    const invalidRequest = await request("[]");
+    await expect(invalidRequest.json()).resolves.toMatchObject({
+      error: { code: -32600, message: "Invalid Request" },
+    });
+  });
+
+  it("rejects missing tool names and unsupported HTTP verbs", async () => {
+    const toolResponse = await request({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: {},
+    });
+    await expect(toolResponse.json()).resolves.toMatchObject({
+      error: { code: -32602, message: "Missing tool name" },
+    });
+
+    const getResponse = await request("{}", { method: "GET" });
+    await expect(getResponse.json()).resolves.toMatchObject({
+      error: { code: -32000, message: "POST only" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add black-box HTTP MCP transport coverage
- close Python info plist parity with dict support and legacy fallback
- re-enable Dependabot and refresh the lockfile to clear audit drift
- rewrite the README first minute and refresh canonical metrics

## Verification
- npm run build
- npm test
- npm run typecheck
- python3 -m pytest python/tests
- npm audit --json
