### PR TITLE
Fix Python mypy shadowing regression

### DIFF
--- a/python/axint/parser.py
+++ b/python/axint/parser.py
@@ -1401,10 +1401,10 @@ def _parse_string_map_or_list(
             )
         )
         return {}
-    out: dict[str, str] = {}
+    list_out: dict[str, str] = {}
     for elt in node.elts:
         if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
-            out[elt.value] = elt.value
+            list_out[elt.value] = elt.value
         else:
             diagnostics.append(
                 ParserDiagnostic(
@@ -1415,7 +1415,7 @@ def _parse_string_map_or_list(
                     line=getattr(elt, "lineno", line),
                 )
             )
-    return out
+    return list_out
 
 
 def _parse_str_list(


### PR DESCRIPTION
## Summary\n- fix the parser helper variable shadowing that tripped mypy on Python 3.12\n- keep the new Info.plist parity path intact\n\n## Verification\n- python3 -m pytest python/tests/test_parser.py python/tests/test_sdk.py python/tests/test_generator.py\n- cd python && python3 -m mypy axint\n- npm test -- tests/mcp/http-transport.test.ts\n