### PR TITLE
Align Axint public positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,12 @@
 <h1 align="center">Axint</h1>
 
 <p align="center">
-  <strong>The Apple-native execution layer for AI agents.</strong>
+  <strong>Axint turns TypeScript and Python into validated Swift for Apple-native features.</strong>
 </p>
 
 <p align="center">
-  Context tells agents what to build. Axint makes it shippable on Apple.<br>
-  Open-source compiler that turns TypeScript into validated Swift —<br>
-  App Intents, SwiftUI views, WidgetKit widgets, and full apps.
+  Open-source compiler for App Intents, SwiftUI views, WidgetKit widgets, and full apps.<br>
+  Compact definitions in, validated Swift out.
 </p>
 
 <p align="center">
@@ -24,73 +23,14 @@
 
 <p align="center">
   <a href="https://axint.ai">Website</a> ·
-  <a href="#first-minute">First minute</a> ·
-  <a href="#sixty-second-compile-demo">Compile demo</a> ·
-  <a href="#sixty-second-mcp-demo">MCP demo</a> ·
+  <a href="https://axint.ai/#playground">Playground</a> ·
+  <a href="#quick-start">Quick Start</a> ·
+  <a href="#mcp-server">MCP Server</a> ·
   <a href="https://docs.axint.ai">Docs</a> ·
   <a href="https://registry.axint.ai">Registry</a>
 </p>
 
 ---
-
-## First minute
-
-If you are evaluating Axint cold, start here:
-
-- **Prereqs** — Node.js 22+ for the TypeScript toolchain. Xcode is optional for the first compile pass.
-- **What you will see** — one TypeScript file compiled to real Swift, then the same compiler surfaced over MCP.
-- **What is real already** — 648 tests, 130 diagnostics, 10 MCP tools, 3 built-in prompts, and four Apple surfaces from one compiler pipeline.
-
-### Sixty-second compile demo
-
-```bash
-npm install -g @axint/compiler
-
-cat > hello-intent.ts <<'TS'
-import { defineIntent, param } from "@axint/compiler";
-
-export default defineIntent({
-  name: "LogWater",
-  title: "Log Water",
-  description: "Track a glass of water from Siri or Shortcuts.",
-  domain: "health",
-  params: {
-    ounces: param.int("How many ounces?"),
-  },
-  perform: async ({ ounces }) => `Logged ${ounces} oz of water`,
-});
-TS
-
-axint compile hello-intent.ts --stdout
-```
-
-What success looks like:
-
-- `struct LogWaterIntent: AppIntent`
-- generated `@Parameter` properties
-- a real `perform()` signature
-- zero handwritten Swift
-
-### Sixty-second MCP demo
-
-```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
-  | npx -y @axint/compiler axint-mcp
-```
-
-That returns the same tool surface agents use in Claude Code, Codex, Cursor, Windsurf, and Xcode-adjacent MCP setups. The fastest evaluator path is:
-
-1. `tools/list`
-2. `axint.schema.compile`
-3. `axint.scaffold`
-
-### Why this matters
-
-Apple surfaces are boilerplate-heavy enough that agents waste tokens recreating framework glue instead of shipping product logic. Axint moves that work into a compiler:
-
-- `defineIntent()` replaces 50–200 lines of Swift for Siri and Shortcuts work.
-- `defineView()`, `defineWidget()`, and `defineApp()` extend the same model across SwiftUI, WidgetKit, and app shells.
-- MCP gives coding agents a direct compiler surface instead of asking them to improvise Apple syntax from scratch.
 
 ## Why Axint
 
@@ -107,7 +47,7 @@ defineWidget()  →  WidgetKit widget
 defineApp()     →  Full app scaffold
 ```
 
-The result: agents ship Apple features at 5–15× fewer tokens than hand-written Swift.
+The result: teams and AI tools can author Apple-native features in a much smaller surface than hand-written Swift, then validate and ship ordinary generated Swift.
 
 ---
 

--- a/extensions/claude-desktop/manifest.json
+++ b/extensions/claude-desktop/manifest.json
@@ -2,9 +2,9 @@
   "manifest_version": "0.3",
   "name": "axint",
   "display_name": "Axint — Apple Compiler for AI",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Compile TypeScript into native Swift for Apple platforms — App Intents, SwiftUI views, WidgetKit widgets, and full apps.",
-  "long_description": "Axint is the open-source compiler that turns TypeScript into native Swift for Apple platforms. Compile App Intents, SwiftUI views, WidgetKit widgets, and full app scaffolds — all from Claude Desktop. AI agents write 5–15× less code while shipping production-ready Apple-native output.\n\nIncludes 12+ pre-built templates covering messaging, productivity, health, commerce, media, navigation, and smart home domains.",
+  "long_description": "Axint turns TypeScript and Python into validated Swift for Apple-native features. Compile App Intents, SwiftUI views, WidgetKit widgets, and full app scaffolds from Claude Desktop, then inspect and ship ordinary generated Swift.\n\nIncludes 25 bundled templates spanning messaging, productivity, health, commerce, media, navigation, smart home, and more.",
   "author": {
     "name": "Axint contributors",
     "url": "https://axint.ai"

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@axint/compiler": "^0.3.8"
+    "@axint/compiler": "^0.3.9"
   }
 }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,5 +1,5 @@
 # Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
-# The compression layer for AI on Apple — AI agents write 5-15× less code
+# Axint turns TypeScript and Python into validated Swift for Apple-native features.
 
 startCommand:
   type: http


### PR DESCRIPTION
## Summary\n- align the public README copy to the canonical Axint one-liner\n- refresh Smithery and Claude Desktop extension copy to match\n- bump the Claude Desktop extension package pin to 0.3.9\n\n## Verification\n- npm run versions:check