### PR TITLE
Sync version surfaces to 0.3.9

### DIFF
--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.9] - 2026-04-19
+
+- Align marketplace packaging with `@axint/compiler` v0.3.9
+- Keep install surfaces in sync with the current MCP/Cloud/docs perimeter
+
 ## [0.3.8] - 2026-04-16
 
 - Align marketplace packaging with `@axint/compiler` v0.3.8

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axint",
-  "version": "0.3.0",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axint",
-      "version": "0.3.0",
+      "version": "0.3.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/vscode": "^1.102.0",

--- a/extensions/xcode/README.md
+++ b/extensions/xcode/README.md
@@ -95,7 +95,7 @@ Add Axint to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/agenticempire/axint", from: "0.3.0"),
+    .package(url: "https://github.com/agenticempire/axint", from: "0.3.9"),
 ],
 targets: [
     .target(


### PR DESCRIPTION
## Summary\n- sync the Xcode README package version to 0.3.9\n- add the VS Code changelog entry for 0.3.9\n- fix the VS Code lockfile root version so install surfaces stop lagging the compiler release\n\n## Testing\n- docs/version surface only\n