### PR TITLE
Add compiler repair packets and MCP access

### DIFF
--- a/docs/FIX_PACKET.md
+++ b/docs/FIX_PACKET.md
@@ -1,0 +1,88 @@
+# Fix Packet
+
+The Fix Packet is Axint's local repair contract for compile and watch runs.
+
+Every `axint compile` and `axint watch` run emits:
+
+- `.axint/fix/latest.json`
+- `.axint/fix/latest.md`
+
+The goal is simple:
+
+1. Axint runs a compiler validation locally.
+2. Axint writes one durable packet with the verdict, findings, and AI-ready fix prompt.
+3. AI tools, Xcode helpers, or future plugins read that same packet instead of asking the user to copy diagnostics by hand.
+
+## What is in the packet
+
+The JSON packet includes:
+
+- schema version and timestamp
+- compiler version
+- source surface, file name, file path, and language
+- verdict: `pass`, `needs_review`, or `fail`
+- counts for errors, warnings, and infos
+- top findings and full diagnostics
+- next steps
+- AI-ready fix prompt
+- Xcode-oriented checklist
+- artifact paths for generated Swift, plist fragments, entitlements, and the packet files themselves
+
+The markdown packet is the same information rendered for human review and easy sharing.
+
+## CLI flow
+
+`axint compile` and `axint watch` emit the packet automatically by default.
+
+You can opt out with:
+
+```bash
+axint compile my-intent.ts --no-fix-packet
+axint watch ./intents --no-fix-packet
+```
+
+You can also change the packet directory:
+
+```bash
+axint compile my-intent.ts --fix-packet-dir .axint/custom-fix
+```
+
+## MCP flow
+
+AI tools can read the latest packet through:
+
+- `axint.fix-packet`
+
+Formats:
+
+- `json` — full structured packet
+- `markdown` — human-readable report
+- `prompt` — AI repair prompt only
+
+This means the repair loop can be:
+
+1. user runs Axint
+2. Axint writes `.axint/fix/latest.json`
+3. AI client calls `axint.fix-packet`
+4. AI client fixes the code
+5. user reruns Axint
+
+## Xcode / plugin loop
+
+This packet is the intended bridge for future Xcode-native and plugin-native flows.
+
+The target loop is:
+
+1. Axint compile or build plugin runs inside the Apple workflow.
+2. Axint emits the latest Fix Packet locally.
+3. Xcode assistant / plugin / MCP agent reads the packet.
+4. The assistant applies the repair or presents the fix prompt.
+5. Axint reruns until the packet becomes `pass`.
+
+That keeps the system consistent:
+
+- one packet format
+- one repair prompt
+- one source of truth
+
+instead of separate diagnostics formats for CLI, MCP, and Xcode.

--- a/metrics.json
+++ b/metrics.json
@@ -1,11 +1,11 @@
 {
   "version": "0.3.9",
-  "mcpTools": 10,
+  "mcpTools": 11,
   "mcpPrompts": 3,
   "bundledTemplates": 26,
   "diagnostics": 130,
   "tests": {
-    "typescript": 574,
+    "typescript": 578,
     "python": 105
   },
   "registryPackages": 8,

--- a/spm-plugin/Plugins/AxintCompilePlugin/AxintCompilePlugin.swift
+++ b/spm-plugin/Plugins/AxintCompilePlugin/AxintCompilePlugin.swift
@@ -27,6 +27,16 @@ struct AxintCompilePlugin: BuildToolPlugin {
         for sourceFile in tsFiles {
             let inputPath = sourceFile.path
             let inputFileName = inputPath.lastComponent
+            let inputStem = (inputFileName as NSString).deletingPathExtension
+            let fixPacketDirectory = context.pluginWorkDirectory
+                .appending("fix")
+                .appending(inputStem)
+
+            try FileManager.default.createDirectory(
+                at: fixPacketDirectory.asURL,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
 
             let compileArgs: [String] = prefixArgs + [
                 "compile",
@@ -34,6 +44,7 @@ struct AxintCompilePlugin: BuildToolPlugin {
                 "--out", outputDirectory.string,
                 "--emit-info-plist",
                 "--emit-entitlements",
+                "--fix-packet-dir", fixPacketDirectory.string,
             ]
 
             let command = Command.prebuildCommand(
@@ -124,12 +135,25 @@ extension AxintCompilePlugin: XcodeBuildToolPlugin {
         )
 
         return tsFiles.map { sourceFile in
+            let inputFileName = sourceFile.path.lastComponent
+            let inputStem = (inputFileName as NSString).deletingPathExtension
+            let fixPacketDirectory = context.pluginWorkDirectory
+                .appending("fix")
+                .appending(inputStem)
+
+            try? FileManager.default.createDirectory(
+                at: fixPacketDirectory.asURL,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+
             let compileArgs: [String] = prefixArgs + [
                 "compile",
                 sourceFile.path.string,
                 "--out", outputDirectory.string,
                 "--emit-info-plist",
                 "--emit-entitlements",
+                "--fix-packet-dir", fixPacketDirectory.string,
             ]
 
             return .prebuildCommand(

--- a/spm-plugin/README.md
+++ b/spm-plugin/README.md
@@ -12,6 +12,7 @@ TypeScript files can contain `defineIntent()`, `defineView()`, `defineWidget()`,
 - Automatic TypeScript → Swift compilation via `swift build`
 - Works in SPM projects and Xcode projects (with or without SPM)
 - Generates `.swift`, `.plist.fragment.xml`, and `.entitlements.fragment.xml` files
+- Emits a per-file Fix Packet (`latest.json` and `latest.md`) for AI/Xcode repair loops
 - Supports all Axint surfaces (intents, views, widgets, apps)
 - Minimal configuration required
 - Clear error messages if dependencies are missing
@@ -111,7 +112,8 @@ The plugin will:
 1. Detect all `.ts` files in your target
 2. Run `axint compile` on each file
 3. Generate `.swift`, `.plist.fragment.xml`, and `.entitlements.fragment.xml` files in the build directory
-4. Make them available for linking
+4. Emit a per-file Fix Packet with the exact next-step prompt and repair metadata
+5. Make the generated Swift available for linking
 
 ## Output Files
 
@@ -122,6 +124,29 @@ For each `.ts` intent file, the plugin generates:
 - **`{Name}Intent.entitlements.fragment.xml`** — Entitlements required by the intent
 
 These are generated in the plugin's work directory and automatically included in your build.
+
+## Fix Packet Flow
+
+Every `.ts` file compiled by `AxintCompilePlugin` now also writes a Fix Packet into the
+plugin work directory:
+
+- `fix/<file-name>/latest.json`
+- `fix/<file-name>/latest.md`
+
+That packet is the handoff contract for AI tools and Xcode helpers:
+
+- `latest.json` is the structured machine-readable artifact
+- `latest.md` is the human-readable repair summary
+
+The intended loop is:
+
+1. Build in Xcode or run `swift build`
+2. Let Axint compile the TypeScript surface
+3. Read the Fix Packet for the file that failed or needs review
+4. Hand the prompt/checklist back to your AI tool or use it directly in Xcode
+5. Rebuild after the fix
+
+This keeps the compiler output simple for humans while still giving AI tooling the full repair packet.
 
 ## Writing Definitions
 

--- a/src/cli/compile.ts
+++ b/src/cli/compile.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { resolve, dirname, basename } from "node:path";
 import {
   compileAnyFile,
   compileFromIR,
@@ -8,6 +8,7 @@ import {
   type AnyCompileResult,
 } from "../core/compiler.js";
 import type { Diagnostic } from "../core/types.js";
+import { emitFixPacketArtifacts } from "../repair/fix-packet.js";
 
 /**
  * Count non-blank lines in a source string. Blank lines (whitespace
@@ -120,6 +121,15 @@ export function registerCompile(program: Command) {
       "--from-ir",
       "Treat <file> as intent IR JSON (from Python SDK or any language) instead of TypeScript. Use - to read from stdin."
     )
+    .option(
+      "--no-fix-packet",
+      "Skip writing the local Fix Packet under .axint/fix/latest.{json,md}"
+    )
+    .option(
+      "--fix-packet-dir <dir>",
+      "Directory for the emitted Fix Packet artifacts",
+      ".axint/fix"
+    )
     .action(
       async (
         file: string,
@@ -134,6 +144,8 @@ export function registerCompile(program: Command) {
           format: boolean;
           strictFormat: boolean;
           fromIr: boolean;
+          fixPacket: boolean;
+          fixPacketDir: string;
         }
       ) => {
         const filePath = resolve(file);
@@ -143,6 +155,9 @@ export function registerCompile(program: Command) {
           let output: UnifiedOutput | null;
           let diagnostics: Diagnostic[];
           let success: boolean;
+          let inputSource: string | undefined;
+          let inputFilePath: string | undefined;
+          const language: "typescript" | "json" = options.fromIr ? "json" : "typescript";
 
           if (options.fromIr) {
             let irRaw: string;
@@ -155,6 +170,8 @@ export function registerCompile(program: Command) {
             } else {
               irRaw = readFileSync(filePath, "utf-8");
             }
+            inputSource = irRaw;
+            inputFilePath = file === "-" ? undefined : filePath;
 
             let parsed: unknown;
             try {
@@ -196,6 +213,13 @@ export function registerCompile(program: Command) {
                   }
                 : null;
           } else {
+            try {
+              inputSource = readFileSync(filePath, "utf-8");
+              inputFilePath = filePath;
+            } catch {
+              inputSource = undefined;
+              inputFilePath = filePath;
+            }
             const result = compileAnyFile(filePath, {
               outDir: options.out,
               validate: options.validate,
@@ -213,6 +237,64 @@ export function registerCompile(program: Command) {
             ) {
               console.error(
                 `\x1b[33mwarning:\x1b[0m --emit-info-plist and --emit-entitlements apply to intents only; ignored for ${result.surface}.`
+              );
+            }
+          }
+
+          let packetArtifacts: ReturnType<typeof emitFixPacketArtifacts> | null = null;
+          if (options.fixPacket) {
+            try {
+              const resolvedOutputPath =
+                success && output && !options.stdout
+                  ? resolve(output.outputPath)
+                  : undefined;
+              packetArtifacts = emitFixPacketArtifacts(
+                {
+                  success,
+                  surface,
+                  diagnostics,
+                  source: inputSource,
+                  fileName:
+                    file === "-"
+                      ? "stdin.ir.json"
+                      : inputFilePath
+                        ? basename(inputFilePath)
+                        : basename(filePath),
+                  filePath: inputFilePath,
+                  language,
+                  outputPath: resolvedOutputPath,
+                  infoPlistPath:
+                    success &&
+                    output &&
+                    !options.stdout &&
+                    surface === "intent" &&
+                    options.emitInfoPlist &&
+                    output.infoPlistFragment
+                      ? resolve(output.outputPath).replace(
+                          /\.swift$/,
+                          ".plist.fragment.xml"
+                        )
+                      : undefined,
+                  entitlementsPath:
+                    success &&
+                    output &&
+                    !options.stdout &&
+                    surface === "intent" &&
+                    options.emitEntitlements &&
+                    output.entitlementsFragment
+                      ? resolve(output.outputPath).replace(
+                          /\.swift$/,
+                          ".entitlements.fragment.xml"
+                        )
+                      : undefined,
+                  packetDir: options.fixPacketDir,
+                  command: "compile",
+                },
+                process.cwd()
+              );
+            } catch (packetErr: unknown) {
+              console.error(
+                `\x1b[33mwarning:\x1b[0m Fix Packet skipped — ${(packetErr as Error).message}`
               );
             }
           }
@@ -247,6 +329,9 @@ export function registerCompile(program: Command) {
           printDiagnostics(diagnostics);
 
           if (!success || !output) {
+            if (packetArtifacts) {
+              console.error(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+            }
             const errorCount = diagnostics.filter((d) => d.severity === "error").length;
             console.error(
               `\x1b[31mCompilation failed with ${errorCount} error(s)\x1b[0m`
@@ -291,10 +376,9 @@ export function registerCompile(program: Command) {
             // Show TS-to-Swift compression so authors can eyeball whether
             // a definition expanded the way they expected. Skipped for
             // --from-ir since "TS lines" isn't meaningful there.
-            if (!options.fromIr) {
+            if (!options.fromIr && inputSource) {
               try {
-                const tsSource = readFileSync(filePath, "utf-8");
-                const tsLines = countNonBlankLines(tsSource);
+                const tsLines = countNonBlankLines(inputSource);
                 const swiftLines = countNonBlankLines(output.swiftCode);
                 const ratio = compressionRatio(tsLines, swiftLines);
                 if (ratio !== null) {
@@ -327,6 +411,10 @@ export function registerCompile(program: Command) {
               const entPath = outPath.replace(/\.swift$/, ".entitlements.fragment.xml");
               writeFileSync(entPath, output.entitlementsFragment, "utf-8");
               console.log(`\x1b[32m✓\x1b[0m Entitlements fragment → ${entPath}`);
+            }
+
+            if (packetArtifacts) {
+              console.log(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
             }
           }
 

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -3,12 +3,14 @@ import {
   writeFileSync,
   mkdirSync,
   existsSync,
+  readFileSync,
   watch as fsWatch,
   statSync,
 } from "node:fs";
 import { resolve, dirname, basename } from "node:path";
 import { spawn } from "node:child_process";
 import { compileFile } from "../core/compiler.js";
+import { emitFixPacketArtifacts } from "../repair/fix-packet.js";
 
 async function runSwiftBuild(projectPath: string): Promise<boolean> {
   return new Promise((resolve) => {
@@ -69,6 +71,15 @@ export function registerWatch(program: Command) {
       "--swift-project <path>",
       "Path to the Swift project root (defaults to --out parent directory)"
     )
+    .option(
+      "--no-fix-packet",
+      "Skip writing the local Fix Packet under .axint/fix/latest.{json,md}"
+    )
+    .option(
+      "--fix-packet-dir <dir>",
+      "Directory for the emitted Fix Packet artifacts",
+      ".axint/fix"
+    )
     .action(
       async (
         file: string,
@@ -81,6 +92,8 @@ export function registerWatch(program: Command) {
           strictFormat: boolean;
           swiftBuild: boolean;
           swiftProject?: string;
+          fixPacket: boolean;
+          fixPacketDir: string;
         }
       ) => {
         const target = resolve(file);
@@ -108,6 +121,58 @@ export function registerWatch(program: Command) {
 
         const swiftProjectPath = options.swiftProject ?? dirname(resolve(options.out));
 
+        function emitPacket(
+          filePath: string,
+          result: ReturnType<typeof compileFile>,
+          _swiftCode?: string
+        ): ReturnType<typeof emitFixPacketArtifacts> | null {
+          if (!options.fixPacket) return null;
+          try {
+            const source = readFileSync(filePath, "utf-8");
+            return emitFixPacketArtifacts(
+              {
+                success: result.success,
+                surface: "intent",
+                diagnostics: result.diagnostics,
+                source,
+                fileName: basename(filePath),
+                filePath,
+                language: "typescript",
+                outputPath:
+                  result.success && result.output
+                    ? resolve(result.output.outputPath)
+                    : undefined,
+                infoPlistPath:
+                  result.success &&
+                  result.output?.infoPlistFragment &&
+                  options.emitInfoPlist
+                    ? resolve(result.output.outputPath).replace(
+                        /\.swift$/,
+                        ".plist.fragment.xml"
+                      )
+                    : undefined,
+                entitlementsPath:
+                  result.success &&
+                  result.output?.entitlementsFragment &&
+                  options.emitEntitlements
+                    ? resolve(result.output.outputPath).replace(
+                        /\.swift$/,
+                        ".entitlements.fragment.xml"
+                      )
+                    : undefined,
+                packetDir: options.fixPacketDir,
+                command: "watch",
+              },
+              process.cwd()
+            );
+          } catch (packetErr: unknown) {
+            console.error(
+              `\x1b[33mwarning:\x1b[0m Fix Packet skipped — ${(packetErr as Error).message}`
+            );
+            return null;
+          }
+        }
+
         function compileOne(filePath: string): boolean {
           const t0 = performance.now();
           const result = compileFile(filePath, {
@@ -130,6 +195,10 @@ export function registerWatch(program: Command) {
           }
 
           if (!result.success || !result.output) {
+            const packetArtifacts = emitPacket(filePath, result);
+            if (packetArtifacts) {
+              console.error(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+            }
             const errors = result.diagnostics.filter(
               (d) => d.severity === "error"
             ).length;
@@ -154,6 +223,10 @@ export function registerWatch(program: Command) {
           console.log(
             `\x1b[32m✓\x1b[0m ${result.output.ir.name} → ${outPath} \x1b[90m(${dt}ms)\x1b[0m`
           );
+          const packetArtifacts = emitPacket(filePath, result, result.output.swiftCode);
+          if (packetArtifacts) {
+            console.log(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+          }
           return true;
         }
 
@@ -183,6 +256,10 @@ export function registerWatch(program: Command) {
           }
 
           if (!result.success || !result.output) {
+            const packetArtifacts = emitPacket(filePath, result);
+            if (packetArtifacts) {
+              console.error(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+            }
             const errors = result.diagnostics.filter(
               (d) => d.severity === "error"
             ).length;
@@ -225,6 +302,10 @@ export function registerWatch(program: Command) {
           console.log(
             `\x1b[32m✓\x1b[0m ${result.output.ir.name} → ${outPath} \x1b[90m(${dt}ms)\x1b[0m`
           );
+          const packetArtifacts = emitPacket(filePath, result, swiftCode);
+          if (packetArtifacts) {
+            console.log(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+          }
           return true;
         }
 

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -286,6 +286,45 @@ export const TOOL_MANIFEST = [
     },
   },
   {
+    name: "axint.fix-packet",
+    description:
+      "Read the latest Fix Packet that Axint emitted locally after a compile or watch run. " +
+      "Returns the exact repair artifact that AI tools or Xcode helpers should consume next: " +
+      "verdict, top findings, full diagnostics, next steps, and an AI-ready fix prompt. " +
+      "Use this after axint compile or axint watch when you want the latest packet without " +
+      "copy-paste or another compile pass.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cwd: {
+          type: "string",
+          description:
+            "Optional working directory to search from. Axint walks upward from this directory " +
+            "until it finds .axint/fix/latest.json.",
+        },
+        packetDir: {
+          type: "string",
+          description:
+            "Optional explicit packet directory override. Use this if the latest packet lives " +
+            "somewhere other than .axint/fix.",
+        },
+        format: {
+          type: "string",
+          enum: ["json", "markdown", "prompt"],
+          description:
+            "Output format. json returns the full packet, markdown returns the human-readable " +
+            "report, and prompt returns only the AI repair prompt.",
+        },
+      },
+    },
+  },
+  {
     name: "axint.schema.compile",
     description:
       "Compile a minimal JSON schema directly to Swift, bypassing the " +

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,7 @@
  *   - axint.suggest:          Suggest Apple-native features for an app domain
  *   - axint.scaffold:         Generate a starter TypeScript intent file
  *   - axint.compile:          Compile TypeScript intent → Swift App Intent
+ *   - axint.fix-packet: Read the latest emitted Fix Packet / AI repair prompt
  *   - axint.validate:         Validate an intent definition without codegen
  *   - axint.schema.compile:   Compile minimal JSON schema → Swift (token saver)
  *   - axint.swift.validate:   Validate an existing Swift source against AX700+ rules
@@ -39,6 +40,11 @@ import { fixSwiftSource } from "../core/swift-fixer.js";
 import { TOOL_MANIFEST } from "./manifest.js";
 import { PROMPT_MANIFEST, getPromptMessages } from "./prompts.js";
 import { handleCompileFromSchema, type SchemaCompileArgs } from "./schema-compile.js";
+import {
+  readLatestFixPacket,
+  renderFixPacketMarkdown,
+  type FixPacketFormat,
+} from "../repair/fix-packet.js";
 
 // Read version from package.json so it stays in sync
 let pkg = { version: "0.3.9" };
@@ -64,6 +70,11 @@ type ScaffoldArgs = {
 };
 
 type TemplateArgs = { id: string };
+type FixPacketArgs = {
+  cwd?: string;
+  packetDir?: string;
+  format?: FixPacketFormat;
+};
 type ToolResult = {
   content: Array<{ type: string; text: string }>;
   isError?: boolean;
@@ -176,6 +187,27 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
     return errorText(errorTextValue);
   }
 
+  if (name === "axint.fix-packet") {
+    const a = args as FixPacketArgs;
+    const packet = readLatestFixPacket({
+      cwd: a.cwd,
+      packetDir: a.packetDir,
+    });
+    if (!packet) {
+      return errorText(
+        "No Fix Packet found. Run `axint compile` or `axint watch` first so Axint can emit .axint/fix/latest.json."
+      );
+    }
+
+    const format = a.format ?? "json";
+    if (format === "prompt") {
+      return diagnosticsText(packet.ai.prompt);
+    }
+    if (format === "markdown") {
+      return diagnosticsText(renderFixPacketMarkdown(packet));
+    }
+    return diagnosticsText(JSON.stringify(packet, null, 2));
+  }
   if (name === "axint.validate") {
     const a = args as { source: string; fileName?: string };
     const result = compileAnySource(a.source, a.fileName || "<validate>");

--- a/src/repair/fix-packet.ts
+++ b/src/repair/fix-packet.ts
@@ -1,0 +1,427 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Diagnostic } from "../core/types.js";
+
+export type FixPacketVerdict = "pass" | "needs_review" | "fail";
+export type FixPacketSurface = "intent" | "view" | "widget" | "app";
+export type FixPacketFormat = "json" | "markdown" | "prompt";
+export type FixPacketCommand = "compile" | "watch" | "mcp";
+
+export interface FixPacketDiagnostic {
+  code: string;
+  severity: "error" | "warning" | "info";
+  message: string;
+  file?: string;
+  line?: number;
+  suggestion?: string;
+}
+
+export interface FixPacket {
+  schemaVersion: 1;
+  createdAt: string;
+  compilerVersion: string;
+  command: FixPacketCommand;
+  source: {
+    surface: FixPacketSurface;
+    language: "typescript" | "json";
+    fileName: string;
+    filePath?: string;
+    sourceLines: number | null;
+  };
+  outcome: {
+    success: boolean;
+    verdict: FixPacketVerdict;
+    headline: string;
+    detail: string;
+    errors: number;
+    warnings: number;
+    infos: number;
+  };
+  artifacts: {
+    outputPath: string | null;
+    infoPlistPath: string | null;
+    entitlementsPath: string | null;
+    packetJsonPath: string;
+    packetMarkdownPath: string;
+  };
+  topFindings: FixPacketDiagnostic[];
+  diagnostics: FixPacketDiagnostic[];
+  nextSteps: string[];
+  ai: {
+    summary: string;
+    prompt: string;
+  };
+  xcode: {
+    summary: string;
+    checklist: string[];
+  };
+}
+
+export interface FixPacketInput {
+  success: boolean;
+  surface: FixPacketSurface;
+  diagnostics: Diagnostic[];
+  source?: string;
+  fileName?: string;
+  filePath?: string;
+  language?: "typescript" | "json";
+  outputPath?: string;
+  infoPlistPath?: string;
+  entitlementsPath?: string;
+  compilerVersion?: string;
+  packetDir?: string;
+  command?: FixPacketCommand;
+}
+
+export interface FixPacketArtifacts {
+  packet: FixPacket;
+  packetDir: string;
+  jsonPath: string;
+  markdownPath: string;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+let compilerVersion = "0.3.9";
+try {
+  const pkg = JSON.parse(
+    readFileSync(resolve(__dirname, "../../package.json"), "utf-8")
+  ) as {
+    version?: string;
+  };
+  if (typeof pkg.version === "string" && pkg.version.length > 0) {
+    compilerVersion = pkg.version;
+  }
+} catch {
+  // Fallback version is fine when bundled or tested outside the repo.
+}
+
+function countNonBlankLines(source?: string): number | null {
+  if (!source) return null;
+  return source.split("\n").filter((line) => line.trim().length > 0).length;
+}
+
+function severityWeight(severity: FixPacketDiagnostic["severity"]): number {
+  switch (severity) {
+    case "error":
+      return 0;
+    case "warning":
+      return 1;
+    default:
+      return 2;
+  }
+}
+
+function serializeDiagnostic(diagnostic: Diagnostic): FixPacketDiagnostic {
+  return {
+    code: diagnostic.code,
+    severity: diagnostic.severity,
+    message: diagnostic.message,
+    file: diagnostic.file,
+    line: diagnostic.line,
+    suggestion: diagnostic.suggestion,
+  };
+}
+
+function getVerdict(
+  success: boolean,
+  errors: number,
+  warnings: number
+): FixPacketVerdict {
+  if (!success || errors > 0) return "fail";
+  if (warnings > 0) return "needs_review";
+  return "pass";
+}
+
+function buildOutcomeCopy(verdict: FixPacketVerdict): {
+  headline: string;
+  detail: string;
+} {
+  switch (verdict) {
+    case "fail":
+      return {
+        headline: "Axint check failed",
+        detail:
+          "Blocking Apple-platform issues were found. Fix the failing findings below, then rerun the check.",
+      };
+    case "needs_review":
+      return {
+        headline: "Axint check needs review",
+        detail:
+          "The code compiled, but Apple-facing warnings still need attention before you trust the result.",
+      };
+    case "pass":
+      return {
+        headline: "Axint check passed",
+        detail:
+          "No blocking or warning diagnostics were emitted for this run. You can keep moving or save the result as a baseline.",
+      };
+  }
+}
+
+function buildNextSteps(verdict: FixPacketVerdict, sourceLabel: string): string[] {
+  switch (verdict) {
+    case "fail":
+      return [
+        `Copy the AI fix prompt and repair ${sourceLabel}.`,
+        "Rerun Axint after the fix lands.",
+        "Only keep shipping once the blocking findings are gone.",
+      ];
+    case "needs_review":
+      return [
+        `Review the warning set for ${sourceLabel} and decide what actually needs a fix.`,
+        "Use the AI fix prompt if you want help making the Apple-specific changes quickly.",
+        "Rerun Axint so the warning set drops to zero before you ship.",
+      ];
+    case "pass":
+      return [
+        `Keep ${sourceLabel} as the current clean baseline.`,
+        "If you touch the code again, rerun Axint before you go back to Xcode or commit.",
+        "Share the markdown packet with an AI tool or teammate only when you want a durable record.",
+      ];
+  }
+}
+
+function buildAiPrompt(packet: FixPacket): string {
+  const lines: string[] = [
+    "You are fixing Apple-platform code after an Axint validation run.",
+    "",
+    "AX codes are Axint diagnostic IDs in the report. They are labels for the findings only; you do not need Axint installed to use them.",
+    "",
+    `Verdict: ${packet.outcome.verdict}`,
+    `Headline: ${packet.outcome.headline}`,
+    `Source file: ${packet.source.filePath ?? packet.source.fileName}`,
+    `Surface: ${packet.source.surface}`,
+    `Compiler version: ${packet.compilerVersion}`,
+    "",
+  ];
+
+  if (packet.topFindings.length > 0) {
+    lines.push("Findings to address:");
+    for (const finding of packet.topFindings) {
+      lines.push(`- ${finding.code} [${finding.severity}] ${finding.message}`);
+      if (finding.file || finding.line) {
+        lines.push(
+          `  Location: ${finding.file ?? packet.source.fileName}${finding.line ? `:${finding.line}` : ""}`
+        );
+      }
+      if (finding.suggestion) {
+        lines.push(`  Suggested direction: ${finding.suggestion}`);
+      }
+    }
+    lines.push("");
+  } else {
+    lines.push("No findings were emitted in this run.");
+    lines.push("");
+  }
+
+  lines.push(
+    "Please update the source so the failing or warning findings are resolved, preserve the intended Apple behavior, and explain the concrete changes you made."
+  );
+
+  return lines.join("\n");
+}
+
+function buildXcodeChecklist(packet: FixPacket): string[] {
+  if (packet.outcome.verdict === "pass") {
+    return [
+      "Open the generated file or project in Xcode.",
+      "Run your normal build or simulator pass.",
+      "Rerun Axint if you make another Apple-facing change.",
+    ];
+  }
+
+  return [
+    "Open the affected file in Xcode or your AI editor.",
+    "Apply the AI fix prompt or make the Apple-specific edits manually.",
+    "Rerun Axint so the result updates before you continue.",
+  ];
+}
+
+function renderFindingLines(finding: FixPacketDiagnostic): string[] {
+  const lines = [`- ${finding.code} [${finding.severity}] ${finding.message}`];
+  if (finding.file || finding.line) {
+    lines.push(
+      `  Location: ${finding.file ?? "unknown"}${finding.line ? `:${finding.line}` : ""}`
+    );
+  }
+  if (finding.suggestion) {
+    lines.push(`  Suggestion: ${finding.suggestion}`);
+  }
+  return lines;
+}
+
+export function resolveFixPacketDir(
+  cwd: string = process.cwd(),
+  packetDir: string = ".axint/fix"
+): string {
+  return resolve(cwd, packetDir);
+}
+
+export function buildFixPacket(
+  input: FixPacketInput & {
+    packetJsonPath: string;
+    packetMarkdownPath: string;
+  }
+): FixPacket {
+  const diagnostics = input.diagnostics.map(serializeDiagnostic);
+  const errors = diagnostics.filter((d) => d.severity === "error").length;
+  const warnings = diagnostics.filter((d) => d.severity === "warning").length;
+  const infos = diagnostics.filter((d) => d.severity === "info").length;
+  const verdict = getVerdict(input.success, errors, warnings);
+  const outcomeCopy = buildOutcomeCopy(verdict);
+  const orderedFindings = [...diagnostics].sort((left, right) => {
+    const severityDelta = severityWeight(left.severity) - severityWeight(right.severity);
+    if (severityDelta !== 0) return severityDelta;
+    return left.code.localeCompare(right.code);
+  });
+  const fileName =
+    input.fileName ??
+    (input.filePath
+      ? basename(input.filePath)
+      : input.language === "json"
+        ? "input.json"
+        : "input.ts");
+
+  const packet: FixPacket = {
+    schemaVersion: 1,
+    createdAt: new Date().toISOString(),
+    compilerVersion: input.compilerVersion ?? compilerVersion,
+    command: input.command ?? "compile",
+    source: {
+      surface: input.surface,
+      language: input.language ?? "typescript",
+      fileName,
+      filePath: input.filePath,
+      sourceLines: countNonBlankLines(input.source),
+    },
+    outcome: {
+      success: input.success,
+      verdict,
+      headline: outcomeCopy.headline,
+      detail: outcomeCopy.detail,
+      errors,
+      warnings,
+      infos,
+    },
+    artifacts: {
+      outputPath: input.outputPath ?? null,
+      infoPlistPath: input.infoPlistPath ?? null,
+      entitlementsPath: input.entitlementsPath ?? null,
+      packetJsonPath: input.packetJsonPath,
+      packetMarkdownPath: input.packetMarkdownPath,
+    },
+    topFindings: orderedFindings.slice(0, 3),
+    diagnostics,
+    nextSteps: buildNextSteps(verdict, fileName),
+    ai: {
+      summary:
+        verdict === "pass"
+          ? "No fixes are required right now."
+          : "Copy the prompt below into your AI tool to fix the Apple-specific issues quickly.",
+      prompt: "",
+    },
+    xcode: {
+      summary:
+        verdict === "pass"
+          ? "This result is clean enough to carry back into Xcode."
+          : "Use this packet as the repair checklist before you go back to Xcode.",
+      checklist: [],
+    },
+  };
+
+  packet.ai.prompt = buildAiPrompt(packet);
+  packet.xcode.checklist = buildXcodeChecklist(packet);
+
+  return packet;
+}
+
+export function renderFixPacketMarkdown(packet: FixPacket): string {
+  const lines: string[] = [
+    `# Axint Fix Packet`,
+    "",
+    `- Verdict: **${packet.outcome.verdict}**`,
+    `- Headline: ${packet.outcome.headline}`,
+    `- Source: ${packet.source.filePath ?? packet.source.fileName}`,
+    `- Surface: ${packet.source.surface}`,
+    `- Compiler: ${packet.compilerVersion}`,
+    `- Generated: ${packet.createdAt}`,
+    "",
+    "## What happened",
+    "",
+    packet.outcome.detail,
+    "",
+    `- Errors: ${packet.outcome.errors}`,
+    `- Warnings: ${packet.outcome.warnings}`,
+    `- Infos: ${packet.outcome.infos}`,
+    "",
+  ];
+
+  if (packet.topFindings.length > 0) {
+    lines.push("## Top findings", "");
+    for (const finding of packet.topFindings) {
+      lines.push(...renderFindingLines(finding), "");
+    }
+  } else {
+    lines.push("## Top findings", "", "No findings were emitted in this run.", "");
+  }
+
+  lines.push("## Next steps", "");
+  for (const step of packet.nextSteps) {
+    lines.push(`- ${step}`);
+  }
+  lines.push("", "## Copy this into your AI", "", "```text", packet.ai.prompt, "```", "");
+
+  return lines.join("\n");
+}
+
+export function emitFixPacketArtifacts(
+  input: FixPacketInput,
+  cwd: string = process.cwd()
+): FixPacketArtifacts {
+  const packetDir = resolveFixPacketDir(cwd, input.packetDir);
+  const jsonPath = resolve(packetDir, "latest.json");
+  const markdownPath = resolve(packetDir, "latest.md");
+
+  const packet = buildFixPacket({
+    ...input,
+    packetJsonPath: jsonPath,
+    packetMarkdownPath: markdownPath,
+  });
+
+  mkdirSync(packetDir, { recursive: true });
+  writeFileSync(jsonPath, `${JSON.stringify(packet, null, 2)}\n`, "utf-8");
+  writeFileSync(markdownPath, `${renderFixPacketMarkdown(packet)}\n`, "utf-8");
+
+  return { packet, packetDir, jsonPath, markdownPath };
+}
+
+export function findLatestFixPacketPath(options?: {
+  cwd?: string;
+  packetDir?: string;
+}): string | null {
+  const cwd = resolve(options?.cwd ?? process.cwd());
+  if (options?.packetDir) {
+    const candidate = resolveFixPacketDir(cwd, options.packetDir);
+    const jsonPath = resolve(candidate, "latest.json");
+    return existsSync(jsonPath) ? jsonPath : null;
+  }
+
+  let current = cwd;
+  for (;;) {
+    const candidate = resolve(current, ".axint/fix/latest.json");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+export function readLatestFixPacket(options?: {
+  cwd?: string;
+  packetDir?: string;
+}): FixPacket | null {
+  const packetPath = findLatestFixPacketPath(options);
+  if (!packetPath) return null;
+  return JSON.parse(readFileSync(packetPath, "utf-8")) as FixPacket;
+}

--- a/tests/core/fix-packet.test.ts
+++ b/tests/core/fix-packet.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  buildFixPacket,
+  emitFixPacketArtifacts,
+  readLatestFixPacket,
+} from "../../src/repair/fix-packet.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("Fix Packet", () => {
+  it("builds a needs_review packet with an AI prompt that explains AX codes", () => {
+    const packet = buildFixPacket({
+      success: true,
+      surface: "intent",
+      fileName: "SetLights.ts",
+      diagnostics: [
+        {
+          code: "AX219",
+          severity: "warning",
+          message: "plist key mismatch",
+          suggestion: "Align the usage description with the entitlement.",
+          file: "SetLights.ts",
+          line: 12,
+        },
+      ],
+      packetJsonPath: "/tmp/latest.json",
+      packetMarkdownPath: "/tmp/latest.md",
+    });
+
+    expect(packet.outcome.verdict).toBe("needs_review");
+    expect(packet.topFindings).toHaveLength(1);
+    expect(packet.ai.prompt).toContain("AX codes are Axint diagnostic IDs");
+    expect(packet.ai.prompt).toContain("AX219");
+  });
+
+  it("builds a fail packet when blocking diagnostics exist", () => {
+    const packet = buildFixPacket({
+      success: false,
+      surface: "intent",
+      fileName: "Workout.ts",
+      diagnostics: [
+        {
+          code: "AX108",
+          severity: "error",
+          message: "entitlement string format mismatch",
+          suggestion: "Use the reserved HealthKit entitlement string.",
+        },
+      ],
+      packetJsonPath: "/tmp/latest.json",
+      packetMarkdownPath: "/tmp/latest.md",
+    });
+
+    expect(packet.outcome.verdict).toBe("fail");
+    expect(packet.outcome.headline).toBe("Axint check failed");
+    expect(packet.nextSteps[0]).toContain("Copy the AI fix prompt");
+  });
+
+  it("emits latest json and markdown artifacts and can rediscover them from a child cwd", () => {
+    const root = mkdtempSync(join(tmpdir(), "axint-fix-packet-"));
+    tempDirs.push(root);
+    const nested = join(root, "apps", "demo");
+    mkdirSync(nested, { recursive: true });
+
+    const artifacts = emitFixPacketArtifacts(
+      {
+        success: true,
+        surface: "view",
+        fileName: "GreetingCard.ts",
+        filePath: join(root, "GreetingCard.ts"),
+        source: "export default defineView({ name: 'GreetingCard' });",
+        diagnostics: [],
+      },
+      root
+    );
+
+    const packetText = readFileSync(artifacts.jsonPath, "utf-8");
+    const markdownText = readFileSync(artifacts.markdownPath, "utf-8");
+    const rediscovered = readLatestFixPacket({ cwd: nested });
+
+    expect(packetText).toContain('"schemaVersion": 1');
+    expect(markdownText).toContain("# Axint Fix Packet");
+    expect(rediscovered?.source.fileName).toBe("GreetingCard.ts");
+    expect(rediscovered?.outcome.verdict).toBe("pass");
+  });
+});

--- a/tests/mcp/fix-packet.test.ts
+++ b/tests/mcp/fix-packet.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { handleToolCall } from "../../src/mcp/server.js";
+import { emitFixPacketArtifacts } from "../../src/repair/fix-packet.js";
+
+describe("axint.fix-packet tool", () => {
+  it("returns the latest Fix Packet through MCP", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "axint-mcp-packet-"));
+    try {
+      emitFixPacketArtifacts(
+        {
+          success: false,
+          surface: "intent",
+          fileName: "SetLights.ts",
+          diagnostics: [
+            {
+              code: "AX108",
+              severity: "error",
+              message: "entitlement string format mismatch",
+              suggestion: "Use the reserved HealthKit entitlement string.",
+            },
+          ],
+        },
+        cwd
+      );
+
+      const promptResult = await handleToolCall("axint.fix-packet", {
+        cwd,
+        format: "prompt",
+      });
+      expect(promptResult.isError).not.toBe(true);
+      expect(promptResult.content[0].text).toContain("AX108");
+      expect(promptResult.content[0].text).toContain("Axint diagnostic IDs");
+
+      const jsonResult = await handleToolCall("axint.fix-packet", {
+        cwd,
+        format: "json",
+      });
+      expect(jsonResult.isError).not.toBe(true);
+      expect(jsonResult.content[0].text).toContain('"verdict": "fail"');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add compiler-emitted Fix Packet artifacts for compile and watch
- expose the latest Fix Packet through MCP as axint.fix-packet
- document and test the new repair packet flow

## Verification
- npm run typecheck
- npx vitest run tests/core/fix-packet.test.ts tests/mcp/fix-packet.test.ts tests/mcp/server.test.ts tests/cli/compile.test.ts tests/cli/watch.test.ts
- npm run build