### PR TITLE
Emit validator repair packets for Xcode flows

### DIFF
--- a/metrics.json
+++ b/metrics.json
@@ -5,7 +5,7 @@
   "bundledTemplates": 26,
   "diagnostics": 130,
   "tests": {
-    "typescript": 578,
+    "typescript": 580,
     "python": 105
   },
   "registryPackages": 8,

--- a/spm-plugin/Plugins/AxintValidatePlugin/AxintValidatePlugin.swift
+++ b/spm-plugin/Plugins/AxintValidatePlugin/AxintValidatePlugin.swift
@@ -24,8 +24,17 @@ struct AxintValidatePlugin: BuildToolPlugin {
 
         let workDir = context.pluginWorkDirectory
         let sentinel = workDir.appending("axint-validate.ok")
+        let fixPacketDirectory = workDir.appending("fix").appending("validate")
 
-        let args = prefixArgs + ["validate-swift", "--quiet"] + inputFiles.map { $0.string }
+        try FileManager.default.createDirectory(
+            at: fixPacketDirectory.asURL,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        let args = prefixArgs
+            + ["validate-swift", "--quiet", "--fix-packet-dir", fixPacketDirectory.string]
+            + inputFiles.map { $0.string }
 
         return [
             .buildCommand(
@@ -94,8 +103,17 @@ extension AxintValidatePlugin: XcodeBuildToolPlugin {
 
         let workDir = context.pluginWorkDirectory
         let sentinel = workDir.appending("axint-validate.ok")
+        let fixPacketDirectory = workDir.appending("fix").appending("validate")
 
-        let args = prefixArgs + ["validate-swift", "--quiet"] + inputFiles.map { $0.string }
+        try? FileManager.default.createDirectory(
+            at: fixPacketDirectory.asURL,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        let args = prefixArgs
+            + ["validate-swift", "--quiet", "--fix-packet-dir", fixPacketDirectory.string]
+            + inputFiles.map { $0.string }
 
         return [
             .buildCommand(

--- a/spm-plugin/README.md
+++ b/spm-plugin/README.md
@@ -148,6 +148,10 @@ The intended loop is:
 
 This keeps the compiler output simple for humans while still giving AI tooling the full repair packet.
 
+`AxintValidatePlugin` uses the same contract for Swift validation runs. When the validator
+finds AX7xx issues, it writes a target-level Fix Packet under `fix/validate/` so Xcode or
+an AI helper can read the repair checklist instead of only relying on raw console output.
+
 ## Writing Definitions
 
 Here's an example TypeScript intent definition:

--- a/src/cli/validate-swift.ts
+++ b/src/cli/validate-swift.ts
@@ -3,6 +3,7 @@ import { readFileSync, statSync, readdirSync } from "node:fs";
 import { resolve, join, extname } from "node:path";
 import { validateSwiftSource } from "../core/swift-validator.js";
 import type { Diagnostic } from "../core/types.js";
+import { emitFixPacketArtifacts } from "../repair/fix-packet.js";
 
 export function registerValidateSwift(program: Command) {
   program
@@ -13,51 +14,104 @@ export function registerValidateSwift(program: Command) {
     .argument("<path>", "Swift file or directory to validate")
     .option("--quiet", "Only print errors, not the success banner")
     .option("--json", "Emit a machine-readable JSON report to stdout")
-    .action(async (pathArg: string, options: { quiet?: boolean; json?: boolean }) => {
-      const target = resolve(pathArg);
-      const files = collectSwiftFiles(target);
+    .option(
+      "--no-fix-packet",
+      "Skip writing the local Fix Packet under .axint/fix/latest.{json,md}"
+    )
+    .option(
+      "--fix-packet-dir <dir>",
+      "Directory for the emitted Fix Packet artifacts",
+      ".axint/fix"
+    )
+    .action(
+      async (
+        pathArg: string,
+        options: {
+          quiet?: boolean;
+          json?: boolean;
+          fixPacket?: boolean;
+          fixPacketDir: string;
+        }
+      ) => {
+        const target = resolve(pathArg);
+        const files = collectSwiftFiles(target);
 
-      if (files.length === 0) {
-        console.error(`\x1b[31merror:\x1b[0m no .swift files found at ${pathArg}`);
-        process.exit(1);
+        if (files.length === 0) {
+          console.error(`\x1b[31merror:\x1b[0m no .swift files found at ${pathArg}`);
+          process.exit(1);
+        }
+
+        const all: Diagnostic[] = [];
+        for (const file of files) {
+          const source = readFileSync(file, "utf-8");
+          const result = validateSwiftSource(source, file);
+          all.push(...result.diagnostics);
+        }
+
+        const errors = all.filter((d) => d.severity === "error");
+        let packetArtifacts: ReturnType<typeof emitFixPacketArtifacts> | null = null;
+
+        if (options.fixPacket !== false) {
+          try {
+            packetArtifacts = emitFixPacketArtifacts(
+              {
+                success: errors.length === 0,
+                surface: "swift",
+                diagnostics: all,
+                source: files.length === 1 ? readFileSync(files[0], "utf-8") : undefined,
+                fileName:
+                  files.length === 1
+                    ? files[0].split(/[\\/]/).pop()
+                    : (target.split(/[\\/]/).pop() ?? "swift-validation"),
+                filePath: files.length === 1 ? files[0] : target,
+                language: "swift",
+                packetDir: options.fixPacketDir,
+                command: "validate_swift",
+              },
+              process.cwd()
+            );
+          } catch (packetErr: unknown) {
+            console.error(
+              `\x1b[33mwarning:\x1b[0m Fix Packet skipped — ${(packetErr as Error).message}`
+            );
+          }
+        }
+
+        if (options.json) {
+          const payload = {
+            ok: errors.length === 0,
+            filesScanned: files.length,
+            diagnostics: all,
+            fixPacketPath: packetArtifacts?.jsonPath ?? null,
+          };
+          process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+          process.exit(errors.length > 0 ? 1 : 0);
+        }
+
+        for (const d of all) {
+          printDiagnostic(d);
+        }
+
+        if (errors.length > 0) {
+          if (packetArtifacts) {
+            console.error(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+          }
+          console.error(
+            `\n\x1b[31m✗\x1b[0m ${errors.length} error${errors.length === 1 ? "" : "s"} in ${files.length} file${files.length === 1 ? "" : "s"}`
+          );
+          process.exit(1);
+        }
+
+        if (!options.quiet) {
+          if (packetArtifacts) {
+            console.log(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+          }
+          console.log(
+            `\x1b[32m✓\x1b[0m ${files.length} Swift file${files.length === 1 ? "" : "s"} passed axint validation`
+          );
+        }
       }
-
-      const all: Diagnostic[] = [];
-      for (const file of files) {
-        const source = readFileSync(file, "utf-8");
-        const result = validateSwiftSource(source, file);
-        all.push(...result.diagnostics);
-      }
-
-      const errors = all.filter((d) => d.severity === "error");
-
-      if (options.json) {
-        const payload = {
-          ok: errors.length === 0,
-          filesScanned: files.length,
-          diagnostics: all,
-        };
-        process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
-        process.exit(errors.length > 0 ? 1 : 0);
-      }
-
-      for (const d of all) {
-        printDiagnostic(d);
-      }
-
-      if (errors.length > 0) {
-        console.error(
-          `\n\x1b[31m✗\x1b[0m ${errors.length} error${errors.length === 1 ? "" : "s"} in ${files.length} file${files.length === 1 ? "" : "s"}`
-        );
-        process.exit(1);
-      }
-
-      if (!options.quiet) {
-        console.log(
-          `\x1b[32m✓\x1b[0m ${files.length} Swift file${files.length === 1 ? "" : "s"} passed axint validation`
-        );
-      }
-    });
+    );
 }
 
 function collectSwiftFiles(target: string): string[] {

--- a/src/repair/fix-packet.ts
+++ b/src/repair/fix-packet.ts
@@ -4,9 +4,9 @@ import { fileURLToPath } from "node:url";
 import type { Diagnostic } from "../core/types.js";
 
 export type FixPacketVerdict = "pass" | "needs_review" | "fail";
-export type FixPacketSurface = "intent" | "view" | "widget" | "app";
+export type FixPacketSurface = "intent" | "view" | "widget" | "app" | "swift";
 export type FixPacketFormat = "json" | "markdown" | "prompt";
-export type FixPacketCommand = "compile" | "watch" | "mcp";
+export type FixPacketCommand = "compile" | "watch" | "mcp" | "validate_swift";
 
 export interface FixPacketDiagnostic {
   code: string;
@@ -24,7 +24,7 @@ export interface FixPacket {
   command: FixPacketCommand;
   source: {
     surface: FixPacketSurface;
-    language: "typescript" | "json";
+    language: "typescript" | "json" | "swift";
     fileName: string;
     filePath?: string;
     sourceLines: number | null;
@@ -65,7 +65,7 @@ export interface FixPacketInput {
   source?: string;
   fileName?: string;
   filePath?: string;
-  language?: "typescript" | "json";
+  language?: "typescript" | "json" | "swift";
   outputPath?: string;
   infoPlistPath?: string;
   entitlementsPath?: string;
@@ -281,7 +281,9 @@ export function buildFixPacket(
       ? basename(input.filePath)
       : input.language === "json"
         ? "input.json"
-        : "input.ts");
+        : input.language === "swift"
+          ? "input.swift"
+          : "input.ts");
 
   const packet: FixPacket = {
     schemaVersion: 1,

--- a/tests/cli/validate-swift.test.ts
+++ b/tests/cli/validate-swift.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { tmpdir } from "node:os";
+
+const CLI = resolve(__dirname, "../../dist/cli/index.js");
+
+const INVALID_SWIFT = `
+import AppIntents
+
+struct BrokenIntent: AppIntent {
+    static var title: LocalizedStringResource = "Broken"
+}
+`;
+
+const VALID_SWIFT = `
+struct PlainSwift {
+    let value: Int = 1
+}
+`;
+
+describe("axint validate-swift", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = resolve(tmpdir(), `axint-validate-swift-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits a Fix Packet when validation fails", () => {
+    const swiftFile = join(tmpDir, "BrokenIntent.swift");
+    const packetDir = join(tmpDir, "fix");
+    writeFileSync(swiftFile, INVALID_SWIFT, "utf-8");
+
+    const result = spawnSync(
+      "node",
+      [CLI, "validate-swift", swiftFile, "--fix-packet-dir", packetDir],
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+      }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Fix Packet");
+
+    const packetPath = join(packetDir, "latest.json");
+    expect(existsSync(packetPath)).toBe(true);
+
+    const packet = JSON.parse(readFileSync(packetPath, "utf-8")) as {
+      command: string;
+      source: { surface: string; language: string };
+      outcome: { verdict: string };
+      diagnostics: Array<{ code: string }>;
+    };
+
+    expect(packet.command).toBe("validate_swift");
+    expect(packet.source.surface).toBe("swift");
+    expect(packet.source.language).toBe("swift");
+    expect(packet.outcome.verdict).toBe("fail");
+    expect(packet.diagnostics.some((diagnostic) => diagnostic.code === "AX701")).toBe(
+      true
+    );
+  });
+
+  it("emits a passing Fix Packet for clean Swift input", () => {
+    const swiftFile = join(tmpDir, "PlainSwift.swift");
+    const packetDir = join(tmpDir, "fix");
+    writeFileSync(swiftFile, VALID_SWIFT, "utf-8");
+
+    const result = spawnSync(
+      "node",
+      [CLI, "validate-swift", swiftFile, "--fix-packet-dir", packetDir],
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+      }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Fix Packet");
+
+    const packetPath = join(packetDir, "latest.json");
+    expect(existsSync(packetPath)).toBe(true);
+
+    const packet = JSON.parse(readFileSync(packetPath, "utf-8")) as {
+      outcome: { verdict: string };
+      diagnostics: Array<unknown>;
+    };
+
+    expect(packet.outcome.verdict).toBe("pass");
+    expect(packet.diagnostics).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- make validate-swift emit Fix Packets just like compile does
- wire the Xcode/SPM validate plugin to write those packets automatically
- add a CLI test for passing and failing validate-swift packet output

## Verification
- npm run typecheck
- npm run build
- npx vitest run tests/cli/validate-swift.test.ts tests/core/fix-packet.test.ts tests/mcp/fix-packet.test.ts
- npm run metrics:check
- swift package dump-package