### PR TITLE
Refresh public release docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,10 +173,12 @@ npm run gen:swift-fixer:check
    - `docs/COVERAGE.md`
    - `docs/RELEASE_NOTES.md`
 
-5. Keep package releases aligned.
+5. If headline numbers or public proof changed, sync the downstream public surfaces that read from the truth bundle before announcing the release.
+
+6. Keep package releases aligned.
    If an intentional release goes out, npm and PyPI should move together so the public version story stays coherent.
 
-6. Only tag and publish once the repo state, docs, and metrics all agree.
+7. Only tag and publish once the repo state, docs, metrics, and downstream public proof all agree.
 
 ## Adding a New Template
 

--- a/extensions/xcode/README.md
+++ b/extensions/xcode/README.md
@@ -56,7 +56,7 @@ codex mcp add axint -- npx -y @axint/compiler axint-mcp
 
 ## Tools Available
 
-Once connected, agents gain 10 specialized tools plus 3 built-in prompts:
+Once connected, agents gain 11 specialized tools plus 3 built-in prompts:
 
 | Tool | What it does |
 |------|-------------|
@@ -65,6 +65,7 @@ Once connected, agents gain 10 specialized tools plus 3 built-in prompts:
 | `axint.scaffold` | Generate a starter TypeScript intent file |
 | `axint.compile` | Compile TypeScript → validated Swift |
 | `axint.validate` | Validate without code generation |
+| `axint.fix-packet` | Fetch the latest repair packet for AI and Xcode workflows |
 | `axint.schema.compile` | Compile minimal JSON → Swift (token-optimized) |
 | `axint.swift.validate` | Validate existing Swift against Axint's build-time rules |
 | `axint.swift.fix` | Auto-fix mechanical Swift validator errors |


### PR DESCRIPTION
## Summary\n- fix the remaining stale MCP tool count in the Xcode extension docs\n- document downstream truth/public-surface sync in the release checklist\n\n## Testing\n- npm run boundary:check\n- npm run metrics:check\n- npm run typecheck\n- npm run lint\n- npm run build