### PR TITLE
Expand HealthKit privacy diagnostics

### DIFF
--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -15,6 +15,7 @@ This page is the quickest way to understand what Axint currently covers in Apple
   - App Shortcuts provider requirements
   - Swift 6 isolation and concurrency hazards
   - Live Activities / ActivityKit repair cases
+  - HealthKit entitlement and privacy usage-description mismatches
 
 ## Canonical proof sources
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -149,7 +149,7 @@ You can also use the simple string form:
 parameterSummary: "Open ${trail} in ${region}"
 ```
 
-## Intent Validation Errors (AX100–AX113)
+## Intent Validation Errors (AX100–AX116)
 
 These validate intent and entity IR against Apple-facing constraints.
 
@@ -216,6 +216,80 @@ These are warnings, not blockers:
 - `AX106`: title is likely too long for Siri / Shortcuts UI
 
 The usual fix is to shorten labels or split one overloaded intent into smaller, clearer intents.
+
+### AX108 / AX109 — Entitlement and Info.plist shape warnings
+
+These warnings catch intent metadata that does not look like real Apple configuration:
+
+- `AX108`: entitlement strings do not look like reverse-DNS identifiers
+- `AX109`: Info.plist keys do not look like normal Apple keys
+
+**Example**
+
+```typescript
+entitlements: ["healthkit"],
+infoPlistKeys: {
+  HealthPermission: "Allow access",
+},
+```
+
+**Fix**
+
+```typescript
+entitlements: ["com.apple.developer.healthkit"],
+infoPlistKeys: {
+  NSHealthShareUsageDescription: "Read workout history to personalize coaching.",
+},
+```
+
+### AX114 / AX115 / AX116 — HealthKit and privacy copy mismatches
+
+These warnings catch one of the easiest ways to end up with a broken Apple integration:
+
+- `AX114`: HealthKit entitlement is present but no HealthKit usage descriptions were declared
+- `AX115`: `NSHealth*UsageDescription` keys were declared without the HealthKit entitlement
+- `AX116`: a privacy usage description is empty or still placeholder copy
+
+**Bad**
+
+```typescript
+export default defineIntent({
+  name: "LogWorkout",
+  title: "Log Workout",
+  description: "Logs a workout.",
+  entitlements: ["com.apple.developer.healthkit"],
+  infoPlistKeys: {
+    NSHealthShareUsageDescription: "TODO: explain why we read data",
+  },
+  params: {},
+  perform: async () => ({ ok: true }),
+});
+```
+
+**Typical diagnostics**
+
+```text
+warning[AX116]: Privacy usage description "NSHealthShareUsageDescription" is empty or still reads like placeholder copy
+```
+
+If the usage strings were missing entirely, Axint would emit `AX114`. If the entitlement were missing but the HealthKit keys stayed behind, it would emit `AX115`.
+
+**Fix**
+
+```typescript
+export default defineIntent({
+  name: "LogWorkout",
+  title: "Log Workout",
+  description: "Logs a workout.",
+  entitlements: ["com.apple.developer.healthkit"],
+  infoPlistKeys: {
+    NSHealthShareUsageDescription: "Read workout history to personalize coaching.",
+    NSHealthUpdateUsageDescription: "Save newly completed workouts to Health.",
+  },
+  params: {},
+  perform: async () => ({ ok: true }),
+});
+```
 
 ### AX110 — Entity name must be PascalCase
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -14,6 +14,10 @@ This release wave sharpens the Xcode workflow and expands Apple-native Swift cov
   - `AX717` — missing `import WidgetKit`
   - `AX718` — missing `import SwiftUI`
   - `AX719` — AppIntent inputs missing `@Parameter`
+- New intent-validation diagnostics:
+  - `AX114` — HealthKit entitlement declared without matching privacy usage descriptions
+  - `AX115` — HealthKit privacy usage descriptions declared without the HealthKit entitlement
+  - `AX116` — privacy usage description is empty or still placeholder copy
 - New safe repair coverage:
   - insert missing Apple framework imports
   - inject missing `TimelineProvider` stubs
@@ -26,6 +30,7 @@ This release wave sharpens the Xcode workflow and expands Apple-native Swift cov
 - Xcode docs now explain the `build -> packet -> fix -> rerun` loop directly
 - Fix Packets now carry a low-confidence signal for Swift files that Axint does not recognize as supported Apple-native surfaces
 - Metrics now expose Xcode fix rule counts and names so coverage can be tracked more explicitly
+- Intent validation now catches a common App Review / HealthKit setup failure before you leave the compiler loop
 
 ### Why it matters
 

--- a/metrics.json
+++ b/metrics.json
@@ -21,7 +21,7 @@
     "axint.create-intent"
   ],
   "bundledTemplates": 26,
-  "diagnostics": 134,
+  "diagnostics": 137,
   "xcodeFixRules": 32,
   "xcodeFixRuleCodes": [
     "AX701",
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 605,
+    "typescript": 609,
     "python": 105
   },
   "registryPackages": 8,

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -212,6 +212,26 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticInfo> = {
     message: "Invalid entity query type",
     category: "entity-validator",
   },
+  AX114: {
+    code: "AX114",
+    severity: "warning",
+    message:
+      "HealthKit entitlements were declared without matching privacy usage descriptions",
+    category: "intent-validator",
+  },
+  AX115: {
+    code: "AX115",
+    severity: "warning",
+    message:
+      "HealthKit privacy usage descriptions were declared without the HealthKit entitlement",
+    category: "intent-validator",
+  },
+  AX116: {
+    code: "AX116",
+    severity: "warning",
+    message: "Privacy usage description is empty or still placeholder copy",
+    category: "intent-validator",
+  },
 
   // ─── Intent Generator (AX200–AX299) ──────────────────────
   AX200: {

--- a/src/core/validator.ts
+++ b/src/core/validator.ts
@@ -13,11 +13,25 @@ const MAX_PARAMETERS = 10;
 /** Maximum title length before Siri may truncate display */
 const MAX_TITLE_LENGTH = 60;
 
+const HEALTHKIT_ENTITLEMENT_KEYS = new Set([
+  "com.apple.developer.healthkit",
+  "com.apple.developer.healthkit.background-delivery",
+]);
+
+const HEALTHKIT_USAGE_DESCRIPTION_KEYS = [
+  "NSHealthShareUsageDescription",
+  "NSHealthUpdateUsageDescription",
+  "NSHealthClinicalHealthRecordsShareUsageDescription",
+];
+
+const PRIVACY_USAGE_DESCRIPTION_PATTERN = /^NS[A-Za-z0-9]+UsageDescription$/;
+
 /**
  * Validate an IR intent for App Intents framework compliance.
  */
 export function validateIntent(intent: IRIntent): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
+  const infoPlistKeys = intent.infoPlistKeys ?? {};
 
   // Rule: Intent name must be PascalCase and non-empty
   if (!intent.name || !/^[A-Z][a-zA-Z0-9]*$/.test(intent.name)) {
@@ -128,7 +142,7 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
   }
 
   // Rule: Info.plist keys must start with "NS" or other known prefixes
-  for (const key of Object.keys(intent.infoPlistKeys ?? {})) {
+  for (const key of Object.keys(infoPlistKeys)) {
     if (!/^(NS|UI|LS|CF|CA|CK)[A-Za-z0-9]+$/.test(key)) {
       diagnostics.push({
         code: "AX109",
@@ -139,6 +153,51 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
           'Apple keys generally start with "NS" (e.g., "NSCalendarsUsageDescription")',
       });
     }
+  }
+
+  const hasHealthKitEntitlement = (intent.entitlements ?? []).some((entitlement) =>
+    HEALTHKIT_ENTITLEMENT_KEYS.has(entitlement)
+  );
+  const declaredHealthKitUsageKeys = HEALTHKIT_USAGE_DESCRIPTION_KEYS.filter(
+    (key) => key in infoPlistKeys
+  );
+
+  if (hasHealthKitEntitlement && declaredHealthKitUsageKeys.length === 0) {
+    diagnostics.push({
+      code: "AX114",
+      severity: "warning",
+      message:
+        "HealthKit entitlements were declared, but no HealthKit privacy usage descriptions were provided",
+      file: intent.sourceFile,
+      suggestion:
+        "Add NSHealthShareUsageDescription and/or NSHealthUpdateUsageDescription with user-facing copy that matches the HealthKit access you request",
+    });
+  }
+
+  if (!hasHealthKitEntitlement && declaredHealthKitUsageKeys.length > 0) {
+    diagnostics.push({
+      code: "AX115",
+      severity: "warning",
+      message:
+        "HealthKit privacy usage descriptions were declared, but the HealthKit entitlement is missing",
+      file: intent.sourceFile,
+      suggestion:
+        "Enable the HealthKit capability (com.apple.developer.healthkit) or remove the stray NSHealth*UsageDescription keys if this intent does not use HealthKit",
+    });
+  }
+
+  for (const [key, value] of Object.entries(infoPlistKeys)) {
+    if (!PRIVACY_USAGE_DESCRIPTION_PATTERN.test(key)) continue;
+    if (!isPlaceholderUsageDescription(value)) continue;
+
+    diagnostics.push({
+      code: "AX116",
+      severity: "warning",
+      message: `Privacy usage description "${key}" is empty or still reads like placeholder copy`,
+      file: intent.sourceFile,
+      suggestion:
+        "Replace it with a concrete user-facing explanation of what the app reads or writes and why",
+    });
   }
 
   // Validate all entities
@@ -250,4 +309,20 @@ function toPascalCase(s: string): string {
   return s
     .replace(/[-_\s]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ""))
     .replace(/^(.)/, (c) => c.toUpperCase());
+}
+
+function isPlaceholderUsageDescription(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return true;
+
+  const normalized = trimmed.toLowerCase();
+  return (
+    normalized.startsWith("todo") ||
+    normalized.startsWith("tbd") ||
+    normalized === "placeholder" ||
+    normalized === "change me" ||
+    normalized.includes("<#") ||
+    normalized.includes("your usage description") ||
+    normalized.includes("insert usage description")
+  );
 }

--- a/tests/core/validator.test.ts
+++ b/tests/core/validator.test.ts
@@ -101,6 +101,58 @@ describe("validateIntent", () => {
       expect(diagnostics.filter((d) => d.code === "AX100")).toHaveLength(0);
     }
   });
+
+  it("warns when HealthKit entitlement is present without usage descriptions (AX114)", () => {
+    const diagnostics = validateIntent(
+      makeIntent({
+        entitlements: ["com.apple.developer.healthkit"],
+      })
+    );
+    const warning = diagnostics.find((d) => d.code === "AX114");
+    expect(warning).toBeDefined();
+    expect(warning!.severity).toBe("warning");
+  });
+
+  it("warns when HealthKit usage descriptions are present without entitlement (AX115)", () => {
+    const diagnostics = validateIntent(
+      makeIntent({
+        infoPlistKeys: {
+          NSHealthShareUsageDescription: "Read workout history to chart progress.",
+        },
+      })
+    );
+    const warning = diagnostics.find((d) => d.code === "AX115");
+    expect(warning).toBeDefined();
+    expect(warning!.severity).toBe("warning");
+  });
+
+  it("warns when privacy usage descriptions are empty or placeholder copy (AX116)", () => {
+    const diagnostics = validateIntent(
+      makeIntent({
+        infoPlistKeys: {
+          NSHealthShareUsageDescription: "TODO: add real copy",
+          NSCalendarsUsageDescription: "",
+        },
+      })
+    );
+    expect(diagnostics.filter((d) => d.code === "AX116")).toHaveLength(2);
+  });
+
+  it("accepts well-formed HealthKit entitlements and privacy strings together", () => {
+    const diagnostics = validateIntent(
+      makeIntent({
+        entitlements: ["com.apple.developer.healthkit"],
+        infoPlistKeys: {
+          NSHealthShareUsageDescription: "Read workout history to personalize coaching.",
+          NSHealthUpdateUsageDescription: "Save newly completed workouts to Health.",
+        },
+      })
+    );
+
+    expect(diagnostics.some((d) => d.code === "AX114")).toBe(false);
+    expect(diagnostics.some((d) => d.code === "AX115")).toBe(false);
+    expect(diagnostics.some((d) => d.code === "AX116")).toBe(false);
+  });
 });
 
 describe("validateSwiftSource", () => {


### PR DESCRIPTION
## Summary
- add HealthKit intent diagnostics for missing entitlement/privacy string alignment
- warn on empty or placeholder NS*UsageDescription copy
- refresh docs and metrics for the new coverage wave

## Testing
- npm run boundary:check
- npm run metrics:check
- npm run typecheck
- npm run lint
- npm run build
- npx vitest run tests/core/validator.test.ts