### PR TITLE
Refresh example coverage and app scene parsing

### DIFF
--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -23,6 +23,7 @@ This page is the quickest way to understand what Axint currently covers in Apple
 - [`ERRORS.md`](./ERRORS.md) is the full diagnostic registry
 - [`FIX_PACKET.md`](./FIX_PACKET.md) is the repair-contract spec for CLI, MCP, and Xcode flows
 - [`../extensions/xcode/README.md`](../extensions/xcode/README.md) is the Xcode workflow guide
+- [`../tests/examples/compile.test.ts`](../tests/examples/compile.test.ts) proves the bundled examples still compile across the supported Apple surfaces
 
 ## How to refresh the snapshot
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -31,6 +31,7 @@ This release wave sharpens the Xcode workflow and expands Apple-native Swift cov
 - Fix Packets now carry a low-confidence signal for Swift files that Axint does not recognize as supported Apple-native surfaces
 - Metrics now expose Xcode fix rule counts and names so coverage can be tracked more explicitly
 - Intent validation now catches a common App Review / HealthKit setup failure before you leave the compiler loop
+- The bundled examples are now part of the proof surface: they compile in CI, and the HealthKit example shows the same entitlement + privacy contract the validator enforces
 
 ### Why it matters
 

--- a/examples/health-log.ts
+++ b/examples/health-log.ts
@@ -1,7 +1,8 @@
 /**
  * Health Log Intent — Log a health measurement
  *
- * Demonstrates: date params, duration, URL, optional fields
+ * Demonstrates: HealthKit entitlements, privacy usage copy, date params,
+ * optional fields, and numeric fidelity for health data.
  */
 import { defineIntent, param } from "@axint/compiler";
 
@@ -10,9 +11,14 @@ export default defineIntent({
   title: "Log Health Metric",
   description: "Records a health measurement like weight, blood pressure, or exercise",
   domain: "health",
+  entitlements: ["com.apple.developer.healthkit"],
+  infoPlistKeys: {
+    NSHealthShareUsageDescription: "Read prior health measurements to compare your progress.",
+    NSHealthUpdateUsageDescription: "Save new health measurements that you log from this shortcut.",
+  },
   params: {
     metric: param.string("What you're logging (e.g., weight, steps)"),
-    value: param.number("The measurement value"),
+    value: param.double("The measurement value"),
     date: param.date("When the measurement was taken"),
     duration: param.duration("Activity duration", { required: false }),
     notes: param.string("Additional notes", { required: false }),

--- a/metrics.json
+++ b/metrics.json
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 609,
+    "typescript": 613,
     "python": 105
   },
   "registryPackages": 8,

--- a/src/core/app-parser.ts
+++ b/src/core/app-parser.ts
@@ -101,59 +101,154 @@ function parseScenes(
   const scenes: IRScene[] = [];
 
   for (const element of arr.elements) {
-    if (!ts.isObjectLiteralExpression(element)) {
+    const parsed = parseSceneElement(element, sourceFile, filePath);
+    if (!parsed) {
       throw new ParserError(
         "AX504",
-        "Each scene must be an object literal",
+        "Each scene must be an object literal or scene.* helper call",
         filePath,
         posOf(sourceFile, element),
-        "Use: { kind: 'windowGroup', view: 'ContentView' }"
+        "Use: { kind: 'windowGroup', view: 'ContentView' } or scene.windowGroup('ContentView')"
       );
     }
-
-    const kind = extractStringProp(element, "kind", sourceFile, filePath) as
-      | SceneKind
-      | undefined;
-    if (!kind || !isValidSceneKind(kind)) {
-      throw new ParserError(
-        "AX505",
-        `Invalid scene kind: "${kind}". Must be one of: windowGroup, window, documentGroup, settings`,
-        filePath,
-        posOf(sourceFile, element),
-        'Use kind: "windowGroup" or kind: "settings"'
-      );
-    }
-
-    const rootView = extractStringProp(element, "view", sourceFile, filePath);
-    if (!rootView) {
-      throw new ParserError(
-        "AX506",
-        "Each scene requires a `view` property referencing the root SwiftUI view",
-        filePath,
-        posOf(sourceFile, element),
-        'Add view: "ContentView"'
-      );
-    }
-
-    const title = extractStringProp(element, "title", sourceFile, filePath);
-    const sceneName = extractStringProp(element, "name", sourceFile, filePath);
-    const platformGuard = extractStringProp(element, "platform", sourceFile, filePath) as
-      | "macOS"
-      | "iOS"
-      | "visionOS"
-      | undefined;
 
     scenes.push({
-      sceneKind: kind,
-      rootView,
-      title,
-      name: sceneName,
-      platformGuard,
-      isDefault: scenes.length === 0 && kind === "windowGroup",
+      ...parsed,
+      isDefault: scenes.length === 0 && parsed.sceneKind === "windowGroup",
     });
   }
 
   return scenes;
+}
+
+function parseSceneElement(
+  element: ts.Expression,
+  sourceFile: ts.SourceFile,
+  filePath: string
+): Omit<IRScene, "isDefault"> | null {
+  if (ts.isObjectLiteralExpression(element)) {
+    return parseSceneObject(element, sourceFile, filePath);
+  }
+
+  if (ts.isCallExpression(element)) {
+    return parseSceneHelperCall(element, sourceFile, filePath);
+  }
+
+  return null;
+}
+
+function parseSceneObject(
+  element: ts.ObjectLiteralExpression,
+  sourceFile: ts.SourceFile,
+  filePath: string
+): Omit<IRScene, "isDefault"> {
+  const kind = extractStringProp(element, "kind", sourceFile, filePath) as
+    | SceneKind
+    | undefined;
+  if (!kind || !isValidSceneKind(kind)) {
+    throw new ParserError(
+      "AX505",
+      `Invalid scene kind: "${kind}". Must be one of: windowGroup, window, documentGroup, settings`,
+      filePath,
+      posOf(sourceFile, element),
+      'Use kind: "windowGroup" or kind: "settings"'
+    );
+  }
+
+  const rootView = extractStringProp(element, "view", sourceFile, filePath);
+  if (!rootView) {
+    throw new ParserError(
+      "AX506",
+      "Each scene requires a `view` property referencing the root SwiftUI view",
+      filePath,
+      posOf(sourceFile, element),
+      'Add view: "ContentView"'
+    );
+  }
+
+  const title = extractStringProp(element, "title", sourceFile, filePath);
+  const sceneName = extractStringProp(element, "name", sourceFile, filePath);
+  const platformGuard = extractStringProp(element, "platform", sourceFile, filePath) as
+    | "macOS"
+    | "iOS"
+    | "visionOS"
+    | undefined;
+
+  return {
+    sceneKind: kind,
+    rootView,
+    title,
+    name: sceneName,
+    platformGuard,
+  };
+}
+
+function parseSceneHelperCall(
+  element: ts.CallExpression,
+  sourceFile: ts.SourceFile,
+  filePath: string
+): Omit<IRScene, "isDefault"> | null {
+  if (
+    !ts.isPropertyAccessExpression(element.expression) ||
+    element.expression.expression.getText(sourceFile) !== "scene"
+  ) {
+    return null;
+  }
+
+  const helper = element.expression.name.text;
+  if (!isValidSceneKind(helper)) {
+    throw new ParserError(
+      "AX505",
+      `Invalid scene helper: "scene.${helper}()". Must be one of: scene.windowGroup(), scene.window(), scene.documentGroup(), scene.settings()`,
+      filePath,
+      posOf(sourceFile, element),
+      "Use one of the supported scene.* helpers."
+    );
+  }
+
+  const [viewArg, optionsArg] = element.arguments;
+  const rootView = viewArg ? readStringLiteral(viewArg) : undefined;
+  if (!rootView) {
+    throw new ParserError(
+      "AX506",
+      "Each scene requires a root SwiftUI view",
+      filePath,
+      posOf(sourceFile, element),
+      "Pass a view name like scene.windowGroup('ContentView')"
+    );
+  }
+
+  let title: string | undefined;
+  let sceneName: string | undefined;
+  let platformGuard: "macOS" | "iOS" | "visionOS" | undefined;
+
+  if (optionsArg !== undefined) {
+    if (!ts.isObjectLiteralExpression(optionsArg)) {
+      throw new ParserError(
+        "AX504",
+        "scene.* helpers accept an optional object literal as the second argument",
+        filePath,
+        posOf(sourceFile, optionsArg),
+        "Use scene.settings('SettingsView', { platform: 'macOS' })"
+      );
+    }
+
+    title = extractStringProp(optionsArg, "title", sourceFile, filePath);
+    sceneName = extractStringProp(optionsArg, "name", sourceFile, filePath);
+    platformGuard = extractStringProp(optionsArg, "platform", sourceFile, filePath) as
+      | "macOS"
+      | "iOS"
+      | "visionOS"
+      | undefined;
+  }
+
+  return {
+    sceneKind: helper,
+    rootView,
+    title,
+    name: sceneName,
+    platformGuard,
+  };
 }
 
 function parseAppStorage(

--- a/tests/core/app-compiler.test.ts
+++ b/tests/core/app-compiler.test.ts
@@ -226,6 +226,27 @@ describe("parseAppSource", () => {
     expect(ir.scenes[1].platformGuard).toBe("macOS");
   });
 
+  it("parses scene.* helpers in the scenes array", () => {
+    const source = `
+      import { defineApp, scene } from "@axint/compiler";
+      export default defineApp({
+        name: "WeatherApp",
+        scenes: [
+          scene.windowGroup("WeatherDashboard"),
+          scene.settings("SettingsView", { platform: "macOS", title: "Settings" }),
+        ],
+      });
+    `;
+    const ir = parseAppSource(source);
+    expect(ir.name).toBe("WeatherApp");
+    expect(ir.scenes).toHaveLength(2);
+    expect(ir.scenes[0].sceneKind).toBe("windowGroup");
+    expect(ir.scenes[0].rootView).toBe("WeatherDashboard");
+    expect(ir.scenes[1].sceneKind).toBe("settings");
+    expect(ir.scenes[1].platformGuard).toBe("macOS");
+    expect(ir.scenes[1].title).toBe("Settings");
+  });
+
   it("throws AX501 for missing defineApp", () => {
     expect(() => parseAppSource("const x = 1;")).toThrow(/No defineApp\(\) call found/);
   });
@@ -301,6 +322,24 @@ describe("compileAppSource", () => {
     expect(result.success).toBe(true);
     expect(result.output!.swiftCode).toContain("struct TodoAppApp: App");
     expect(result.output!.swiftCode).toContain("TodoListView()");
+  });
+
+  it("compiles helper-based scenes end-to-end", () => {
+    const source = `
+      import { defineApp, scene } from "@axint/compiler";
+      export default defineApp({
+        name: "WeatherApp",
+        scenes: [
+          scene.windowGroup("WeatherDashboard"),
+          scene.settings("SettingsView", { platform: "macOS" }),
+        ],
+      });
+    `;
+    const result = compileAppSource(source);
+    expect(result.success).toBe(true);
+    expect(result.output!.swiftCode).toContain("WeatherDashboard()");
+    expect(result.output!.swiftCode).toContain("SettingsView()");
+    expect(result.output!.swiftCode).toContain("#if os(macOS)");
   });
 
   it("returns parser errors as diagnostics", () => {

--- a/tests/examples/compile.test.ts
+++ b/tests/examples/compile.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { compileAnyFile } from "../../src/core/compiler.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const examplesDir = join(__dirname, "../../examples");
+const exampleFiles = readdirSync(examplesDir)
+  .filter((file) => file.endsWith(".ts"))
+  .sort();
+
+const EXPECTED_SURFACES = new Map<string, "intent" | "view" | "widget" | "app">([
+  ["calendar-assistant.ts", "intent"],
+  ["health-log.ts", "intent"],
+  ["messaging.ts", "intent"],
+  ["profile-card.ts", "view"],
+  ["smart-home.ts", "intent"],
+  ["step-counter.ts", "widget"],
+  ["trail-planner.ts", "intent"],
+  ["weather-app.ts", "app"],
+]);
+
+describe("bundled examples", () => {
+  it("compile cleanly across every shipped Apple surface example", () => {
+    expect(exampleFiles).toEqual([...EXPECTED_SURFACES.keys()].sort());
+
+    for (const file of exampleFiles) {
+      const result = compileAnyFile(join(examplesDir, file));
+      const diagnosticSummary = result.diagnostics
+        .map((diagnostic) => `${diagnostic.code}: ${diagnostic.message}`)
+        .join("; ");
+
+      expect(result.success, `${file} failed: ${diagnosticSummary}`).toBe(true);
+      expect(result.surface).toBe(EXPECTED_SURFACES.get(file));
+      expect(result.output).toBeDefined();
+    }
+  });
+
+  it("keeps the HealthKit example aligned with the current entitlement + privacy contract", () => {
+    const file = join(examplesDir, "health-log.ts");
+    const source = readFileSync(file, "utf-8");
+
+    expect(source).toContain("com.apple.developer.healthkit");
+    expect(source).toContain("NSHealthShareUsageDescription");
+    expect(source).toContain("NSHealthUpdateUsageDescription");
+    expect(source).toContain("param.double");
+
+    const result = compileAnyFile(file, {
+      emitInfoPlist: true,
+      emitEntitlements: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.surface).toBe("intent");
+    expect(result.diagnostics.some((d) => d.code === "AX114")).toBe(false);
+    expect(result.diagnostics.some((d) => d.code === "AX115")).toBe(false);
+    expect(result.diagnostics.some((d) => d.code === "AX116")).toBe(false);
+
+    if (result.surface !== "intent" || !result.output) {
+      throw new Error("health-log.ts did not compile as an intent example");
+    }
+
+    expect(result.output.infoPlistFragment).toContain("NSHealthShareUsageDescription");
+    expect(result.output.infoPlistFragment).toContain("NSHealthUpdateUsageDescription");
+    expect(result.output.entitlementsFragment).toContain("com.apple.developer.healthkit");
+  });
+});


### PR DESCRIPTION
## Summary\n- bring the HealthKit example up to the current entitlement and privacy contract\n- compile every bundled example in CI and keep the HealthKit example under validator coverage\n- teach the app parser to accept documented scene.* helpers so the examples and SDK stay in sync\n\n## Testing\n- npm run typecheck:examples\n- npx vitest run tests/examples/compile.test.ts tests/core/app-compiler.test.ts\n- npx vitest run tests/examples/compile.test.ts tests/core/app-compiler.test.ts tests/core/validator.test.ts tests/cli/cli.test.ts\n- npm run metrics:emit\n- npm run metrics:check\n- npm run boundary:check\n- npm run typecheck\n- npm run lint\n- npm run build