### PR TITLE
Tighten Python Info.plist and HealthKit parity

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -32,6 +32,7 @@ This release wave sharpens the Xcode workflow and expands Apple-native Swift cov
 - Metrics now expose Xcode fix rule counts and names so coverage can be tracked more explicitly
 - Intent validation now catches a common App Review / HealthKit setup failure before you leave the compiler loop
 - The bundled examples are now part of the proof surface: they compile in CI, and the HealthKit example shows the same entitlement + privacy contract the validator enforces
+- The Python SDK now accepts real Info.plist usage-description copy, ships a HealthKit example, and mirrors the HealthKit/privacy diagnostics that landed in TypeScript
 
 ### Why it matters
 

--- a/metrics.json
+++ b/metrics.json
@@ -59,7 +59,7 @@
   ],
   "tests": {
     "typescript": 613,
-    "python": 105
+    "python": 114
   },
   "registryPackages": 8,
   "distributionSurfaces": 4

--- a/python/README.md
+++ b/python/README.md
@@ -40,7 +40,9 @@ create_event = define_intent(
         "is_all_day": param.boolean("Whether the event is all-day", optional=True, default=False),
     },
     entitlements=["com.apple.developer.calendars"],
-    info_plist_keys=["NSCalendarsUsageDescription"],
+    info_plist_keys={
+        "NSCalendarsUsageDescription": "Create and edit calendar events you request.",
+    },
 )
 ```
 

--- a/python/axint/generator.py
+++ b/python/axint/generator.py
@@ -230,9 +230,12 @@ def generate_info_plist_fragment(intent: IntentIR) -> str | None:
         '<plist version="1.0">',
         "<dict>",
     ]
-    for key in intent.info_plist_keys:
+    for key, value in intent.info_plist_keys:
         lines.append(f"    <key>{escape_xml(key)}</key>")
-        lines.append(f"    <string>TODO: Add description for {escape_xml(key)}</string>")
+        description = value
+        if description == key:
+            description = f"TODO: Add description for {key}"
+        lines.append(f"    <string>{escape_xml(description)}</string>")
     lines.append("</dict>")
     lines.append("</plist>")
     lines.append("")

--- a/python/axint/ir.py
+++ b/python/axint/ir.py
@@ -195,7 +195,7 @@ class IntentIR:
         if self.entitlements:
             out["entitlements"] = list(self.entitlements)
         if self.info_plist_keys:
-            out["infoPlistKeys"] = {k: v for k, v in self.info_plist_keys}
+            out["infoPlistKeys"] = dict(self.info_plist_keys)
         if self.return_type is not None:
             out["returnType"] = self.return_type
         if self.source_file is not None:

--- a/python/axint/ir.py
+++ b/python/axint/ir.py
@@ -44,14 +44,14 @@ WidgetRefreshPolicy = Literal["atEnd", "after", "never"]
 SceneKind = Literal["windowGroup", "window", "documentGroup", "settings"]
 
 
-def _parse_plist_keys(raw: Any) -> tuple[str, ...]:
-    """Accept dict (TS format) or list (Python format) for backwards compat."""
+def _parse_plist_keys(raw: Any) -> tuple[tuple[str, str], ...]:
+    """Accept dict (TS format) or list (legacy Python format) for backwards compat."""
     if raw is None:
         return ()
     if isinstance(raw, dict):
-        return tuple(raw.keys())
+        return tuple((str(k), str(v)) for k, v in raw.items())
     if isinstance(raw, (list, tuple)):
-        return tuple(str(k) for k in raw)
+        return tuple((str(k), str(k)) for k in raw)
     return ()
 
 
@@ -177,7 +177,7 @@ class IntentIR:
     domain: str
     parameters: tuple[IntentParameter, ...] = ()
     entitlements: tuple[str, ...] = ()
-    info_plist_keys: tuple[str, ...] = ()
+    info_plist_keys: tuple[tuple[str, str], ...] = ()
     is_discoverable: bool = True
     return_type: str | None = None
     source_file: str | None = None
@@ -195,10 +195,7 @@ class IntentIR:
         if self.entitlements:
             out["entitlements"] = list(self.entitlements)
         if self.info_plist_keys:
-            # TS side expects Record<string, string> — emit as dict with
-            # usage-description values. The Python SDK currently only stores
-            # key names, so we use the key itself as the placeholder value.
-            out["infoPlistKeys"] = {k: k for k in self.info_plist_keys}
+            out["infoPlistKeys"] = {k: v for k, v in self.info_plist_keys}
         if self.return_type is not None:
             out["returnType"] = self.return_type
         if self.source_file is not None:

--- a/python/axint/parser.py
+++ b/python/axint/parser.py
@@ -1436,10 +1436,10 @@ def _parse_plist_key_map(
         )
         return []
 
-    out: list[tuple[str, str]] = []
+    legacy_keys: list[tuple[str, str]] = []
     for elt in node.elts:
         if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
-            out.append((elt.value, elt.value))
+            legacy_keys.append((elt.value, elt.value))
         else:
             diagnostics.append(
                 ParserDiagnostic(
@@ -1450,7 +1450,7 @@ def _parse_plist_key_map(
                     line=getattr(elt, "lineno", line),
                 )
             )
-    return out
+    return legacy_keys
 
 
 def _literal_str(

--- a/python/axint/parser.py
+++ b/python/axint/parser.py
@@ -306,8 +306,8 @@ def _ir_from_call(call: ast.Call, *, file: str | None) -> IntentIR:
     entitlements = _parse_str_list(
         kwargs.get("entitlements"), "entitlements", diagnostics, file, call.lineno
     )
-    info_plist_keys = _parse_str_list(
-        kwargs.get("info_plist_keys"), "info_plist_keys", diagnostics, file, call.lineno
+    info_plist_keys = _parse_plist_key_map(
+        kwargs.get("info_plist_keys"), diagnostics, file, call.lineno
     )
 
     is_discoverable = True
@@ -1387,6 +1387,65 @@ def _parse_str_list(
                     code="AXP008",
                     severity="error",
                     message=f"`{field}=` entries must be string literals",
+                    file=file,
+                    line=getattr(elt, "lineno", line),
+                )
+            )
+    return out
+
+
+def _parse_plist_key_map(
+    node: ast.expr | None,
+    diagnostics: list[ParserDiagnostic],
+    file: str | None,
+    line: int,
+) -> list[tuple[str, str]]:
+    if node is None:
+        return []
+
+    if isinstance(node, ast.Dict):
+        out: list[tuple[str, str]] = []
+        for key_node, value_node in zip(node.keys, node.values, strict=False):
+            if key_node is None:
+                diagnostics.append(
+                    ParserDiagnostic(
+                        code="AXP008",
+                        severity="error",
+                        message="`info_plist_keys=` keys must be string literals",
+                        file=file,
+                        line=line,
+                    )
+                )
+                continue
+
+            key = _literal_str(key_node, "info_plist_keys key", diagnostics, file, line)
+            value = _literal_str(value_node, "info_plist_keys value", diagnostics, file, line)
+            if key and value:
+                out.append((key, value))
+        return out
+
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        diagnostics.append(
+            ParserDiagnostic(
+                code="AXP008",
+                severity="error",
+                message="`info_plist_keys=` must be a dict or a list/tuple of strings",
+                file=file,
+                line=line,
+            )
+        )
+        return []
+
+    out: list[tuple[str, str]] = []
+    for elt in node.elts:
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+            out.append((elt.value, elt.value))
+        else:
+            diagnostics.append(
+                ParserDiagnostic(
+                    code="AXP008",
+                    severity="error",
+                    message="`info_plist_keys=` entries must be string literals",
                     file=file,
                     line=getattr(elt, "lineno", line),
                 )

--- a/python/axint/sdk.py
+++ b/python/axint/sdk.py
@@ -181,7 +181,7 @@ class IntentDefinition:
     params: dict[str, IntentParameterSpec] = field(default_factory=dict)
     perform: Callable[[], Any] | None = None
     entitlements: tuple[str, ...] = ()
-    info_plist_keys: tuple[str, ...] = ()
+    info_plist_keys: tuple[tuple[str, str], ...] = ()
     is_discoverable: bool = True
 
     def to_ir(self, *, source_file: str | None = None, source_line: int | None = None) -> IntentIR:
@@ -205,6 +205,16 @@ class IntentDefinition:
 
 # Re-exported type alias so users can annotate their own variables.
 Intent = IntentDefinition
+
+
+def _normalize_info_plist_keys(
+    info_plist_keys: dict[str, str] | list[str] | tuple[str, ...] | None,
+) -> tuple[tuple[str, str], ...]:
+    if info_plist_keys is None:
+        return ()
+    if isinstance(info_plist_keys, dict):
+        return tuple((str(key), str(value)) for key, value in info_plist_keys.items())
+    return tuple((str(key), str(key)) for key in info_plist_keys)
 
 
 # ─── Entity Support ────────────────────────────────────────────────────────
@@ -291,7 +301,7 @@ def define_intent(
     params: dict[str, IntentParameterSpec] | None = None,
     perform: Callable[[], Any] | None = None,
     entitlements: list[str] | tuple[str, ...] | None = None,
-    info_plist_keys: list[str] | tuple[str, ...] | None = None,
+    info_plist_keys: dict[str, str] | list[str] | tuple[str, ...] | None = None,
     is_discoverable: bool = True,
 ) -> IntentDefinition:
     """
@@ -318,7 +328,9 @@ def define_intent(
     entitlements
         Apple entitlement identifiers this intent requires.
     info_plist_keys
-        Info.plist keys to emit next to the generated Swift.
+        Info.plist keys to emit next to the generated Swift. Pass a
+        dict to control the exact usage-description copy, or a list/tuple
+        for the legacy placeholder behavior.
     is_discoverable
         Whether Siri can surface this intent proactively.
     """
@@ -330,7 +342,7 @@ def define_intent(
         params=dict(params or {}),
         perform=perform,
         entitlements=tuple(entitlements or ()),
-        info_plist_keys=tuple(info_plist_keys or ()),
+        info_plist_keys=_normalize_info_plist_keys(info_plist_keys),
         is_discoverable=is_discoverable,
     )
 

--- a/python/axint/validator.py
+++ b/python/axint/validator.py
@@ -212,7 +212,7 @@ def validate_intent(intent: IntentIR) -> list[ValidatorDiagnostic]:
                 )
             )
 
-    info_plist_keys = {key: value for key, value in intent.info_plist_keys}
+    info_plist_keys = dict(intent.info_plist_keys)
     has_healthkit_entitlement = any(
         entitlement in HEALTHKIT_ENTITLEMENT_KEYS for entitlement in intent.entitlements
     )

--- a/python/axint/validator.py
+++ b/python/axint/validator.py
@@ -17,6 +17,19 @@ from .ir import AppIR, IntentIR, ViewIR, WidgetIR
 MAX_PARAMETERS = 10
 MAX_TITLE_LENGTH = 60
 
+HEALTHKIT_ENTITLEMENT_KEYS = {
+    "com.apple.developer.healthkit",
+    "com.apple.developer.healthkit.background-delivery",
+}
+
+HEALTHKIT_USAGE_DESCRIPTION_KEYS = {
+    "NSHealthShareUsageDescription",
+    "NSHealthUpdateUsageDescription",
+    "NSHealthClinicalHealthRecordsShareUsageDescription",
+}
+
+PRIVACY_USAGE_DESCRIPTION_PATTERN = re.compile(r"^NS[A-Za-z0-9]+UsageDescription$")
+
 SWIFT_KEYWORDS = {
     "associatedtype",
     "class",
@@ -198,6 +211,72 @@ def validate_intent(intent: IntentIR) -> list[ValidatorDiagnostic]:
                     suggestion='Use reverse-DNS, e.g., "com.apple.developer.siri"',
                 )
             )
+
+    info_plist_keys = {key: value for key, value in intent.info_plist_keys}
+    has_healthkit_entitlement = any(
+        entitlement in HEALTHKIT_ENTITLEMENT_KEYS for entitlement in intent.entitlements
+    )
+    declared_healthkit_usage_keys = [
+        key for key in HEALTHKIT_USAGE_DESCRIPTION_KEYS if key in info_plist_keys
+    ]
+
+    if has_healthkit_entitlement and not declared_healthkit_usage_keys:
+        diagnostics.append(
+            ValidatorDiagnostic(
+                code="AX114",
+                severity="warning",
+                message=(
+                    "HealthKit entitlements were declared, but no HealthKit privacy usage "
+                    "descriptions were provided"
+                ),
+                file=intent.source_file,
+                suggestion=(
+                    "Add NSHealthShareUsageDescription and/or "
+                    "NSHealthUpdateUsageDescription with user-facing copy that matches the "
+                    "HealthKit access you request"
+                ),
+            )
+        )
+
+    if declared_healthkit_usage_keys and not has_healthkit_entitlement:
+        diagnostics.append(
+            ValidatorDiagnostic(
+                code="AX115",
+                severity="warning",
+                message=(
+                    "HealthKit privacy usage descriptions were declared, but the HealthKit "
+                    "entitlement is missing"
+                ),
+                file=intent.source_file,
+                suggestion=(
+                    "Enable the HealthKit capability (com.apple.developer.healthkit) or "
+                    "remove the stray NSHealth*UsageDescription keys if this intent does not "
+                    "use HealthKit"
+                ),
+            )
+        )
+
+    for key, value in info_plist_keys.items():
+        if not PRIVACY_USAGE_DESCRIPTION_PATTERN.match(key):
+            continue
+        if not _is_placeholder_usage_description(key, value):
+            continue
+
+        diagnostics.append(
+            ValidatorDiagnostic(
+                code="AX116",
+                severity="warning",
+                message=(
+                    f'Privacy usage description "{key}" is empty or still reads like '
+                    "placeholder copy"
+                ),
+                file=intent.source_file,
+                suggestion=(
+                    "Replace it with a concrete user-facing explanation of what the app "
+                    "reads or writes and why"
+                ),
+            )
+        )
 
     return diagnostics
 
@@ -536,3 +615,22 @@ def _to_pascal_case(s: str) -> str:
         return "UnnamedIntent"
     parts = re.split(r"[-_\s]+", s)
     return "".join(part.capitalize() for part in parts if part)
+
+
+def _is_placeholder_usage_description(key: str, value: str) -> bool:
+    trimmed = value.strip()
+    if not trimmed:
+        return True
+    if trimmed == key:
+        return True
+
+    normalized = trimmed.lower()
+    return (
+        normalized.startswith("todo")
+        or normalized.startswith("tbd")
+        or normalized == "placeholder"
+        or normalized == "change me"
+        or "<#" in normalized
+        or "your usage description" in normalized
+        or "insert usage description" in normalized
+    )

--- a/python/examples/create_event.py
+++ b/python/examples/create_event.py
@@ -24,5 +24,7 @@ create_event = define_intent(
         ),
     },
     entitlements=["com.apple.developer.calendars"],
-    info_plist_keys=["NSCalendarsUsageDescription"],
+    info_plist_keys={
+        "NSCalendarsUsageDescription": "Create and edit calendar events you request.",
+    },
 )

--- a/python/examples/health_log.py
+++ b/python/examples/health_log.py
@@ -1,0 +1,28 @@
+"""Example: HealthKit logging intent.
+
+Run it:
+
+    axint-py parse examples/health_log.py
+    axint-py compile examples/health_log.py --stdout
+"""
+
+from axint import define_intent, param
+
+health_log = define_intent(
+    name="LogHealthMetric",
+    title="Log Health Metric",
+    description="Records a health measurement like weight, blood pressure, or exercise.",
+    domain="health",
+    entitlements=["com.apple.developer.healthkit"],
+    info_plist_keys={
+        "NSHealthShareUsageDescription": "Read prior health measurements to compare your progress.",
+        "NSHealthUpdateUsageDescription": "Save new health measurements that you log from this shortcut.",
+    },
+    params={
+        "metric": param.string("What you're logging (for example weight or steps)"),
+        "value": param.double("The measurement value"),
+        "date": param.date("When the measurement was taken"),
+        "duration": param.duration("Activity duration", optional=True),
+        "notes": param.string("Additional notes", optional=True),
+    },
+)

--- a/python/tests/test_examples.py
+++ b/python/tests/test_examples.py
@@ -1,0 +1,83 @@
+"""Proof that bundled Python examples still compile across supported surfaces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from axint import (
+    generate_entitlements_fragment,
+    generate_info_plist_fragment,
+    generate_swift,
+    generate_swift_app,
+    generate_swift_view,
+    generate_swift_widget,
+    parse_file,
+    parse_file_apps,
+    parse_file_views,
+    parse_file_widgets,
+    validate_app,
+    validate_intent,
+    validate_view,
+    validate_widget,
+)
+
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
+
+
+def test_python_examples_compile_cleanly() -> None:
+    intent_files = ["create_event.py", "health_log.py"]
+    view_files = ["profile_card.py"]
+    widget_files = ["step_counter_widget.py"]
+    app_files = ["weather_app.py"]
+
+    for name in intent_files:
+        path = EXAMPLES_DIR / name
+        intents = parse_file(path)
+        assert len(intents) == 1
+        diagnostics = validate_intent(intents[0])
+        assert diagnostics == []
+        swift = generate_swift(intents[0])
+        assert "struct" in swift
+
+    for name in view_files:
+        path = EXAMPLES_DIR / name
+        views = parse_file_views(path)
+        assert len(views) == 1
+        diagnostics = validate_view(views[0])
+        assert diagnostics == []
+        swift = generate_swift_view(views[0])
+        assert "struct" in swift
+
+    for name in widget_files:
+        path = EXAMPLES_DIR / name
+        widgets = parse_file_widgets(path)
+        assert len(widgets) == 1
+        diagnostics = validate_widget(widgets[0])
+        assert diagnostics == []
+        swift = generate_swift_widget(widgets[0])
+        assert "Widget" in swift
+
+    for name in app_files:
+        path = EXAMPLES_DIR / name
+        apps = parse_file_apps(path)
+        assert len(apps) == 1
+        diagnostics = validate_app(apps[0])
+        assert diagnostics == []
+        swift = generate_swift_app(apps[0])
+        assert "@main" in swift
+
+
+def test_health_log_example_emits_real_privacy_copy() -> None:
+    intent = parse_file(EXAMPLES_DIR / "health_log.py")[0]
+    assert not any(d.code == "AX114" for d in validate_intent(intent))
+    assert not any(d.code == "AX115" for d in validate_intent(intent))
+    assert not any(d.code == "AX116" for d in validate_intent(intent))
+
+    plist_fragment = generate_info_plist_fragment(intent)
+    entitlements_fragment = generate_entitlements_fragment(intent)
+
+    assert plist_fragment is not None
+    assert entitlements_fragment is not None
+    assert "Read prior health measurements to compare your progress." in plist_fragment
+    assert "Save new health measurements that you log from this shortcut." in plist_fragment
+    assert "com.apple.developer.healthkit" in entitlements_fragment

--- a/python/tests/test_generator.py
+++ b/python/tests/test_generator.py
@@ -150,12 +150,28 @@ def test_info_plist_fragment() -> None:
         title="Log Workout",
         description="Logs a workout",
         domain="health",
-        info_plist_keys=["NSHealthUpdateUsageDescription"],
+        info_plist_keys={
+            "NSHealthUpdateUsageDescription": "Save workout data you log from this shortcut.",
+        },
     )
     frag = generate_info_plist_fragment(intent.to_ir())
     assert frag is not None
     assert "<key>NSHealthUpdateUsageDescription</key>" in frag
+    assert "Save workout data you log from this shortcut." in frag
     assert '<plist version="1.0">' in frag
+
+
+def test_info_plist_fragment_legacy_list_uses_placeholder_copy() -> None:
+    intent = define_intent(
+        name="HealthIntent",
+        title="Log Workout",
+        description="Logs a workout",
+        domain="health",
+        info_plist_keys=["NSHealthUpdateUsageDescription"],
+    )
+    frag = generate_info_plist_fragment(intent.to_ir())
+    assert frag is not None
+    assert "TODO: Add description for NSHealthUpdateUsageDescription" in frag
 
 
 def test_info_plist_fragment_none_when_empty() -> None:

--- a/python/tests/test_parser.py
+++ b/python/tests/test_parser.py
@@ -82,6 +82,35 @@ intent = define_intent(
     ir = parse_source(src)[0]
     assert ir.entitlements == ("com.apple.developer.healthkit",)
     assert len(ir.info_plist_keys) == 2
+    assert ir.info_plist_keys[0][0] == "NSHealthUpdateUsageDescription"
+
+
+def test_parses_info_plist_key_mapping() -> None:
+    src = '''
+from axint import define_intent
+
+intent = define_intent(
+    name="HealthIntent",
+    title="Log Workout",
+    description="Logs a workout",
+    domain="health",
+    info_plist_keys={
+        "NSHealthUpdateUsageDescription": "Save workout data you log from this shortcut.",
+        "NSHealthShareUsageDescription": "Read prior workout data to compare progress.",
+    },
+)
+'''
+    ir = parse_source(src)[0]
+    assert ir.info_plist_keys == (
+        (
+            "NSHealthUpdateUsageDescription",
+            "Save workout data you log from this shortcut.",
+        ),
+        (
+            "NSHealthShareUsageDescription",
+            "Read prior workout data to compare progress.",
+        ),
+    )
 
 
 def test_parses_number_alias_as_int() -> None:

--- a/python/tests/test_sdk.py
+++ b/python/tests/test_sdk.py
@@ -52,7 +52,9 @@ def test_define_intent_full() -> None:
             "is_all_day": param.boolean("Whether the event is all-day", optional=True, default=False),
         },
         entitlements=["com.apple.developer.calendars"],
-        info_plist_keys=["NSCalendarsUsageDescription"],
+        info_plist_keys={
+            "NSCalendarsUsageDescription": "Create and edit calendar events you request.",
+        },
         is_discoverable=True,
     )
     ir = intent.to_ir()
@@ -64,7 +66,22 @@ def test_define_intent_full() -> None:
     assert ir.parameters[3].optional is True
     assert ir.parameters[3].default is False
     assert ir.entitlements == ("com.apple.developer.calendars",)
-    assert ir.info_plist_keys == ("NSCalendarsUsageDescription",)
+    assert ir.info_plist_keys == (
+        ("NSCalendarsUsageDescription", "Create and edit calendar events you request."),
+    )
+
+
+def test_define_intent_legacy_info_plist_list_keeps_placeholder_shape() -> None:
+    intent = define_intent(
+        name="CreateCalendarEventIntent",
+        title="Create Calendar Event",
+        description="Creates a new event on the user's calendar",
+        domain="productivity",
+        info_plist_keys=["NSCalendarsUsageDescription"],
+    )
+    assert intent.info_plist_keys == (
+        ("NSCalendarsUsageDescription", "NSCalendarsUsageDescription"),
+    )
 
 
 def test_ir_to_dict_matches_ts_schema() -> None:

--- a/python/tests/test_validator.py
+++ b/python/tests/test_validator.py
@@ -118,3 +118,62 @@ def test_accepts_valid_entitlement() -> None:
     diagnostics = validate_intent(intent.to_ir())
     ent_warns = [d for d in diagnostics if d.code == "AX108"]
     assert ent_warns == []
+
+
+def test_warns_when_healthkit_entitlement_lacks_usage_descriptions() -> None:
+    intent = define_intent(
+        name="HealthIntent",
+        title="Log Workout",
+        description="Logs a workout",
+        domain="health",
+        entitlements=["com.apple.developer.healthkit"],
+    )
+    diagnostics = validate_intent(intent.to_ir())
+    assert any(d.code == "AX114" for d in diagnostics)
+
+
+def test_warns_when_healthkit_usage_descriptions_lack_entitlement() -> None:
+    intent = define_intent(
+        name="HealthIntent",
+        title="Log Workout",
+        description="Logs a workout",
+        domain="health",
+        info_plist_keys={
+            "NSHealthShareUsageDescription": "Read prior workout data to compare progress.",
+        },
+    )
+    diagnostics = validate_intent(intent.to_ir())
+    assert any(d.code == "AX115" for d in diagnostics)
+
+
+def test_warns_when_privacy_usage_copy_is_placeholder() -> None:
+    intent = define_intent(
+        name="HealthIntent",
+        title="Log Workout",
+        description="Logs a workout",
+        domain="health",
+        info_plist_keys={
+            "NSHealthShareUsageDescription": "TODO: explain why this app reads HealthKit data",
+            "NSHealthUpdateUsageDescription": "",
+        },
+    )
+    diagnostics = validate_intent(intent.to_ir())
+    assert len([d for d in diagnostics if d.code == "AX116"]) == 2
+
+
+def test_accepts_healthkit_entitlement_with_real_usage_copy() -> None:
+    intent = define_intent(
+        name="HealthIntent",
+        title="Log Workout",
+        description="Logs a workout",
+        domain="health",
+        entitlements=["com.apple.developer.healthkit"],
+        info_plist_keys={
+            "NSHealthShareUsageDescription": "Read prior workout data to compare your progress.",
+            "NSHealthUpdateUsageDescription": "Save new workout data you log from this shortcut.",
+        },
+    )
+    diagnostics = validate_intent(intent.to_ir())
+    assert not any(d.code == "AX114" for d in diagnostics)
+    assert not any(d.code == "AX115" for d in diagnostics)
+    assert not any(d.code == "AX116" for d in diagnostics)


### PR DESCRIPTION
## Summary\n- let the Python SDK accept explicit Info.plist usage-description copy while keeping legacy list input working\n- mirror the HealthKit/privacy diagnostics on the Python validator side and add a real HealthKit Python example\n- compile-test the bundled Python examples so parity stays provable instead of implied\n\n## Testing\n- python3 -m pytest tests/test_sdk.py tests/test_parser.py tests/test_generator.py tests/test_validator.py tests/test_examples.py\n- python3 -m pytest tests/test_cli.py\n- python3 -m pytest\n- npm run metrics:emit\n- npm run metrics:check\n- npm run boundary:check\n- npm run build