### PR TITLE
Sharpen Fix Packet repair guidance

### DIFF
--- a/docs/FIX_PACKET.md
+++ b/docs/FIX_PACKET.md
@@ -31,6 +31,15 @@ The JSON packet includes:
 
 The markdown packet is the same information rendered for human review and easy sharing.
 
+The AI prompt is intentionally structured so it is more useful than a generic
+LLM debugging dump. It now gives the model:
+
+- what broke
+- why it matters for the Apple workflow
+- the concrete change direction for each top finding
+- generated artifact hints for Swift, plist, and entitlements when Axint has them
+- the next repair steps and Xcode checklist
+
 If Axint cannot recognize a supported Apple-native Swift surface, the packet drops to
 `confidence: low` instead of pretending the file is fully covered.
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -29,6 +29,11 @@ This release wave sharpens the Xcode workflow and expands Apple-native Swift cov
 
 - Xcode docs now explain the `build -> packet -> fix -> rerun` loop directly
 - Fix Packets now carry a low-confidence signal for Swift files that Axint does not recognize as supported Apple-native surfaces
+- Fix Packets now read like a structured Apple repair brief instead of a flat error dump:
+  - `What broke`
+  - `Why it matters`
+  - `Make this change`
+  - generated artifact hints for Swift, plist, and entitlements when available
 - Metrics now expose Xcode fix rule counts and names so coverage can be tracked more explicitly
 - Intent validation now catches a common App Review / HealthKit setup failure before you leave the compiler loop
 - The bundled examples are now part of the proof surface: they compile in CI, and the HealthKit example shows the same entitlement + privacy contract the validator enforces

--- a/metrics.json
+++ b/metrics.json
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 613,
+    "typescript": 614,
     "python": 114
   },
   "registryPackages": 8,

--- a/src/repair/fix-packet.ts
+++ b/src/repair/fix-packet.ts
@@ -222,46 +222,101 @@ function buildCoverageAssessment(
   };
 }
 
+function buildFindingImpact(finding: FixPacketDiagnostic): string {
+  switch (finding.severity) {
+    case "error":
+      return "This blocks the Apple-native validation/build path until it is fixed.";
+    case "warning":
+      return "This is an Apple-facing warning. Review or fix it before you trust the result.";
+    case "info":
+      return "This is supporting context from Axint for the current Apple surface.";
+  }
+}
+
+function buildArtifactHints(packet: FixPacket): string[] {
+  const hints: string[] = [];
+  if (packet.artifacts.outputPath) {
+    hints.push(
+      `Generated Swift output: ${packet.artifacts.outputPath} (keep this in sync with the source edits).`
+    );
+  }
+  if (packet.artifacts.infoPlistPath) {
+    hints.push(
+      `Info.plist fragment: ${packet.artifacts.infoPlistPath} (use this when you need the exact Apple usage-description copy).`
+    );
+  }
+  if (packet.artifacts.entitlementsPath) {
+    hints.push(
+      `Entitlements fragment: ${packet.artifacts.entitlementsPath} (keep entitlements aligned with the code and plist copy).`
+    );
+  }
+  return hints;
+}
+
 function buildAiPrompt(packet: FixPacket): string {
   const lines: string[] = [
-    "You are fixing Apple-platform code after an Axint validation run.",
+    "You are repairing Apple-native code after an Axint validation run.",
+    "Goal: resolve the Apple-specific findings below, preserve the intended feature behavior, and bring the result back to pass.",
     "",
     "AX codes are Axint diagnostic IDs in the report. They are labels for the findings only; you do not need Axint installed to use them.",
     "",
-    `Verdict: ${packet.outcome.verdict}`,
-    `Headline: ${packet.outcome.headline}`,
-    `Source file: ${packet.source.filePath ?? packet.source.fileName}`,
-    `Surface: ${packet.source.surface}`,
-    `Confidence: ${packet.coverage.confidence}`,
-    `Compiler version: ${packet.compilerVersion}`,
+    "Current result:",
+    `- Verdict: ${packet.outcome.verdict}`,
+    `- Headline: ${packet.outcome.headline}`,
+    `- Source file: ${packet.source.filePath ?? packet.source.fileName}`,
+    `- Surface: ${packet.source.surface}`,
+    `- Confidence: ${packet.coverage.confidence}`,
+    `- Compiler version: ${packet.compilerVersion}`,
     "",
   ];
 
   if (packet.coverage.confidence === "low") {
-    lines.push(`Coverage note: ${packet.coverage.summary}`, "");
+    lines.push("Coverage note:", `- ${packet.coverage.summary}`, "");
   }
 
   if (packet.topFindings.length > 0) {
-    lines.push("Findings to address:");
+    lines.push("What broke:");
     for (const finding of packet.topFindings) {
       lines.push(`- ${finding.code} [${finding.severity}] ${finding.message}`);
+      lines.push(`  Why it matters: ${buildFindingImpact(finding)}`);
       if (finding.file || finding.line) {
         lines.push(
           `  Location: ${finding.file ?? packet.source.fileName}${finding.line ? `:${finding.line}` : ""}`
         );
       }
       if (finding.suggestion) {
-        lines.push(`  Suggested direction: ${finding.suggestion}`);
+        lines.push(`  Make this change: ${finding.suggestion}`);
       }
     }
     lines.push("");
   } else {
-    lines.push("No findings were emitted in this run.");
+    lines.push("What broke:");
+    lines.push("- No findings were emitted in this run.");
     lines.push("");
   }
 
+  const artifactHints = buildArtifactHints(packet);
+  if (artifactHints.length > 0) {
+    lines.push("Generated artifacts to use:");
+    for (const hint of artifactHints) {
+      lines.push(`- ${hint}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("Repair plan:");
+  for (const step of packet.nextSteps) {
+    lines.push(`- ${step}`);
+  }
+  lines.push("");
+
   lines.push(
-    "Please update the source so the failing or warning findings are resolved, preserve the intended Apple behavior, and explain the concrete changes you made."
+    "When you answer:",
+    "- Update the source, plist copy, and entitlements only where needed to resolve the findings.",
+    "- Preserve unrelated behavior, naming, and product intent.",
+    "- Mention any remaining Apple-specific uncertainty instead of guessing.",
+    "",
+    "Please produce the concrete repair."
   );
 
   return lines.join("\n");
@@ -390,6 +445,7 @@ export function buildFixPacket(
 }
 
 export function renderFixPacketMarkdown(packet: FixPacket): string {
+  const artifactHints = buildArtifactHints(packet);
   const lines: string[] = [
     `# Axint Fix Packet`,
     "",
@@ -424,6 +480,20 @@ export function renderFixPacketMarkdown(packet: FixPacket): string {
 
   lines.push("## Next steps", "");
   for (const step of packet.nextSteps) {
+    lines.push(`- ${step}`);
+  }
+  lines.push("");
+
+  if (artifactHints.length > 0) {
+    lines.push("## Generated artifacts", "");
+    for (const hint of artifactHints) {
+      lines.push(`- ${hint}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Xcode checklist", "");
+  for (const step of packet.xcode.checklist) {
     lines.push(`- ${step}`);
   }
   lines.push("", "## Copy this into your AI", "", "```text", packet.ai.prompt, "```", "");

--- a/tests/core/fix-packet.test.ts
+++ b/tests/core/fix-packet.test.ts
@@ -6,6 +6,7 @@ import {
   buildFixPacket,
   emitFixPacketArtifacts,
   readLatestFixPacket,
+  renderFixPacketMarkdown,
 } from "../../src/repair/fix-packet.js";
 
 const tempDirs: string[] = [];
@@ -18,11 +19,12 @@ afterEach(() => {
 });
 
 describe("Fix Packet", () => {
-  it("builds a needs_review packet with an AI prompt that explains AX codes", () => {
+  it("builds a needs_review packet with a structured Apple repair brief", () => {
     const packet = buildFixPacket({
       success: true,
       surface: "intent",
       fileName: "SetLights.ts",
+      filePath: "/tmp/SetLights.ts",
       diagnostics: [
         {
           code: "AX219",
@@ -33,6 +35,9 @@ describe("Fix Packet", () => {
           line: 12,
         },
       ],
+      outputPath: "/tmp/SetLights.intent.swift",
+      infoPlistPath: "/tmp/SetLights.Info.plist",
+      entitlementsPath: "/tmp/SetLights.entitlements",
       packetJsonPath: "/tmp/latest.json",
       packetMarkdownPath: "/tmp/latest.md",
     });
@@ -40,6 +45,12 @@ describe("Fix Packet", () => {
     expect(packet.outcome.verdict).toBe("needs_review");
     expect(packet.topFindings).toHaveLength(1);
     expect(packet.ai.prompt).toContain("AX codes are Axint diagnostic IDs");
+    expect(packet.ai.prompt).toContain("What broke:");
+    expect(packet.ai.prompt).toContain("Why it matters:");
+    expect(packet.ai.prompt).toContain("Make this change:");
+    expect(packet.ai.prompt).toContain("Generated artifacts to use:");
+    expect(packet.ai.prompt).toContain("/tmp/SetLights.Info.plist");
+    expect(packet.ai.prompt).toContain("Repair plan:");
     expect(packet.ai.prompt).toContain("AX219");
   });
 
@@ -137,7 +148,35 @@ describe("Fix Packet", () => {
 
     expect(packetText).toContain('"schemaVersion": 1');
     expect(markdownText).toContain("# Axint Fix Packet");
+    expect(markdownText).toContain("## Xcode checklist");
     expect(rediscovered?.source.fileName).toBe("GreetingCard.ts");
     expect(rediscovered?.outcome.verdict).toBe("pass");
+  });
+
+  it("renders generated artifact hints into markdown when they exist", () => {
+    const packet = buildFixPacket({
+      success: false,
+      surface: "intent",
+      fileName: "LogWorkout.ts",
+      diagnostics: [
+        {
+          code: "AX108",
+          severity: "error",
+          message: "entitlement string format mismatch",
+          suggestion: "Use the reserved HealthKit entitlement string.",
+        },
+      ],
+      outputPath: "/tmp/LogWorkout.intent.swift",
+      infoPlistPath: "/tmp/LogWorkout.Info.plist",
+      entitlementsPath: "/tmp/LogWorkout.entitlements",
+      packetJsonPath: "/tmp/latest.json",
+      packetMarkdownPath: "/tmp/latest.md",
+    });
+
+    const markdown = renderFixPacketMarkdown(packet);
+
+    expect(markdown).toContain("## Generated artifacts");
+    expect(markdown).toContain("/tmp/LogWorkout.Info.plist");
+    expect(markdown).toContain("## Xcode checklist");
   });
 });


### PR DESCRIPTION
## Summary
- turn the Fix Packet AI prompt into a structured Apple repair brief
- include generated artifact hints and the Xcode checklist in the markdown packet
- refresh proof/docs for the stronger repair-contract tests

## Testing
- npm run typecheck
- npm run build
- npm run metrics:check
- npm run boundary:check
- npx vitest run tests/core/fix-packet.test.ts tests/mcp/fix-packet.test.ts tests/cli/xcode-packet.test.ts