### PR TITLE
Add Cloud health regression diagnostics

### DIFF
--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -149,7 +149,7 @@ You can also use the simple string form:
 parameterSummary: "Open ${trail} in ${region}"
 ```
 
-## Intent Validation Errors (AX100–AX116)
+## Intent Validation Errors (AX100–AX118)
 
 These validate intent and entity IR against Apple-facing constraints.
 
@@ -273,6 +273,47 @@ warning[AX116]: Privacy usage description "NSHealthShareUsageDescription" is emp
 ```
 
 If the usage strings were missing entirely, Axint would emit `AX114`. If the entitlement were missing but the HealthKit keys stayed behind, it would emit `AX115`.
+
+### AX117 / AX118 — probable HealthKit shorthand from real Cloud failures
+
+These warnings catch a real class of copy/paste mistakes we saw in Cloud reports:
+
+- `AX117`: shorthand entitlement strings like `healthkit.write` instead of the real Apple entitlement key
+- `AX118`: shorthand plist keys like `HealthUsageDescription` instead of `NSHealthShareUsageDescription` / `NSHealthUpdateUsageDescription`
+
+**Bad**
+
+```typescript
+export default defineIntent({
+  name: "LogWater",
+  title: "Log Water Intake",
+  description: "Records a serving of water to the health journal",
+  entitlements: ["healthkit.write"],
+  infoPlistKeys: {
+    HealthUsageDescription: "Logs water intake",
+  },
+  params: {},
+  perform: async () => ({ ok: true }),
+});
+```
+
+**Typical diagnostics**
+
+```text
+warning[AX117]: Entitlement "healthkit.write" looks like shorthand for HealthKit, not the real Apple entitlement key
+warning[AX118]: Info.plist key "HealthUsageDescription" looks like shorthand, not Apple's real HealthKit usage-description key
+warning[AX114]: HealthKit entitlements were declared, but no HealthKit privacy usage descriptions were provided
+```
+
+**Fix**
+
+```typescript
+entitlements: ["com.apple.developer.healthkit"],
+infoPlistKeys: {
+  NSHealthShareUsageDescription: "Read hydration history to personalize reminders.",
+  NSHealthUpdateUsageDescription: "Save newly logged water intake to Health.",
+},
+```
 
 **Fix**
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -18,6 +18,8 @@ This release wave sharpens the Xcode workflow and expands Apple-native Swift cov
   - `AX114` — HealthKit entitlement declared without matching privacy usage descriptions
   - `AX115` — HealthKit privacy usage descriptions declared without the HealthKit entitlement
   - `AX116` — privacy usage description is empty or still placeholder copy
+  - `AX117` — probable HealthKit entitlement shorthand instead of the real Apple entitlement key
+  - `AX118` — probable HealthKit plist shorthand instead of Apple's real usage-description keys
 - New safe repair coverage:
   - insert missing Apple framework imports
   - inject missing `TimelineProvider` stubs
@@ -38,6 +40,7 @@ This release wave sharpens the Xcode workflow and expands Apple-native Swift cov
 - Intent validation now catches a common App Review / HealthKit setup failure before you leave the compiler loop
 - The bundled examples are now part of the proof surface: they compile in CI, and the HealthKit example shows the same entitlement + privacy contract the validator enforces
 - The Python SDK now accepts real Info.plist usage-description copy, ships a HealthKit example, and mirrors the HealthKit/privacy diagnostics that landed in TypeScript
+- The compiler now keeps a real Cloud HealthKit failure as a regression test, so shorthand entitlement/plist mistakes stay actionable instead of drifting back to generic warnings
 
 ### Why it matters
 

--- a/metrics.json
+++ b/metrics.json
@@ -21,7 +21,7 @@
     "axint.create-intent"
   ],
   "bundledTemplates": 26,
-  "diagnostics": 137,
+  "diagnostics": 139,
   "xcodeFixRules": 32,
   "xcodeFixRuleCodes": [
     "AX701",
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 614,
+    "typescript": 617,
     "python": 114
   },
   "registryPackages": 8,

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -232,6 +232,20 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticInfo> = {
     message: "Privacy usage description is empty or still placeholder copy",
     category: "intent-validator",
   },
+  AX117: {
+    code: "AX117",
+    severity: "warning",
+    message:
+      "HealthKit entitlement uses shorthand instead of the real Apple entitlement key",
+    category: "intent-validator",
+  },
+  AX118: {
+    code: "AX118",
+    severity: "warning",
+    message:
+      "HealthKit Info.plist usage-description key uses shorthand instead of Apple's real key",
+    category: "intent-validator",
+  },
 
   // ─── Intent Generator (AX200–AX299) ──────────────────────
   AX200: {

--- a/src/core/validator.ts
+++ b/src/core/validator.ts
@@ -18,11 +18,24 @@ const HEALTHKIT_ENTITLEMENT_KEYS = new Set([
   "com.apple.developer.healthkit.background-delivery",
 ]);
 
+const HEALTHKIT_ENTITLEMENT_ALIASES = new Map<string, string>([
+  ["healthkit", "com.apple.developer.healthkit"],
+  ["healthkit.read", "com.apple.developer.healthkit"],
+  ["healthkit.write", "com.apple.developer.healthkit"],
+]);
+
 const HEALTHKIT_USAGE_DESCRIPTION_KEYS = [
   "NSHealthShareUsageDescription",
   "NSHealthUpdateUsageDescription",
   "NSHealthClinicalHealthRecordsShareUsageDescription",
 ];
+
+const HEALTHKIT_USAGE_DESCRIPTION_ALIASES = new Map<string, string[]>([
+  [
+    "HealthUsageDescription",
+    ["NSHealthShareUsageDescription", "NSHealthUpdateUsageDescription"],
+  ],
+]);
 
 const PRIVACY_USAGE_DESCRIPTION_PATTERN = /^NS[A-Za-z0-9]+UsageDescription$/;
 
@@ -129,6 +142,18 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
 
   // Rule: Entitlement strings must look like reverse-DNS identifiers
   for (const ent of intent.entitlements ?? []) {
+    const canonicalEntitlement = HEALTHKIT_ENTITLEMENT_ALIASES.get(ent);
+    if (canonicalEntitlement) {
+      diagnostics.push({
+        code: "AX117",
+        severity: "warning",
+        message: `Entitlement "${ent}" looks like shorthand for HealthKit, not the real Apple entitlement key`,
+        file: intent.sourceFile,
+        suggestion: `Use "${canonicalEntitlement}" so the capability matches Apple's entitlement name`,
+      });
+      continue;
+    }
+
     if (!/^[a-zA-Z0-9._-]+$/.test(ent) || !ent.includes(".")) {
       diagnostics.push({
         code: "AX108",
@@ -143,6 +168,18 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
 
   // Rule: Info.plist keys must start with "NS" or other known prefixes
   for (const key of Object.keys(infoPlistKeys)) {
+    const healthKitAliases = HEALTHKIT_USAGE_DESCRIPTION_ALIASES.get(key);
+    if (healthKitAliases) {
+      diagnostics.push({
+        code: "AX118",
+        severity: "warning",
+        message: `Info.plist key "${key}" looks like shorthand, not Apple's real HealthKit usage-description key`,
+        file: intent.sourceFile,
+        suggestion: `Use ${healthKitAliases.join(" and/or ")} with user-facing copy that matches the HealthKit access you request`,
+      });
+      continue;
+    }
+
     if (!/^(NS|UI|LS|CF|CA|CK)[A-Za-z0-9]+$/.test(key)) {
       diagnostics.push({
         code: "AX109",
@@ -155,8 +192,10 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
     }
   }
 
-  const hasHealthKitEntitlement = (intent.entitlements ?? []).some((entitlement) =>
-    HEALTHKIT_ENTITLEMENT_KEYS.has(entitlement)
+  const hasHealthKitEntitlement = (intent.entitlements ?? []).some(
+    (entitlement) =>
+      HEALTHKIT_ENTITLEMENT_KEYS.has(entitlement) ||
+      HEALTHKIT_ENTITLEMENT_ALIASES.has(entitlement)
   );
   const declaredHealthKitUsageKeys = HEALTHKIT_USAGE_DESCRIPTION_KEYS.filter(
     (key) => key in infoPlistKeys

--- a/tests/core/diagnostics.test.ts
+++ b/tests/core/diagnostics.test.ts
@@ -205,6 +205,7 @@ describe("DIAGNOSTIC_CODES registry", () => {
   it("has intent validator range codes (AX100-AX199)", () => {
     expect(getDiagnostic("AX100")).toBeDefined();
     expect(getDiagnostic("AX109")).toBeDefined();
+    expect(getDiagnostic("AX118")).toBeDefined();
   });
 
   it("has intent generator range codes (AX200-AX299)", () => {

--- a/tests/core/validator.test.ts
+++ b/tests/core/validator.test.ts
@@ -138,6 +138,32 @@ describe("validateIntent", () => {
     expect(diagnostics.filter((d) => d.code === "AX116")).toHaveLength(2);
   });
 
+  it("warns when a Cloud-style HealthKit shorthand entitlement is used (AX117)", () => {
+    const diagnostics = validateIntent(
+      makeIntent({
+        entitlements: ["healthkit.write"],
+      })
+    );
+
+    const warning = diagnostics.find((d) => d.code === "AX117");
+    expect(warning).toBeDefined();
+    expect(warning?.suggestion).toContain("com.apple.developer.healthkit");
+  });
+
+  it("warns when a Cloud-style HealthKit plist shorthand key is used (AX118)", () => {
+    const diagnostics = validateIntent(
+      makeIntent({
+        infoPlistKeys: {
+          HealthUsageDescription: "Logs water intake to Health.",
+        },
+      })
+    );
+
+    const warning = diagnostics.find((d) => d.code === "AX118");
+    expect(warning).toBeDefined();
+    expect(diagnostics.some((d) => d.code === "AX109")).toBe(false);
+  });
+
   it("accepts well-formed HealthKit entitlements and privacy strings together", () => {
     const diagnostics = validateIntent(
       makeIntent({

--- a/tests/regressions/cloud-health-review.test.ts
+++ b/tests/regressions/cloud-health-review.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { compileSource } from "../../src/core/compiler.js";
+import { buildFixPacket } from "../../src/repair/fix-packet.js";
+
+const CLOUD_HEALTH_REVIEW_SOURCE = `import { defineIntent, param } from "@axint/compiler";
+
+export default defineIntent({
+  name: "LogWater",
+  title: "Log Water Intake",
+  description: "Records a serving of water to the health journal",
+  domain: "health",
+  entitlements: ["healthkit.write"],
+  infoPlistKeys: {
+    HealthUsageDescription: "Logs water intake",
+  },
+  params: {
+    amountMl: param.number("How many milliliters", { default: 250 }),
+    note: param.string("Optional note", { default: "" }),
+  },
+  perform: async ({ amountMl, note }) => {
+    return { amountMl, note, loggedAt: new Date().toISOString() };
+  },
+});
+`;
+
+describe("Cloud failure regressions", () => {
+  it("keeps the Health review demo failure actionable in the compiler loop", () => {
+    const result = compileSource(CLOUD_HEALTH_REVIEW_SOURCE, "log-water-review.ts", {
+      emitInfoPlist: true,
+      emitEntitlements: true,
+    });
+    const codes = result.diagnostics.map((diagnostic) => diagnostic.code);
+
+    expect(result.success).toBe(true);
+    expect(codes).toContain("AX117");
+    expect(codes).toContain("AX118");
+    expect(codes).toContain("AX114");
+
+    const packet = buildFixPacket({
+      success: result.success,
+      surface: "intent",
+      fileName: "log-water-review.ts",
+      source: CLOUD_HEALTH_REVIEW_SOURCE,
+      diagnostics: result.diagnostics,
+      outputPath: result.output?.outputPath,
+      packetJsonPath: "/tmp/latest.json",
+      packetMarkdownPath: "/tmp/latest.md",
+    });
+
+    expect(packet.outcome.verdict).toBe("needs_review");
+    expect(packet.ai.prompt).toContain("com.apple.developer.healthkit");
+    expect(packet.ai.prompt).toContain("NSHealthShareUsageDescription");
+  });
+});


### PR DESCRIPTION
## Summary
- turn the live Cloud HealthKit shorthand failure into a permanent compiler regression
- add new diagnostics for probable HealthKit entitlement and plist shorthand
- refresh diagnostics docs and proof counts for the stronger Apple coverage

## Testing
- npm run typecheck
- npm run build
- npm run metrics:emit
- npm run metrics:check
- npm run boundary:check
- npx vitest run tests/core/validator.test.ts tests/core/diagnostics.test.ts tests/regressions/cloud-health-review.test.ts