### PR TITLE
Add automatic Axint check summaries

### DIFF
--- a/docs/FIX_PACKET.md
+++ b/docs/FIX_PACKET.md
@@ -2,16 +2,19 @@
 
 The Fix Packet is Axint's local repair contract for compile and watch runs.
 
-Every `axint compile` and `axint watch` run emits:
+Every `axint compile`, `axint watch`, and `axint validate-swift` run emits:
 
 - `.axint/fix/latest.json`
 - `.axint/fix/latest.md`
+- `.axint/fix/latest.check.json`
+- `.axint/fix/latest.check.md`
 
 The goal is simple:
 
 1. Axint runs a compiler validation locally.
 2. Axint writes one durable packet with the verdict, findings, and AI-ready fix prompt.
-3. AI tools, Xcode helpers, or future plugins read that same packet instead of asking the user to copy diagnostics by hand.
+3. Axint also writes a lighter human-first check summary so the first read is a verdict, not a wall of raw diagnostics.
+4. AI tools, Xcode helpers, or future plugins read that same packet instead of asking the user to copy diagnostics by hand.
 
 ## What is in the packet
 
@@ -31,6 +34,11 @@ The JSON packet includes:
 
 The markdown packet is the same information rendered for human review and easy sharing.
 
+The `latest.check.*` files are the lightweight verdict layer:
+
+- `latest.check.json` — compact machine-readable summary for UI or workflow glue
+- `latest.check.md` — compact human-readable summary that leads with verdict, top findings, and next step
+
 The AI prompt is intentionally structured so it is more useful than a generic
 LLM debugging dump. It now gives the model:
 
@@ -45,7 +53,7 @@ If Axint cannot recognize a supported Apple-native Swift surface, the packet dro
 
 ## CLI flow
 
-`axint compile` and `axint watch` emit the packet automatically by default.
+`axint compile`, `axint watch`, and `axint validate-swift` emit both the Fix Packet and the lightweight Axint Check automatically by default.
 
 You can opt out with:
 
@@ -87,15 +95,21 @@ This packet is the intended bridge for future Xcode-native and plugin-native flo
 The target loop is:
 
 1. Axint compile or build plugin runs inside the Apple workflow.
-2. Axint emits the latest Fix Packet locally.
-3. Xcode assistant / plugin / MCP agent reads the packet.
-4. The assistant applies the repair or presents the fix prompt.
-5. Axint reruns until the packet becomes `pass`.
+2. Axint emits both the latest Axint Check and the richer Fix Packet locally.
+3. Xcode assistant / plugin / MCP agent reads the Axint Check first for the quick verdict.
+4. The assistant opens the Fix Packet when it needs the full AI repair brief.
+5. Axint reruns until the result becomes `pass`.
 
 That keeps the system consistent:
 
+- one quick-check format
 - one packet format
 - one repair prompt
 - one source of truth
 
 instead of separate diagnostics formats for CLI, MCP, and Xcode.
+
+The Xcode-facing commands now map directly to those two layers:
+
+- `axint xcode check` — quick verdict, top findings, next step, or AI prompt
+- `axint xcode packet` — full Fix Packet, markdown, JSON, prompt, or packet path

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -6,6 +6,12 @@ This release wave sharpens the Xcode workflow and expands Apple-native Swift cov
 
 ### Added
 
+- `latest.check.json` / `latest.check.md`
+  - Every compile, watch, and validate-swift run now emits a lightweight Axint Check verdict next to the richer Fix Packet
+  - The summary leads with pass / needs review / fail, top findings, and the next step instead of dropping straight into raw packet detail
+- `axint xcode check`
+  - Reads the latest Xcode-side Axint Check from DerivedData or a plugin work directory
+  - Can print markdown, raw JSON, or the AI repair prompt directly
 - `axint xcode packet`
   - Reads the latest Fix Packet from Xcode DerivedData or a plugin work directory
   - Can print markdown, raw JSON, the AI repair prompt, or the packet path
@@ -29,7 +35,9 @@ This release wave sharpens the Xcode workflow and expands Apple-native Swift cov
 
 ### Improved
 
+- Compile, watch, and validate-swift now share one repair-artifact emission path, so the lightweight verdict summary and the full packet stay in lockstep instead of drifting across CLI surfaces
 - Xcode docs now explain the `build -> packet -> fix -> rerun` loop directly
+- Xcode docs now also explain the `build -> check -> packet -> fix -> rerun` loop so the Apple workflow starts with the simple verdict before it expands into repair detail
 - Fix Packets now carry a low-confidence signal for Swift files that Axint does not recognize as supported Apple-native surfaces
 - Fix Packets now read like a structured Apple repair brief instead of a flat error dump:
   - `What broke`

--- a/metrics.json
+++ b/metrics.json
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 617,
+    "typescript": 622,
     "python": 114
   },
   "registryPackages": 8,

--- a/spm-plugin/README.md
+++ b/spm-plugin/README.md
@@ -132,25 +132,35 @@ plugin work directory:
 
 - `fix/<file-name>/latest.json`
 - `fix/<file-name>/latest.md`
+- `fix/<file-name>/latest.check.json`
+- `fix/<file-name>/latest.check.md`
 
 That packet is the handoff contract for AI tools and Xcode helpers:
 
-- `latest.json` is the structured machine-readable artifact
-- `latest.md` is the human-readable repair summary
+- `latest.check.json` is the compact verdict layer for tooling and quick UI
+- `latest.check.md` is the compact human-first summary
+- `latest.json` is the structured machine-readable repair artifact
+- `latest.md` is the full human-readable repair brief
 
 The intended loop is:
 
 1. Build in Xcode or run `swift build`
 2. Let Axint compile the TypeScript surface
-3. Read the Fix Packet for the file that failed or needs review
-4. Hand the prompt/checklist back to your AI tool or use it directly in Xcode
+3. Read the Axint Check first so you can see pass / needs review / fail immediately
+4. Open the Fix Packet only when you need the full repair prompt/checklist
 5. Rebuild after the fix
 
 This keeps the compiler output simple for humans while still giving AI tooling the full repair packet.
 
 `AxintValidatePlugin` uses the same contract for Swift validation runs. When the validator
-finds AX7xx issues, it writes a target-level Fix Packet under `fix/validate/` so Xcode or
-an AI helper can read the repair checklist instead of only relying on raw console output.
+finds AX7xx issues, it writes a target-level Axint Check and Fix Packet under `fix/validate/`
+so Xcode or an AI helper can read the quick verdict first and the repair checklist second
+instead of only relying on raw console output.
+
+CLI helpers:
+
+- `axint xcode check --kind validate`
+- `axint xcode packet --kind validate --format prompt`
 
 ## Writing Definitions
 

--- a/src/cli/compile.ts
+++ b/src/cli/compile.ts
@@ -8,7 +8,10 @@ import {
   type AnyCompileResult,
 } from "../core/compiler.js";
 import type { Diagnostic } from "../core/types.js";
-import { emitFixPacketArtifacts } from "../repair/fix-packet.js";
+import {
+  printRepairArtifactLines,
+  tryEmitRepairArtifacts,
+} from "../repair/repair-artifacts.js";
 
 /**
  * Count non-blank lines in a source string. Blank lines (whitespace
@@ -241,60 +244,62 @@ export function registerCompile(program: Command) {
             }
           }
 
-          let packetArtifacts: ReturnType<typeof emitFixPacketArtifacts> | null = null;
+          let repairArtifacts:
+            | ReturnType<typeof tryEmitRepairArtifacts>["artifacts"]
+            | null = null;
           if (options.fixPacket) {
-            try {
-              const resolvedOutputPath =
-                success && output && !options.stdout
-                  ? resolve(output.outputPath)
-                  : undefined;
-              packetArtifacts = emitFixPacketArtifacts(
-                {
-                  success,
-                  surface,
-                  diagnostics,
-                  source: inputSource,
-                  fileName:
-                    file === "-"
-                      ? "stdin.ir.json"
-                      : inputFilePath
-                        ? basename(inputFilePath)
-                        : basename(filePath),
-                  filePath: inputFilePath,
-                  language,
-                  outputPath: resolvedOutputPath,
-                  infoPlistPath:
-                    success &&
-                    output &&
-                    !options.stdout &&
-                    surface === "intent" &&
-                    options.emitInfoPlist &&
-                    output.infoPlistFragment
-                      ? resolve(output.outputPath).replace(
-                          /\.swift$/,
-                          ".plist.fragment.xml"
-                        )
-                      : undefined,
-                  entitlementsPath:
-                    success &&
-                    output &&
-                    !options.stdout &&
-                    surface === "intent" &&
-                    options.emitEntitlements &&
-                    output.entitlementsFragment
-                      ? resolve(output.outputPath).replace(
-                          /\.swift$/,
-                          ".entitlements.fragment.xml"
-                        )
-                      : undefined,
-                  packetDir: options.fixPacketDir,
-                  command: "compile",
-                },
-                process.cwd()
-              );
-            } catch (packetErr: unknown) {
+            const resolvedOutputPath =
+              success && output && !options.stdout
+                ? resolve(output.outputPath)
+                : undefined;
+            const repairResult = tryEmitRepairArtifacts(
+              {
+                success,
+                surface,
+                diagnostics,
+                source: inputSource,
+                fileName:
+                  file === "-"
+                    ? "stdin.ir.json"
+                    : inputFilePath
+                      ? basename(inputFilePath)
+                      : basename(filePath),
+                filePath: inputFilePath,
+                language,
+                outputPath: resolvedOutputPath,
+                infoPlistPath:
+                  success &&
+                  output &&
+                  !options.stdout &&
+                  surface === "intent" &&
+                  options.emitInfoPlist &&
+                  output.infoPlistFragment
+                    ? resolve(output.outputPath).replace(
+                        /\.swift$/,
+                        ".plist.fragment.xml"
+                      )
+                    : undefined,
+                entitlementsPath:
+                  success &&
+                  output &&
+                  !options.stdout &&
+                  surface === "intent" &&
+                  options.emitEntitlements &&
+                  output.entitlementsFragment
+                    ? resolve(output.outputPath).replace(
+                        /\.swift$/,
+                        ".entitlements.fragment.xml"
+                      )
+                    : undefined,
+                packetDir: options.fixPacketDir,
+                command: "compile",
+              },
+              process.cwd()
+            );
+            repairArtifacts = repairResult.artifacts;
+            if (repairResult.error) {
               console.error(
-                `\x1b[33mwarning:\x1b[0m Fix Packet skipped — ${(packetErr as Error).message}`
+                `\x1b[33mwarning:\x1b[0m Fix Packet skipped — ${repairResult.error.message}`
               );
             }
           }
@@ -317,6 +322,8 @@ export function registerCompile(program: Command) {
                     line: d.line,
                     suggestion: d.suggestion,
                   })),
+                  fixPacketPath: repairArtifacts?.packet.jsonPath ?? null,
+                  checkSummaryPath: repairArtifacts?.check.jsonPath ?? null,
                 },
                 null,
                 2
@@ -329,8 +336,8 @@ export function registerCompile(program: Command) {
           printDiagnostics(diagnostics);
 
           if (!success || !output) {
-            if (packetArtifacts) {
-              console.error(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+            if (repairArtifacts) {
+              printRepairArtifactLines(repairArtifacts, console.error);
             }
             const errorCount = diagnostics.filter((d) => d.severity === "error").length;
             console.error(
@@ -413,8 +420,8 @@ export function registerCompile(program: Command) {
               console.log(`\x1b[32m✓\x1b[0m Entitlements fragment → ${entPath}`);
             }
 
-            if (packetArtifacts) {
-              console.log(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+            if (repairArtifacts) {
+              printRepairArtifactLines(repairArtifacts, console.log);
             }
           }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,6 +19,7 @@
  *   axint xcode verify            Verify the MCP connection is working
  *   axint xcode fix <path>        Auto-fix mechanical Swift validator errors
  *   axint xcode doctor            Audit environment for Apple-platform agentic coding
+ *   axint xcode check             Print the latest Xcode Axint Check summary or AI prompt
  *   axint xcode packet            Print the latest Xcode Fix Packet or AI prompt
  *   axint xcode extension install Install the notarized Axint Source Editor Extension
  *   axint xcode extension status  Report whether the extension is installed
@@ -29,6 +30,7 @@ import { Command, InvalidArgumentError } from "commander";
 import { readFileSync, existsSync } from "node:fs";
 import { resolve, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { XcodeCheckOutput } from "./xcode-check.js";
 import type { XcodePacketKind, XcodePacketOutput } from "./xcode-packet.js";
 import { scaffoldProject } from "./scaffold.js";
 import { registerCompile } from "./compile.js";
@@ -48,6 +50,7 @@ const VERSION = pkg.version as string;
 
 const program = new Command();
 const XCODE_PACKET_KINDS = ["any", "compile", "validate"] as const;
+const XCODE_CHECK_FORMATS = ["markdown", "json", "prompt"] as const;
 const XCODE_PACKET_FORMATS = ["markdown", "prompt", "json", "path"] as const;
 
 function parseChoice<T extends string>(
@@ -198,6 +201,36 @@ xcode
     const { runXcodeDoctor } = await import("./xcode-doctor.js");
     await runXcodeDoctor();
   });
+
+xcode
+  .command("check")
+  .description("Read the latest Xcode Axint Check summary emitted by Axint build plugins")
+  .option(
+    "--root <dir>",
+    "DerivedData root, plugin work directory, or exact latest.json packet path"
+  )
+  .option(
+    "--kind <kind>",
+    "Check type to read (any, compile, validate)",
+    (value) => parseChoice("kind", value, XCODE_PACKET_KINDS),
+    "any"
+  )
+  .option(
+    "--format <format>",
+    "Output format (markdown, json, prompt)",
+    (value) => parseChoice("format", value, XCODE_CHECK_FORMATS),
+    "markdown"
+  )
+  .action(
+    async (options: {
+      root?: string;
+      kind: XcodePacketKind;
+      format: XcodeCheckOutput;
+    }) => {
+      const { runXcodeCheck } = await import("./xcode-check.js");
+      await runXcodeCheck(options);
+    }
+  );
 
 xcode
   .command("packet")

--- a/src/cli/validate-swift.ts
+++ b/src/cli/validate-swift.ts
@@ -3,7 +3,10 @@ import { readFileSync, statSync, readdirSync } from "node:fs";
 import { resolve, join, extname } from "node:path";
 import { validateSwiftSource } from "../core/swift-validator.js";
 import type { Diagnostic } from "../core/types.js";
-import { emitFixPacketArtifacts } from "../repair/fix-packet.js";
+import {
+  printRepairArtifactLines,
+  tryEmitRepairArtifacts,
+} from "../repair/repair-artifacts.js";
 
 export function registerValidateSwift(program: Command) {
   program
@@ -49,30 +52,32 @@ export function registerValidateSwift(program: Command) {
         }
 
         const errors = all.filter((d) => d.severity === "error");
-        let packetArtifacts: ReturnType<typeof emitFixPacketArtifacts> | null = null;
+        let repairArtifacts:
+          | ReturnType<typeof tryEmitRepairArtifacts>["artifacts"]
+          | null = null;
 
         if (options.fixPacket !== false) {
-          try {
-            packetArtifacts = emitFixPacketArtifacts(
-              {
-                success: errors.length === 0,
-                surface: "swift",
-                diagnostics: all,
-                source: files.length === 1 ? readFileSync(files[0], "utf-8") : undefined,
-                fileName:
-                  files.length === 1
-                    ? files[0].split(/[\\/]/).pop()
-                    : (target.split(/[\\/]/).pop() ?? "swift-validation"),
-                filePath: files.length === 1 ? files[0] : target,
-                language: "swift",
-                packetDir: options.fixPacketDir,
-                command: "validate_swift",
-              },
-              process.cwd()
-            );
-          } catch (packetErr: unknown) {
+          const repairResult = tryEmitRepairArtifacts(
+            {
+              success: errors.length === 0,
+              surface: "swift",
+              diagnostics: all,
+              source: files.length === 1 ? readFileSync(files[0], "utf-8") : undefined,
+              fileName:
+                files.length === 1
+                  ? files[0].split(/[\\/]/).pop()
+                  : (target.split(/[\\/]/).pop() ?? "swift-validation"),
+              filePath: files.length === 1 ? files[0] : target,
+              language: "swift",
+              packetDir: options.fixPacketDir,
+              command: "validate_swift",
+            },
+            process.cwd()
+          );
+          repairArtifacts = repairResult.artifacts;
+          if (repairResult.error) {
             console.error(
-              `\x1b[33mwarning:\x1b[0m Fix Packet skipped — ${(packetErr as Error).message}`
+              `\x1b[33mwarning:\x1b[0m Fix Packet skipped — ${repairResult.error.message}`
             );
           }
         }
@@ -82,7 +87,8 @@ export function registerValidateSwift(program: Command) {
             ok: errors.length === 0,
             filesScanned: files.length,
             diagnostics: all,
-            fixPacketPath: packetArtifacts?.jsonPath ?? null,
+            fixPacketPath: repairArtifacts?.packet.jsonPath ?? null,
+            checkSummaryPath: repairArtifacts?.check.jsonPath ?? null,
           };
           process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
           process.exit(errors.length > 0 ? 1 : 0);
@@ -93,8 +99,8 @@ export function registerValidateSwift(program: Command) {
         }
 
         if (errors.length > 0) {
-          if (packetArtifacts) {
-            console.error(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+          if (repairArtifacts) {
+            printRepairArtifactLines(repairArtifacts, console.error);
           }
           console.error(
             `\n\x1b[31m✗\x1b[0m ${errors.length} error${errors.length === 1 ? "" : "s"} in ${files.length} file${files.length === 1 ? "" : "s"}`
@@ -103,8 +109,8 @@ export function registerValidateSwift(program: Command) {
         }
 
         if (!options.quiet) {
-          if (packetArtifacts) {
-            console.log(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+          if (repairArtifacts) {
+            printRepairArtifactLines(repairArtifacts, console.log);
           }
           console.log(
             `\x1b[32m✓\x1b[0m ${files.length} Swift file${files.length === 1 ? "" : "s"} passed axint validation`

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -10,7 +10,10 @@ import {
 import { resolve, dirname, basename } from "node:path";
 import { spawn } from "node:child_process";
 import { compileFile } from "../core/compiler.js";
-import { emitFixPacketArtifacts } from "../repair/fix-packet.js";
+import {
+  printRepairArtifactLines,
+  tryEmitRepairArtifacts,
+} from "../repair/repair-artifacts.js";
 
 async function runSwiftBuild(projectPath: string): Promise<boolean> {
   return new Promise((resolve) => {
@@ -123,54 +126,52 @@ export function registerWatch(program: Command) {
 
         function emitPacket(
           filePath: string,
-          result: ReturnType<typeof compileFile>,
-          _swiftCode?: string
-        ): ReturnType<typeof emitFixPacketArtifacts> | null {
+          result: ReturnType<typeof compileFile>
+        ): ReturnType<typeof tryEmitRepairArtifacts>["artifacts"] | null {
           if (!options.fixPacket) return null;
-          try {
-            const source = readFileSync(filePath, "utf-8");
-            return emitFixPacketArtifacts(
-              {
-                success: result.success,
-                surface: "intent",
-                diagnostics: result.diagnostics,
-                source,
-                fileName: basename(filePath),
-                filePath,
-                language: "typescript",
-                outputPath:
-                  result.success && result.output
-                    ? resolve(result.output.outputPath)
-                    : undefined,
-                infoPlistPath:
-                  result.success &&
-                  result.output?.infoPlistFragment &&
-                  options.emitInfoPlist
-                    ? resolve(result.output.outputPath).replace(
-                        /\.swift$/,
-                        ".plist.fragment.xml"
-                      )
-                    : undefined,
-                entitlementsPath:
-                  result.success &&
-                  result.output?.entitlementsFragment &&
-                  options.emitEntitlements
-                    ? resolve(result.output.outputPath).replace(
-                        /\.swift$/,
-                        ".entitlements.fragment.xml"
-                      )
-                    : undefined,
-                packetDir: options.fixPacketDir,
-                command: "watch",
-              },
-              process.cwd()
-            );
-          } catch (packetErr: unknown) {
+          const source = readFileSync(filePath, "utf-8");
+          const repairResult = tryEmitRepairArtifacts(
+            {
+              success: result.success,
+              surface: "intent",
+              diagnostics: result.diagnostics,
+              source,
+              fileName: basename(filePath),
+              filePath,
+              language: "typescript",
+              outputPath:
+                result.success && result.output
+                  ? resolve(result.output.outputPath)
+                  : undefined,
+              infoPlistPath:
+                result.success &&
+                result.output?.infoPlistFragment &&
+                options.emitInfoPlist
+                  ? resolve(result.output.outputPath).replace(
+                      /\.swift$/,
+                      ".plist.fragment.xml"
+                    )
+                  : undefined,
+              entitlementsPath:
+                result.success &&
+                result.output?.entitlementsFragment &&
+                options.emitEntitlements
+                  ? resolve(result.output.outputPath).replace(
+                      /\.swift$/,
+                      ".entitlements.fragment.xml"
+                    )
+                  : undefined,
+              packetDir: options.fixPacketDir,
+              command: "watch",
+            },
+            process.cwd()
+          );
+          if (repairResult.error) {
             console.error(
-              `\x1b[33mwarning:\x1b[0m Fix Packet skipped — ${(packetErr as Error).message}`
+              `\x1b[33mwarning:\x1b[0m Fix Packet skipped — ${repairResult.error.message}`
             );
-            return null;
           }
+          return repairResult.artifacts;
         }
 
         function compileOne(filePath: string): boolean {
@@ -197,7 +198,7 @@ export function registerWatch(program: Command) {
           if (!result.success || !result.output) {
             const packetArtifacts = emitPacket(filePath, result);
             if (packetArtifacts) {
-              console.error(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+              printRepairArtifactLines(packetArtifacts, console.error);
             }
             const errors = result.diagnostics.filter(
               (d) => d.severity === "error"
@@ -223,9 +224,9 @@ export function registerWatch(program: Command) {
           console.log(
             `\x1b[32m✓\x1b[0m ${result.output.ir.name} → ${outPath} \x1b[90m(${dt}ms)\x1b[0m`
           );
-          const packetArtifacts = emitPacket(filePath, result, result.output.swiftCode);
+          const packetArtifacts = emitPacket(filePath, result);
           if (packetArtifacts) {
-            console.log(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+            printRepairArtifactLines(packetArtifacts, console.log);
           }
           return true;
         }
@@ -258,7 +259,7 @@ export function registerWatch(program: Command) {
           if (!result.success || !result.output) {
             const packetArtifacts = emitPacket(filePath, result);
             if (packetArtifacts) {
-              console.error(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+              printRepairArtifactLines(packetArtifacts, console.error);
             }
             const errors = result.diagnostics.filter(
               (d) => d.severity === "error"
@@ -302,9 +303,9 @@ export function registerWatch(program: Command) {
           console.log(
             `\x1b[32m✓\x1b[0m ${result.output.ir.name} → ${outPath} \x1b[90m(${dt}ms)\x1b[0m`
           );
-          const packetArtifacts = emitPacket(filePath, result, swiftCode);
+          const packetArtifacts = emitPacket(filePath, result);
           if (packetArtifacts) {
-            console.log(`\x1b[36m→\x1b[0m Fix Packet → ${packetArtifacts.jsonPath}`);
+            printRepairArtifactLines(packetArtifacts, console.log);
           }
           return true;
         }

--- a/src/cli/xcode-check.ts
+++ b/src/cli/xcode-check.ts
@@ -1,0 +1,67 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  buildCheckSummary,
+  renderCheckSummaryMarkdown,
+  type CheckSummary,
+} from "../repair/check-summary.js";
+import type { FixPacket } from "../repair/fix-packet.js";
+import {
+  defaultDerivedDataRoot,
+  findLatestXcodePacket,
+  type XcodePacketKind,
+} from "./xcode-packet.js";
+
+export type XcodeCheckOutput = "markdown" | "json" | "prompt";
+
+interface XcodeCheckOptions {
+  root?: string;
+  kind: XcodePacketKind;
+  format: XcodeCheckOutput;
+}
+
+function readExistingSummary(packetPath: string): CheckSummary | null {
+  const jsonPath = packetPath.replace(/latest\.json$/, "latest.check.json");
+  if (!existsSync(jsonPath)) return null;
+  try {
+    return JSON.parse(readFileSync(jsonPath, "utf-8")) as CheckSummary;
+  } catch {
+    return null;
+  }
+}
+
+function renderCheckOutput(
+  packetPath: string,
+  packet: FixPacket,
+  format: XcodeCheckOutput
+): string {
+  const summary = readExistingSummary(packetPath) ?? buildCheckSummary(packet);
+  switch (format) {
+    case "json":
+      return JSON.stringify(summary, null, 2);
+    case "prompt":
+      return summary.ai.prompt;
+    case "markdown":
+    default:
+      return renderCheckSummaryMarkdown(summary);
+  }
+}
+
+export async function runXcodeCheck(options: XcodeCheckOptions): Promise<void> {
+  const root = resolve(options.root ?? defaultDerivedDataRoot());
+  const candidate = findLatestXcodePacket(root, options.kind);
+
+  if (!candidate) {
+    console.error(
+      `error: no ${options.kind === "any" ? "" : `${options.kind} `}Axint Check found under ${root}`
+    );
+    console.error(
+      "hint: build in Xcode first, or point --root at a DerivedData or plugin work directory."
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `${renderCheckOutput(candidate.path, candidate.packet, options.format)}\n`
+  );
+}

--- a/src/cli/xcode-packet.ts
+++ b/src/cli/xcode-packet.ts
@@ -36,7 +36,7 @@ const SKIP_DIRS = new Set([
   "artifacts",
 ]);
 
-function defaultDerivedDataRoot(): string {
+export function defaultDerivedDataRoot(): string {
   return resolve(homedir(), "Library/Developer/Xcode/DerivedData");
 }
 

--- a/src/repair/check-summary.ts
+++ b/src/repair/check-summary.ts
@@ -1,0 +1,175 @@
+import { dirname, resolve } from "node:path";
+import { mkdirSync, writeFileSync } from "node:fs";
+import type {
+  FixPacket,
+  FixPacketCommand,
+  FixPacketConfidence,
+  FixPacketDiagnostic,
+  FixPacketSurface,
+  FixPacketVerdict,
+} from "./fix-packet.js";
+
+export interface CheckSummary {
+  schemaVersion: 1;
+  createdAt: string;
+  compilerVersion: string;
+  command: FixPacketCommand;
+  source: {
+    surface: FixPacketSurface;
+    language: "typescript" | "json" | "swift";
+    fileName: string;
+    filePath?: string;
+    sourceLines: number | null;
+  };
+  outcome: {
+    verdict: FixPacketVerdict;
+    headline: string;
+    detail: string;
+    errors: number;
+    warnings: number;
+    infos: number;
+  };
+  coverage: {
+    confidence: FixPacketConfidence;
+    summary: string;
+  };
+  topFindings: FixPacketDiagnostic[];
+  nextAction: string;
+  packet: {
+    jsonPath: string;
+    markdownPath: string;
+  };
+  ai: {
+    summary: string;
+    prompt: string;
+  };
+  xcode: {
+    summary: string;
+  };
+}
+
+export interface CheckSummaryArtifacts {
+  summary: CheckSummary;
+  jsonPath: string;
+  markdownPath: string;
+}
+
+function findingLine(finding: FixPacketDiagnostic): string {
+  const location =
+    finding.file || finding.line
+      ? ` (${finding.file ?? "unknown"}${finding.line ? `:${finding.line}` : ""})`
+      : "";
+  return `- ${finding.code} [${finding.severity}] ${finding.message}${location}`;
+}
+
+export function buildCheckSummary(packet: FixPacket): CheckSummary {
+  return {
+    schemaVersion: 1,
+    createdAt: packet.createdAt,
+    compilerVersion: packet.compilerVersion,
+    command: packet.command,
+    source: { ...packet.source },
+    outcome: {
+      verdict: packet.outcome.verdict,
+      headline: packet.outcome.headline,
+      detail: packet.outcome.detail,
+      errors: packet.outcome.errors,
+      warnings: packet.outcome.warnings,
+      infos: packet.outcome.infos,
+    },
+    coverage: { ...packet.coverage },
+    topFindings: packet.topFindings.map((finding) => ({ ...finding })),
+    nextAction:
+      packet.nextSteps[0] ??
+      "Rerun Axint after the next Apple-facing change so the check stays current.",
+    packet: {
+      jsonPath: packet.artifacts.packetJsonPath,
+      markdownPath: packet.artifacts.packetMarkdownPath,
+    },
+    ai: {
+      summary: packet.ai.summary,
+      prompt: packet.ai.prompt,
+    },
+    xcode: {
+      summary: packet.xcode.summary,
+    },
+  };
+}
+
+export function renderCheckSummaryMarkdown(summary: CheckSummary): string {
+  const lines: string[] = [
+    "# Axint Check",
+    "",
+    `- Verdict: **${summary.outcome.verdict}**`,
+    `- Headline: ${summary.outcome.headline}`,
+    `- Source: ${summary.source.filePath ?? summary.source.fileName}`,
+    `- Surface: ${summary.source.surface}`,
+    `- Confidence: ${summary.coverage.confidence}`,
+    `- Compiler: ${summary.compilerVersion}`,
+    `- Generated: ${summary.createdAt}`,
+    "",
+    "## What happened",
+    "",
+    summary.outcome.detail,
+    "",
+    summary.coverage.summary,
+    "",
+    `- Errors: ${summary.outcome.errors}`,
+    `- Warnings: ${summary.outcome.warnings}`,
+    `- Infos: ${summary.outcome.infos}`,
+    "",
+  ];
+
+  if (summary.topFindings.length > 0) {
+    lines.push("## Top findings", "");
+    for (const finding of summary.topFindings) {
+      lines.push(findingLine(finding));
+      if (finding.suggestion) {
+        lines.push(`  Suggestion: ${finding.suggestion}`);
+      }
+    }
+    lines.push("");
+  } else {
+    lines.push("## Top findings", "", "No findings were emitted in this run.", "");
+  }
+
+  lines.push(
+    "## Next step",
+    "",
+    `- ${summary.nextAction}`,
+    "",
+    "## AI handoff",
+    "",
+    `- ${summary.ai.summary}`,
+    `- Fix Packet JSON: ${summary.packet.jsonPath}`,
+    `- Fix Packet Markdown: ${summary.packet.markdownPath}`,
+    "",
+    "## Xcode handoff",
+    "",
+    `- ${summary.xcode.summary}`
+  );
+
+  return lines.join("\n");
+}
+
+export function resolveCheckSummaryPaths(packet: FixPacket): {
+  jsonPath: string;
+  markdownPath: string;
+} {
+  const packetDir = dirname(packet.artifacts.packetJsonPath);
+  return {
+    jsonPath: resolve(packetDir, "latest.check.json"),
+    markdownPath: resolve(packetDir, "latest.check.md"),
+  };
+}
+
+export function emitCheckSummaryArtifacts(packet: FixPacket): CheckSummaryArtifacts {
+  const summary = buildCheckSummary(packet);
+  const { jsonPath, markdownPath } = resolveCheckSummaryPaths(packet);
+
+  mkdirSync(dirname(jsonPath), { recursive: true });
+  writeFileSync(jsonPath, `${JSON.stringify(summary, null, 2)}\n`, "utf-8");
+  writeFileSync(markdownPath, `${renderCheckSummaryMarkdown(summary)}\n`, "utf-8");
+
+  return { summary, jsonPath, markdownPath };
+}

--- a/src/repair/repair-artifacts.ts
+++ b/src/repair/repair-artifacts.ts
@@ -1,0 +1,45 @@
+import {
+  emitFixPacketArtifacts,
+  type FixPacketArtifacts,
+  type FixPacketInput,
+} from "./fix-packet.js";
+import {
+  emitCheckSummaryArtifacts,
+  type CheckSummaryArtifacts,
+} from "./check-summary.js";
+
+export interface RepairArtifacts {
+  packet: FixPacketArtifacts;
+  check: CheckSummaryArtifacts;
+}
+
+export function emitRepairArtifacts(
+  input: FixPacketInput,
+  cwd: string = process.cwd()
+): RepairArtifacts {
+  const packet = emitFixPacketArtifacts(input, cwd);
+  const check = emitCheckSummaryArtifacts(packet.packet);
+  return { packet, check };
+}
+
+export function tryEmitRepairArtifacts(
+  input: FixPacketInput,
+  cwd: string = process.cwd()
+): { artifacts: RepairArtifacts | null; error: Error | null } {
+  try {
+    return { artifacts: emitRepairArtifacts(input, cwd), error: null };
+  } catch (error: unknown) {
+    return {
+      artifacts: null,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+}
+
+export function printRepairArtifactLines(
+  artifacts: RepairArtifacts,
+  writeLine: (line: string) => void
+) {
+  writeLine(`\x1b[36m→\x1b[0m Axint Check → ${artifacts.check.jsonPath}`);
+  writeLine(`\x1b[36m→\x1b[0m Fix Packet → ${artifacts.packet.jsonPath}`);
+}

--- a/tests/cli/validate-swift.test.ts
+++ b/tests/cli/validate-swift.test.ts
@@ -49,10 +49,13 @@ describe("axint validate-swift", () => {
     );
 
     expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Axint Check");
     expect(result.stderr).toContain("Fix Packet");
 
     const packetPath = join(packetDir, "latest.json");
+    const checkPath = join(packetDir, "latest.check.json");
     expect(existsSync(packetPath)).toBe(true);
+    expect(existsSync(checkPath)).toBe(true);
 
     const packet = JSON.parse(readFileSync(packetPath, "utf-8")) as {
       command: string;
@@ -85,10 +88,13 @@ describe("axint validate-swift", () => {
     );
 
     expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Axint Check");
     expect(result.stdout).toContain("Fix Packet");
 
     const packetPath = join(packetDir, "latest.json");
+    const checkPath = join(packetDir, "latest.check.json");
     expect(existsSync(packetPath)).toBe(true);
+    expect(existsSync(checkPath)).toBe(true);
 
     const packet = JSON.parse(readFileSync(packetPath, "utf-8")) as {
       outcome: { verdict: string };

--- a/tests/cli/xcode-check.test.ts
+++ b/tests/cli/xcode-check.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { buildFixPacket } from "../../src/repair/fix-packet.js";
+import { emitCheckSummaryArtifacts } from "../../src/repair/check-summary.js";
+
+const CLI = resolve(__dirname, "../../dist/cli/index.js");
+
+describe("axint xcode check", () => {
+  let tempRoot: string;
+  let derivedDataRoot: string;
+
+  beforeEach(() => {
+    tempRoot = resolve(tmpdir(), `axint-xcode-check-${Date.now()}`);
+    derivedDataRoot = join(tempRoot, "DerivedData");
+    mkdirSync(derivedDataRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  function writePacket(
+    packetPath: string,
+    args: {
+      command: "compile" | "validate_swift";
+      verdict: "pass" | "needs_review" | "fail";
+      fileName: string;
+      filePath: string;
+      prompt: string;
+    },
+    timeMs: number
+  ) {
+    mkdirSync(dirname(packetPath), { recursive: true });
+    const packet = buildFixPacket({
+      success: args.verdict !== "fail",
+      surface: args.command === "validate_swift" ? "swift" : "intent",
+      diagnostics:
+        args.verdict === "pass"
+          ? []
+          : [
+              {
+                code: "AX118",
+                severity: args.verdict === "fail" ? "error" : "warning",
+                message: "Use Apple's real HealthKit usage-description keys.",
+                suggestion:
+                  "Replace HealthUsageDescription with NSHealthShareUsageDescription.",
+              },
+            ],
+      source:
+        args.command === "validate_swift"
+          ? "struct BrokenIntent: AppIntent {}"
+          : "export default defineIntent({ name: 'HealthReview' });",
+      fileName: args.fileName,
+      filePath: args.filePath,
+      language: args.command === "validate_swift" ? "swift" : "typescript",
+      packetJsonPath: packetPath,
+      packetMarkdownPath: packetPath.replace(/latest\.json$/, "latest.md"),
+      command: args.command,
+    });
+    packet.ai.prompt = args.prompt;
+    writeFileSync(packetPath, `${JSON.stringify(packet, null, 2)}\n`, "utf-8");
+    emitCheckSummaryArtifacts(packet);
+    const timeSeconds = timeMs / 1000;
+    utimesSync(packetPath, timeSeconds, timeSeconds);
+  }
+
+  it("renders the latest validate check summary from a DerivedData tree", () => {
+    const validatePacketPath = join(
+      derivedDataRoot,
+      "Demo-abc",
+      "SourcePackages",
+      "plugins",
+      "axint.output",
+      "Demo.output",
+      "AxintValidatePlugin",
+      "fix",
+      "validate",
+      "latest.json"
+    );
+
+    writePacket(
+      validatePacketPath,
+      {
+        command: "validate_swift",
+        verdict: "needs_review",
+        fileName: "HealthReviewIntent.swift",
+        filePath: "/tmp/HealthReviewIntent.swift",
+        prompt: "repair prompt",
+      },
+      1_710_000_100_000
+    );
+
+    const result = spawnSync(
+      "node",
+      [CLI, "xcode", "check", "--root", derivedDataRoot, "--kind", "validate"],
+      { encoding: "utf-8" }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("# Axint Check");
+    expect(result.stdout).toContain("needs_review");
+    expect(result.stdout).toContain("AX118");
+  });
+
+  it("returns the prompt when the prompt format is requested", () => {
+    const compilePacketPath = join(
+      derivedDataRoot,
+      "Demo-abc",
+      "Build",
+      "Intermediates.noindex",
+      "Plugins",
+      "AxintCompilePlugin",
+      "fix",
+      "health-review",
+      "latest.json"
+    );
+
+    writePacket(
+      compilePacketPath,
+      {
+        command: "compile",
+        verdict: "fail",
+        fileName: "health-review.ts",
+        filePath: "/tmp/health-review.ts",
+        prompt: "exact AI repair prompt",
+      },
+      1_710_000_000_000
+    );
+
+    const result = spawnSync(
+      "node",
+      [CLI, "xcode", "check", "--root", derivedDataRoot, "--format", "prompt"],
+      { encoding: "utf-8" }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("exact AI repair prompt");
+  });
+
+  it("fails cleanly when no check is available yet", () => {
+    const result = spawnSync(
+      "node",
+      [CLI, "xcode", "check", "--root", derivedDataRoot, "--kind", "validate"],
+      { encoding: "utf-8" }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("no validate Axint Check found");
+    expect(result.stderr).toContain("DerivedData");
+  });
+});

--- a/tests/core/check-summary.test.ts
+++ b/tests/core/check-summary.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  buildCheckSummary,
+  emitCheckSummaryArtifacts,
+  renderCheckSummaryMarkdown,
+} from "../../src/repair/check-summary.js";
+import { buildFixPacket } from "../../src/repair/fix-packet.js";
+
+describe("Check Summary", () => {
+  it("builds a human-first summary from a Fix Packet", () => {
+    const packet = buildFixPacket({
+      success: true,
+      surface: "intent",
+      diagnostics: [
+        {
+          code: "AX118",
+          severity: "warning",
+          message: "Use Apple's real HealthKit usage-description keys.",
+          suggestion:
+            "Replace HealthUsageDescription with NSHealthShareUsageDescription and/or NSHealthUpdateUsageDescription.",
+        },
+      ],
+      source: "export default defineIntent({ name: 'HealthReview' });",
+      fileName: "health-review.ts",
+      filePath: "/tmp/health-review.ts",
+      language: "typescript",
+      packetJsonPath: "/tmp/latest.json",
+      packetMarkdownPath: "/tmp/latest.md",
+    });
+
+    const summary = buildCheckSummary(packet);
+    const markdown = renderCheckSummaryMarkdown(summary);
+
+    expect(summary.outcome.verdict).toBe("needs_review");
+    expect(summary.nextAction).toContain("Review");
+    expect(summary.packet.jsonPath).toBe("/tmp/latest.json");
+    expect(markdown).toContain("# Axint Check");
+    expect(markdown).toContain("AX118");
+    expect(markdown).toContain("Fix Packet JSON: /tmp/latest.json");
+  });
+
+  it("writes summary artifacts next to the packet artifacts", () => {
+    const packetRoot = mkdtempSync(join(tmpdir(), "axint-check-summary-"));
+    const packet = buildFixPacket({
+      success: false,
+      surface: "swift",
+      diagnostics: [
+        {
+          code: "AX701",
+          severity: "error",
+          message: "AppIntent is missing perform().",
+          file: "/tmp/BrokenIntent.swift",
+          line: 4,
+          suggestion: "Add a perform() implementation that returns a result.",
+        },
+      ],
+      source: "struct BrokenIntent: AppIntent {}",
+      fileName: "BrokenIntent.swift",
+      filePath: "/tmp/BrokenIntent.swift",
+      language: "swift",
+      packetJsonPath: join(packetRoot, "latest.json"),
+      packetMarkdownPath: join(packetRoot, "latest.md"),
+      command: "validate_swift",
+    });
+
+    const artifacts = emitCheckSummaryArtifacts(packet);
+    const jsonText = readFileSync(artifacts.jsonPath, "utf-8");
+    const markdownText = readFileSync(artifacts.markdownPath, "utf-8");
+
+    expect(artifacts.jsonPath).toMatch(/latest\.check\.json$/);
+    expect(jsonText).toContain('"verdict": "fail"');
+    expect(markdownText).toContain("AppIntent is missing perform().");
+  });
+});


### PR DESCRIPTION
## Summary
- emit a lightweight Axint Check summary next to every Fix Packet for compile, watch, and validate-swift runs
- add `axint xcode check` so Xcode workflows can read the latest verdict before opening the full packet
- centralize repair artifact emission so CLI surfaces stay aligned on the same summary + packet contract

## Validation
- npm run typecheck
- npm run build
- npx vitest run tests/core/check-summary.test.ts tests/core/fix-packet.test.ts tests/cli/validate-swift.test.ts tests/cli/xcode-check.test.ts tests/cli/xcode-packet.test.ts tests/cli/compile.test.ts tests/cli/watch.test.ts tests/cli/xcode.test.ts tests/mcp/fix-packet.test.ts tests/mcp/server.test.ts
- npm run metrics:check
- npm run boundary:check
- swift package dump-package
