### PR TITLE
Tighten dependency automation and audit policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,16 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "06:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
     commit-message:
       prefix: "deps"
     groups:
@@ -23,12 +27,16 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/python"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "06:15"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "python"
     commit-message:
       prefix: "deps"
     groups:
@@ -38,11 +46,15 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "06:30"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "github-actions"
     commit-message:
       prefix: "deps"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           cache: "npm"
 
       - run: npm ci
-      - run: npm audit --audit-level=moderate || true
+      - run: npm audit --audit-level=moderate
       - run: npm run versions:check
       - run: npm run metrics:check
       - run: npm run boundary:check

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,3 +26,12 @@ When using Axint in production:
 2. Validate all untrusted agent definitions before compilation
 3. Review generated App Intent code before deployment
 4. Use code signing for all compiled artifacts
+
+## Dependency and audit policy
+
+- Dependabot version updates are configured in `.github/dependabot.yml` for npm,
+  Python, and GitHub Actions on a grouped weekly cadence.
+- CI treats `npm audit --audit-level=moderate` as a real gate on the TypeScript
+  compiler job. Security issues should not be silently ignored in the default path.
+- If an advisory must be temporarily tolerated, document the rationale in a
+  visible pull request or follow-up issue instead of masking the audit step.


### PR DESCRIPTION
## Summary
- add explicit grouped labels and target branches to Dependabot updates
- stop ignoring moderate npm audit findings in CI
- document the public dependency and audit policy in SECURITY.md

## Validation
- npm audit --audit-level=moderate
- npm run boundary:check
- npm run metrics:check
- npm run lint