### PR TITLE
Tighten release parity and refresh public examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://docs.axint.ai
+    about: Install, Xcode, Fix Packet, and compiler coverage docs live here.
+  - name: Community discussions
+    url: https://github.com/agenticempire/axint/discussions
+    about: Ask usage questions, share examples, or discuss ideas before opening a tracked issue.
+  - name: Security policy
+    url: https://github.com/agenticempire/axint/security/policy
+    about: Report vulnerabilities privately through the coordinated security process.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,3 +22,5 @@ Closes #
 - [ ] Tests added/updated
 - [ ] Lint and type checks pass (`npm run lint && npm run typecheck`)
 - [ ] Documentation updated (if applicable)
+- [ ] Boundary and metrics checks pass if public surfaces changed (`npm run boundary:check && npm run metrics:check`)
+- [ ] Version parity and release notes checked if package/release surfaces changed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,15 @@ jobs:
       - name: Install Python build tools
         run: pip install build twine
 
+      - name: Require PyPI token for coordinated releases
+        if: env.HAS_PYPI_TOKEN != 'true'
+        run: |
+          echo "::error::PYPI_TOKEN is required so npm and PyPI stay aligned on intentional releases."
+          exit 1
+
+      - name: Verify coordinated release preflight
+        run: npm run release:check
+
       - name: Run Python tests
         working-directory: python
         run: |
@@ -78,12 +87,14 @@ jobs:
           npm publish --access public --provenance
 
       - name: Publish to PyPI
-        if: env.HAS_PYPI_TOKEN == 'true'
         working-directory: python
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: twine upload dist/* --skip-existing
+
+      - name: Verify coordinated release post-publish
+        run: npm run release:check -- --require-both-live
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ npm-debug.log*
 *.generated.swift
 *.swift
 !examples/*.swift
+!examples/swift/*.swift
 !extensions/xcode/source-editor-extension/**/*.swift
 !spm-plugin/**/*.swift
 !tools/swift-syntax-helper/**/*.swift

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,16 @@ npm run gen:swift-fixer:check
 5. If headline numbers or public proof changed, sync the downstream public surfaces that read from the truth bundle before announcing the release.
 
 6. Keep package releases aligned.
-   If an intentional release goes out, npm and PyPI should move together so the public version story stays coherent.
+   Intentional releases now require npm and PyPI to move together. The release workflow:
+   - requires `PYPI_TOKEN`
+   - verifies both registries are in sync before publish
+   - verifies both registries are live after publish
+
+   You can run the same guard locally with:
+
+   ```bash
+   npm run release:check
+   ```
 
 7. Only tag and publish once the repo state, docs, metrics, and downstream public proof all agree.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@axint/compiler"><img src="https://img.shields.io/npm/v/@axint/compiler?color=f05138&label=npm" alt="npm" /></a>
+  <a href="https://pypi.org/project/axint/"><img src="https://img.shields.io/pypi/v/axint?label=pypi&color=2563eb" alt="PyPI" /></a>
   <a href="https://github.com/agenticempire/axint/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" /></a>
   <a href="https://github.com/agenticempire/axint/actions/workflows/ci.yml"><img src="https://github.com/agenticempire/axint/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://glama.ai/mcp/servers/agenticempire/axint"><img src="https://glama.ai/mcp/servers/agenticempire/axint/badges/score.svg" alt="axint MCP server" /></a>
@@ -37,6 +38,7 @@
 ## Start Here
 
 - Try Axint live in the [playground](https://axint.ai/#playground) or browse the public [axint-examples](https://github.com/agenticempire/axint-examples) repo.
+- Want maintained repo-native samples? Start with [examples/README.md](examples/README.md), [python/examples/README.md](python/examples/README.md), and [examples/swift/README.md](examples/swift/README.md).
 - Need install help? Start with the [canonical install discussion](https://github.com/agenticempire/axint/discussions/14).
 - Want to contribute? Look at [good first issue](https://github.com/agenticempire/axint/issues?q=is%3Aopen+label%3A%22good+first+issue%22) and [help wanted](https://github.com/agenticempire/axint/issues?q=is%3Aopen+label%3A%22help+wanted%22) tasks.
 - If Axint is useful, [star the repo](https://github.com/agenticempire/axint/stargazers), follow [@agenticempire on X](https://x.com/agenticempire), and share what you build in [Discussions](https://github.com/agenticempire/axint/discussions/15).
@@ -226,7 +228,7 @@ Built-in prompts:
 
 ## Diagnostics
 
-134 diagnostic codes across the validator surface with fix suggestions and color-coded output:
+139 diagnostic codes across the validator surface with fix suggestions and color-coded output:
 
 | Range           | Domain              |
 | --------------- | ------------------- |
@@ -276,11 +278,20 @@ No install required — [axint.ai/#playground](https://axint.ai/#playground) run
 
 Extensions for [Claude Code](extensions/claude-code), [Codex](extensions/codex), [VS Code / Cursor](extensions/vscode), [Windsurf](extensions/windsurf), [JetBrains](extensions/jetbrains), [Neovim](extensions/neovim), and [Xcode](extensions/xcode).
 
+## Examples
+
+- [TypeScript example index](examples/README.md) — maintained intent, view, widget, and app entry points
+- [Python example index](python/examples/README.md) — maintained SDK parity examples
+- [Swift repair examples](examples/swift/README.md) — validator, Fix Packet, and Xcode repair-loop samples
+
 ### Workflow docs
 
 - [Fix Packet](docs/FIX_PACKET.md) — the repair contract for CLI, MCP, and Xcode
 - [Coverage Snapshot](docs/COVERAGE.md) — what Axint currently covers and how to refresh the metrics
 - [Release Notes](docs/RELEASE_NOTES.md) — the latest Apple coverage and Xcode workflow improvements
+- [Architecture](ARCHITECTURE.md) — compiler, validator, MCP, Fix Packet, and Xcode pipeline map
+- [Security](SECURITY.md) — vulnerability reporting and dependency/audit policy
+- [Contributing](CONTRIBUTING.md) — first contribution path and public release checklist
 
 ---
 
@@ -297,8 +308,8 @@ axint/
 ├── python/          # Python SDK
 ├── extensions/      # Editor extensions (9 editors)
 ├── spm-plugin/      # Xcode SPM build plugin
-├── tests/           # 605 TypeScript tests + 105 Python tests
-├── examples/        # Example definitions
+├── tests/           # 623 TypeScript tests + 114 Python tests
+├── examples/        # TypeScript + Swift repair-loop examples
 └── docs/            # Error reference, assets
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,25 @@
+# TypeScript examples
+
+These are the maintained TypeScript entry points for the public compiler surface.
+
+| File | Surface | What it demonstrates |
+| --- | --- | --- |
+| `calendar-assistant.ts` | Intent | Calendar creation flow with date and duration parameters |
+| `health-log.ts` | Intent | HealthKit entitlement + Info.plist privacy copy |
+| `messaging.ts` | Intent | Basic messaging intent structure |
+| `profile-card.ts` | View | SwiftUI view composition and conditional rendering |
+| `smart-home.ts` | Intent | Device-style control intent |
+| `step-counter.ts` | Widget | WidgetKit entry/body/family coverage |
+| `trail-planner.ts` | Intent | Richer parameter coverage for outdoor planning |
+| `weather-app.ts` | App | Full app scaffold with scenes and app storage |
+
+Quick ways to use them:
+
+```bash
+npx @axint/compiler compile examples/health-log.ts --stdout
+npx @axint/compiler compile examples/profile-card.ts --stdout
+npx @axint/compiler compile examples/step-counter.ts --stdout
+npx @axint/compiler compile examples/weather-app.ts --stdout
+```
+
+Need the Swift/Xcode repair-loop examples too? See [`examples/swift/README.md`](./swift/README.md).

--- a/examples/swift/README.md
+++ b/examples/swift/README.md
@@ -1,0 +1,26 @@
+# Swift repair-loop examples
+
+These examples exist for the validator, Fix Packet, and Xcode packet surfaces.
+
+| File | Expectation | What it demonstrates |
+| --- | --- | --- |
+| `broken-intent.swift` | Needs review / fail | Missing `import AppIntents`, missing `perform()`, missing `@Parameter` |
+| `clean-intent.swift` | Pass | A minimal AppIntent that satisfies Axint's Swift validator |
+| `broken-widget.swift` | Needs review / fail | Missing `import WidgetKit` on a widget surface |
+| `clean-view.swift` | Pass | A minimal SwiftUI view that should validate cleanly |
+
+Try them directly:
+
+```bash
+axint validate-swift examples/swift/broken-intent.swift
+axint validate-swift examples/swift/clean-intent.swift --json
+axint validate-swift examples/swift --fix-packet-dir .axint/fix
+axint xcode packet --kind validate --format prompt
+```
+
+The loop is intentionally simple:
+
+1. Run a check.
+2. Read the verdict and top findings.
+3. Copy the Fix Packet prompt into your AI tool or use it as a manual repair checklist.
+4. Re-run until the result drops to `pass`.

--- a/examples/swift/broken-intent.swift
+++ b/examples/swift/broken-intent.swift
@@ -1,0 +1,5 @@
+struct WaterCheck: AppIntent {
+    static var title: LocalizedStringResource = "Water Check"
+
+    let ounces: Double
+}

--- a/examples/swift/broken-widget.swift
+++ b/examples/swift/broken-widget.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+struct StepsWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "steps", provider: Provider()) { _ in
+            Text("Steps")
+        }
+    }
+}

--- a/examples/swift/clean-intent.swift
+++ b/examples/swift/clean-intent.swift
@@ -1,0 +1,12 @@
+import AppIntents
+
+struct WaterCheck: AppIntent {
+    static var title: LocalizedStringResource = "Water Check"
+
+    @Parameter(title: "Ounces")
+    var ounces: Double
+
+    func perform() async throws -> some IntentResult {
+        .result()
+    }
+}

--- a/examples/swift/clean-view.swift
+++ b/examples/swift/clean-view.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct QuickStatusView: View {
+    var body: some View {
+        Text("Ready")
+    }
+}

--- a/metrics.json
+++ b/metrics.json
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 622,
+    "typescript": 623,
     "python": 114
   },
   "registryPackages": 8,

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "gen:swift-fixer:check": "tsx scripts/gen-swift-fixer.ts --check",
     "versions:sync": "node scripts/sync-versions.mjs",
     "versions:check": "node scripts/check-versions.mjs",
+    "release:check": "node scripts/check-release-parity.mjs",
     "metrics:emit": "node scripts/emit-metrics.mjs",
     "metrics:check": "node scripts/check-metrics.mjs",
     "boundary:check": "node scripts/check-public-boundary.mjs",

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -1,0 +1,22 @@
+# Python examples
+
+These examples mirror the maintained public Python SDK surfaces.
+
+| File | Surface | What it demonstrates |
+| --- | --- | --- |
+| `create_event.py` | Intent | Basic event-creation flow from Python |
+| `health_log.py` | Intent | HealthKit + privacy copy in the native Python pipeline |
+| `profile_card.py` | View | SwiftUI view generation from Python |
+| `step_counter_widget.py` | Widget | WidgetKit coverage from Python |
+| `weather_app.py` | App | Full app generation from the Python SDK |
+
+Try them directly:
+
+```bash
+axint-py parse python/examples/create_event.py --json
+axint-py compile python/examples/health_log.py --stdout
+axint-py compile python/examples/step_counter_widget.py --stdout
+axint-py compile python/examples/weather_app.py --stdout
+```
+
+The Python SDK uses the same public version contract as npm. Intentional releases should move both package managers together.

--- a/scripts/check-release-parity.mjs
+++ b/scripts/check-release-parity.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Enforce the public release contract:
+// - root package.json is the canonical version
+// - release tags must match that version
+// - npm and PyPI should either both have the version already or neither should
+// - after publish, both registries must report the released version live
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { readCanonicalVersion } from "./versions.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const REQUIRE_BOTH_LIVE = process.argv.includes("--require-both-live");
+
+const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf-8"));
+const npmName = pkg.name;
+const version = readCanonicalVersion();
+const pypiName = readPyProjectName();
+
+const refTag = process.env.GITHUB_REF_NAME;
+if (refTag?.startsWith("v") && refTag.slice(1) !== version) {
+  fail(
+    `git tag ${refTag} does not match canonical version ${version}. Run npm run versions:sync before tagging.`
+  );
+}
+
+const npmLive = isNpmVersionPublished(npmName, version);
+const pypiLive = await isPyPIVersionPublished(pypiName, version);
+
+if (!REQUIRE_BOTH_LIVE && npmLive !== pypiLive) {
+  fail(
+    `${npmName}@${version} and ${pypiName} ${version} are out of sync before publish. ` +
+      `Fix the missing registry publish before cutting another release tag.`
+  );
+}
+
+if (REQUIRE_BOTH_LIVE && (!npmLive || !pypiLive)) {
+  fail(
+    `post-publish parity failed: npm=${statusWord(npmLive)} / pypi=${statusWord(pypiLive)} for ${version}`
+  );
+}
+
+console.log(
+  [
+    REQUIRE_BOTH_LIVE ? "release parity verified live" : "release parity preflight passed",
+    `version=${version}`,
+    `npm=${statusWord(npmLive)}`,
+    `pypi=${statusWord(pypiLive)}`,
+  ].join(" · ")
+);
+
+function readPyProjectName() {
+  const pyproject = readFileSync(resolve(ROOT, "python/pyproject.toml"), "utf-8");
+  const match = pyproject.match(/^name\s*=\s*"([^"]+)"/m);
+  if (!match) fail("python/pyproject.toml has no project.name");
+  return match[1];
+}
+
+function isNpmVersionPublished(name, targetVersion) {
+  const result = spawnSync("npm", ["view", `${name}@${targetVersion}`, "version"], {
+    cwd: ROOT,
+    encoding: "utf-8",
+  });
+  if (result.status !== 0) return false;
+  return result.stdout.trim() === targetVersion;
+}
+
+async function isPyPIVersionPublished(name, targetVersion) {
+  const response = await fetch(
+    `https://pypi.org/pypi/${encodeURIComponent(name)}/${targetVersion}/json`,
+    {
+      headers: {
+        "user-agent": "axint-release-parity-check",
+      },
+    }
+  );
+  if (response.status === 404) return false;
+  if (!response.ok) {
+    fail(`PyPI parity lookup failed with ${response.status} ${response.statusText}`);
+  }
+  return true;
+}
+
+function statusWord(value) {
+  return value ? "live" : "missing";
+}
+
+function fail(message) {
+  console.error(`release parity check failed: ${message}`);
+  process.exit(1);
+}

--- a/tests/cli/watch.test.ts
+++ b/tests/cli/watch.test.ts
@@ -103,11 +103,12 @@ describe.skipIf(isCI)("axint watch", () => {
     mkdirSync(tmpDir, { recursive: true });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     if (proc && !proc.killed) {
       proc.kill("SIGINT");
-      proc = null;
+      await waitForExit(proc);
     }
+    proc = null;
     if (existsSync(tmpDir)) {
       rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -197,3 +198,22 @@ describe.skipIf(isCI)("axint watch", () => {
     expect(existsSync(join(outDir, "GreetIntent.swift"))).toBe(true);
   }, 15_000);
 });
+
+function waitForExit(proc: ChildProcess, timeoutMs = 2_000): Promise<void> {
+  return new Promise((resolve) => {
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      resolve();
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      proc.kill("SIGKILL");
+      resolve();
+    }, timeoutMs);
+
+    proc.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}

--- a/tests/examples/swift-examples.test.ts
+++ b/tests/examples/swift-examples.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { validateSwiftSource } from "../../src/core/swift-validator.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const examplesDir = join(__dirname, "../../examples/swift");
+
+const CASES: Array<{ file: string; expectedErrors: string[] }> = [
+  { file: "broken-intent.swift", expectedErrors: ["AX701", "AX716", "AX719"] },
+  { file: "clean-intent.swift", expectedErrors: [] },
+  { file: "broken-widget.swift", expectedErrors: ["AX717"] },
+  { file: "clean-view.swift", expectedErrors: [] },
+];
+
+describe("swift repair examples", () => {
+  it("stay aligned with the current validator and fix-packet workflow", () => {
+    for (const testCase of CASES) {
+      const file = join(examplesDir, testCase.file);
+      const source = readFileSync(file, "utf-8");
+      const result = validateSwiftSource(source, file);
+      const errorCodes = result.diagnostics
+        .filter((diagnostic) => diagnostic.severity === "error")
+        .map((diagnostic) => diagnostic.code);
+
+      for (const code of testCase.expectedErrors) {
+        expect(errorCodes, `${testCase.file} should include ${code}`).toContain(code);
+      }
+
+      if (testCase.expectedErrors.length === 0) {
+        expect(errorCodes, `${testCase.file} should validate cleanly`).toHaveLength(0);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What\n- enforce coordinated npm + PyPI parity in the release workflow\n- add maintained example indexes for TypeScript, Python, and Swift repair loops\n- add tracked Swift validator examples plus coverage tests\n- tighten public repo trust surfaces with issue routing and PR checklist improvements\n- harden the flaky watch cleanup test so the suite stays clean\n\n## Why\n- finish the remaining public release-discipline work from the sprint\n- make the repo look and behave like a real diligence surface\n- keep newer Xcode / Fix Packet surfaces backed by maintained examples instead of docs-only copy\n\n## Validation\n- npm run boundary:check\n- npm run metrics:check\n- npm run release:check\n- npm test\n- npm run build