### PR TITLE
Add path output for xcode check

### DIFF
--- a/metrics.json
+++ b/metrics.json
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 623,
+    "typescript": 624,
     "python": 114
   },
   "registryPackages": 8,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@
  *   axint xcode verify            Verify the MCP connection is working
  *   axint xcode fix <path>        Auto-fix mechanical Swift validator errors
  *   axint xcode doctor            Audit environment for Apple-platform agentic coding
- *   axint xcode check             Print the latest Xcode Axint Check summary or AI prompt
+ *   axint xcode check             Print the latest Xcode Axint Check summary, prompt, or artifact path
  *   axint xcode packet            Print the latest Xcode Fix Packet or AI prompt
  *   axint xcode extension install Install the notarized Axint Source Editor Extension
  *   axint xcode extension status  Report whether the extension is installed
@@ -50,7 +50,7 @@ const VERSION = pkg.version as string;
 
 const program = new Command();
 const XCODE_PACKET_KINDS = ["any", "compile", "validate"] as const;
-const XCODE_CHECK_FORMATS = ["markdown", "json", "prompt"] as const;
+const XCODE_CHECK_FORMATS = ["markdown", "json", "prompt", "path"] as const;
 const XCODE_PACKET_FORMATS = ["markdown", "prompt", "json", "path"] as const;
 
 function parseChoice<T extends string>(
@@ -217,7 +217,7 @@ xcode
   )
   .option(
     "--format <format>",
-    "Output format (markdown, json, prompt)",
+    "Output format (markdown, json, prompt, path)",
     (value) => parseChoice("format", value, XCODE_CHECK_FORMATS),
     "markdown"
   )

--- a/src/cli/xcode-check.ts
+++ b/src/cli/xcode-check.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import {
   buildCheckSummary,
   renderCheckSummaryMarkdown,
+  resolveCheckSummaryPaths,
   type CheckSummary,
 } from "../repair/check-summary.js";
 import type { FixPacket } from "../repair/fix-packet.js";
@@ -12,7 +13,7 @@ import {
   type XcodePacketKind,
 } from "./xcode-packet.js";
 
-export type XcodeCheckOutput = "markdown" | "json" | "prompt";
+export type XcodeCheckOutput = "markdown" | "json" | "prompt" | "path";
 
 interface XcodeCheckOptions {
   root?: string;
@@ -37,6 +38,10 @@ function renderCheckOutput(
 ): string {
   const summary = readExistingSummary(packetPath) ?? buildCheckSummary(packet);
   switch (format) {
+    case "path":
+      return readExistingSummary(packetPath)
+        ? packetPath.replace(/latest\.json$/, "latest.check.json")
+        : resolveCheckSummaryPaths(packet).jsonPath;
     case "json":
       return JSON.stringify(summary, null, 2);
     case "prompt":

--- a/tests/cli/xcode-check.test.ts
+++ b/tests/cli/xcode-check.test.ts
@@ -140,6 +140,43 @@ describe("axint xcode check", () => {
     expect(result.stdout.trim()).toBe("exact AI repair prompt");
   });
 
+  it("returns the latest check artifact path when path output is requested", () => {
+    const compilePacketPath = join(
+      derivedDataRoot,
+      "Demo-abc",
+      "Build",
+      "Intermediates.noindex",
+      "Plugins",
+      "AxintCompilePlugin",
+      "fix",
+      "health-review",
+      "latest.json"
+    );
+
+    writePacket(
+      compilePacketPath,
+      {
+        command: "compile",
+        verdict: "needs_review",
+        fileName: "health-review.ts",
+        filePath: "/tmp/health-review.ts",
+        prompt: "repair prompt",
+      },
+      1_710_000_000_000
+    );
+
+    const result = spawnSync(
+      "node",
+      [CLI, "xcode", "check", "--root", derivedDataRoot, "--format", "path"],
+      { encoding: "utf-8" }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(
+      compilePacketPath.replace(/latest\.json$/, "latest.check.json")
+    );
+  });
+
   it("fails cleanly when no check is available yet", () => {
     const result = spawnSync(
       "node",


### PR DESCRIPTION
## Summary
- add `path` output for `axint xcode check`
- print the latest `latest.check.json` artifact path for scripted Xcode workflows
- cover the new output mode in CLI tests and refresh metrics

## Verification
- npm run typecheck
- npm run build
- npx vitest run tests/cli/xcode-check.test.ts tests/cli/xcode-packet.test.ts tests/cli/validate-swift.test.ts
- npm run metrics:check