### PR TITLE
Promote login in local Axint reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,22 @@ No install required — [axint.ai/#playground](https://axint.ai/#playground) run
 
 ---
 
+## Optional login
+
+`axint login` is optional. The open-source compiler stays useful without an account.
+
+If you do sign in, Axint can:
+
+- unlock richer terminal check reports
+- enable `axint publish` against the public Registry
+- connect future hosted report and Cloud features without changing the local compiler flow
+
+```bash
+axint login
+```
+
+---
+
 ## Editor extensions
 
 Extensions for [Claude Code](extensions/claude-code), [Codex](extensions/codex), [VS Code / Cursor](extensions/vscode), [Windsurf](extensions/windsurf), [JetBrains](extensions/jetbrains), [Neovim](extensions/neovim), and [Xcode](extensions/xcode).
@@ -308,7 +324,7 @@ axint/
 ├── python/          # Python SDK
 ├── extensions/      # Editor extensions (9 editors)
 ├── spm-plugin/      # Xcode SPM build plugin
-├── tests/           # 623 TypeScript tests + 114 Python tests
+├── tests/           # 626 TypeScript tests + 114 Python tests
 ├── examples/        # TypeScript + Swift repair-loop examples
 └── docs/            # Error reference, assets
 ```

--- a/docs/FIX_PACKET.md
+++ b/docs/FIX_PACKET.md
@@ -55,6 +55,10 @@ If Axint cannot recognize a supported Apple-native Swift surface, the packet dro
 
 `axint compile`, `axint watch`, and `axint validate-swift` emit both the Fix Packet and the lightweight Axint Check automatically by default.
 
+When you are anonymous, the terminal output keeps the report lean and shows a gentle
+`axint login` prompt. When you are signed in, the terminal output expands into the
+richer signed-in verdict view automatically.
+
 You can opt out with:
 
 ```bash

--- a/metrics.json
+++ b/metrics.json
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 624,
+    "typescript": 626,
     "python": 114
   },
   "registryPackages": 8,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,7 +9,7 @@
  *   axint validate-swift <path>   Validate existing Swift sources against Axint's build-time rules
  *   axint eject <file>            Eject intent to standalone Swift (no vendor lock-in)
  *   axint templates               List bundled intent templates
- *   axint login                   Authenticate with the Axint Registry
+ *   axint login                   Authenticate with the Axint Registry and unlock richer reports
  *   axint publish                 Publish an intent to the Registry
  *   axint add <package>           Install a template from the Registry
  *   axint search [query]          Search the Axint Registry for intent templates

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -6,7 +6,9 @@ import { registryBaseUrl } from "../core/env.js";
 export function registerLogin(program: Command) {
   program
     .command("login")
-    .description("Authenticate with the Axint Registry via GitHub")
+    .description(
+      "Authenticate with the Axint Registry via GitHub to unlock publish, richer terminal reports, and hosted Axint features"
+    )
     .action(async () => {
       const { homedir } = await import("node:os");
       const { join } = await import("node:path");
@@ -17,6 +19,10 @@ export function registerLogin(program: Command) {
 
       console.log();
       console.log(`  \x1b[38;5;208m◆\x1b[0m \x1b[1mAxint\x1b[0m · login`);
+      console.log();
+      console.log(
+        "  Sign in once to unlock richer terminal reports, `axint publish`, and hosted Axint features when available."
+      );
       console.log();
 
       try {
@@ -109,6 +115,9 @@ export function registerLogin(program: Command) {
 
         console.log(
           `  \x1b[32m✓\x1b[0m Logged in! Credentials saved to \x1b[2m${credPath}\x1b[0m`
+        );
+        console.log(
+          "  Future Axint checks will show the richer signed-in terminal report."
         );
         console.log();
       } catch (err: unknown) {

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -3,6 +3,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { compileFile } from "../core/compiler.js";
 import { hashBundle } from "../core/bundle-hash.js";
+import { loadAxintCredentials, resolveCredentialsPath } from "../core/credentials.js";
 import { registryBaseUrl } from "../core/env.js";
 import { loadAxintConfig } from "../core/axint-config.js";
 
@@ -139,9 +140,7 @@ export function registerPublish(program: Command, version: string) {
         return;
       }
 
-      const { homedir } = await import("node:os");
-      const { join } = await import("node:path");
-      const credPath = join(homedir(), ".axint", "credentials.json");
+      const credPath = resolveCredentialsPath();
 
       if (!existsSync(credPath)) {
         console.error(
@@ -150,10 +149,8 @@ export function registerPublish(program: Command, version: string) {
         process.exit(1);
       }
 
-      let creds: { access_token: string; registry: string };
-      try {
-        creds = JSON.parse(readFileSync(credPath, "utf-8"));
-      } catch {
+      const creds = loadAxintCredentials();
+      if (!creds) {
         console.error(
           `  \x1b[31merror:\x1b[0m Corrupt credentials file. Run \`axint login\` again.`
         );

--- a/src/core/credentials.ts
+++ b/src/core/credentials.ts
@@ -1,0 +1,55 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface AxintCredentials {
+  access_token: string;
+  registry: string;
+}
+
+export interface AxintLoginState {
+  signedIn: boolean;
+  registry?: string;
+}
+
+export function resolveCredentialsPath(home: string = homedir()): string {
+  return join(home, ".axint", "credentials.json");
+}
+
+export function loadAxintCredentials(home: string = homedir()): AxintCredentials | null {
+  const credPath = resolveCredentialsPath(home);
+  if (!existsSync(credPath)) return null;
+
+  try {
+    const parsed = JSON.parse(
+      readFileSync(credPath, "utf-8")
+    ) as Partial<AxintCredentials>;
+    if (
+      typeof parsed.access_token === "string" &&
+      parsed.access_token.length > 0 &&
+      typeof parsed.registry === "string" &&
+      parsed.registry.length > 0
+    ) {
+      return {
+        access_token: parsed.access_token,
+        registry: parsed.registry,
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+export function getAxintLoginState(home: string = homedir()): AxintLoginState {
+  const creds = loadAxintCredentials(home);
+  if (!creds) {
+    return { signedIn: false };
+  }
+
+  return {
+    signedIn: true,
+    registry: creds.registry,
+  };
+}

--- a/src/repair/repair-artifacts.ts
+++ b/src/repair/repair-artifacts.ts
@@ -1,3 +1,4 @@
+import { getAxintLoginState } from "../core/credentials.js";
 import {
   emitFixPacketArtifacts,
   type FixPacketArtifacts,
@@ -6,6 +7,7 @@ import {
 import {
   emitCheckSummaryArtifacts,
   type CheckSummaryArtifacts,
+  type CheckSummary,
 } from "./check-summary.js";
 
 export interface RepairArtifacts {
@@ -40,6 +42,49 @@ export function printRepairArtifactLines(
   artifacts: RepairArtifacts,
   writeLine: (line: string) => void
 ) {
-  writeLine(`\x1b[36m→\x1b[0m Axint Check → ${artifacts.check.jsonPath}`);
-  writeLine(`\x1b[36m→\x1b[0m Fix Packet → ${artifacts.packet.jsonPath}`);
+  for (const line of renderRepairArtifactLines(artifacts, {
+    signedIn: getAxintLoginState().signedIn,
+  })) {
+    writeLine(line);
+  }
+}
+
+export function renderRepairArtifactLines(
+  artifacts: RepairArtifacts,
+  options: { signedIn?: boolean } = {}
+): string[] {
+  const lines = [
+    `\x1b[36m→\x1b[0m Axint Check → ${artifacts.check.jsonPath}`,
+    `\x1b[36m→\x1b[0m Fix Packet → ${artifacts.packet.jsonPath}`,
+  ];
+
+  if (options.signedIn) {
+    lines.push(...renderSignedInSummaryLines(artifacts.check.summary));
+  } else {
+    lines.push(
+      "  \x1b[2mTip:\x1b[0m Run `axint login` to unlock richer terminal reports, publish, and hosted Axint features when available."
+    );
+  }
+
+  return lines;
+}
+
+function renderSignedInSummaryLines(summary: CheckSummary): string[] {
+  const verdict =
+    summary.outcome.verdict === "needs_review"
+      ? "Needs review"
+      : summary.outcome.verdict[0]!.toUpperCase() + summary.outcome.verdict.slice(1);
+  const topFinding = summary.topFindings[0];
+
+  const lines = [
+    "  \x1b[35m↳\x1b[0m Signed in · richer terminal report enabled",
+    `    Verdict: ${verdict} · ${summary.outcome.headline}`,
+  ];
+
+  if (topFinding) {
+    lines.push(`    Top finding: ${topFinding.code} · ${topFinding.message}`);
+  }
+
+  lines.push(`    Next: ${summary.nextAction}`);
+  return lines;
 }

--- a/tests/core/repair-artifacts.test.ts
+++ b/tests/core/repair-artifacts.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { buildFixPacket } from "../../src/repair/fix-packet.js";
+import { buildCheckSummary } from "../../src/repair/check-summary.js";
+import { renderRepairArtifactLines } from "../../src/repair/repair-artifacts.js";
+
+describe("repair artifact terminal lines", () => {
+  function buildArtifacts() {
+    const packet = buildFixPacket({
+      success: true,
+      surface: "intent",
+      diagnostics: [
+        {
+          code: "AX118",
+          severity: "warning",
+          message: "Use Apple's real HealthKit usage-description keys.",
+          suggestion:
+            "Replace HealthUsageDescription with NSHealthShareUsageDescription and/or NSHealthUpdateUsageDescription.",
+        },
+      ],
+      source: "export default defineIntent({ name: 'HealthReview' });",
+      fileName: "health-review.ts",
+      filePath: "/tmp/health-review.ts",
+      language: "typescript",
+      packetJsonPath: "/tmp/latest.json",
+      packetMarkdownPath: "/tmp/latest.md",
+    });
+
+    const summary = buildCheckSummary(packet);
+
+    return {
+      packet: {
+        packet,
+        packetDir: "/tmp",
+        jsonPath: "/tmp/latest.json",
+        markdownPath: "/tmp/latest.md",
+      },
+      check: {
+        summary,
+        jsonPath: "/tmp/latest.check.json",
+        markdownPath: "/tmp/latest.check.md",
+      },
+    };
+  }
+
+  it("promotes login in the anonymous terminal report", () => {
+    const lines = renderRepairArtifactLines(buildArtifacts(), { signedIn: false });
+    const text = lines.join("\n");
+
+    expect(text).toContain("Axint Check");
+    expect(text).toContain("Fix Packet");
+    expect(text).toContain("axint login");
+    expect(text).toContain("richer terminal reports");
+  });
+
+  it("shows the richer signed-in summary in terminal output", () => {
+    const lines = renderRepairArtifactLines(buildArtifacts(), { signedIn: true });
+    const text = lines.join("\n");
+
+    expect(text).toContain("Signed in");
+    expect(text).toContain("Needs review");
+    expect(text).toContain("AX118");
+    expect(text).toContain("Next:");
+  });
+});


### PR DESCRIPTION
## Summary
- explain what `axint login` unlocks in the CLI itself
- promote login gently in anonymous local report output
- show a richer signed-in terminal summary from the existing Check/Fix Packet layer
- document the optional login flow in the README and Fix Packet docs
- refresh metrics and add focused tests for anonymous vs signed-in output

## Verification
- npm run typecheck
- npx vitest run tests/core/check-summary.test.ts tests/core/repair-artifacts.test.ts tests/cli/registry.test.ts
- npm run build
- npm run metrics:emit
- npm run metrics:check
