### PR TITLE
Clarify Axint login benefit copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,9 +280,9 @@ No install required — [axint.ai/#playground](https://axint.ai/#playground) run
 
 If you do sign in, Axint can:
 
-- unlock richer terminal check reports
+- unlock fuller repair summaries in the terminal
 - enable `axint publish` against the public Registry
-- connect future hosted report and Cloud features without changing the local compiler flow
+- connect Cloud runs to saved history, reopenable reports, and shareable links as hosted features roll out
 
 ```bash
 axint login

--- a/docs/FIX_PACKET.md
+++ b/docs/FIX_PACKET.md
@@ -56,8 +56,10 @@ If Axint cannot recognize a supported Apple-native Swift surface, the packet dro
 `axint compile`, `axint watch`, and `axint validate-swift` emit both the Fix Packet and the lightweight Axint Check automatically by default.
 
 When you are anonymous, the terminal output keeps the report lean and shows a gentle
-`axint login` prompt. When you are signed in, the terminal output expands into the
-richer signed-in verdict view automatically.
+`axint login` prompt that explains the real upside: fuller repair guidance in the terminal,
+Registry publish access, and Cloud-linked benefits like saved runs, reopenable history,
+and shareable links as those hosted features roll out. When you are signed in, the terminal
+output expands into the fuller signed-in verdict view automatically.
 
 You can opt out with:
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,7 +9,7 @@
  *   axint validate-swift <path>   Validate existing Swift sources against Axint's build-time rules
  *   axint eject <file>            Eject intent to standalone Swift (no vendor lock-in)
  *   axint templates               List bundled intent templates
- *   axint login                   Authenticate with the Axint Registry and unlock richer reports
+ *   axint login                   Authenticate with the Axint Registry and unlock fuller repair reports
  *   axint publish                 Publish an intent to the Registry
  *   axint add <package>           Install a template from the Registry
  *   axint search [query]          Search the Axint Registry for intent templates

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -7,7 +7,7 @@ export function registerLogin(program: Command) {
   program
     .command("login")
     .description(
-      "Authenticate with the Axint Registry via GitHub to unlock publish, richer terminal reports, and hosted Axint features"
+      "Authenticate with the Axint Registry via GitHub to unlock publish, better repair summaries, and future Axint Cloud benefits"
     )
     .action(async () => {
       const { homedir } = await import("node:os");
@@ -21,7 +21,7 @@ export function registerLogin(program: Command) {
       console.log(`  \x1b[38;5;208m◆\x1b[0m \x1b[1mAxint\x1b[0m · login`);
       console.log();
       console.log(
-        "  Sign in once to unlock richer terminal reports, `axint publish`, and hosted Axint features when available."
+        "  Sign in once to get better repair guidance in terminal, publish to the Registry, and connect future Axint Cloud runs to saved history and shareable links."
       );
       console.log();
 
@@ -117,7 +117,7 @@ export function registerLogin(program: Command) {
           `  \x1b[32m✓\x1b[0m Logged in! Credentials saved to \x1b[2m${credPath}\x1b[0m`
         );
         console.log(
-          "  Future Axint checks will show the richer signed-in terminal report."
+          "  Future Axint checks will show the fuller signed-in repair report and be ready for saved Cloud-linked history as hosted features land."
         );
         console.log();
       } catch (err: unknown) {

--- a/src/repair/repair-artifacts.ts
+++ b/src/repair/repair-artifacts.ts
@@ -62,7 +62,7 @@ export function renderRepairArtifactLines(
     lines.push(...renderSignedInSummaryLines(artifacts.check.summary));
   } else {
     lines.push(
-      "  \x1b[2mTip:\x1b[0m Run `axint login` to unlock richer terminal reports, publish, and hosted Axint features when available."
+      "  \x1b[2mTip:\x1b[0m Run `axint login` to unlock fuller repair summaries in terminal, `axint publish`, and Axint Cloud features like saved runs, reopenable history, and shareable links as they roll out."
     );
   }
 
@@ -77,7 +77,7 @@ function renderSignedInSummaryLines(summary: CheckSummary): string[] {
   const topFinding = summary.topFindings[0];
 
   const lines = [
-    "  \x1b[35m↳\x1b[0m Signed in · richer terminal report enabled",
+    "  \x1b[35m↳\x1b[0m Signed in · fuller repair report enabled",
     `    Verdict: ${verdict} · ${summary.outcome.headline}`,
   ];
 

--- a/tests/cli/registry.test.ts
+++ b/tests/cli/registry.test.ts
@@ -111,6 +111,10 @@ describe("registry CLI commands", () => {
       registry: "https://registry.example.test",
     });
     expect(spawnMock).toHaveBeenCalled();
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("better repair guidance in terminal");
+    expect(output).toContain("saved history");
+    expect(output).toContain("shareable links");
   });
 
   it("covers axint publish and sends the compiled bundle to the registry", async () => {

--- a/tests/core/repair-artifacts.test.ts
+++ b/tests/core/repair-artifacts.test.ts
@@ -49,7 +49,9 @@ describe("repair artifact terminal lines", () => {
     expect(text).toContain("Axint Check");
     expect(text).toContain("Fix Packet");
     expect(text).toContain("axint login");
-    expect(text).toContain("richer terminal reports");
+    expect(text).toContain("fuller repair summaries");
+    expect(text).toContain("saved runs");
+    expect(text).toContain("shareable links");
   });
 
   it("shows the richer signed-in summary in terminal output", () => {


### PR DESCRIPTION
## Summary
- rewrite the anonymous `axint login` nudge around concrete benefits instead of vague richer-detail phrasing
- tighten the `axint login` command copy around publish access, better terminal repair guidance, and Cloud-side history/link benefits
- pin the new messaging in CLI and repair artifact tests

## Testing
- npm run typecheck
- npx vitest run tests/core/check-summary.test.ts tests/core/repair-artifacts.test.ts tests/cli/registry.test.ts
- npm run build
- npm run metrics:check
