### PR TITLE
add axint-dsl parser with four-point recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ tools/swift-syntax-helper/Package.resolved
 tsup.config.bundled_*
 tests/.tmp-compiler-tests/
 
+# local scratch
+tmp/
+
 # Python
 __pycache__/
 *.pyc

--- a/metrics.json
+++ b/metrics.json
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 626,
+    "typescript": 657,
     "python": 114
   },
   "registryPackages": 8,

--- a/metrics.json
+++ b/metrics.json
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 657,
+    "typescript": 655,
     "python": 114
   },
   "registryPackages": 8,

--- a/spec/language/examples/01-hello.axint
+++ b/spec/language/examples/01-hello.axint
@@ -1,0 +1,4 @@
+intent Hello {
+  title: "Hello"
+  description: "A minimal App Intent that says hello."
+}

--- a/spec/language/examples/02-send-message.axint
+++ b/spec/language/examples/02-send-message.axint
@@ -1,0 +1,17 @@
+intent SendMessage {
+  title: "Send Message"
+  description: "Sends a message to a contact via your preferred messaging app."
+  domain: "messaging"
+
+  param recipient: string {
+    description: "Who to send the message to"
+  }
+
+  param body: string {
+    description: "The message content"
+  }
+
+  param urgent: boolean? {
+    description: "Mark as urgent"
+  }
+}

--- a/spec/language/examples/03-set-lights.axint
+++ b/spec/language/examples/03-set-lights.axint
@@ -1,0 +1,19 @@
+intent SetLights {
+  title: "Set Lights"
+  description: "Adjusts the smart lights in a room."
+  domain: "smart-home"
+
+  param room: string {
+    description: "Which room to control"
+  }
+
+  param brightness: int {
+    description: "Brightness percentage (0-100)"
+    default: 100
+  }
+
+  param on: boolean {
+    description: "Turn lights on or off"
+    default: true
+  }
+}

--- a/spec/language/examples/04-log-health.axint
+++ b/spec/language/examples/04-log-health.axint
@@ -1,0 +1,29 @@
+intent LogHealthMetric {
+  title: "Log Health Metric"
+  description: "Records a health measurement like weight, blood pressure, or exercise."
+  domain: "health"
+
+  param metric: string {
+    description: "What you're logging (e.g., weight, steps)"
+  }
+
+  param value: double {
+    description: "The measurement value"
+  }
+
+  param takenAt: date {
+    description: "When the measurement was taken"
+  }
+
+  param activityLength: duration? {
+    description: "Activity duration"
+  }
+
+  param source: url? {
+    description: "Source URL for the measurement"
+  }
+
+  param notes: string? {
+    description: "Additional notes"
+  }
+}

--- a/spec/language/examples/05-create-event.axint
+++ b/spec/language/examples/05-create-event.axint
@@ -1,0 +1,30 @@
+intent CreateCalendarEvent {
+  title: "Create Calendar Event"
+  description: "Creates a new event in the user's calendar."
+  domain: "productivity"
+
+  param eventTitle: string {
+    description: "Event title"
+  }
+
+  param startDate: date {
+    description: "Event date"
+  }
+
+  param length: duration {
+    description: "Event duration"
+    default: "1h"
+  }
+
+  param location: string? {
+    description: "Location"
+  }
+
+  entitlements {
+    "com.apple.developer.siri"
+  }
+
+  infoPlistKeys {
+    "NSCalendarsUsageDescription": "Axint needs calendar access to create events."
+  }
+}

--- a/spec/language/examples/06-priority-enum.axint
+++ b/spec/language/examples/06-priority-enum.axint
@@ -1,0 +1,15 @@
+enum Priority { low medium high }
+
+intent FlagTask {
+  title: "Flag Task"
+  description: "Flags a task with a priority level."
+
+  param taskId: string {
+    description: "Task identifier"
+  }
+
+  param priority: Priority {
+    description: "Priority level"
+    default: medium
+  }
+}

--- a/spec/language/examples/07-array-param.axint
+++ b/spec/language/examples/07-array-param.axint
@@ -1,0 +1,13 @@
+intent AddTags {
+  title: "Add Tags"
+  description: "Adds one or more tags to a note."
+  domain: "productivity"
+
+  param noteId: string {
+    description: "The note to tag"
+  }
+
+  param tags: [string] {
+    description: "Tags to apply"
+  }
+}

--- a/spec/language/examples/08-optional-array.axint
+++ b/spec/language/examples/08-optional-array.axint
@@ -1,0 +1,18 @@
+intent SearchNotes {
+  title: "Search Notes"
+  description: "Searches notes with optional tag filters."
+  domain: "productivity"
+
+  param searchTerm: string {
+    description: "What to search for"
+  }
+
+  param tags: [string]? {
+    description: "Restrict results to notes with these tags"
+  }
+
+  param limit: int {
+    description: "Maximum number of results"
+    default: 20
+  }
+}

--- a/spec/language/examples/09-custom-category.axint
+++ b/spec/language/examples/09-custom-category.axint
@@ -1,0 +1,17 @@
+intent StartFocusSession {
+  title: "Start Focus Session"
+  description: "Begins a focus session and silences notifications."
+  domain: "productivity"
+  category: "focus"
+  discoverable: true
+  donateOnPerform: true
+
+  param length: duration {
+    description: "How long to focus"
+    default: "25m"
+  }
+
+  param label: string? {
+    description: "What you're focusing on"
+  }
+}

--- a/spec/language/examples/10-simple-summary.axint
+++ b/spec/language/examples/10-simple-summary.axint
@@ -1,0 +1,14 @@
+intent SetTimer {
+  title: "Set Timer"
+  description: "Starts a countdown timer."
+
+  param length: duration {
+    description: "How long to run the timer"
+  }
+
+  param label: string? {
+    description: "An optional label for the timer"
+  }
+
+  summary: "Set a ${length} timer for ${label}"
+}

--- a/spec/language/examples/11-when-summary.axint
+++ b/spec/language/examples/11-when-summary.axint
@@ -1,0 +1,18 @@
+intent ShareLocation {
+  title: "Share Location"
+  description: "Shares your current location with a contact."
+  domain: "social"
+
+  param recipient: string {
+    description: "Who to share with"
+  }
+
+  param note: string? {
+    description: "An optional note to send along"
+  }
+
+  summary when note {
+    then: "Share location with ${recipient} — ${note}"
+    otherwise: "Share location with ${recipient}"
+  }
+}

--- a/spec/language/examples/12-switch-summary.axint
+++ b/spec/language/examples/12-switch-summary.axint
@@ -1,0 +1,19 @@
+intent SetBrightness {
+  title: "Set Brightness"
+  description: "Adjusts the display brightness for a given mode."
+
+  param mode: string {
+    description: "Brightness mode"
+  }
+
+  param value: int {
+    description: "Brightness value (0-100)"
+  }
+
+  summary switch mode {
+    case "manual": "Set brightness to ${value}"
+    case "auto": "Switch brightness to automatic"
+    case "night": "Enable night mode"
+    default: "Adjust brightness"
+  }
+}

--- a/spec/language/examples/13-trail-entity.axint
+++ b/spec/language/examples/13-trail-entity.axint
@@ -1,0 +1,38 @@
+entity Trail {
+  display {
+    title: name
+    subtitle: region
+    image: "figure.hiking"
+  }
+
+  property id: string {
+    description: "Trail identifier"
+  }
+
+  property name: string {
+    description: "Trail name"
+  }
+
+  property region: string {
+    description: "Trail region"
+  }
+
+  property distanceKm: double {
+    description: "Distance in kilometers"
+  }
+
+  property openNow: boolean {
+    description: "Whether the trail is open"
+  }
+
+  query: property
+}
+
+intent OpenTrail {
+  title: "Open Trail"
+  description: "Opens a trail and shows its details."
+
+  param trail: Trail {
+    description: "Trail to open"
+  }
+}

--- a/spec/language/examples/14-plan-trail.axint
+++ b/spec/language/examples/14-plan-trail.axint
@@ -1,0 +1,61 @@
+entity Trail {
+  display {
+    title: name
+    subtitle: region
+    image: "figure.hiking"
+  }
+
+  property id: string {
+    description: "Trail identifier"
+  }
+
+  property name: string {
+    description: "Trail name"
+  }
+
+  property region: string {
+    description: "Trail region"
+  }
+
+  property distanceKm: double {
+    description: "Distance in kilometers"
+  }
+
+  property openNow: boolean {
+    description: "Whether the trail is open"
+  }
+
+  query: property
+}
+
+intent PlanTrail {
+  title: "Plan Trail"
+  description: "Build a trail plan from queryable entities and runtime options."
+
+  param activity: string {
+    description: "Activity type"
+    options: dynamic ActivityOptions
+  }
+
+  param trail: Trail {
+    description: "Trail to open"
+  }
+
+  param includeNearby: boolean {
+    description: "Limit results to nearby trails"
+    default: true
+  }
+
+  param region: string? {
+    description: "Trail region"
+  }
+
+  summary switch includeNearby {
+    case true: summary when region {
+      then: "Plan ${activity} on ${trail} near ${region}"
+      otherwise: "Plan ${activity} on ${trail} near me"
+    }
+    case false: "Plan ${activity} on ${trail}"
+    default: "Plan trail"
+  }
+}

--- a/spec/language/examples/15-returns-entity.axint
+++ b/spec/language/examples/15-returns-entity.axint
@@ -1,0 +1,44 @@
+entity Contact {
+  display {
+    title: name
+    subtitle: handle
+    image: "person.circle"
+  }
+
+  property id: string {
+    description: "Contact identifier"
+  }
+
+  property name: string {
+    description: "Contact name"
+  }
+
+  property handle: string {
+    description: "Contact handle (email or phone)"
+  }
+
+  query: property
+}
+
+intent FindContact {
+  title: "Find Contact"
+  description: "Looks up a single contact by name."
+
+  param name: string {
+    description: "Contact name to look up"
+  }
+
+  returns: Contact
+}
+
+intent ListRecentContacts {
+  title: "List Recent Contacts"
+  description: "Returns the contacts you've messaged most recently."
+
+  param limit: int {
+    description: "Maximum number to return"
+    default: 10
+  }
+
+  returns: [Contact]
+}

--- a/spec/language/examples/README.md
+++ b/spec/language/examples/README.md
@@ -1,0 +1,31 @@
+# Examples
+
+Fifteen canonical `.axint` files, each paired with the Swift file the compiler is expected to emit. These examples drive the spec's conformance suite: every production in the grammar shows up in at least one example, and every example round-trips through parse → IR → Swift → validate with zero diagnostics.
+
+Ordered roughly from simplest to most complex. Each file exercises a distinct feature so an agent reading a subset still sees the full surface.
+
+| # | File                                    | Exercises                                              |
+|---|-----------------------------------------|--------------------------------------------------------|
+| 1 | `01-hello.axint`                        | Minimal intent: no params, no metadata                 |
+| 2 | `02-send-message.axint`                 | String params, one optional param, `domain`            |
+| 3 | `03-set-lights.axint`                   | Int + boolean defaults                                 |
+| 4 | `04-log-health.axint`                   | `date`, `duration`, `url`, two optional params         |
+| 5 | `05-create-event.axint`                 | Duration with default, entitlements, infoPlistKeys     |
+| 6 | `06-priority-enum.axint`                | Enum type as param                                     |
+| 7 | `07-array-param.axint`                  | Array param `[string]`                                 |
+| 8 | `08-optional-array.axint`               | Optional array param `[string]?`                       |
+| 9 | `09-custom-category.axint`              | `category`, `discoverable`, `donateOnPerform`          |
+| 10 | `10-simple-summary.axint`              | `summary: "template"` form                             |
+| 11 | `11-when-summary.axint`                | `summary when paramName { then / otherwise }`          |
+| 12 | `12-switch-summary.axint`              | `summary switch paramName { case / default }`          |
+| 13 | `13-trail-entity.axint`                | Single entity + intent using it                        |
+| 14 | `14-plan-trail.axint`                  | Entity + dynamic options + nested switch/when summary  |
+| 15 | `15-returns-entity.axint`              | Intent returning an entity (single + array)            |
+
+Each example has a matching `.swift` file showing the expected output. Both files are checked into the conformance suite under `axint/tests/language/conformance/`.
+
+## Negative corpus
+
+The fifteen files above are the positive corpus — every one parses, validates, and emits Swift cleanly. A matching negative corpus lives in [`broken/`](./broken), where each file is deliberately invalid and targets exactly one `AX...` diagnostic. Together the two corpora give the conformance runner a symmetric assertion: valid files pass with zero diagnostics, invalid files produce exactly the one code their filename claims.
+
+When a new diagnostic is added to `diagnostics.md`, a broken example must land in `broken/` in the same PR. See [`broken/README.md`](./broken/README.md) for the current catalog.

--- a/spec/language/examples/broken/01-ax001-empty.axint
+++ b/spec/language/examples/broken/01-ax001-empty.axint
@@ -1,0 +1,5 @@
+# expect: AX001
+# File contains no intent or entity declaration.
+
+# A comment-only file is legal lexically but triggers AX001 at the
+# top-level parser because at least one top-level decl is required.

--- a/spec/language/examples/broken/02-ax002-no-name.axint
+++ b/spec/language/examples/broken/02-ax002-no-name.axint
@@ -1,0 +1,7 @@
+# expect: AX002
+# intent keyword is not followed by an identifier.
+
+intent {
+  title: "Send Message"
+  description: "Send a message to a recipient."
+}

--- a/spec/language/examples/broken/03-ax003-no-title.axint
+++ b/spec/language/examples/broken/03-ax003-no-title.axint
@@ -1,0 +1,10 @@
+# expect: AX003
+# intent body is missing the required title clause.
+
+intent SendMessage {
+  description: "Send a message to a recipient."
+
+  param recipient: string {
+    description: "Who to send the message to"
+  }
+}

--- a/spec/language/examples/broken/04-ax004-no-desc.axint
+++ b/spec/language/examples/broken/04-ax004-no-desc.axint
@@ -1,0 +1,10 @@
+# expect: AX004
+# intent body is missing the required description clause.
+
+intent SendMessage {
+  title: "Send Message"
+
+  param recipient: string {
+    description: "Who to send the message to"
+  }
+}

--- a/spec/language/examples/broken/05-ax005-bad-type.axint
+++ b/spec/language/examples/broken/05-ax005-bad-type.axint
@@ -1,0 +1,13 @@
+# expect: AX005
+# Param uses a type (`number`) that is not a known primitive, entity, or enum.
+# `number` is not in the type keyword list — the valid numeric types are `int`, `double`, `float`.
+
+intent SetBrightness {
+  title: "Set Brightness"
+  description: "Set the brightness level."
+
+  param level: number {
+    description: "Brightness percentage (0-100)"
+    default: 100
+  }
+}

--- a/spec/language/examples/broken/06-ax015-no-display.axint
+++ b/spec/language/examples/broken/06-ax015-no-display.axint
@@ -1,0 +1,14 @@
+# expect: AX015
+# Entity is missing its display block.
+
+entity Trail {
+  property id: string {
+    description: "Trail identifier"
+  }
+
+  property name: string {
+    description: "Trail name"
+  }
+
+  query: property
+}

--- a/spec/language/examples/broken/07-ax020-missing-entity.axint
+++ b/spec/language/examples/broken/07-ax020-missing-entity.axint
@@ -1,0 +1,12 @@
+# expect: AX020
+# Param references an entity (`Trail`) that is not declared in this file.
+# v1 is single-file — the entity must live in the same file as the intent.
+
+intent OpenTrail {
+  title: "Open Trail"
+  description: "Opens a trail and shows its details."
+
+  param trail: Trail {
+    description: "Trail to open"
+  }
+}

--- a/spec/language/examples/broken/08-ax021-missing-property.axint
+++ b/spec/language/examples/broken/08-ax021-missing-property.axint
@@ -1,0 +1,25 @@
+# expect: AX021
+# display.title names a property (`label`) that is not declared on the entity.
+# The entity declares `name` and `region` — `label` does not exist.
+
+entity Trail {
+  display {
+    title: label
+    subtitle: region
+    image: "figure.hiking"
+  }
+
+  property id: string {
+    description: "Trail identifier"
+  }
+
+  property name: string {
+    description: "Trail name"
+  }
+
+  property region: string {
+    description: "Trail region"
+  }
+
+  query: property
+}

--- a/spec/language/examples/broken/09-ax023-missing-summary-param.axint
+++ b/spec/language/examples/broken/09-ax023-missing-summary-param.axint
@@ -1,0 +1,17 @@
+# expect: AX023
+# summary template references ${destination} but the intent declares no such param.
+
+intent SendMessage {
+  title: "Send Message"
+  description: "Send a message to a recipient."
+
+  param recipient: string {
+    description: "Who to send the message to"
+  }
+
+  param body: string {
+    description: "Message body"
+  }
+
+  summary: "Send ${body} to ${destination}"
+}

--- a/spec/language/examples/broken/10-ax100-bad-case.axint
+++ b/spec/language/examples/broken/10-ax100-bad-case.axint
@@ -1,0 +1,11 @@
+# expect: AX100
+# Intent name is not PascalCase — `sendMessage` starts lowercase.
+
+intent sendMessage {
+  title: "Send Message"
+  description: "Send a message to a recipient."
+
+  param recipient: string {
+    description: "Who to send the message to"
+  }
+}

--- a/spec/language/examples/broken/11-ax103-dup-params.axint
+++ b/spec/language/examples/broken/11-ax103-dup-params.axint
@@ -1,0 +1,15 @@
+# expect: AX103
+# Intent has two params named `recipient`.
+
+intent SendMessage {
+  title: "Send Message"
+  description: "Send a message to a recipient."
+
+  param recipient: string {
+    description: "Who to send the message to"
+  }
+
+  param recipient: string {
+    description: "Duplicate — should raise AX103"
+  }
+}

--- a/spec/language/examples/broken/12-ax106-default-type.axint
+++ b/spec/language/examples/broken/12-ax106-default-type.axint
@@ -1,0 +1,12 @@
+# expect: AX106
+# Param is declared `int` but the default value is a string literal.
+
+intent SetBrightness {
+  title: "Set Brightness"
+  description: "Set the brightness level."
+
+  param level: int {
+    description: "Brightness percentage (0-100)"
+    default: "one hundred"
+  }
+}

--- a/spec/language/examples/broken/13-ax107-optional-default.axint
+++ b/spec/language/examples/broken/13-ax107-optional-default.axint
@@ -1,0 +1,17 @@
+# expect: AX107
+# Optional param has a non-null default — contradictory.
+# Either the type is `boolean` (non-optional with default true) or the default is removed.
+
+intent SendMessage {
+  title: "Send Message"
+  description: "Send a message to a recipient."
+
+  param recipient: string {
+    description: "Who to send the message to"
+  }
+
+  param urgent: boolean? {
+    description: "Mark as urgent"
+    default: true
+  }
+}

--- a/spec/language/examples/broken/14-ax109-switch-no-default.axint
+++ b/spec/language/examples/broken/14-ax109-switch-no-default.axint
@@ -1,0 +1,21 @@
+# expect: AX109
+# summary switch on a boolean covers only `case true` — missing `case false`
+# and there is no `default` branch, so the switch is non-exhaustive.
+
+intent SendMessage {
+  title: "Send Message"
+  description: "Send a message to a recipient."
+
+  param recipient: string {
+    description: "Who to send the message to"
+  }
+
+  param urgent: boolean {
+    description: "Mark as urgent"
+    default: false
+  }
+
+  summary switch urgent {
+    case true: "URGENT: send to ${recipient}"
+  }
+}

--- a/spec/language/examples/broken/15-ax112-query-no-desc.axint
+++ b/spec/language/examples/broken/15-ax112-query-no-desc.axint
@@ -1,0 +1,18 @@
+# expect: AX112
+# Entity declares `query: property` but no property has a `description` field.
+# `query: property` requires every property to carry a description so the
+# generated EntityPropertyQuery has a valid comparator title.
+
+entity Trail {
+  display {
+    title: name
+    subtitle: region
+    image: "figure.hiking"
+  }
+
+  property id: string {}
+  property name: string {}
+  property region: string {}
+
+  query: property
+}

--- a/spec/language/examples/broken/README.md
+++ b/spec/language/examples/broken/README.md
@@ -1,0 +1,39 @@
+# Negative-test corpus
+
+Every file in this directory is intentionally invalid. Each file targets exactly one diagnostic code so the conformance suite can assert:
+
+1. The parser/validator fires the expected `AX...` code.
+2. No other diagnostics fire alongside it.
+3. The emitted line and column point at the offending token.
+
+This corpus is the pressure test referenced in `principles.md` — "if the diagnostic doesn't make the fix obvious in a single edit, the language is wrong, not the file." Each entry below includes the one-line edit that would make the file valid.
+
+## Files
+
+| File                        | Target code | What's broken                                                              |
+|-----------------------------|-------------|----------------------------------------------------------------------------|
+| `01-ax001-empty.axint`      | AX001       | File contains no `intent` or `entity` declaration.                         |
+| `02-ax002-no-name.axint`    | AX002       | `intent` keyword not followed by a name.                                   |
+| `03-ax003-no-title.axint`   | AX003       | `intent` body is missing `title`.                                          |
+| `04-ax004-no-desc.axint`    | AX004       | `intent` body is missing `description`.                                    |
+| `05-ax005-bad-type.axint`   | AX005       | Param type is not a primitive, entity, or enum.                            |
+| `06-ax015-no-display.axint` | AX015       | `entity` is missing its `display` block.                                   |
+| `07-ax020-missing-entity.axint` | AX020   | Param references an entity not declared in the file.                       |
+| `08-ax021-missing-property.axint` | AX021 | `display.title` names a property that doesn't exist on the entity.         |
+| `09-ax023-missing-summary-param.axint` | AX023 | `summary` template references a param the intent doesn't declare.     |
+| `10-ax100-bad-case.axint`   | AX100       | Intent name is not `PascalCase`.                                           |
+| `11-ax103-dup-params.axint` | AX103       | Intent has two params with the same name.                                  |
+| `12-ax106-default-type.axint` | AX106     | `default` value type doesn't match declared param type.                    |
+| `13-ax107-optional-default.axint` | AX107 | Optional param with a non-null default — contradictory.                    |
+| `14-ax109-switch-no-default.axint` | AX109 | `summary switch` over a `boolean` covers only one case, no `default`.    |
+| `15-ax112-query-no-desc.axint` | AX112   | `query: property` but no property has a `description`.                     |
+
+## How the test harness consumes this
+
+The conformance runner globs `broken/*.axint`, parses each filename prefix (`NN-axNNN-...`), runs the full pipeline, and asserts that exactly one diagnostic fires whose code matches the filename. A file that triggers the wrong code — or more than one code — fails the suite.
+
+A file in this folder is a spec bug to be fixed, not a grammar feature.
+
+## Adding more
+
+When a new diagnostic is added to `diagnostics.md`, a broken example lands here in the same PR. The PR is blocked until the pair exists. That is how the corpus stays honest.

--- a/src/core/axint-dsl/ast.ts
+++ b/src/core/axint-dsl/ast.ts
@@ -1,0 +1,310 @@
+/**
+ * Axint DSL — AST nodes
+ *
+ * One node per production in spec/language/grammar.md. The parser emits a
+ * tree of these; the lowering stage walks the tree and produces IRIntent /
+ * IREntity (see spec/language/ir-mapping.md). Every node carries a span so
+ * diagnostics can point to any subtree.
+ *
+ * Shape rule: fields that are syntactically required live as non-optional
+ * properties; fields that are syntactically optional are typed as `T | undefined`
+ * via the `?:` modifier. This makes the parser's output self-documenting —
+ * if a required field is missing, the parser didn't produce an AST node at
+ * all and surfaced a diagnostic instead.
+ */
+
+import type { TokenSpan } from "./token.js";
+
+// ─── File ────────────────────────────────────────────────────────────
+
+export interface FileNode {
+  readonly kind: "File";
+  readonly span: TokenSpan;
+  readonly declarations: readonly TopLevelDecl[];
+}
+
+export type TopLevelDecl = IntentDecl | EntityDecl | EnumDecl;
+
+// ─── Identifier ──────────────────────────────────────────────────────
+
+export interface Ident {
+  readonly kind: "Ident";
+  readonly span: TokenSpan;
+  readonly name: string;
+}
+
+// ─── Literals ────────────────────────────────────────────────────────
+
+export type LiteralNode =
+  | StringLiteral
+  | IntegerLiteral
+  | DecimalLiteral
+  | BooleanLiteral
+  | IdentLiteral;
+
+export interface StringLiteral {
+  readonly kind: "StringLiteral";
+  readonly span: TokenSpan;
+  /** Decoded value with escapes applied. */
+  readonly value: string;
+}
+
+export interface IntegerLiteral {
+  readonly kind: "IntegerLiteral";
+  readonly span: TokenSpan;
+  readonly value: number;
+}
+
+export interface DecimalLiteral {
+  readonly kind: "DecimalLiteral";
+  readonly span: TokenSpan;
+  readonly value: number;
+}
+
+export interface BooleanLiteral {
+  readonly kind: "BooleanLiteral";
+  readonly span: TokenSpan;
+  readonly value: boolean;
+}
+
+/**
+ * An identifier used as a literal. Grammar rule: only valid as a `case`
+ * value in a `summary switch` where it refers to an enum case. An unknown
+ * enum case is rejected at validation time as AX106 (replace_literal).
+ * AX109 is a different diagnostic — it fires when a switch is missing a
+ * default or is non-exhaustive over the enum.
+ */
+export interface IdentLiteral {
+  readonly kind: "IdentLiteral";
+  readonly span: TokenSpan;
+  readonly name: string;
+}
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export type TypeNode = PrimitiveType | ArrayType | NamedType | OptionalType;
+
+export type PrimitiveKind =
+  | "string"
+  | "int"
+  | "double"
+  | "float"
+  | "boolean"
+  | "date"
+  | "duration"
+  | "url";
+
+export interface PrimitiveType {
+  readonly kind: "PrimitiveType";
+  readonly span: TokenSpan;
+  readonly primitive: PrimitiveKind;
+}
+
+export interface ArrayType {
+  readonly kind: "ArrayType";
+  readonly span: TokenSpan;
+  readonly element: TypeNode;
+}
+
+/** Reference to a declared entity or enum in the same file. */
+export interface NamedType {
+  readonly kind: "NamedType";
+  readonly span: TokenSpan;
+  readonly name: string;
+}
+
+export interface OptionalType {
+  readonly kind: "OptionalType";
+  readonly span: TokenSpan;
+  readonly inner: TypeNode;
+}
+
+/**
+ * Narrower than `TypeNode` — `returns: T?` is forbidden in v1 (see
+ * grammar.md on `return-type`). An array wraps a single atom; no nested
+ * arrays, no optionals.
+ */
+export type ReturnTypeNode = PrimitiveType | NamedType | ReturnArrayType;
+
+export interface ReturnArrayType {
+  readonly kind: "ReturnArrayType";
+  readonly span: TokenSpan;
+  readonly element: PrimitiveType | NamedType;
+}
+
+// ─── Enum ────────────────────────────────────────────────────────────
+
+export interface EnumDecl {
+  readonly kind: "EnumDecl";
+  readonly span: TokenSpan;
+  readonly name: Ident;
+  readonly cases: readonly Ident[];
+}
+
+// ─── Entity ──────────────────────────────────────────────────────────
+
+export interface EntityDecl {
+  readonly kind: "EntityDecl";
+  readonly span: TokenSpan;
+  readonly name: Ident;
+  readonly display: DisplayBlock;
+  readonly properties: readonly PropertyDecl[];
+  readonly query: QueryClause;
+}
+
+export interface DisplayBlock {
+  readonly kind: "DisplayBlock";
+  readonly span: TokenSpan;
+  readonly title: DisplayPropertyRef;
+  readonly subtitle?: DisplayPropertyRef;
+  readonly image?: DisplayImage;
+}
+
+/** `title: propName` or `subtitle: propName`. Target is a bare identifier. */
+export interface DisplayPropertyRef {
+  readonly kind: "DisplayPropertyRef";
+  readonly span: TokenSpan;
+  readonly field: "title" | "subtitle";
+  readonly property: Ident;
+}
+
+/** `image: "sf.symbol.name"`. Target is a quoted string literal. */
+export interface DisplayImage {
+  readonly kind: "DisplayImage";
+  readonly span: TokenSpan;
+  readonly asset: StringLiteral;
+}
+
+export interface PropertyDecl {
+  readonly kind: "PropertyDecl";
+  readonly span: TokenSpan;
+  readonly name: Ident;
+  readonly type: TypeNode;
+  readonly description: StringLiteral;
+}
+
+export interface QueryClause {
+  readonly kind: "QueryClause";
+  readonly span: TokenSpan;
+  readonly queryKind: "all" | "id" | "string" | "property";
+}
+
+// ─── Intent ──────────────────────────────────────────────────────────
+
+export interface IntentDecl {
+  readonly kind: "IntentDecl";
+  readonly span: TokenSpan;
+  readonly name: Ident;
+  readonly title: StringLiteral;
+  readonly description: StringLiteral;
+  readonly meta: readonly MetaClause[];
+  readonly params: readonly ParamDecl[];
+  readonly summary?: SummaryDecl;
+  readonly returns?: ReturnsClause;
+  readonly entitlements?: EntitlementsBlock;
+  readonly infoPlistKeys?: InfoPlistBlock;
+}
+
+export type MetaClause =
+  | {
+      readonly kind: "DomainMeta";
+      readonly span: TokenSpan;
+      readonly value: StringLiteral;
+    }
+  | {
+      readonly kind: "CategoryMeta";
+      readonly span: TokenSpan;
+      readonly value: StringLiteral;
+    }
+  | {
+      readonly kind: "DiscoverableMeta";
+      readonly span: TokenSpan;
+      readonly value: BooleanLiteral;
+    }
+  | {
+      readonly kind: "DonateOnPerformMeta";
+      readonly span: TokenSpan;
+      readonly value: BooleanLiteral;
+    };
+
+export interface ParamDecl {
+  readonly kind: "ParamDecl";
+  readonly span: TokenSpan;
+  readonly name: Ident;
+  readonly type: TypeNode;
+  readonly description: StringLiteral;
+  readonly defaultValue?: LiteralNode;
+  readonly options?: DynamicOptions;
+}
+
+export interface DynamicOptions {
+  readonly kind: "DynamicOptions";
+  readonly span: TokenSpan;
+  readonly provider: Ident;
+}
+
+export interface ReturnsClause {
+  readonly kind: "ReturnsClause";
+  readonly span: TokenSpan;
+  readonly type: ReturnTypeNode;
+}
+
+export interface EntitlementsBlock {
+  readonly kind: "EntitlementsBlock";
+  readonly span: TokenSpan;
+  readonly values: readonly StringLiteral[];
+}
+
+export interface InfoPlistBlock {
+  readonly kind: "InfoPlistBlock";
+  readonly span: TokenSpan;
+  readonly entries: readonly InfoPlistEntry[];
+}
+
+export interface InfoPlistEntry {
+  readonly kind: "InfoPlistEntry";
+  readonly span: TokenSpan;
+  readonly key: StringLiteral;
+  readonly value: StringLiteral;
+}
+
+// ─── Summary ─────────────────────────────────────────────────────────
+
+export type SummaryDecl = SummaryTemplate | SummaryWhen | SummarySwitch;
+
+export interface SummaryTemplate {
+  readonly kind: "SummaryTemplate";
+  readonly span: TokenSpan;
+  readonly template: StringLiteral;
+}
+
+export interface SummaryWhen {
+  readonly kind: "SummaryWhen";
+  readonly span: TokenSpan;
+  readonly param: Ident;
+  readonly then: SummaryValue;
+  readonly otherwise?: SummaryValue;
+}
+
+export interface SummarySwitch {
+  readonly kind: "SummarySwitch";
+  readonly span: TokenSpan;
+  readonly param: Ident;
+  readonly cases: readonly SummaryCase[];
+  readonly default?: SummaryValue;
+}
+
+export interface SummaryCase {
+  readonly kind: "SummaryCase";
+  readonly span: TokenSpan;
+  readonly value:
+    | StringLiteral
+    | IntegerLiteral
+    | DecimalLiteral
+    | BooleanLiteral
+    | IdentLiteral;
+  readonly body: SummaryValue;
+}
+
+/** Leaf string template, or a nested summary declaration. */
+export type SummaryValue = StringLiteral | SummaryDecl;

--- a/src/core/axint-dsl/diagnostic.ts
+++ b/src/core/axint-dsl/diagnostic.ts
@@ -1,0 +1,86 @@
+/**
+ * Axint DSL — Diagnostic record
+ *
+ * Exact mirror of spec/language/diagnostic-protocol.md. The schemaVersion is
+ * pinned to 1; any additive change bumps the protocol version (see
+ * spec/language/README.md on versioning).
+ *
+ * Two shapes live here because the protocol is the external contract:
+ *   - `Position` and `Span` match the JSON the compiler emits under
+ *     `axint check --format=json` — 1-indexed line/column, end exclusive.
+ *   - The internal lexer/parser span (byte offsets + line/column) lives in
+ *     `token.ts` as `TokenSpan`. Converting between them is a pure function
+ *     and happens at the diagnostic-emission boundary so internal code can
+ *     keep using byte offsets for slicing and the formatter.
+ *
+ * Diagnostics are data, not exceptions. The parser returns them alongside a
+ * best-effort AST so one parse pass yields every repairable signal a caller
+ * needs (see spec/language/parser-recovery.md).
+ */
+
+/**
+ * Pinned schema version for the diagnostic record shape. Consumers that
+ * parse JSON diagnostics must refuse records with an unknown version.
+ */
+export const DIAGNOSTIC_SCHEMA_VERSION = 1 as const;
+
+/** 1-indexed line and column. */
+export interface Position {
+  readonly line: number;
+  readonly column: number;
+}
+
+/** Half-open range: `end` is exclusive. A zero-width span is an insertion point. */
+export interface Span {
+  readonly start: Position;
+  readonly end: Position;
+}
+
+/** Matches the spec — no `info` tier in v1. */
+export type DiagnosticSeverity = "error" | "warning";
+
+/**
+ * Closed fix-kind taxonomy. Six kinds, exhaustive — changing this set is a
+ * schemaVersion bump. See diagnostic-protocol.md §Fix kinds.
+ */
+export type FixKind =
+  | "insert_required_clause"
+  | "remove_field"
+  | "replace_literal"
+  | "change_type"
+  | "rename_identifier"
+  | "replace_identifier";
+
+/**
+ * A machine-readable repair hint. `suggestedEdit.text` is present when the
+ * compiler can synthesize the full replacement; `candidates` is present when
+ * the target resolves to a closed set of valid identifiers.
+ *
+ * Applying the edit is textual: replace the bytes at `targetSpan` with
+ * `suggestedEdit.text`. For insertion kinds, `targetSpan` is zero-width at
+ * the insertion point.
+ */
+export interface Fix {
+  readonly kind: FixKind;
+  readonly targetSpan: Span;
+  readonly suggestedEdit?: { readonly text: string };
+  readonly candidates?: readonly string[];
+}
+
+export interface Diagnostic {
+  readonly schemaVersion: typeof DIAGNOSTIC_SCHEMA_VERSION;
+  /** One of the codes in spec/language/diagnostics.md. */
+  readonly code: string;
+  readonly severity: DiagnosticSeverity;
+  /** One sentence. Wording may change without a protocol bump. */
+  readonly message: string;
+  /** Path relative to the project root — reported verbatim by the compiler. */
+  readonly file: string;
+  readonly span: Span;
+  /**
+   * Always present. `null` when no principled author-side fix exists
+   * (compiler-bug codes AX200–AX202, registry code AX600). Every other
+   * diagnostic carries a `Fix` with a `kind` and a `targetSpan`.
+   */
+  readonly fix: Fix | null;
+}

--- a/src/core/axint-dsl/index.ts
+++ b/src/core/axint-dsl/index.ts
@@ -1,0 +1,76 @@
+/**
+ * Axint DSL — public entry point
+ *
+ * The `.axint` authoring surface. One call takes source text and returns
+ * an AST plus a flat diagnostic stream; downstream the AST lowers to the
+ * same IRIntent / IREntity shape the TS and Python SDKs produce.
+ *
+ * See spec/language/ under the repo root for the full specification.
+ */
+
+export { parse } from "./parser.js";
+export type { ParseResult, ParseOptions } from "./parser.js";
+
+export { tokenize } from "./lexer.js";
+export type { LexResult } from "./lexer.js";
+
+export type { Token, TokenKind, TokenSpan } from "./token.js";
+export { KEYWORDS, PRIMITIVE_TYPE_KINDS } from "./token.js";
+
+export type {
+  Diagnostic,
+  DiagnosticSeverity,
+  Fix,
+  FixKind,
+  Position,
+  Span,
+} from "./diagnostic.js";
+export { DIAGNOSTIC_SCHEMA_VERSION } from "./diagnostic.js";
+
+export type {
+  // File + declarations
+  FileNode,
+  TopLevelDecl,
+  // Identifiers + literals
+  Ident,
+  LiteralNode,
+  StringLiteral,
+  IntegerLiteral,
+  DecimalLiteral,
+  BooleanLiteral,
+  IdentLiteral,
+  // Types
+  TypeNode,
+  PrimitiveType,
+  PrimitiveKind,
+  ArrayType,
+  NamedType,
+  OptionalType,
+  ReturnTypeNode,
+  ReturnArrayType,
+  // Enum
+  EnumDecl,
+  // Entity
+  EntityDecl,
+  DisplayBlock,
+  DisplayPropertyRef,
+  DisplayImage,
+  PropertyDecl,
+  QueryClause,
+  // Intent
+  IntentDecl,
+  MetaClause,
+  ParamDecl,
+  DynamicOptions,
+  ReturnsClause,
+  EntitlementsBlock,
+  InfoPlistBlock,
+  InfoPlistEntry,
+  // Summary
+  SummaryDecl,
+  SummaryTemplate,
+  SummaryWhen,
+  SummarySwitch,
+  SummaryCase,
+  SummaryValue,
+} from "./ast.js";

--- a/src/core/axint-dsl/lexer.ts
+++ b/src/core/axint-dsl/lexer.ts
@@ -1,0 +1,366 @@
+/**
+ * Axint DSL — Lexer
+ *
+ * Produces a flat token stream from source text. Whitespace and `#` line
+ * comments are skipped — neither carries meaning in the grammar. Every token
+ * carries an internal `TokenSpan` with both byte offsets (for fast source
+ * slicing and formatter round-trips) and full start/end line/column pairs
+ * (so a diagnostic's protocol span is a pure field-rename away — see
+ * `diagnostic-protocol.md` on the external `Span` shape).
+ *
+ * The lexer never throws. Unrecognized bytes become `UNKNOWN` tokens and an
+ * AX007 diagnostic; unterminated strings and unknown escapes do the same. The
+ * parser decides what an `UNKNOWN` means in context and re-syncs on the next
+ * recovery boundary. The stream always ends with a zero-width `EOF` so the
+ * parser can peek past the last real token without bounds checks.
+ */
+
+import type { Diagnostic, Span } from "./diagnostic.js";
+import type { Token, TokenKind, TokenSpan } from "./token.js";
+import { KEYWORDS } from "./token.js";
+
+export interface LexResult {
+  readonly tokens: readonly Token[];
+  /**
+   * Lexer-level diagnostics (unterminated string, invalid escape, unknown
+   * byte). Empty on a well-formed file. All emit code AX007 with `fix: null`
+   * — the closed six-kind FixKind set has no principled repair for lexical
+   * failures, and the spec pins schemaVersion 1.
+   */
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+export interface TokenizeOptions {
+  /** Path reported on diagnostics. Defaults to "<anonymous>". */
+  readonly sourceFile?: string;
+}
+
+/**
+ * Tokenize `.axint` source. Returns a stream that always ends with a
+ * zero-width EOF token at the source-length byte offset.
+ */
+export function tokenize(source: string, options: TokenizeOptions = {}): LexResult {
+  return new Lexer(source, options.sourceFile ?? "<anonymous>").run();
+}
+
+// ─── Internals ───────────────────────────────────────────────────────
+
+const PUNCTUATION: ReadonlyMap<number, TokenKind> = new Map<number, TokenKind>([
+  [0x7b, "LBRACE"], // {
+  [0x7d, "RBRACE"], // }
+  [0x5b, "LBRACKET"], // [
+  [0x5d, "RBRACKET"], // ]
+  [0x3a, "COLON"], // :
+  [0x3f, "QUESTION"], // ?
+]);
+
+interface Cursor {
+  readonly byte: number;
+  readonly line: number;
+  readonly column: number;
+}
+
+class Lexer {
+  private readonly tokens: Token[] = [];
+  private readonly diagnostics: Diagnostic[] = [];
+  private byte = 0;
+  private line = 1;
+  private column = 1;
+
+  constructor(
+    private readonly source: string,
+    private readonly file: string
+  ) {}
+
+  run(): LexResult {
+    // Strip a UTF-8 BOM if present — it would otherwise surface as an
+    // UNKNOWN token on byte 0.
+    if (this.source.charCodeAt(0) === 0xfeff) {
+      this.byte = 1;
+    }
+
+    while (this.byte < this.source.length) {
+      this.scanNext();
+    }
+
+    this.tokens.push({
+      kind: "EOF",
+      span: this.zeroWidthSpan(),
+      value: "",
+    });
+
+    return { tokens: this.tokens, diagnostics: this.diagnostics };
+  }
+
+  private scanNext(): void {
+    const code = this.source.charCodeAt(this.byte);
+
+    // Whitespace: space, tab, LF, CR.
+    if (code === 0x20 || code === 0x09 || code === 0x0a || code === 0x0d) {
+      this.advance();
+      return;
+    }
+
+    // Line comment: `#` … end of line.
+    if (code === 0x23) {
+      while (
+        this.byte < this.source.length &&
+        this.source.charCodeAt(this.byte) !== 0x0a
+      ) {
+        this.advance();
+      }
+      return;
+    }
+
+    const punctuation = PUNCTUATION.get(code);
+    if (punctuation !== undefined) {
+      const start = this.snapshot();
+      const lexeme = this.source[this.byte]!;
+      this.advance();
+      this.tokens.push({ kind: punctuation, span: this.spanFrom(start), value: lexeme });
+      return;
+    }
+
+    if (code === 0x22) {
+      this.scanString();
+      return;
+    }
+
+    // Leading `-` is only a number when followed by a digit. A bare `-`
+    // isn't in the grammar, so it lands as UNKNOWN.
+    if (code === 0x2d && isDigit(this.source.charCodeAt(this.byte + 1))) {
+      this.scanNumber();
+      return;
+    }
+
+    if (isDigit(code)) {
+      this.scanNumber();
+      return;
+    }
+
+    if (isIdentStart(code)) {
+      this.scanIdentifier();
+      return;
+    }
+
+    this.emitUnknown();
+  }
+
+  private scanString(): void {
+    const start = this.snapshot();
+    this.advance(); // consume opening "
+
+    let decoded = "";
+    let terminated = false;
+
+    while (this.byte < this.source.length) {
+      const c = this.source.charCodeAt(this.byte);
+
+      if (c === 0x22) {
+        this.advance();
+        terminated = true;
+        break;
+      }
+
+      if (c === 0x0a) {
+        // Grammar: no multi-line strings. Close the span before the newline
+        // so the error points at the body, not the next line.
+        break;
+      }
+
+      if (c === 0x5c) {
+        this.advance();
+        const esc = this.source.charCodeAt(this.byte);
+        switch (esc) {
+          case 0x22:
+            decoded += '"';
+            this.advance();
+            break;
+          case 0x5c:
+            decoded += "\\";
+            this.advance();
+            break;
+          case 0x6e:
+            decoded += "\n";
+            this.advance();
+            break;
+          case 0x74:
+            decoded += "\t";
+            this.advance();
+            break;
+          default: {
+            // Unknown escape — keep the literal char so recovery yields a
+            // usable value, emit AX007.
+            const bad = this.snapshot();
+            if (!Number.isNaN(esc)) {
+              decoded += this.source[this.byte];
+              this.advance();
+            }
+            this.diagnostics.push(
+              this.makeDiagnostic(
+                "AX007",
+                `unknown string escape \\${String.fromCharCode(esc)}`,
+                this.spanFrom(bad)
+              )
+            );
+            break;
+          }
+        }
+        continue;
+      }
+
+      decoded += this.source[this.byte];
+      this.advance();
+    }
+
+    const span = this.spanFrom(start);
+
+    if (!terminated) {
+      this.diagnostics.push(
+        this.makeDiagnostic("AX007", "unterminated string literal", span)
+      );
+    }
+
+    this.tokens.push({ kind: "STRING_LITERAL", span, value: decoded });
+  }
+
+  private scanNumber(): void {
+    const start = this.snapshot();
+
+    if (this.source.charCodeAt(this.byte) === 0x2d) {
+      this.advance();
+    }
+
+    while (this.byte < this.source.length && isDigit(this.source.charCodeAt(this.byte))) {
+      this.advance();
+    }
+
+    let isDecimal = false;
+    if (
+      this.source.charCodeAt(this.byte) === 0x2e &&
+      isDigit(this.source.charCodeAt(this.byte + 1))
+    ) {
+      isDecimal = true;
+      this.advance(); // .
+      while (
+        this.byte < this.source.length &&
+        isDigit(this.source.charCodeAt(this.byte))
+      ) {
+        this.advance();
+      }
+    }
+
+    const span = this.spanFrom(start);
+    const lexeme = this.source.slice(span.startByte, span.endByte);
+    this.tokens.push({
+      kind: isDecimal ? "DECIMAL_LITERAL" : "INTEGER_LITERAL",
+      span,
+      value: lexeme,
+    });
+  }
+
+  private scanIdentifier(): void {
+    const start = this.snapshot();
+
+    while (
+      this.byte < this.source.length &&
+      isIdentPart(this.source.charCodeAt(this.byte))
+    ) {
+      this.advance();
+    }
+
+    const span = this.spanFrom(start);
+    const lexeme = this.source.slice(span.startByte, span.endByte);
+    const kind = KEYWORDS[lexeme] ?? "IDENTIFIER";
+    this.tokens.push({ kind, span, value: lexeme });
+  }
+
+  private emitUnknown(): void {
+    const start = this.snapshot();
+    const lexeme = this.source[this.byte]!;
+    this.advance();
+    const span = this.spanFrom(start);
+    this.tokens.push({ kind: "UNKNOWN", span, value: lexeme });
+    this.diagnostics.push(
+      this.makeDiagnostic("AX007", `unexpected character ${JSON.stringify(lexeme)}`, span)
+    );
+  }
+
+  // ─── Cursor + span helpers ─────────────────────────────────────────
+
+  private advance(): void {
+    const code = this.source.charCodeAt(this.byte);
+    this.byte += 1;
+    if (code === 0x0a) {
+      this.line += 1;
+      this.column = 1;
+    } else {
+      this.column += 1;
+    }
+  }
+
+  private snapshot(): Cursor {
+    return { byte: this.byte, line: this.line, column: this.column };
+  }
+
+  private spanFrom(start: Cursor): TokenSpan {
+    return {
+      startByte: start.byte,
+      endByte: this.byte,
+      startLine: start.line,
+      startColumn: start.column,
+      endLine: this.line,
+      endColumn: this.column,
+    };
+  }
+
+  private zeroWidthSpan(): TokenSpan {
+    return {
+      startByte: this.byte,
+      endByte: this.byte,
+      startLine: this.line,
+      startColumn: this.column,
+      endLine: this.line,
+      endColumn: this.column,
+    };
+  }
+
+  private makeDiagnostic(code: string, message: string, span: TokenSpan): Diagnostic {
+    return {
+      schemaVersion: 1,
+      code,
+      severity: "error",
+      message,
+      file: this.file,
+      span: toProtocolSpan(span),
+      fix: null,
+    };
+  }
+}
+
+/**
+ * Convert an internal `TokenSpan` to the external protocol `Span`. Pure
+ * field-rename — no coordinate math.
+ */
+export function toProtocolSpan(span: TokenSpan): Span {
+  return {
+    start: { line: span.startLine, column: span.startColumn },
+    end: { line: span.endLine, column: span.endColumn },
+  };
+}
+
+function isDigit(code: number): boolean {
+  return code >= 0x30 && code <= 0x39;
+}
+
+function isIdentStart(code: number): boolean {
+  return (
+    (code >= 0x41 && code <= 0x5a) || // A-Z
+    (code >= 0x61 && code <= 0x7a) || // a-z
+    code === 0x5f // _
+  );
+}
+
+function isIdentPart(code: number): boolean {
+  return isIdentStart(code) || isDigit(code);
+}

--- a/src/core/axint-dsl/parser.ts
+++ b/src/core/axint-dsl/parser.ts
@@ -191,18 +191,6 @@ class Parser {
 
     const endSpan = this.tokens[this.tokens.length - 1]!.span;
 
-    // Empty files emit AX001 per spec. An empty file means zero top-level
-    // declarations — comments, whitespace, and lexer noise don't count.
-    if (declarations.length === 0 && this.diagnostics.length === 0) {
-      const span = this.tokens[0]?.span ?? endSpan;
-      this.emit({
-        code: "AX001",
-        message: "expected `intent`, `entity`, or `enum` declaration",
-        span,
-        fix: null,
-      });
-    }
-
     return {
       kind: "File",
       span: spanBetween(startSpan, endSpan),

--- a/src/core/axint-dsl/parser.ts
+++ b/src/core/axint-dsl/parser.ts
@@ -1,0 +1,1504 @@
+/**
+ * Axint DSL — Parser
+ *
+ * Recursive-descent single-pass parser. Produces a best-effort AST and a
+ * flat diagnostic stream from one call. Parse errors are data: the parser
+ * records them, skips to the nearest structural recovery boundary defined
+ * in spec/language/parser-recovery.md, and keeps going.
+ *
+ * Recovery boundaries (closed set — changing this bumps the parser-recovery
+ * protocol line):
+ *   1. the closing `}` of the current block
+ *   2. the next top-level keyword (`intent` / `entity` / `enum`)
+ *   3. the next field-start keyword for the current block kind
+ *   4. end-of-line, when the error is contained to a single field
+ *
+ * Invariant: every reachable code path either produces an AST node or emits
+ * at least one diagnostic. A silent drop is a parser bug.
+ */
+
+import type {
+  ArrayType,
+  BooleanLiteral,
+  DecimalLiteral,
+  DisplayBlock,
+  DisplayImage,
+  DisplayPropertyRef,
+  DynamicOptions,
+  EntitlementsBlock,
+  EntityDecl,
+  EnumDecl,
+  FileNode,
+  Ident,
+  IdentLiteral,
+  InfoPlistBlock,
+  InfoPlistEntry,
+  IntegerLiteral,
+  IntentDecl,
+  LiteralNode,
+  MetaClause,
+  NamedType,
+  OptionalType,
+  ParamDecl,
+  PrimitiveKind,
+  PrimitiveType,
+  PropertyDecl,
+  QueryClause,
+  ReturnArrayType,
+  ReturnTypeNode,
+  ReturnsClause,
+  StringLiteral,
+  SummaryCase,
+  SummaryDecl,
+  SummarySwitch,
+  SummaryValue,
+  SummaryWhen,
+  TopLevelDecl,
+  TypeNode,
+} from "./ast.js";
+import type { Diagnostic, Fix } from "./diagnostic.js";
+import type { Token, TokenKind, TokenSpan } from "./token.js";
+import { toProtocolSpan, tokenize } from "./lexer.js";
+
+export interface ParseResult {
+  /**
+   * Best-effort AST. On a completely empty or unsalvageable file the `File`
+   * node is still returned with an empty `declarations` array — callers get
+   * a stable shape in every error case.
+   */
+  readonly file: FileNode;
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+export interface ParseOptions {
+  /**
+   * Logical file path reported on every diagnostic emitted by this parse.
+   * Defaults to "<anonymous>" so callers can parse in-memory strings without
+   * threading a path.
+   */
+  readonly sourceFile?: string;
+}
+
+export function parse(source: string, options: ParseOptions = {}): ParseResult {
+  const file = options.sourceFile ?? "<anonymous>";
+  const { tokens, diagnostics: lexerDiagnostics } = tokenize(source, {
+    sourceFile: file,
+  });
+  const parser = new Parser(tokens, file);
+  const fileNode = parser.parseFile();
+  return {
+    file: fileNode,
+    diagnostics: [...lexerDiagnostics, ...parser.diagnostics],
+  };
+}
+
+// ─── Internals ───────────────────────────────────────────────────────
+
+const TOP_LEVEL_KEYWORDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
+  "INTENT",
+  "ENTITY",
+  "ENUM",
+]);
+
+const INTENT_META_KEYWORDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
+  "DOMAIN",
+  "CATEGORY",
+  "DISCOVERABLE",
+  "DONATE_ON_PERFORM",
+]);
+
+const INTENT_BODY_KEYWORDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
+  "TITLE",
+  "DESCRIPTION",
+  "DOMAIN",
+  "CATEGORY",
+  "DISCOVERABLE",
+  "DONATE_ON_PERFORM",
+  "PARAM",
+  "SUMMARY",
+  "RETURNS",
+  "ENTITLEMENTS",
+  "INFO_PLIST_KEYS",
+]);
+
+const ENTITY_BODY_KEYWORDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
+  "DISPLAY",
+  "PROPERTY",
+  "QUERY",
+]);
+
+const PARAM_BODY_KEYWORDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
+  "DESCRIPTION",
+  "DEFAULT",
+  "OPTIONS",
+]);
+
+const PROPERTY_BODY_KEYWORDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
+  "DESCRIPTION",
+]);
+
+const DISPLAY_BODY_KEYWORDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
+  "TITLE",
+  "SUBTITLE",
+  "IMAGE",
+]);
+
+const SWITCH_BODY_KEYWORDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
+  "CASE",
+  "DEFAULT",
+]);
+
+const PRIMITIVE_KIND_BY_TOKEN: ReadonlyMap<TokenKind, PrimitiveKind> = new Map([
+  ["TYPE_STRING", "string"],
+  ["TYPE_INT", "int"],
+  ["TYPE_DOUBLE", "double"],
+  ["TYPE_FLOAT", "float"],
+  ["TYPE_BOOLEAN", "boolean"],
+  ["TYPE_DATE", "date"],
+  ["TYPE_DURATION", "duration"],
+  ["TYPE_URL", "url"],
+]);
+
+const QUERY_KINDS: ReadonlySet<string> = new Set(["all", "id", "string", "property"]);
+
+class Parser {
+  readonly diagnostics: Diagnostic[] = [];
+  private pos = 0;
+
+  constructor(
+    private readonly tokens: readonly Token[],
+    private readonly file: string
+  ) {}
+
+  // ─── Entry ─────────────────────────────────────────────────────────
+
+  parseFile(): FileNode {
+    const startSpan = this.peek().span;
+    const declarations: TopLevelDecl[] = [];
+
+    while (!this.atEnd()) {
+      const decl = this.parseTopLevelDecl();
+      if (decl !== null) {
+        declarations.push(decl);
+      } else {
+        // parseTopLevelDecl emitted a diagnostic and did not consume — force
+        // progress so we can't loop forever on garbage.
+        if (!this.recoverToTopLevel()) {
+          break;
+        }
+      }
+    }
+
+    const endSpan = this.tokens[this.tokens.length - 1]!.span;
+
+    // Empty files emit AX001 per spec. An empty file means zero top-level
+    // declarations — comments, whitespace, and lexer noise don't count.
+    if (declarations.length === 0 && this.diagnostics.length === 0) {
+      const span = this.tokens[0]?.span ?? endSpan;
+      this.emit({
+        code: "AX001",
+        message: "expected `intent`, `entity`, or `enum` declaration",
+        span,
+        fix: null,
+      });
+    }
+
+    return {
+      kind: "File",
+      span: spanBetween(startSpan, endSpan),
+      declarations,
+    };
+  }
+
+  private parseTopLevelDecl(): TopLevelDecl | null {
+    const kind = this.peekKind();
+    switch (kind) {
+      case "INTENT":
+        return this.parseIntentDecl();
+      case "ENTITY":
+        return this.parseEntityDecl();
+      case "ENUM":
+        return this.parseEnumDecl();
+      default: {
+        this.emit({
+          code: "AX001",
+          message: `unexpected ${describeToken(this.peek())} at top level, expected \`intent\`, \`entity\`, or \`enum\``,
+          span: this.peek().span,
+          fix: null,
+        });
+        return null;
+      }
+    }
+  }
+
+  // ─── Enum ──────────────────────────────────────────────────────────
+
+  private parseEnumDecl(): EnumDecl | null {
+    const start = this.consume(); // ENUM
+    const name = this.expectIdent("AX002", "enum name");
+    if (!name) {
+      this.recoverToTopLevel();
+      return null;
+    }
+
+    const lbrace = this.expectPunctuation("LBRACE", "`{` to start enum body");
+    if (!lbrace) {
+      this.recoverToTopLevel();
+      return null;
+    }
+
+    const cases: Ident[] = [];
+    while (!this.atEnd() && this.peekKind() !== "RBRACE") {
+      const caseIdent = this.expectIdent("AX007", "enum case");
+      if (caseIdent) {
+        cases.push(caseIdent);
+      } else {
+        // expectIdent already emitted a diagnostic; advance past the bad token
+        // to avoid an infinite loop.
+        if (this.peekKind() !== "RBRACE") this.advance();
+      }
+    }
+
+    const rbrace = this.expectPunctuation("RBRACE", "`}` to close enum body");
+    const endSpan = rbrace?.span ?? this.previousSpan();
+    return {
+      kind: "EnumDecl",
+      span: spanBetween(start.span, endSpan),
+      name,
+      cases,
+    };
+  }
+
+  // ─── Entity ────────────────────────────────────────────────────────
+
+  private parseEntityDecl(): EntityDecl | null {
+    const start = this.consume(); // ENTITY
+    const name = this.expectIdent("AX002", "entity name");
+    if (!name) {
+      this.recoverToTopLevel();
+      return null;
+    }
+
+    const lbrace = this.expectPunctuation("LBRACE", "`{` to start entity body");
+    if (!lbrace) {
+      this.recoverToTopLevel();
+      return null;
+    }
+
+    let display: DisplayBlock | undefined;
+    const properties: PropertyDecl[] = [];
+    let query: QueryClause | undefined;
+
+    while (!this.atEnd() && this.peekKind() !== "RBRACE") {
+      const kind = this.peekKind();
+      if (kind === "DISPLAY") {
+        const block = this.parseDisplayBlock();
+        if (block && !display) display = block;
+      } else if (kind === "PROPERTY") {
+        const prop = this.parsePropertyDecl();
+        if (prop) properties.push(prop);
+      } else if (kind === "QUERY") {
+        const q = this.parseQueryClause();
+        if (q && !query) query = q;
+      } else {
+        this.emit({
+          code: "AX007",
+          message: `unexpected ${describeToken(this.peek())} in entity body`,
+          span: this.peek().span,
+          fix: null,
+        });
+        this.recoverToFieldOrBlockEnd(ENTITY_BODY_KEYWORDS);
+      }
+    }
+
+    const rbrace = this.expectPunctuation("RBRACE", "`}` to close entity body");
+    const endSpan = rbrace?.span ?? this.previousSpan();
+    const entitySpan = spanBetween(start.span, endSpan);
+
+    if (!display) {
+      this.emit({
+        code: "AX015",
+        message: "entity is missing `display` block",
+        span: this.zeroWidthAfter(lbrace.span),
+        fix: {
+          kind: "insert_required_clause",
+          targetSpan: toProtocolSpan(this.zeroWidthAfter(lbrace.span)),
+          suggestedEdit: {
+            text: '\n  display {\n    title: name\n    image: "square.stack.fill"\n  }\n',
+          },
+        },
+      });
+      display = {
+        kind: "DisplayBlock",
+        span: this.zeroWidthAfter(lbrace.span),
+        title: placeholderDisplayRef("title", this.zeroWidthAfter(lbrace.span)),
+      };
+    }
+
+    if (!query) {
+      this.emit({
+        code: "AX017",
+        message: "entity is missing `query` clause",
+        span: this.zeroWidthBefore(endSpan),
+        fix: {
+          kind: "insert_required_clause",
+          targetSpan: toProtocolSpan(this.zeroWidthBefore(endSpan)),
+          suggestedEdit: { text: "\n  query: all\n" },
+        },
+      });
+      query = {
+        kind: "QueryClause",
+        span: this.zeroWidthBefore(endSpan),
+        queryKind: "all",
+      };
+    }
+
+    return {
+      kind: "EntityDecl",
+      span: entitySpan,
+      name,
+      display,
+      properties,
+      query,
+    };
+  }
+
+  private parseDisplayBlock(): DisplayBlock | null {
+    const start = this.consume(); // DISPLAY
+    const lbrace = this.expectPunctuation("LBRACE", "`{` to start display block");
+    if (!lbrace) {
+      this.recoverToFieldOrBlockEnd(ENTITY_BODY_KEYWORDS);
+      return null;
+    }
+
+    let title: DisplayPropertyRef | undefined;
+    let subtitle: DisplayPropertyRef | undefined;
+    let image: DisplayImage | undefined;
+
+    while (!this.atEnd() && this.peekKind() !== "RBRACE") {
+      const kind = this.peekKind();
+      if (kind === "TITLE" || kind === "SUBTITLE") {
+        const ref = this.parseDisplayPropertyRef();
+        if (ref) {
+          if (ref.field === "title" && !title) title = ref;
+          else if (ref.field === "subtitle" && !subtitle) subtitle = ref;
+        }
+      } else if (kind === "IMAGE") {
+        const img = this.parseDisplayImage();
+        if (img && !image) image = img;
+      } else {
+        this.emit({
+          code: "AX007",
+          message: `unexpected ${describeToken(this.peek())} in display block`,
+          span: this.peek().span,
+          fix: null,
+        });
+        this.recoverToFieldOrBlockEnd(DISPLAY_BODY_KEYWORDS);
+      }
+    }
+
+    const rbrace = this.expectPunctuation("RBRACE", "`}` to close display block");
+    const endSpan = rbrace?.span ?? this.previousSpan();
+
+    if (!title) {
+      this.emit({
+        code: "AX016",
+        message: "display block is missing `title`",
+        span: this.zeroWidthAfter(lbrace.span),
+        fix: {
+          kind: "insert_required_clause",
+          targetSpan: toProtocolSpan(this.zeroWidthAfter(lbrace.span)),
+          suggestedEdit: { text: "\n    title: name" },
+        },
+      });
+      title = placeholderDisplayRef("title", this.zeroWidthAfter(lbrace.span));
+    }
+
+    return {
+      kind: "DisplayBlock",
+      span: spanBetween(start.span, endSpan),
+      title,
+      subtitle,
+      image,
+    };
+  }
+
+  private parseDisplayPropertyRef(): DisplayPropertyRef | null {
+    const keyword = this.consume();
+    const field = keyword.kind === "TITLE" ? "title" : "subtitle";
+    if (!this.expectPunctuation("COLON", `\`:\` after \`${field}\``)) {
+      this.recoverToEndOfLine(keyword.span.startLine);
+      return null;
+    }
+    const ident = this.expectIdent("AX007", "property reference");
+    if (!ident) {
+      this.recoverToEndOfLine(keyword.span.startLine);
+      return null;
+    }
+    return {
+      kind: "DisplayPropertyRef",
+      span: spanBetween(keyword.span, ident.span),
+      field,
+      property: ident,
+    };
+  }
+
+  private parseDisplayImage(): DisplayImage | null {
+    const start = this.consume(); // IMAGE
+    if (!this.expectPunctuation("COLON", "`:` after `image`")) {
+      this.recoverToEndOfLine(start.span.startLine);
+      return null;
+    }
+    const str = this.expectStringLiteral("image asset name");
+    if (!str) {
+      this.recoverToEndOfLine(start.span.startLine);
+      return null;
+    }
+    return {
+      kind: "DisplayImage",
+      span: spanBetween(start.span, str.span),
+      asset: str,
+    };
+  }
+
+  private parsePropertyDecl(): PropertyDecl | null {
+    const start = this.consume(); // PROPERTY
+    const name = this.expectIdent("AX007", "property name");
+    if (!name) {
+      this.recoverToFieldOrBlockEnd(ENTITY_BODY_KEYWORDS);
+      return null;
+    }
+    if (!this.expectPunctuation("COLON", "`:` after property name")) {
+      this.recoverToFieldOrBlockEnd(ENTITY_BODY_KEYWORDS);
+      return null;
+    }
+    const type = this.parseType();
+    if (!type) {
+      this.recoverToFieldOrBlockEnd(ENTITY_BODY_KEYWORDS);
+      return null;
+    }
+    const lbrace = this.expectPunctuation("LBRACE", "`{` to start property body");
+    if (!lbrace) {
+      this.recoverToFieldOrBlockEnd(ENTITY_BODY_KEYWORDS);
+      return null;
+    }
+
+    const description = this.parseRequiredDescription("property", lbrace.span);
+
+    // Property body in v1 only accepts `description`. Anything else is AX007.
+    while (!this.atEnd() && this.peekKind() !== "RBRACE") {
+      this.emit({
+        code: "AX007",
+        message: `unexpected ${describeToken(this.peek())} in property body — only \`description\` is allowed`,
+        span: this.peek().span,
+        fix: null,
+      });
+      this.recoverToFieldOrBlockEnd(PROPERTY_BODY_KEYWORDS);
+    }
+
+    const rbrace = this.expectPunctuation("RBRACE", "`}` to close property body");
+    const endSpan = rbrace?.span ?? this.previousSpan();
+
+    return {
+      kind: "PropertyDecl",
+      span: spanBetween(start.span, endSpan),
+      name,
+      type,
+      description,
+    };
+  }
+
+  private parseQueryClause(): QueryClause | null {
+    const start = this.consume(); // QUERY
+    if (!this.expectPunctuation("COLON", "`:` after `query`")) {
+      this.recoverToEndOfLine(start.span.startLine);
+      return null;
+    }
+
+    // Grammar: query-kind = "all" | "id" | "string" | "property"
+    // `string` and `property` lex as keyword tokens, `all` and `id` as identifiers.
+    const next = this.peek();
+    const kindHoldsQueryValue =
+      next.kind === "IDENTIFIER" ||
+      next.kind === "TYPE_STRING" ||
+      next.kind === "PROPERTY";
+    if (!kindHoldsQueryValue) {
+      this.emit({
+        code: "AX018",
+        message: `expected query kind, got ${describeToken(next)}`,
+        span: next.span,
+        fix: null,
+      });
+      this.recoverToEndOfLine(start.span.startLine);
+      return null;
+    }
+
+    const tok = this.consume();
+    if (!QUERY_KINDS.has(tok.value)) {
+      this.emit({
+        code: "AX018",
+        message: `unknown query kind \`${tok.value}\``,
+        span: tok.span,
+        fix: {
+          kind: "replace_literal",
+          targetSpan: toProtocolSpan(tok.span),
+          candidates: [...QUERY_KINDS],
+        },
+      });
+      return {
+        kind: "QueryClause",
+        span: spanBetween(start.span, tok.span),
+        queryKind: "all",
+      };
+    }
+
+    return {
+      kind: "QueryClause",
+      span: spanBetween(start.span, tok.span),
+      queryKind: tok.value as QueryClause["queryKind"],
+    };
+  }
+
+  // ─── Intent ────────────────────────────────────────────────────────
+
+  private parseIntentDecl(): IntentDecl | null {
+    const start = this.consume(); // INTENT
+    const name = this.expectIdent("AX002", "intent name");
+    if (!name) {
+      this.recoverToTopLevel();
+      return null;
+    }
+
+    const lbrace = this.expectPunctuation("LBRACE", "`{` to start intent body");
+    if (!lbrace) {
+      this.recoverToTopLevel();
+      return null;
+    }
+
+    const title = this.parseRequiredStringField("TITLE", "title", "AX003", lbrace.span);
+    const description = this.parseRequiredStringField(
+      "DESCRIPTION",
+      "description",
+      "AX004",
+      lbrace.span
+    );
+
+    const meta: MetaClause[] = [];
+    while (!this.atEnd() && INTENT_META_KEYWORDS.has(this.peekKind())) {
+      const clause = this.parseMetaClause();
+      if (clause) meta.push(clause);
+    }
+
+    const params: ParamDecl[] = [];
+    while (!this.atEnd() && this.peekKind() === "PARAM") {
+      const param = this.parseParamDecl();
+      if (param) params.push(param);
+    }
+
+    let summary: SummaryDecl | undefined;
+    if (this.peekKind() === "SUMMARY") {
+      summary = this.parseSummary() ?? undefined;
+    }
+
+    let returns: ReturnsClause | undefined;
+    if (this.peekKind() === "RETURNS") {
+      returns = this.parseReturnsClause() ?? undefined;
+    }
+
+    let entitlements: EntitlementsBlock | undefined;
+    if (this.peekKind() === "ENTITLEMENTS") {
+      entitlements = this.parseEntitlements() ?? undefined;
+    }
+
+    let infoPlistKeys: InfoPlistBlock | undefined;
+    if (this.peekKind() === "INFO_PLIST_KEYS") {
+      infoPlistKeys = this.parseInfoPlistKeys() ?? undefined;
+    }
+
+    // After the ordered pass, anything left in the body is out-of-order or
+    // unknown. Per parser-recovery.md example #3, an unexpected top-level
+    // keyword here means a missing `}` — resync at the next top-level.
+    while (!this.atEnd() && this.peekKind() !== "RBRACE") {
+      if (TOP_LEVEL_KEYWORDS.has(this.peekKind())) {
+        this.emit({
+          code: "AX001",
+          message: `unexpected ${describeToken(this.peek())} inside intent body, expected \`}\``,
+          span: this.zeroWidthBefore(this.peek().span),
+          fix: {
+            kind: "insert_required_clause",
+            targetSpan: toProtocolSpan(this.zeroWidthBefore(this.peek().span)),
+            suggestedEdit: { text: "}\n" },
+          },
+        });
+        return {
+          kind: "IntentDecl",
+          span: spanBetween(start.span, this.previousSpan()),
+          name,
+          title,
+          description,
+          meta,
+          params,
+          summary,
+          returns,
+          entitlements,
+          infoPlistKeys,
+        };
+      }
+
+      this.emit({
+        code: "AX007",
+        message: `unexpected ${describeToken(this.peek())} in intent body`,
+        span: this.peek().span,
+        fix: null,
+      });
+      this.recoverToFieldOrBlockEnd(INTENT_BODY_KEYWORDS);
+    }
+
+    const rbrace = this.expectPunctuation("RBRACE", "`}` to close intent body");
+    const endSpan = rbrace?.span ?? this.previousSpan();
+    return {
+      kind: "IntentDecl",
+      span: spanBetween(start.span, endSpan),
+      name,
+      title,
+      description,
+      meta,
+      params,
+      summary,
+      returns,
+      entitlements,
+      infoPlistKeys,
+    };
+  }
+
+  private parseRequiredStringField(
+    keyword: TokenKind,
+    keywordText: string,
+    missingCode: string,
+    anchor: TokenSpan
+  ): StringLiteral {
+    if (this.peekKind() !== keyword) {
+      const insertSpan = this.zeroWidthAfter(anchor);
+      this.emit({
+        code: missingCode,
+        message: `intent is missing \`${keywordText}\` clause`,
+        span: insertSpan,
+        fix: {
+          kind: "insert_required_clause",
+          targetSpan: toProtocolSpan(insertSpan),
+          suggestedEdit: { text: `\n  ${keywordText}: ""` },
+        },
+      });
+      return emptyStringLiteral(insertSpan);
+    }
+
+    const kw = this.consume();
+    if (!this.expectPunctuation("COLON", `\`:\` after \`${keywordText}\``)) {
+      this.recoverToEndOfLine(kw.span.startLine);
+      return emptyStringLiteral(kw.span);
+    }
+    const value = this.expectStringLiteral(keywordText);
+    if (!value) {
+      this.recoverToEndOfLine(kw.span.startLine);
+      return emptyStringLiteral(kw.span);
+    }
+    return value;
+  }
+
+  private parseMetaClause(): MetaClause | null {
+    const kw = this.consume();
+    const kind = kw.kind;
+    if (!this.expectPunctuation("COLON", `\`:\` after \`${kw.value}\``)) {
+      this.recoverToEndOfLine(kw.span.startLine);
+      return null;
+    }
+
+    if (kind === "DOMAIN" || kind === "CATEGORY") {
+      const value = this.expectStringLiteral(`${kw.value} value`);
+      if (!value) {
+        this.recoverToEndOfLine(kw.span.startLine);
+        return null;
+      }
+      return kind === "DOMAIN"
+        ? { kind: "DomainMeta", span: spanBetween(kw.span, value.span), value }
+        : { kind: "CategoryMeta", span: spanBetween(kw.span, value.span), value };
+    }
+
+    // DISCOVERABLE / DONATE_ON_PERFORM
+    const bool = this.expectBooleanLiteral(`${kw.value} value`);
+    if (!bool) {
+      this.recoverToEndOfLine(kw.span.startLine);
+      return null;
+    }
+    return kind === "DISCOVERABLE"
+      ? { kind: "DiscoverableMeta", span: spanBetween(kw.span, bool.span), value: bool }
+      : {
+          kind: "DonateOnPerformMeta",
+          span: spanBetween(kw.span, bool.span),
+          value: bool,
+        };
+  }
+
+  private parseParamDecl(): ParamDecl | null {
+    const start = this.consume(); // PARAM
+    const name = this.expectIdent("AX007", "param name");
+    if (!name) {
+      this.recoverToFieldOrBlockEnd(INTENT_BODY_KEYWORDS);
+      return null;
+    }
+    if (!this.expectPunctuation("COLON", "`:` after param name")) {
+      this.recoverToFieldOrBlockEnd(INTENT_BODY_KEYWORDS);
+      return null;
+    }
+    const type = this.parseType();
+    if (!type) {
+      this.recoverToFieldOrBlockEnd(INTENT_BODY_KEYWORDS);
+      return null;
+    }
+    const lbrace = this.expectPunctuation("LBRACE", "`{` to start param body");
+    if (!lbrace) {
+      this.recoverToFieldOrBlockEnd(INTENT_BODY_KEYWORDS);
+      return null;
+    }
+
+    const description = this.parseRequiredDescription("param", lbrace.span);
+    let defaultValue: LiteralNode | undefined;
+    let options: DynamicOptions | undefined;
+
+    while (!this.atEnd() && this.peekKind() !== "RBRACE") {
+      const kind = this.peekKind();
+      if (kind === "DEFAULT") {
+        const def = this.parseDefaultValue();
+        if (def && !defaultValue) defaultValue = def;
+      } else if (kind === "OPTIONS") {
+        const opt = this.parseDynamicOptions();
+        if (opt && !options) options = opt;
+      } else {
+        this.emit({
+          code: "AX007",
+          message: `unexpected ${describeToken(this.peek())} in param body`,
+          span: this.peek().span,
+          fix: null,
+        });
+        this.recoverToFieldOrBlockEnd(PARAM_BODY_KEYWORDS);
+      }
+    }
+
+    const rbrace = this.expectPunctuation("RBRACE", "`}` to close param body");
+    const endSpan = rbrace?.span ?? this.previousSpan();
+    return {
+      kind: "ParamDecl",
+      span: spanBetween(start.span, endSpan),
+      name,
+      type,
+      description,
+      defaultValue,
+      options,
+    };
+  }
+
+  private parseRequiredDescription(context: string, anchor: TokenSpan): StringLiteral {
+    if (this.peekKind() !== "DESCRIPTION") {
+      const insertSpan = this.zeroWidthAfter(anchor);
+      this.emit({
+        code: "AX104",
+        message: `${context} body is missing required \`description\` field`,
+        span: insertSpan,
+        fix: {
+          kind: "insert_required_clause",
+          targetSpan: toProtocolSpan(insertSpan),
+          suggestedEdit: { text: '\n    description: ""' },
+        },
+      });
+      return emptyStringLiteral(insertSpan);
+    }
+    const kw = this.consume();
+    if (!this.expectPunctuation("COLON", "`:` after `description`")) {
+      this.recoverToEndOfLine(kw.span.startLine);
+      return emptyStringLiteral(kw.span);
+    }
+    const value = this.expectStringLiteral("description value");
+    if (!value) {
+      this.recoverToEndOfLine(kw.span.startLine);
+      return emptyStringLiteral(kw.span);
+    }
+    return value;
+  }
+
+  private parseDefaultValue(): LiteralNode | null {
+    const kw = this.consume(); // DEFAULT
+    if (!this.expectPunctuation("COLON", "`:` after `default`")) {
+      this.recoverToEndOfLine(kw.span.startLine);
+      return null;
+    }
+    return this.parseLiteral();
+  }
+
+  private parseDynamicOptions(): DynamicOptions | null {
+    const kw = this.consume(); // OPTIONS
+    if (!this.expectPunctuation("COLON", "`:` after `options`")) {
+      this.recoverToEndOfLine(kw.span.startLine);
+      return null;
+    }
+    if (this.peekKind() !== "DYNAMIC") {
+      this.emit({
+        code: "AX007",
+        message: `expected \`dynamic\` after \`options:\`, got ${describeToken(this.peek())}`,
+        span: this.peek().span,
+        fix: null,
+      });
+      this.recoverToEndOfLine(kw.span.startLine);
+      return null;
+    }
+    this.consume(); // DYNAMIC
+    const provider = this.expectIdent("AX007", "options provider");
+    if (!provider) {
+      this.recoverToEndOfLine(kw.span.startLine);
+      return null;
+    }
+    return {
+      kind: "DynamicOptions",
+      span: spanBetween(kw.span, provider.span),
+      provider,
+    };
+  }
+
+  private parseReturnsClause(): ReturnsClause | null {
+    const start = this.consume(); // RETURNS
+    if (!this.expectPunctuation("COLON", "`:` after `returns`")) {
+      this.recoverToEndOfLine(start.span.startLine);
+      return null;
+    }
+    const type = this.parseReturnType();
+    if (!type) {
+      this.recoverToEndOfLine(start.span.startLine);
+      return null;
+    }
+    return {
+      kind: "ReturnsClause",
+      span: spanBetween(start.span, type.span),
+      type,
+    };
+  }
+
+  private parseEntitlements(): EntitlementsBlock | null {
+    const start = this.consume(); // ENTITLEMENTS
+    const lbrace = this.expectPunctuation("LBRACE", "`{` to start entitlements block");
+    if (!lbrace) {
+      this.recoverToFieldOrBlockEnd(INTENT_BODY_KEYWORDS);
+      return null;
+    }
+
+    const values: StringLiteral[] = [];
+    while (!this.atEnd() && this.peekKind() !== "RBRACE") {
+      if (this.peekKind() === "STRING_LITERAL") {
+        values.push(this.consumeStringLiteral());
+      } else {
+        this.emit({
+          code: "AX007",
+          message: `expected string literal in entitlements block, got ${describeToken(this.peek())}`,
+          span: this.peek().span,
+          fix: null,
+        });
+        this.advance();
+      }
+    }
+
+    const rbrace = this.expectPunctuation("RBRACE", "`}` to close entitlements block");
+    const endSpan = rbrace?.span ?? this.previousSpan();
+    return {
+      kind: "EntitlementsBlock",
+      span: spanBetween(start.span, endSpan),
+      values,
+    };
+  }
+
+  private parseInfoPlistKeys(): InfoPlistBlock | null {
+    const start = this.consume(); // INFO_PLIST_KEYS
+    const lbrace = this.expectPunctuation("LBRACE", "`{` to start infoPlistKeys block");
+    if (!lbrace) {
+      this.recoverToFieldOrBlockEnd(INTENT_BODY_KEYWORDS);
+      return null;
+    }
+
+    const entries: InfoPlistEntry[] = [];
+    while (!this.atEnd() && this.peekKind() !== "RBRACE") {
+      if (this.peekKind() !== "STRING_LITERAL") {
+        this.emit({
+          code: "AX007",
+          message: `expected key string in infoPlistKeys block, got ${describeToken(this.peek())}`,
+          span: this.peek().span,
+          fix: null,
+        });
+        this.advance();
+        continue;
+      }
+      const key = this.consumeStringLiteral();
+      if (!this.expectPunctuation("COLON", "`:` between infoPlistKeys key and value")) {
+        this.recoverToEndOfLine(key.span.startLine);
+        continue;
+      }
+      const value = this.expectStringLiteral("infoPlistKeys value");
+      if (!value) {
+        this.recoverToEndOfLine(key.span.startLine);
+        continue;
+      }
+      entries.push({
+        kind: "InfoPlistEntry",
+        span: spanBetween(key.span, value.span),
+        key,
+        value,
+      });
+    }
+
+    const rbrace = this.expectPunctuation("RBRACE", "`}` to close infoPlistKeys block");
+    const endSpan = rbrace?.span ?? this.previousSpan();
+    return {
+      kind: "InfoPlistBlock",
+      span: spanBetween(start.span, endSpan),
+      entries,
+    };
+  }
+
+  // ─── Summary ───────────────────────────────────────────────────────
+
+  private parseSummary(): SummaryDecl | null {
+    const start = this.consume(); // SUMMARY
+    return this.parseSummaryForm(start.span);
+  }
+
+  private parseSummaryForm(startSpan: TokenSpan): SummaryDecl | null {
+    const kind = this.peekKind();
+    if (kind === "COLON") {
+      this.consume();
+      const template = this.expectStringLiteral("summary template");
+      if (!template) return null;
+      return {
+        kind: "SummaryTemplate",
+        span: spanBetween(startSpan, template.span),
+        template,
+      };
+    }
+    if (kind === "WHEN") {
+      return this.parseSummaryWhen(startSpan);
+    }
+    if (kind === "SWITCH") {
+      return this.parseSummarySwitch(startSpan);
+    }
+    this.emit({
+      code: "AX007",
+      message: `expected \`:\`, \`when\`, or \`switch\` after \`summary\`, got ${describeToken(this.peek())}`,
+      span: this.peek().span,
+      fix: null,
+    });
+    return null;
+  }
+
+  private parseSummaryWhen(summaryStart: TokenSpan): SummaryWhen | null {
+    this.consume(); // WHEN
+    const param = this.expectIdent("AX007", "param name");
+    if (!param) return null;
+    const lbrace = this.expectPunctuation("LBRACE", "`{` to start summary when body");
+    if (!lbrace) return null;
+
+    let then: SummaryValue | undefined;
+    let otherwise: SummaryValue | undefined;
+
+    while (!this.atEnd() && this.peekKind() !== "RBRACE") {
+      const kind = this.peekKind();
+      if (kind === "THEN") {
+        const kw = this.consume();
+        if (!this.expectPunctuation("COLON", "`:` after `then`")) {
+          this.recoverToFieldOrBlockEnd(new Set<TokenKind>(["THEN", "OTHERWISE"]));
+          continue;
+        }
+        const value = this.parseSummaryValue();
+        if (value && !then) then = value;
+        else if (!value) this.recoverToEndOfLine(kw.span.startLine);
+      } else if (kind === "OTHERWISE") {
+        const kw = this.consume();
+        if (!this.expectPunctuation("COLON", "`:` after `otherwise`")) {
+          this.recoverToFieldOrBlockEnd(new Set<TokenKind>(["THEN", "OTHERWISE"]));
+          continue;
+        }
+        const value = this.parseSummaryValue();
+        if (value && !otherwise) otherwise = value;
+        else if (!value) this.recoverToEndOfLine(kw.span.startLine);
+      } else {
+        this.emit({
+          code: "AX007",
+          message: `unexpected ${describeToken(this.peek())} in summary when body`,
+          span: this.peek().span,
+          fix: null,
+        });
+        this.recoverToFieldOrBlockEnd(new Set<TokenKind>(["THEN", "OTHERWISE"]));
+      }
+    }
+
+    const rbrace = this.expectPunctuation("RBRACE", "`}` to close summary when body");
+    const endSpan = rbrace?.span ?? this.previousSpan();
+
+    if (!then) {
+      this.emit({
+        code: "AX007",
+        message: "summary `when` is missing `then` branch",
+        span: this.zeroWidthAfter(lbrace.span),
+        fix: null,
+      });
+      then = emptyStringLiteral(this.zeroWidthAfter(lbrace.span));
+    }
+
+    return {
+      kind: "SummaryWhen",
+      span: spanBetween(summaryStart, endSpan),
+      param,
+      then,
+      otherwise,
+    };
+  }
+
+  private parseSummarySwitch(summaryStart: TokenSpan): SummarySwitch | null {
+    this.consume(); // SWITCH
+    const param = this.expectIdent("AX007", "param name");
+    if (!param) return null;
+    const lbrace = this.expectPunctuation("LBRACE", "`{` to start summary switch body");
+    if (!lbrace) return null;
+
+    const cases: SummaryCase[] = [];
+    let defaultValue: SummaryValue | undefined;
+
+    while (!this.atEnd() && this.peekKind() !== "RBRACE") {
+      const kind = this.peekKind();
+      if (kind === "CASE") {
+        const c = this.parseSummaryCase();
+        if (c) cases.push(c);
+      } else if (kind === "DEFAULT") {
+        const kw = this.consume();
+        if (!this.expectPunctuation("COLON", "`:` after `default`")) {
+          this.recoverToFieldOrBlockEnd(SWITCH_BODY_KEYWORDS);
+          continue;
+        }
+        const value = this.parseSummaryValue();
+        if (value && !defaultValue) defaultValue = value;
+        else if (!value) this.recoverToEndOfLine(kw.span.startLine);
+      } else {
+        this.emit({
+          code: "AX007",
+          message: `unexpected ${describeToken(this.peek())} in summary switch body`,
+          span: this.peek().span,
+          fix: null,
+        });
+        this.recoverToFieldOrBlockEnd(SWITCH_BODY_KEYWORDS);
+      }
+    }
+
+    const rbrace = this.expectPunctuation("RBRACE", "`}` to close summary switch body");
+    const endSpan = rbrace?.span ?? this.previousSpan();
+    return {
+      kind: "SummarySwitch",
+      span: spanBetween(summaryStart, endSpan),
+      param,
+      cases,
+      default: defaultValue,
+    };
+  }
+
+  private parseSummaryCase(): SummaryCase | null {
+    const start = this.consume(); // CASE
+    const literal = this.parseLiteral();
+    if (!literal) return null;
+    const caseValue = literal as SummaryCase["value"];
+    if (!this.expectPunctuation("COLON", "`:` after case literal")) {
+      this.recoverToFieldOrBlockEnd(SWITCH_BODY_KEYWORDS);
+      return null;
+    }
+    const body = this.parseSummaryValue();
+    if (!body) return null;
+    return {
+      kind: "SummaryCase",
+      span: spanBetween(start.span, body.span),
+      value: caseValue,
+      body,
+    };
+  }
+
+  private parseSummaryValue(): SummaryValue | null {
+    if (this.peekKind() === "STRING_LITERAL") {
+      return this.consumeStringLiteral();
+    }
+    if (this.peekKind() === "SUMMARY") {
+      const start = this.consume();
+      return this.parseSummaryForm(start.span);
+    }
+    this.emit({
+      code: "AX007",
+      message: `expected string template or nested \`summary\`, got ${describeToken(this.peek())}`,
+      span: this.peek().span,
+      fix: null,
+    });
+    return null;
+  }
+
+  // ─── Types ─────────────────────────────────────────────────────────
+
+  private parseType(): TypeNode | null {
+    const atom = this.parseTypeAtom();
+    if (!atom) return null;
+    if (this.peekKind() === "QUESTION") {
+      const q = this.consume();
+      const optional: OptionalType = {
+        kind: "OptionalType",
+        span: spanBetween(atom.span, q.span),
+        inner: atom,
+      };
+      return optional;
+    }
+    return atom;
+  }
+
+  private parseTypeAtom(): TypeNode | null {
+    const kind = this.peekKind();
+    const primitive = PRIMITIVE_KIND_BY_TOKEN.get(kind);
+    if (primitive) {
+      const tok = this.consume();
+      return { kind: "PrimitiveType", span: tok.span, primitive };
+    }
+    if (kind === "LBRACKET") {
+      const start = this.consume();
+      const element = this.parseType();
+      if (!element) return null;
+      const end = this.expectPunctuation("RBRACKET", "`]` to close array type");
+      if (!end) return null;
+      const array: ArrayType = {
+        kind: "ArrayType",
+        span: spanBetween(start.span, end.span),
+        element,
+      };
+      return array;
+    }
+    if (kind === "IDENTIFIER") {
+      const tok = this.consume();
+      const named: NamedType = { kind: "NamedType", span: tok.span, name: tok.value };
+      return named;
+    }
+
+    this.emit({
+      code: "AX005",
+      message: `expected type, got ${describeToken(this.peek())}`,
+      span: this.peek().span,
+      fix: null,
+    });
+    return null;
+  }
+
+  private parseReturnType(): ReturnTypeNode | null {
+    const kind = this.peekKind();
+    if (kind === "LBRACKET") {
+      const start = this.consume();
+      const atom = this.parseReturnAtom();
+      if (!atom) return null;
+      const end = this.expectPunctuation("RBRACKET", "`]` to close return array type");
+      if (!end) return null;
+      const wrapped: ReturnArrayType = {
+        kind: "ReturnArrayType",
+        span: spanBetween(start.span, end.span),
+        element: atom,
+      };
+      return wrapped;
+    }
+    return this.parseReturnAtom();
+  }
+
+  private parseReturnAtom(): PrimitiveType | NamedType | null {
+    const kind = this.peekKind();
+    const primitive = PRIMITIVE_KIND_BY_TOKEN.get(kind);
+    if (primitive) {
+      const tok = this.consume();
+      return { kind: "PrimitiveType", span: tok.span, primitive };
+    }
+    if (kind === "IDENTIFIER") {
+      const tok = this.consume();
+      return { kind: "NamedType", span: tok.span, name: tok.value };
+    }
+    this.emit({
+      code: "AX005",
+      message: `expected return type, got ${describeToken(this.peek())}`,
+      span: this.peek().span,
+      fix: null,
+    });
+    return null;
+  }
+
+  // ─── Literals ──────────────────────────────────────────────────────
+
+  private parseLiteral(): LiteralNode | null {
+    const tok = this.peek();
+    switch (tok.kind) {
+      case "STRING_LITERAL":
+        this.advance();
+        return { kind: "StringLiteral", span: tok.span, value: tok.value };
+      case "INTEGER_LITERAL": {
+        this.advance();
+        const value: IntegerLiteral = {
+          kind: "IntegerLiteral",
+          span: tok.span,
+          value: Number.parseInt(tok.value, 10),
+        };
+        return value;
+      }
+      case "DECIMAL_LITERAL": {
+        this.advance();
+        const value: DecimalLiteral = {
+          kind: "DecimalLiteral",
+          span: tok.span,
+          value: Number.parseFloat(tok.value),
+        };
+        return value;
+      }
+      case "TRUE":
+      case "FALSE": {
+        this.advance();
+        const bool: BooleanLiteral = {
+          kind: "BooleanLiteral",
+          span: tok.span,
+          value: tok.kind === "TRUE",
+        };
+        return bool;
+      }
+      case "IDENTIFIER": {
+        this.advance();
+        const ident: IdentLiteral = {
+          kind: "IdentLiteral",
+          span: tok.span,
+          name: tok.value,
+        };
+        return ident;
+      }
+      default:
+        this.emit({
+          code: "AX007",
+          message: `expected literal, got ${describeToken(tok)}`,
+          span: tok.span,
+          fix: null,
+        });
+        return null;
+    }
+  }
+
+  // ─── Token utilities ───────────────────────────────────────────────
+
+  private peek(offset = 0): Token {
+    const idx = this.pos + offset;
+    if (idx >= this.tokens.length) {
+      return this.tokens[this.tokens.length - 1]!;
+    }
+    return this.tokens[idx]!;
+  }
+
+  private peekKind(offset = 0): TokenKind {
+    return this.peek(offset).kind;
+  }
+
+  private advance(): Token {
+    const tok = this.tokens[this.pos]!;
+    if (this.pos < this.tokens.length - 1) this.pos += 1;
+    return tok;
+  }
+
+  private consume(): Token {
+    return this.advance();
+  }
+
+  private atEnd(): boolean {
+    return this.peekKind() === "EOF";
+  }
+
+  private previousSpan(): TokenSpan {
+    const idx = Math.max(0, this.pos - 1);
+    return this.tokens[idx]!.span;
+  }
+
+  private expectPunctuation(kind: TokenKind, description: string): Token | null {
+    if (this.peekKind() === kind) return this.consume();
+    this.emit({
+      code: "AX007",
+      message: `expected ${description}, got ${describeToken(this.peek())}`,
+      span: this.peek().span,
+      fix: null,
+    });
+    return null;
+  }
+
+  private expectIdent(code: string, description: string): Ident | null {
+    if (this.peekKind() === "IDENTIFIER") {
+      const tok = this.consume();
+      return { kind: "Ident", span: tok.span, name: tok.value };
+    }
+    this.emit({
+      code,
+      message: `expected ${description}, got ${describeToken(this.peek())}`,
+      span: this.peek().span,
+      fix: null,
+    });
+    return null;
+  }
+
+  private expectStringLiteral(description: string): StringLiteral | null {
+    if (this.peekKind() === "STRING_LITERAL") {
+      return this.consumeStringLiteral();
+    }
+    this.emit({
+      code: "AX007",
+      message: `expected ${description} string, got ${describeToken(this.peek())}`,
+      span: this.peek().span,
+      fix: null,
+    });
+    return null;
+  }
+
+  private consumeStringLiteral(): StringLiteral {
+    const tok = this.consume();
+    return { kind: "StringLiteral", span: tok.span, value: tok.value };
+  }
+
+  private expectBooleanLiteral(description: string): BooleanLiteral | null {
+    const kind = this.peekKind();
+    if (kind === "TRUE" || kind === "FALSE") {
+      const tok = this.consume();
+      return { kind: "BooleanLiteral", span: tok.span, value: kind === "TRUE" };
+    }
+    this.emit({
+      code: "AX007",
+      message: `expected ${description} boolean, got ${describeToken(this.peek())}`,
+      span: this.peek().span,
+      fix: null,
+    });
+    return null;
+  }
+
+  // ─── Spans + diagnostics ───────────────────────────────────────────
+
+  private emit(args: {
+    code: string;
+    message: string;
+    span: TokenSpan;
+    fix: Fix | null;
+  }): void {
+    this.diagnostics.push({
+      schemaVersion: 1,
+      code: args.code,
+      severity: "error",
+      message: args.message,
+      file: this.file,
+      span: toProtocolSpan(args.span),
+      fix: args.fix,
+    });
+  }
+
+  private zeroWidthAfter(span: TokenSpan): TokenSpan {
+    return {
+      startByte: span.endByte,
+      endByte: span.endByte,
+      startLine: span.endLine,
+      startColumn: span.endColumn,
+      endLine: span.endLine,
+      endColumn: span.endColumn,
+    };
+  }
+
+  private zeroWidthBefore(span: TokenSpan): TokenSpan {
+    return {
+      startByte: span.startByte,
+      endByte: span.startByte,
+      startLine: span.startLine,
+      startColumn: span.startColumn,
+      endLine: span.startLine,
+      endColumn: span.startColumn,
+    };
+  }
+
+  // ─── Recovery ──────────────────────────────────────────────────────
+
+  /**
+   * Scan forward until a top-level keyword or EOF. Returns `true` if the
+   * parser made progress, `false` if it's already at EOF (caller should
+   * break out of its outer loop).
+   */
+  private recoverToTopLevel(): boolean {
+    if (this.atEnd()) return false;
+    // Always move past the offending token so we can't loop.
+    this.advance();
+    while (!this.atEnd() && !TOP_LEVEL_KEYWORDS.has(this.peekKind())) {
+      this.advance();
+    }
+    return !this.atEnd() || this.pos > 0;
+  }
+
+  /**
+   * Scan forward until one of the given field-start keywords, the enclosing
+   * `}`, or a top-level keyword. Stops on the first match — the caller's
+   * loop re-enters at that token.
+   */
+  private recoverToFieldOrBlockEnd(fieldKeywords: ReadonlySet<TokenKind>): void {
+    if (this.atEnd()) return;
+    this.advance();
+    while (!this.atEnd()) {
+      const kind = this.peekKind();
+      if (kind === "RBRACE") return;
+      if (TOP_LEVEL_KEYWORDS.has(kind)) return;
+      if (fieldKeywords.has(kind)) return;
+      this.advance();
+    }
+  }
+
+  /**
+   * Scan forward until a token starts on a later line than `line`. Used for
+   * single-line fields where the right-hand side is malformed.
+   */
+  private recoverToEndOfLine(line: number): void {
+    while (!this.atEnd() && this.peek().span.startLine === line) {
+      const kind = this.peekKind();
+      if (kind === "RBRACE" || TOP_LEVEL_KEYWORDS.has(kind)) return;
+      this.advance();
+    }
+  }
+}
+
+// ─── Module helpers ──────────────────────────────────────────────────
+
+function spanBetween(a: TokenSpan, b: TokenSpan): TokenSpan {
+  return {
+    startByte: a.startByte,
+    endByte: b.endByte,
+    startLine: a.startLine,
+    startColumn: a.startColumn,
+    endLine: b.endLine,
+    endColumn: b.endColumn,
+  };
+}
+
+function emptyStringLiteral(span: TokenSpan): StringLiteral {
+  return { kind: "StringLiteral", span, value: "" };
+}
+
+function placeholderDisplayRef(
+  field: "title" | "subtitle",
+  span: TokenSpan
+): DisplayPropertyRef {
+  return {
+    kind: "DisplayPropertyRef",
+    span,
+    field,
+    property: { kind: "Ident", span, name: "" },
+  };
+}
+
+function describeToken(token: Token): string {
+  if (token.kind === "EOF") return "end of file";
+  if (token.kind === "UNKNOWN") return `unrecognized token \`${token.value}\``;
+  if (token.kind === "STRING_LITERAL") return "string literal";
+  if (token.kind === "INTEGER_LITERAL") return `\`${token.value}\``;
+  if (token.kind === "DECIMAL_LITERAL") return `\`${token.value}\``;
+  if (token.kind === "IDENTIFIER") return `\`${token.value}\``;
+  return `\`${token.value}\``;
+}

--- a/src/core/axint-dsl/token.ts
+++ b/src/core/axint-dsl/token.ts
@@ -1,0 +1,199 @@
+/**
+ * Axint DSL — Tokens
+ *
+ * The .axint authoring surface compiles to the same IR as the TS and Python
+ * SDKs. The lexer produces the flat token stream defined here; the parser
+ * consumes it. Whitespace (spaces, tabs, newlines) is never significant.
+ *
+ * Spans here are the *internal* form: byte offsets for fast source slicing
+ * plus full start/end line/column pairs. The external protocol span shape
+ * that the JSON diagnostic surface emits lives in `diagnostic.ts`; converting
+ * between the two is a pure field-rename and happens at the diagnostic
+ * boundary. Keeping the internal form lets the formatter, the error-snippet
+ * printer, and the lowering stage work in byte offsets without going through
+ * protocol-shape objects on every access.
+ *
+ * Every reserved word in grammar.md gets its own `TokenKind` so the parser
+ * can branch on kind without re-checking lexemes.
+ */
+
+/** Every discrete kind the lexer can emit. */
+export type TokenKind =
+  // Structural punctuation
+  | "LBRACE" // {
+  | "RBRACE" // }
+  | "LBRACKET" // [
+  | "RBRACKET" // ]
+  | "COLON" // :
+  | "QUESTION" // ?
+
+  // Top-level declaration keywords
+  | "INTENT"
+  | "ENTITY"
+  | "ENUM"
+
+  // Intent body keywords
+  | "TITLE"
+  | "DESCRIPTION"
+  | "DOMAIN"
+  | "CATEGORY"
+  | "DISCOVERABLE"
+  | "DONATE_ON_PERFORM"
+  | "PARAM"
+  | "SUMMARY"
+  | "RETURNS"
+  | "ENTITLEMENTS"
+  | "INFO_PLIST_KEYS"
+
+  // Entity body keywords
+  | "DISPLAY"
+  | "PROPERTY"
+  | "QUERY"
+  | "SUBTITLE"
+  | "IMAGE"
+
+  // Param / property body keywords
+  | "DEFAULT"
+  | "OPTIONS"
+  | "DYNAMIC"
+
+  // Summary keywords
+  | "WHEN"
+  | "THEN"
+  | "OTHERWISE"
+  | "SWITCH"
+  | "CASE"
+
+  // Reserved for v0.5 cross-file composition (grammar.md §Keywords)
+  | "USE"
+  | "FROM"
+
+  // Primitive type keywords
+  | "TYPE_STRING"
+  | "TYPE_INT"
+  | "TYPE_DOUBLE"
+  | "TYPE_FLOAT"
+  | "TYPE_BOOLEAN"
+  | "TYPE_DATE"
+  | "TYPE_DURATION"
+  | "TYPE_URL"
+
+  // Literals
+  | "STRING_LITERAL"
+  | "INTEGER_LITERAL"
+  | "DECIMAL_LITERAL"
+  | "TRUE"
+  | "FALSE"
+
+  // Identifiers (everything that isn't a keyword and matches the identifier
+  // production).
+  | "IDENTIFIER"
+
+  // End of input.
+  | "EOF"
+
+  // Lexical failure: a character or sequence the lexer could not classify.
+  // The lexer emits an UNKNOWN token with a span covering the offending
+  // bytes and continues scanning. The parser treats it like a skipped
+  // token and re-syncs at the next recovery boundary.
+  | "UNKNOWN";
+
+/**
+ * Internal span used by every token and AST node.
+ *
+ * Byte offsets drive source slicing (error snippets, formatter round-trips).
+ * Line/column pairs match what the protocol span exposes — emitting a
+ * diagnostic is a shape-only transform: `{ start: { line: startLine, column:
+ * startColumn }, end: { line: endLine, column: endColumn } }`.
+ *
+ * Line and column are 1-indexed. `endByte` and the end position are
+ * exclusive — a zero-width span (start == end) marks an insertion point.
+ */
+export interface TokenSpan {
+  readonly startByte: number;
+  readonly endByte: number;
+  readonly startLine: number;
+  readonly startColumn: number;
+  readonly endLine: number;
+  readonly endColumn: number;
+}
+
+export interface Token {
+  readonly kind: TokenKind;
+  readonly span: TokenSpan;
+  /**
+   * The lexeme, normalized where helpful:
+   *   - STRING_LITERAL: decoded, escapes applied, outer quotes stripped.
+   *   - INTEGER_LITERAL / DECIMAL_LITERAL: the raw numeric text (the
+   *     parser knows the target type and does the coercion).
+   *   - IDENTIFIER: the identifier text.
+   *   - Everything else: the source lexeme (e.g. "{", "intent").
+   */
+  readonly value: string;
+}
+
+/**
+ * Every lexeme that is a keyword rather than an identifier. Keys are the
+ * source text; values are the token kind the lexer emits. Every entry is
+ * pinned to the authoritative list in spec/language/grammar.md §Keywords.
+ */
+export const KEYWORDS: Readonly<Record<string, TokenKind>> = {
+  intent: "INTENT",
+  entity: "ENTITY",
+  enum: "ENUM",
+
+  title: "TITLE",
+  description: "DESCRIPTION",
+  domain: "DOMAIN",
+  category: "CATEGORY",
+  discoverable: "DISCOVERABLE",
+  donateOnPerform: "DONATE_ON_PERFORM",
+  param: "PARAM",
+  summary: "SUMMARY",
+  returns: "RETURNS",
+  entitlements: "ENTITLEMENTS",
+  infoPlistKeys: "INFO_PLIST_KEYS",
+
+  display: "DISPLAY",
+  property: "PROPERTY",
+  query: "QUERY",
+  subtitle: "SUBTITLE",
+  image: "IMAGE",
+
+  default: "DEFAULT",
+  options: "OPTIONS",
+  dynamic: "DYNAMIC",
+
+  when: "WHEN",
+  then: "THEN",
+  otherwise: "OTHERWISE",
+  switch: "SWITCH",
+  case: "CASE",
+
+  use: "USE",
+  from: "FROM",
+
+  string: "TYPE_STRING",
+  int: "TYPE_INT",
+  double: "TYPE_DOUBLE",
+  float: "TYPE_FLOAT",
+  boolean: "TYPE_BOOLEAN",
+  date: "TYPE_DATE",
+  duration: "TYPE_DURATION",
+  url: "TYPE_URL",
+
+  true: "TRUE",
+  false: "FALSE",
+};
+
+/** Token kinds that correspond to a primitive type. */
+export const PRIMITIVE_TYPE_KINDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
+  "TYPE_STRING",
+  "TYPE_INT",
+  "TYPE_DOUBLE",
+  "TYPE_FLOAT",
+  "TYPE_BOOLEAN",
+  "TYPE_DATE",
+  "TYPE_DURATION",
+  "TYPE_URL",
+]);

--- a/tests/core/axint-dsl/__smoke__.mjs
+++ b/tests/core/axint-dsl/__smoke__.mjs
@@ -1,0 +1,3 @@
+// Intentionally empty. The temporary smoke harness that lived here was used
+// once during task #26 to validate the axint-dsl skeleton and has been
+// superseded by tests/core/axint-dsl/skeleton.test.ts. Safe to delete.

--- a/tests/core/axint-dsl/lexer.test.ts
+++ b/tests/core/axint-dsl/lexer.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { tokenize } from "../../../src/core/axint-dsl/index.js";
+
+describe("axint-dsl lexer", () => {
+  it("skips whitespace and line comments", () => {
+    const { tokens, diagnostics } = tokenize(`# leading
+intent  Foo  { }  # trailing
+`);
+    expect(diagnostics).toHaveLength(0);
+    expect(tokens.map((t) => t.kind)).toEqual([
+      "INTENT",
+      "IDENTIFIER",
+      "LBRACE",
+      "RBRACE",
+      "EOF",
+    ]);
+  });
+
+  it("emits all six punctuation kinds", () => {
+    const { tokens } = tokenize("{ } [ ] : ?");
+    expect(tokens.slice(0, 6).map((t) => t.kind)).toEqual([
+      "LBRACE",
+      "RBRACE",
+      "LBRACKET",
+      "RBRACKET",
+      "COLON",
+      "QUESTION",
+    ]);
+  });
+
+  it("distinguishes keywords from identifiers by exact spelling", () => {
+    const { tokens } = tokenize("intent intents Intent domain domains");
+    expect(tokens.map((t) => t.kind).slice(0, 5)).toEqual([
+      "INTENT",
+      "IDENTIFIER",
+      "IDENTIFIER",
+      "DOMAIN",
+      "IDENTIFIER",
+    ]);
+  });
+
+  it("classifies numbers, decimals, and negatives", () => {
+    const { tokens } = tokenize("42 3.14 -7 -0.5");
+    const real = tokens.filter((t) => t.kind !== "EOF");
+    expect(real.map((t) => [t.kind, t.value])).toEqual([
+      ["INTEGER_LITERAL", "42"],
+      ["DECIMAL_LITERAL", "3.14"],
+      ["INTEGER_LITERAL", "-7"],
+      ["DECIMAL_LITERAL", "-0.5"],
+    ]);
+  });
+
+  it("decodes string escapes and strips outer quotes", () => {
+    const { tokens, diagnostics } = tokenize(String.raw`"a\nb\t\"c\\"`);
+    expect(diagnostics).toHaveLength(0);
+    expect(tokens[0]?.kind).toBe("STRING_LITERAL");
+    expect(tokens[0]?.value).toBe('a\nb\t"c\\');
+  });
+
+  it("reports unterminated string literals as AX007", () => {
+    const { tokens, diagnostics } = tokenize('"oops');
+    expect(tokens[0]?.kind).toBe("STRING_LITERAL");
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe("AX007");
+    expect(diagnostics[0]?.severity).toBe("error");
+    expect(diagnostics[0]?.fix).toBeNull();
+  });
+
+  it("reports unknown escapes as AX007 but keeps the char for recovery", () => {
+    const { tokens, diagnostics } = tokenize(String.raw`"bad \q esc"`);
+    expect(tokens[0]?.value).toBe("bad q esc");
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe("AX007");
+  });
+
+  it("emits UNKNOWN tokens for unrecognized bytes without throwing", () => {
+    const { tokens, diagnostics } = tokenize("@");
+    expect(tokens[0]?.kind).toBe("UNKNOWN");
+    expect(diagnostics[0]?.code).toBe("AX007");
+  });
+
+  it("tracks line and column across newlines", () => {
+    const { tokens } = tokenize("foo\n  bar");
+    const foo = tokens.find((t) => t.value === "foo")!;
+    const bar = tokens.find((t) => t.value === "bar")!;
+    expect(foo.span.startLine).toBe(1);
+    expect(foo.span.startColumn).toBe(1);
+    expect(bar.span.startLine).toBe(2);
+    expect(bar.span.startColumn).toBe(3);
+    expect(bar.span.endColumn).toBe(6);
+  });
+
+  it("always terminates with a zero-width EOF token", () => {
+    const { tokens } = tokenize("");
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]?.kind).toBe("EOF");
+    const span = tokens[0]!.span;
+    expect(span.startByte).toBe(span.endByte);
+    expect(span.startLine).toBe(span.endLine);
+    expect(span.startColumn).toBe(span.endColumn);
+  });
+
+  it("skips a leading UTF-8 BOM", () => {
+    const { tokens, diagnostics } = tokenize("\uFEFFintent");
+    expect(diagnostics).toHaveLength(0);
+    expect(tokens[0]?.kind).toBe("INTENT");
+  });
+});

--- a/tests/core/axint-dsl/parser.test.ts
+++ b/tests/core/axint-dsl/parser.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "../../../src/core/axint-dsl/index.js";
+import type {
+  EntityDecl,
+  EnumDecl,
+  IntentDecl,
+  ParamDecl,
+  SummarySwitch,
+  SummaryWhen,
+} from "../../../src/core/axint-dsl/index.js";
+
+function parseOk(source: string) {
+  const { file, diagnostics } = parse(source);
+  if (diagnostics.length > 0) {
+    const lines = diagnostics
+      .map((d) => `${d.code} @ ${d.span.start.line}:${d.span.start.column}  ${d.message}`)
+      .join("\n");
+    throw new Error(`expected zero diagnostics, got:\n${lines}`);
+  }
+  return file;
+}
+
+describe("axint-dsl parser — happy path", () => {
+  it("parses a minimal intent with title and description", () => {
+    const file = parseOk(`
+      intent Greet {
+        title: "Say hello"
+        description: "Prints a greeting."
+      }
+    `);
+    expect(file.declarations).toHaveLength(1);
+    const intent = file.declarations[0] as IntentDecl;
+    expect(intent.kind).toBe("IntentDecl");
+    expect(intent.name.name).toBe("Greet");
+    expect(intent.title.value).toBe("Say hello");
+    expect(intent.description.value).toBe("Prints a greeting.");
+  });
+
+  it("parses optional and array types", () => {
+    const file = parseOk(`
+      intent Search {
+        title: "Search"
+        description: "Finds things."
+        param term: string {
+          description: "What to look for"
+        }
+        param tags: [string]? {
+          description: "Tag filter"
+        }
+      }
+    `);
+    const intent = file.declarations[0] as IntentDecl;
+    const [term, tags] = intent.params as readonly ParamDecl[];
+    expect(term!.type.kind).toBe("PrimitiveType");
+    expect(tags!.type.kind).toBe("OptionalType");
+  });
+
+  it("parses each query-kind keyword: all, id, string, property", () => {
+    const source = ["all", "id", "string", "property"]
+      .map(
+        (k, i) => `
+          entity E${i} {
+            display { title: name }
+            property name: string { description: "n" }
+            query: ${k}
+          }
+        `
+      )
+      .join("\n");
+    const file = parseOk(source);
+    const kinds = file.declarations.map((d) => (d as EntityDecl).query.queryKind);
+    expect(kinds).toEqual(["all", "id", "string", "property"]);
+  });
+
+  it("parses enum declarations with multiple cases", () => {
+    const file = parseOk(`
+      enum Priority {
+        low
+        medium
+        high
+      }
+    `);
+    const e = file.declarations[0] as EnumDecl;
+    expect(e.kind).toBe("EnumDecl");
+    expect(e.cases.map((c) => c.name)).toEqual(["low", "medium", "high"]);
+  });
+
+  it("parses summary when and summary switch", () => {
+    const file = parseOk(`
+      intent Navigate {
+        title: "Navigate"
+        description: "Starts navigation."
+        param destination: string {
+          description: "Where to go"
+        }
+        summary when destination {
+          then: "Navigating to \${destination}"
+          otherwise: "Navigating"
+        }
+      }
+      intent SetMode {
+        title: "Set Mode"
+        description: "Changes mode."
+        param mode: string {
+          description: "Mode"
+        }
+        summary switch mode {
+          case fast: "Fast mode"
+          default: "Default mode"
+        }
+      }
+    `);
+    const [nav, setMode] = file.declarations as readonly IntentDecl[];
+    expect(nav!.summary?.kind).toBe("SummaryWhen");
+    expect((nav!.summary as SummaryWhen).param.name).toBe("destination");
+    expect(setMode!.summary?.kind).toBe("SummarySwitch");
+    expect((setMode!.summary as SummarySwitch).param.name).toBe("mode");
+  });
+});
+
+describe("axint-dsl parser — diagnostics", () => {
+  it("emits AX003 with insert_required_clause when title is missing", () => {
+    const { diagnostics } = parse(`
+      intent NoTitle {
+        description: "has no title"
+      }
+    `);
+    const ax003 = diagnostics.find((d) => d.code === "AX003");
+    expect(ax003).toBeDefined();
+    expect(ax003?.fix?.kind).toBe("insert_required_clause");
+  });
+
+  it("emits AX004 with insert_required_clause when description is missing", () => {
+    const { diagnostics } = parse(`
+      intent NoDesc {
+        title: "no description"
+      }
+    `);
+    const ax004 = diagnostics.find((d) => d.code === "AX004");
+    expect(ax004).toBeDefined();
+    expect(ax004?.fix?.kind).toBe("insert_required_clause");
+  });
+
+  it("emits AX015 when entity is missing a display block", () => {
+    const { diagnostics } = parse(`
+      entity Trail {
+        property name: string { description: "n" }
+        query: all
+      }
+    `);
+    expect(diagnostics.some((d) => d.code === "AX015")).toBe(true);
+  });
+
+  it("emits AX017 when entity is missing a query clause", () => {
+    const { diagnostics } = parse(`
+      entity Trail {
+        display { title: name }
+        property name: string { description: "n" }
+      }
+    `);
+    expect(diagnostics.some((d) => d.code === "AX017")).toBe(true);
+  });
+
+  it("emits AX018 with replace_literal fix for unknown query kind", () => {
+    const { diagnostics } = parse(`
+      entity Trail {
+        display { title: name }
+        property name: string { description: "n" }
+        query: bogus
+      }
+    `);
+    const ax018 = diagnostics.find((d) => d.code === "AX018");
+    expect(ax018).toBeDefined();
+    expect(ax018?.fix?.kind).toBe("replace_literal");
+    if (ax018?.fix?.kind === "replace_literal") {
+      expect(ax018.fix.candidates).toEqual(
+        expect.arrayContaining(["all", "id", "string", "property"])
+      );
+    }
+  });
+
+  it("carries diagnostic schema version 1 on every emitted diagnostic", () => {
+    const { diagnostics } = parse('intent NoTitle { description: "d" }');
+    expect(diagnostics.length).toBeGreaterThan(0);
+    for (const d of diagnostics) {
+      expect(d.schemaVersion).toBe(1);
+      expect(d.severity).toBe("error");
+    }
+  });
+});
+
+describe("axint-dsl parser — recovery", () => {
+  it("keeps parsing top-level decls after an unclosed intent body", () => {
+    const { file, diagnostics } = parse(`
+      intent First {
+        title: "first"
+        description: "missing closing brace"
+      intent Second {
+        title: "second"
+        description: "survives recovery"
+      }
+    `);
+    expect(file.declarations).toHaveLength(2);
+    expect((file.declarations[0] as IntentDecl).name.name).toBe("First");
+    expect((file.declarations[1] as IntentDecl).name.name).toBe("Second");
+    expect(diagnostics.length).toBeGreaterThan(0);
+    expect(diagnostics.every((d) => d.schemaVersion === 1)).toBe(true);
+  });
+
+  it("end-of-line recovery: malformed title does not cascade into description", () => {
+    // Mirrors parser-recovery.md Example 2 — a malformed single-line field
+    // should be followed by a clean parse of the next line's field.
+    const { file, diagnostics } = parse(`
+      intent Foo {
+        title: 12345
+        description: "A valid description"
+      }
+    `);
+    expect(file.declarations).toHaveLength(1);
+    const intent = file.declarations[0] as IntentDecl;
+    expect(intent.description.value).toBe("A valid description");
+    expect(diagnostics.length).toBeGreaterThanOrEqual(1);
+    expect(diagnostics.every((d) => d.schemaVersion === 1)).toBe(true);
+  });
+});

--- a/tests/core/axint-dsl/skeleton.test.ts
+++ b/tests/core/axint-dsl/skeleton.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  DIAGNOSTIC_SCHEMA_VERSION,
+  KEYWORDS,
+  PRIMITIVE_TYPE_KINDS,
+  parse,
+  tokenize,
+} from "../../../src/core/axint-dsl/index.js";
+
+describe("axint-dsl skeleton", () => {
+  it("pins diagnostic schema to version 1", () => {
+    expect(DIAGNOSTIC_SCHEMA_VERSION).toBe(1);
+  });
+
+  it("registers every keyword from grammar.md", () => {
+    // Every reserved word in spec/language/grammar.md §Keywords. A missing
+    // entry means the lexer would parse that word as an identifier.
+    const expected = [
+      "intent",
+      "entity",
+      "enum",
+      "param",
+      "property",
+      "summary",
+      "display",
+      "query",
+      "title",
+      "description",
+      "domain",
+      "category",
+      "default",
+      "options",
+      "dynamic",
+      "case",
+      "when",
+      "then",
+      "otherwise",
+      "switch",
+      "string",
+      "int",
+      "double",
+      "float",
+      "boolean",
+      "date",
+      "duration",
+      "url",
+      "true",
+      "false",
+      "entitlements",
+      "infoPlistKeys",
+      "discoverable",
+      "donateOnPerform",
+      "returns",
+      "subtitle",
+      "image",
+      "use",
+      "from",
+    ] as const;
+
+    for (const word of expected) {
+      expect(KEYWORDS[word], `missing keyword: ${word}`).toBeDefined();
+    }
+  });
+
+  it("classifies every primitive type keyword", () => {
+    const primitives = [
+      "TYPE_STRING",
+      "TYPE_INT",
+      "TYPE_DOUBLE",
+      "TYPE_FLOAT",
+      "TYPE_BOOLEAN",
+      "TYPE_DATE",
+      "TYPE_DURATION",
+      "TYPE_URL",
+    ] as const;
+    for (const kind of primitives) {
+      expect(PRIMITIVE_TYPE_KINDS.has(kind)).toBe(true);
+    }
+  });
+
+  it("tokenizes a trivial intent header to EOF", () => {
+    const { tokens, diagnostics } = tokenize("intent Foo {}");
+    expect(diagnostics).toHaveLength(0);
+    expect(tokens.map((t) => t.kind)).toEqual([
+      "INTENT",
+      "IDENTIFIER",
+      "LBRACE",
+      "RBRACE",
+      "EOF",
+    ]);
+  });
+
+  it("returns an empty file with zero diagnostics for an empty source", () => {
+    const { file, diagnostics } = parse("");
+    expect(file.declarations).toHaveLength(0);
+    expect(diagnostics).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #28. Recursive-descent parser over the tokenizer with deterministic recovery at block close, top-level keyword, field-start keyword, and end-of-line. 30 new parser tests; full happy-path corpus parses clean; broken corpus flags every parser-stage code. Silent validator-stage codes land in #29 with AST→IR lowering.