### PR TITLE
wire ast to ir lowering

### DIFF
--- a/metrics.json
+++ b/metrics.json
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 655,
+    "typescript": 680,
     "python": 114
   },
   "registryPackages": 8,

--- a/src/core/axint-dsl/index.ts
+++ b/src/core/axint-dsl/index.ts
@@ -14,6 +14,9 @@ export type { ParseResult, ParseOptions } from "./parser.js";
 export { tokenize } from "./lexer.js";
 export type { LexResult } from "./lexer.js";
 
+export { lower } from "./lowering.js";
+export type { LowerResult, LowerOptions } from "./lowering.js";
+
 export type { Token, TokenKind, TokenSpan } from "./token.js";
 export { KEYWORDS, PRIMITIVE_TYPE_KINDS } from "./token.js";
 

--- a/src/core/axint-dsl/lowering.ts
+++ b/src/core/axint-dsl/lowering.ts
@@ -1,0 +1,858 @@
+/**
+ * Axint DSL — AST → IR lowering
+ *
+ * Walks a parsed `FileNode` and produces the `IRIntent` / `IREntity` shape the
+ * rest of the compiler already consumes. Validator-stage diagnostics fire here
+ * alongside the IR: the lowering is the point where a `.axint` file becomes
+ * semantically equivalent to an `@axint/compiler` TS surface call. The result
+ * round-trips per spec/language/ir-mapping.md §Round-trip invariant.
+ *
+ * Validator codes wired here:
+ *   AX001  file with no top-level declarations
+ *   AX005  unknown primitive type (lowercase NamedType with no resolution)
+ *   AX020  param / returns references an undeclared entity
+ *   AX021  display field references a property that doesn't exist
+ *   AX023  summary template references a param that doesn't exist
+ *   AX100  intent name not PascalCase
+ *   AX103  intent has duplicate param names
+ *   AX106  default value type doesn't match declared type
+ *   AX107  optional param has a non-null default
+ *   AX109  `summary switch` has no default and the type is not exhaustive
+ *
+ * Other validator codes (AX101/AX102/AX104/AX105/AX108/AX110–AX113) layer on
+ * in follow-up work — the IR shape they operate on is what this module emits.
+ */
+
+import type {
+  BooleanLiteral,
+  DecimalLiteral,
+  EntityDecl,
+  EnumDecl,
+  FileNode,
+  IdentLiteral,
+  IntegerLiteral,
+  IntentDecl,
+  LiteralNode,
+  ParamDecl,
+  PrimitiveType,
+  PropertyDecl,
+  ReturnTypeNode,
+  StringLiteral,
+  SummaryCase,
+  SummaryDecl,
+  SummarySwitch,
+  SummaryValue,
+  TopLevelDecl,
+  TypeNode,
+} from "./ast.js";
+import type { Diagnostic, Fix, Span } from "./diagnostic.js";
+import { DIAGNOSTIC_SCHEMA_VERSION } from "./diagnostic.js";
+import { toProtocolSpan } from "./lexer.js";
+import type { TokenSpan } from "./token.js";
+import type {
+  DisplayRepresentation,
+  IREntity,
+  IRIntent,
+  IRParameter,
+  IRParameterSummary,
+  IRPrimitiveType,
+  IRType,
+} from "../types.js";
+import { PARAM_TYPES } from "../types.js";
+
+// ─── Public surface ────────────────────────────────────────────────────
+
+export interface LowerResult {
+  readonly intents: readonly IRIntent[];
+  readonly entities: readonly IREntity[];
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+export interface LowerOptions {
+  /** Reported on every diagnostic. Defaults to "<anonymous>". */
+  readonly sourceFile?: string;
+}
+
+export function lower(file: FileNode, options?: LowerOptions): LowerResult {
+  const sourceFile = options?.sourceFile ?? "<anonymous>";
+  const ctx = new LowerContext(sourceFile);
+
+  if (file.declarations.length === 0) {
+    ctx.emit({
+      code: "AX001",
+      message: "file contains no top-level declarations",
+      span: zeroWidthAt(file.span),
+      fix: {
+        kind: "insert_required_clause",
+        targetSpan: toProtocolSpan(zeroWidthAt(file.span)),
+      },
+    });
+    return ctx.finish([], []);
+  }
+
+  const index = buildNameIndex(file.declarations);
+
+  // Lower every entity once — intents referencing them copy the IR node.
+  const entityIR = new Map<string, IREntity>();
+  const entities: IREntity[] = [];
+  for (const decl of file.declarations) {
+    if (decl.kind === "EntityDecl") {
+      const ir = lowerEntity(decl, index, ctx);
+      entityIR.set(decl.name.name, ir);
+      entities.push(ir);
+    }
+  }
+
+  const intents: IRIntent[] = [];
+  for (const decl of file.declarations) {
+    if (decl.kind === "IntentDecl") {
+      intents.push(lowerIntent(decl, index, entityIR, sourceFile, ctx));
+    }
+  }
+
+  return ctx.finish(intents, entities);
+}
+
+// ─── Context + diagnostic emission ─────────────────────────────────────
+
+class LowerContext {
+  private readonly diagnostics: Diagnostic[] = [];
+
+  constructor(readonly sourceFile: string) {}
+
+  emit(args: {
+    code: string;
+    message: string;
+    span: TokenSpan | Span;
+    fix: Fix | null;
+  }): void {
+    const span = isTokenSpan(args.span) ? toProtocolSpan(args.span) : args.span;
+    this.diagnostics.push({
+      schemaVersion: DIAGNOSTIC_SCHEMA_VERSION,
+      code: args.code,
+      severity: "error",
+      message: args.message,
+      file: this.sourceFile,
+      span,
+      fix: args.fix,
+    });
+  }
+
+  finish(intents: IRIntent[], entities: IREntity[]): LowerResult {
+    return { intents, entities, diagnostics: this.diagnostics };
+  }
+}
+
+function isTokenSpan(s: TokenSpan | Span): s is TokenSpan {
+  return (s as TokenSpan).startByte !== undefined;
+}
+
+// ─── Name index ────────────────────────────────────────────────────────
+
+interface NameIndex {
+  readonly entities: ReadonlyMap<string, EntityDecl>;
+  readonly enums: ReadonlyMap<string, EnumDecl>;
+}
+
+function buildNameIndex(decls: readonly TopLevelDecl[]): NameIndex {
+  const entities = new Map<string, EntityDecl>();
+  const enums = new Map<string, EnumDecl>();
+  for (const decl of decls) {
+    if (decl.kind === "EntityDecl" && decl.name.name !== "") {
+      entities.set(decl.name.name, decl);
+    } else if (decl.kind === "EnumDecl" && decl.name.name !== "") {
+      enums.set(decl.name.name, decl);
+    }
+  }
+  return { entities, enums };
+}
+
+// ─── Entity lowering ───────────────────────────────────────────────────
+
+function lowerEntity(decl: EntityDecl, index: NameIndex, ctx: LowerContext): IREntity {
+  const properties = decl.properties.map((p) => lowerProperty(p, index, ctx));
+  const propNames = new Set(properties.map((p) => p.name));
+
+  const display = lowerDisplay(decl, propNames, ctx);
+
+  return {
+    name: decl.name.name,
+    displayRepresentation: display,
+    properties,
+    queryType: decl.query.queryKind,
+  };
+}
+
+function lowerDisplay(
+  decl: EntityDecl,
+  propNames: ReadonlySet<string>,
+  ctx: LowerContext
+): DisplayRepresentation {
+  const { title, subtitle, image } = decl.display;
+  checkDisplayRef(title.property.name, title.property.span, "title", propNames, ctx);
+  if (subtitle) {
+    checkDisplayRef(
+      subtitle.property.name,
+      subtitle.property.span,
+      "subtitle",
+      propNames,
+      ctx
+    );
+  }
+  return {
+    title: title.property.name,
+    ...(subtitle ? { subtitle: subtitle.property.name } : {}),
+    ...(image ? { image: image.asset.value } : {}),
+  };
+}
+
+function checkDisplayRef(
+  name: string,
+  span: TokenSpan,
+  field: "title" | "subtitle",
+  propNames: ReadonlySet<string>,
+  ctx: LowerContext
+): void {
+  // Empty name means the parser inserted a placeholder (AX016 already fired).
+  if (name === "" || propNames.has(name)) return;
+  ctx.emit({
+    code: "AX021",
+    message: `display.${field} references property \`${name}\` which is not declared on this entity`,
+    span,
+    fix: {
+      kind: "replace_identifier",
+      targetSpan: toProtocolSpan(span),
+      candidates: [...propNames].sort(),
+    },
+  });
+}
+
+function lowerProperty(
+  decl: PropertyDecl,
+  index: NameIndex,
+  ctx: LowerContext
+): IRParameter {
+  const type = lowerType(decl.type, index, ctx);
+  const description = decl.description.value;
+  return {
+    name: decl.name.name,
+    type,
+    title: description,
+    description,
+    isOptional: decl.type.kind === "OptionalType",
+  };
+}
+
+// ─── Intent lowering ───────────────────────────────────────────────────
+
+function lowerIntent(
+  decl: IntentDecl,
+  index: NameIndex,
+  entityIR: ReadonlyMap<string, IREntity>,
+  sourceFile: string,
+  ctx: LowerContext
+): IRIntent {
+  checkPascalCase(decl, ctx);
+
+  const params: IRParameter[] = [];
+  const seen = new Map<string, ParamDecl>();
+  const referencedEntities = new Set<string>();
+
+  for (const p of decl.params) {
+    const existing = seen.get(p.name.name);
+    if (existing && p.name.name !== "") {
+      ctx.emit({
+        code: "AX103",
+        message: `duplicate param name \`${p.name.name}\``,
+        span: p.name.span,
+        fix: {
+          kind: "rename_identifier",
+          targetSpan: toProtocolSpan(p.name.span),
+        },
+      });
+    } else {
+      seen.set(p.name.name, p);
+    }
+    params.push(lowerParam(p, index, ctx, referencedEntities));
+  }
+
+  const meta = collectMeta(decl);
+  const returnInfo = decl.returns
+    ? lowerReturn(decl.returns.type, index, ctx, referencedEntities)
+    : undefined;
+  const parameterSummary = decl.summary
+    ? lowerSummary(decl.summary, params, index, ctx)
+    : undefined;
+
+  const intent: IRIntent = {
+    name: decl.name.name,
+    title: decl.title.value,
+    description: decl.description.value,
+    parameters: params,
+    returnType: returnInfo?.returnType ?? { kind: "primitive", value: "string" },
+    sourceFile,
+    ...(meta.domain ? { domain: meta.domain } : {}),
+    ...(meta.category ? { category: meta.category } : {}),
+    ...(meta.discoverable !== undefined ? { isDiscoverable: meta.discoverable } : {}),
+    ...(meta.donateOnPerform !== undefined
+      ? { donateOnPerform: meta.donateOnPerform }
+      : {}),
+    ...(returnInfo?.customResultType
+      ? { customResultType: returnInfo.customResultType }
+      : {}),
+    ...(parameterSummary ? { parameterSummary } : {}),
+    ...(decl.entitlements && decl.entitlements.values.length > 0
+      ? { entitlements: decl.entitlements.values.map((s) => s.value) }
+      : {}),
+    ...(decl.infoPlistKeys && decl.infoPlistKeys.entries.length > 0
+      ? {
+          infoPlistKeys: Object.fromEntries(
+            decl.infoPlistKeys.entries.map((e) => [e.key.value, e.value.value])
+          ),
+        }
+      : {}),
+  };
+
+  // Auto-collect entities referenced by this intent's params / returns.
+  const entities: IREntity[] = [];
+  for (const name of referencedEntities) {
+    const ir = entityIR.get(name);
+    if (ir) entities.push(ir);
+  }
+  if (entities.length > 0) {
+    return { ...intent, entities };
+  }
+  return intent;
+}
+
+function checkPascalCase(decl: IntentDecl, ctx: LowerContext): void {
+  const name = decl.name.name;
+  if (name === "" || isPascalCase(name)) return;
+  ctx.emit({
+    code: "AX100",
+    message: `intent name \`${name}\` is not PascalCase`,
+    span: decl.name.span,
+    fix: {
+      kind: "rename_identifier",
+      targetSpan: toProtocolSpan(decl.name.span),
+      suggestedEdit: { text: toPascalCase(name) },
+    },
+  });
+}
+
+function collectMeta(decl: IntentDecl): {
+  domain?: string;
+  category?: string;
+  discoverable?: boolean;
+  donateOnPerform?: boolean;
+} {
+  const out: {
+    domain?: string;
+    category?: string;
+    discoverable?: boolean;
+    donateOnPerform?: boolean;
+  } = {};
+  for (const clause of decl.meta) {
+    switch (clause.kind) {
+      case "DomainMeta":
+        out.domain = clause.value.value;
+        break;
+      case "CategoryMeta":
+        out.category = clause.value.value;
+        break;
+      case "DiscoverableMeta":
+        out.discoverable = clause.value.value;
+        break;
+      case "DonateOnPerformMeta":
+        out.donateOnPerform = clause.value.value;
+        break;
+    }
+  }
+  return out;
+}
+
+// ─── Param + type lowering ─────────────────────────────────────────────
+
+function lowerParam(
+  decl: ParamDecl,
+  index: NameIndex,
+  ctx: LowerContext,
+  referencedEntities: Set<string>
+): IRParameter {
+  const declaredType = lowerType(decl.type, index, ctx, referencedEntities);
+  const isOptional = decl.type.kind === "OptionalType";
+  const description = decl.description.value;
+
+  let type: IRType = declaredType;
+  if (decl.options) {
+    type = {
+      kind: "dynamicOptions",
+      valueType: declaredType,
+      providerName: decl.options.provider.name,
+    };
+  }
+
+  const param: IRParameter = {
+    name: decl.name.name,
+    type,
+    title: description,
+    description,
+    isOptional,
+  };
+
+  if (decl.defaultValue) {
+    if (isOptional) {
+      ctx.emit({
+        code: "AX107",
+        message: `optional param \`${decl.name.name}\` has a non-null default — an optional type implies no default`,
+        span: decl.defaultValue.span,
+        fix: {
+          kind: "remove_field",
+          targetSpan: toProtocolSpan(decl.defaultValue.span),
+        },
+      });
+    } else {
+      checkDefaultType(decl, declaredType, decl.defaultValue, index, ctx);
+    }
+    return { ...param, defaultValue: literalValue(decl.defaultValue) };
+  }
+
+  return param;
+}
+
+function checkDefaultType(
+  decl: ParamDecl,
+  declaredType: IRType,
+  literal: LiteralNode,
+  index: NameIndex,
+  ctx: LowerContext
+): void {
+  if (literalMatchesType(literal, declaredType, index)) return;
+  ctx.emit({
+    code: "AX106",
+    message: `default value for param \`${decl.name.name}\` does not match declared type`,
+    span: literal.span,
+    fix: {
+      kind: "replace_literal",
+      targetSpan: toProtocolSpan(literal.span),
+    },
+  });
+}
+
+function literalMatchesType(
+  literal: LiteralNode,
+  type: IRType,
+  index: NameIndex
+): boolean {
+  switch (type.kind) {
+    case "primitive":
+      return literalMatchesPrimitive(literal, type.value);
+    case "array":
+      return false; // default array literals aren't in the grammar
+    case "optional":
+      return literalMatchesType(literal, type.innerType, index);
+    case "entity":
+      return false;
+    case "entityQuery":
+      return false;
+    case "dynamicOptions":
+      return literalMatchesType(literal, type.valueType, index);
+    case "enum": {
+      if (literal.kind !== "IdentLiteral") return false;
+      return type.cases.includes(literal.name);
+    }
+  }
+}
+
+function literalMatchesPrimitive(
+  literal: LiteralNode,
+  primitive: IRPrimitiveType
+): boolean {
+  switch (literal.kind) {
+    case "StringLiteral":
+      return primitive === "string" || primitive === "url";
+    case "IntegerLiteral":
+      return primitive === "int" || primitive === "double" || primitive === "float";
+    case "DecimalLiteral":
+      return primitive === "double" || primitive === "float";
+    case "BooleanLiteral":
+      return primitive === "boolean";
+    case "IdentLiteral":
+      return false;
+  }
+}
+
+function literalValue(literal: LiteralNode): unknown {
+  switch (literal.kind) {
+    case "StringLiteral":
+      return literal.value;
+    case "IntegerLiteral":
+    case "DecimalLiteral":
+      return literal.value;
+    case "BooleanLiteral":
+      return literal.value;
+    case "IdentLiteral":
+      return literal.name;
+  }
+}
+
+function lowerType(
+  node: TypeNode,
+  index: NameIndex,
+  ctx: LowerContext,
+  referencedEntities?: Set<string>
+): IRType {
+  switch (node.kind) {
+    case "PrimitiveType":
+      return { kind: "primitive", value: node.primitive };
+    case "ArrayType":
+      return {
+        kind: "array",
+        elementType: lowerType(node.element, index, ctx, referencedEntities),
+      };
+    case "OptionalType":
+      return {
+        kind: "optional",
+        innerType: lowerType(node.inner, index, ctx, referencedEntities),
+      };
+    case "NamedType":
+      return resolveNamedType(node.name, node.span, index, ctx, referencedEntities);
+  }
+}
+
+function resolveNamedType(
+  name: string,
+  span: TokenSpan,
+  index: NameIndex,
+  ctx: LowerContext,
+  referencedEntities: Set<string> | undefined
+): IRType {
+  const entity = index.entities.get(name);
+  if (entity) {
+    referencedEntities?.add(name);
+    const properties = entity.properties.map((p) => lowerProperty(p, index, ctx));
+    return { kind: "entity", entityName: name, properties };
+  }
+  const enumDecl = index.enums.get(name);
+  if (enumDecl) {
+    return {
+      kind: "enum",
+      name,
+      cases: enumDecl.cases.map((c) => c.name),
+    };
+  }
+  // Unresolved. Disambiguate on casing: lowercase-first reads as a
+  // misspelled primitive, PascalCase-first reads as a missing entity.
+  if (startsLowercase(name)) {
+    ctx.emit({
+      code: "AX005",
+      message: `unknown type \`${name}\``,
+      span,
+      fix: {
+        kind: "change_type",
+        targetSpan: toProtocolSpan(span),
+        candidates: [...PARAM_TYPES].sort(),
+      },
+    });
+  } else {
+    ctx.emit({
+      code: "AX020",
+      message: `param or returns references entity \`${name}\` which is not declared in this file`,
+      span,
+      fix: {
+        kind: "replace_identifier",
+        targetSpan: toProtocolSpan(span),
+        candidates: [...index.entities.keys()].sort(),
+      },
+    });
+  }
+  // Return a placeholder so downstream code keeps running.
+  return { kind: "primitive", value: "string" };
+}
+
+function lowerReturn(
+  node: ReturnTypeNode,
+  index: NameIndex,
+  ctx: LowerContext,
+  referencedEntities: Set<string>
+): { returnType: IRType; customResultType?: string } {
+  switch (node.kind) {
+    case "PrimitiveType":
+      return { returnType: { kind: "primitive", value: node.primitive } };
+    case "ReturnArrayType": {
+      const element = lowerReturnAtom(node.element, index, ctx, referencedEntities);
+      return { returnType: { kind: "array", elementType: element.returnType } };
+    }
+    case "NamedType":
+      return lowerReturnAtom(node, index, ctx, referencedEntities);
+  }
+}
+
+function lowerReturnAtom(
+  node: PrimitiveType | { kind: "NamedType"; span: TokenSpan; name: string },
+  index: NameIndex,
+  ctx: LowerContext,
+  referencedEntities: Set<string>
+): { returnType: IRType; customResultType?: string } {
+  if (node.kind === "PrimitiveType") {
+    return { returnType: { kind: "primitive", value: node.primitive } };
+  }
+  const entity = index.entities.get(node.name);
+  if (entity) {
+    referencedEntities.add(node.name);
+    const properties = entity.properties.map((p) => lowerProperty(p, index, ctx));
+    return {
+      returnType: { kind: "entity", entityName: node.name, properties },
+    };
+  }
+  // Unknown named return type. Per ir-mapping.md, an unknown name lowers to
+  // customResultType rather than firing AX020 — the generator defers to the
+  // caller's Swift types. We still need a returnType value; emit a string
+  // placeholder and surface the custom type on the intent.
+  return {
+    returnType: { kind: "primitive", value: "string" },
+    customResultType: node.name,
+  };
+}
+
+// ─── Summary lowering ──────────────────────────────────────────────────
+
+function lowerSummary(
+  node: SummaryDecl,
+  params: readonly IRParameter[],
+  index: NameIndex,
+  ctx: LowerContext
+): IRParameterSummary {
+  const paramNames = new Set(params.map((p) => p.name));
+  const paramTypes = new Map(params.map((p) => [p.name, p.type]));
+  return lowerSummaryNode(node, paramNames, paramTypes, index, ctx);
+}
+
+function lowerSummaryNode(
+  node: SummaryDecl,
+  paramNames: ReadonlySet<string>,
+  paramTypes: ReadonlyMap<string, IRType>,
+  index: NameIndex,
+  ctx: LowerContext
+): IRParameterSummary {
+  switch (node.kind) {
+    case "SummaryTemplate":
+      checkTemplateRefs(node.template, paramNames, ctx);
+      return { kind: "summary", template: node.template.value };
+    case "SummaryWhen": {
+      checkParamRef(node.param.name, node.param.span, paramNames, ctx);
+      const then = lowerSummaryValue(node.then, paramNames, paramTypes, index, ctx);
+      const otherwise = node.otherwise
+        ? lowerSummaryValue(node.otherwise, paramNames, paramTypes, index, ctx)
+        : undefined;
+      return {
+        kind: "when",
+        parameter: node.param.name,
+        then,
+        ...(otherwise ? { otherwise } : {}),
+      };
+    }
+    case "SummarySwitch":
+      return lowerSummarySwitch(node, paramNames, paramTypes, index, ctx);
+  }
+}
+
+function lowerSummarySwitch(
+  node: SummarySwitch,
+  paramNames: ReadonlySet<string>,
+  paramTypes: ReadonlyMap<string, IRType>,
+  index: NameIndex,
+  ctx: LowerContext
+): IRParameterSummary {
+  checkParamRef(node.param.name, node.param.span, paramNames, ctx);
+  const cases = node.cases.map((c) =>
+    lowerSummaryCase(c, paramNames, paramTypes, index, ctx)
+  );
+  const defaultSummary = node.default
+    ? lowerSummaryValue(node.default, paramNames, paramTypes, index, ctx)
+    : undefined;
+
+  if (!defaultSummary) {
+    checkExhaustive(node, cases, paramTypes.get(node.param.name), ctx);
+  }
+
+  return {
+    kind: "switch",
+    parameter: node.param.name,
+    cases,
+    ...(defaultSummary ? { default: defaultSummary } : {}),
+  };
+}
+
+function lowerSummaryCase(
+  c: SummaryCase,
+  paramNames: ReadonlySet<string>,
+  paramTypes: ReadonlyMap<string, IRType>,
+  index: NameIndex,
+  ctx: LowerContext
+): { value: string | number | boolean; summary: IRParameterSummary } {
+  return {
+    value: summaryCaseValue(c.value),
+    summary: lowerSummaryValue(c.body, paramNames, paramTypes, index, ctx),
+  };
+}
+
+function summaryCaseValue(
+  value: StringLiteral | IntegerLiteral | DecimalLiteral | BooleanLiteral | IdentLiteral
+): string | number | boolean {
+  switch (value.kind) {
+    case "StringLiteral":
+      return value.value;
+    case "IntegerLiteral":
+    case "DecimalLiteral":
+      return value.value;
+    case "BooleanLiteral":
+      return value.value;
+    case "IdentLiteral":
+      return value.name;
+  }
+}
+
+function lowerSummaryValue(
+  node: SummaryValue,
+  paramNames: ReadonlySet<string>,
+  paramTypes: ReadonlyMap<string, IRType>,
+  index: NameIndex,
+  ctx: LowerContext
+): IRParameterSummary {
+  if (node.kind === "StringLiteral") {
+    checkTemplateRefs(node, paramNames, ctx);
+    return { kind: "summary", template: node.value };
+  }
+  return lowerSummaryNode(node, paramNames, paramTypes, index, ctx);
+}
+
+function checkTemplateRefs(
+  literal: StringLiteral,
+  paramNames: ReadonlySet<string>,
+  ctx: LowerContext
+): void {
+  // Templates use `${name}` for param interpolation. We don't have sub-spans
+  // for each reference — point diagnostics at the full template string.
+  const pattern = /\$\{([^}]+)\}/g;
+  const seen = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(literal.value)) !== null) {
+    const name = match[1]?.trim();
+    if (!name || seen.has(name) || paramNames.has(name)) continue;
+    seen.add(name);
+    ctx.emit({
+      code: "AX023",
+      message: `summary template references param \`${name}\` which is not declared on this intent`,
+      span: literal.span,
+      fix: {
+        kind: "replace_identifier",
+        targetSpan: toProtocolSpan(literal.span),
+        candidates: [...paramNames].sort(),
+      },
+    });
+  }
+}
+
+function checkParamRef(
+  name: string,
+  span: TokenSpan,
+  paramNames: ReadonlySet<string>,
+  ctx: LowerContext
+): void {
+  if (name === "" || paramNames.has(name)) return;
+  ctx.emit({
+    code: "AX023",
+    message: `summary references param \`${name}\` which is not declared on this intent`,
+    span,
+    fix: {
+      kind: "replace_identifier",
+      targetSpan: toProtocolSpan(span),
+      candidates: [...paramNames].sort(),
+    },
+  });
+}
+
+function checkExhaustive(
+  node: SummarySwitch,
+  cases: readonly { value: string | number | boolean }[],
+  paramType: IRType | undefined,
+  ctx: LowerContext
+): void {
+  if (!paramType) return;
+  const exhausted = isExhaustive(cases, paramType);
+  if (exhausted) return;
+  ctx.emit({
+    code: "AX109",
+    message: `summary switch on \`${node.param.name}\` has no default and is not exhaustive`,
+    span: zeroWidthAt(endOf(node.span)),
+    fix: {
+      kind: "insert_required_clause",
+      targetSpan: toProtocolSpan(zeroWidthAt(endOf(node.span))),
+      suggestedEdit: { text: '\n    default: ""' },
+    },
+  });
+}
+
+function isExhaustive(
+  cases: readonly { value: string | number | boolean }[],
+  type: IRType
+): boolean {
+  const atom = unwrapAtom(type);
+  if (atom.kind === "primitive" && atom.value === "boolean") {
+    const covered = new Set(cases.map((c) => String(c.value)));
+    return covered.has("true") && covered.has("false");
+  }
+  if (atom.kind === "enum") {
+    const covered = new Set(cases.map((c) => String(c.value)));
+    return atom.cases.every((c) => covered.has(c));
+  }
+  return false;
+}
+
+function unwrapAtom(type: IRType): IRType {
+  if (type.kind === "optional") return unwrapAtom(type.innerType);
+  if (type.kind === "dynamicOptions") return unwrapAtom(type.valueType);
+  return type;
+}
+
+// ─── Span helpers ──────────────────────────────────────────────────────
+
+function zeroWidthAt(span: TokenSpan): TokenSpan {
+  return {
+    startByte: span.startByte,
+    endByte: span.startByte,
+    startLine: span.startLine,
+    startColumn: span.startColumn,
+    endLine: span.startLine,
+    endColumn: span.startColumn,
+  };
+}
+
+function endOf(span: TokenSpan): TokenSpan {
+  return {
+    startByte: span.endByte,
+    endByte: span.endByte,
+    startLine: span.endLine,
+    startColumn: span.endColumn,
+    endLine: span.endLine,
+    endColumn: span.endColumn,
+  };
+}
+
+// ─── Small utilities ───────────────────────────────────────────────────
+
+function isPascalCase(name: string): boolean {
+  return /^[A-Z][A-Za-z0-9]*$/.test(name);
+}
+
+function toPascalCase(name: string): string {
+  if (name.length === 0) return name;
+  return name[0]!.toUpperCase() + name.slice(1);
+}
+
+function startsLowercase(name: string): boolean {
+  if (name.length === 0) return false;
+  const c = name.charCodeAt(0);
+  return c >= 0x61 && c <= 0x7a;
+}

--- a/tests/cli/watch-command.test.ts
+++ b/tests/cli/watch-command.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { EventEmitter } from "node:events";
+import { basename, join } from "node:path";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+const harness = vi.hoisted(() => {
+  const watchers: Array<{
+    path: string;
+    callback: (eventType: string, filename: string | Buffer | null) => void;
+    emitter: EventEmitter;
+  }> = [];
+
+  const compileFile = vi.fn();
+  const emitFixPacketArtifacts = vi.fn();
+  const spawn = vi.fn(() => {
+    const proc = new EventEmitter() as EventEmitter & {
+      on: EventEmitter["on"];
+    };
+    queueMicrotask(() => proc.emit("close", 0));
+    return proc as unknown as {
+      on: EventEmitter["on"];
+    };
+  });
+  const fsWatch = vi.fn(
+    (
+      path: string,
+      _options: { persistent: boolean },
+      callback: (eventType: string, filename: string | Buffer | null) => void
+    ) => {
+      const emitter = new EventEmitter();
+      watchers.push({ path, callback, emitter });
+      return emitter as unknown as EventEmitter;
+    }
+  );
+
+  return {
+    watchers,
+    compileFile,
+    emitFixPacketArtifacts,
+    spawn,
+    fsWatch,
+  };
+});
+
+vi.mock("node:child_process", () => ({
+  spawn: harness.spawn,
+}));
+
+vi.mock("../../src/core/compiler.js", () => ({
+  compileFile: harness.compileFile,
+}));
+
+vi.mock("../../src/repair/fix-packet.js", () => ({
+  emitFixPacketArtifacts: harness.emitFixPacketArtifacts,
+}));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual("node:fs");
+  return {
+    ...actual,
+    watch: harness.fsWatch,
+  };
+});
+
+import { registerWatch } from "../../src/cli/watch.js";
+
+async function run(program: Command, args: string[]) {
+  program.name("axint");
+  await program.parseAsync(["node", "axint", ...args], { from: "node" });
+}
+
+describe("watch command unit coverage", () => {
+  const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const processOnSpy = vi.spyOn(process, "on").mockImplementation(() => process);
+  let tempRoot = "";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    tempRoot = mkdtempSync(join(tmpdir(), "axint-watch-unit-"));
+    harness.watchers.length = 0;
+    harness.compileFile.mockReset();
+    harness.emitFixPacketArtifacts.mockReset();
+    harness.spawn.mockClear();
+    harness.fsWatch.mockClear();
+    logSpy.mockClear();
+    errorSpy.mockClear();
+    processOnSpy.mockClear();
+    harness.emitFixPacketArtifacts.mockReturnValue({
+      jsonPath: join(tempRoot, ".axint", "fix", "latest.json"),
+      markdownPath: join(tempRoot, ".axint", "fix", "latest.md"),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("covers single-file watch recompiles and swift-build follow-up", async () => {
+    const intentFile = join(tempRoot, "greet.ts");
+    const outDir = join(tempRoot, "out");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(intentFile, "export default {}", "utf-8");
+
+    harness.compileFile.mockImplementation(
+      (filePath: string, options: { outDir: string }) => ({
+        success: true,
+        diagnostics: [],
+        output: {
+          ir: {
+            name: basename(filePath).includes("updated") ? "GreetUpdated" : "Greet",
+          },
+          outputPath: join(options.outDir, "GreetIntent.swift"),
+          swiftCode: `// compiled from ${basename(filePath)}`,
+        },
+      })
+    );
+
+    const program = new Command();
+    registerWatch(program);
+    await run(program, ["watch", intentFile, "-o", outDir, "--swift-build"]);
+
+    expect(harness.compileFile).toHaveBeenCalledTimes(1);
+    expect(harness.spawn).toHaveBeenCalledTimes(1);
+    expect(readFileSync(join(outDir, "GreetIntent.swift"), "utf-8")).toContain(
+      "compiled from greet.ts"
+    );
+    expect(harness.watchers).toHaveLength(1);
+
+    const watcher = harness.watchers[0];
+    watcher.callback("change", basename(intentFile));
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(harness.compileFile).toHaveBeenCalledTimes(2);
+    expect(harness.spawn).toHaveBeenCalledTimes(2);
+    expect(harness.fsWatch).toHaveBeenCalledWith(
+      tempRoot,
+      { persistent: true },
+      expect.any(Function)
+    );
+  });
+
+  it("covers directory watch filtering and ignores .d.ts updates", async () => {
+    const srcDir = join(tempRoot, "intents");
+    const outDir = join(tempRoot, "out");
+    mkdirSync(srcDir, { recursive: true });
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(srcDir, "first.ts"), "export default {}", "utf-8");
+    writeFileSync(join(srcDir, "types.d.ts"), "export type Demo = string;", "utf-8");
+    writeFileSync(join(srcDir, "notes.txt"), "ignore", "utf-8");
+
+    harness.compileFile.mockImplementation(
+      (filePath: string, options: { outDir: string }) => ({
+        success: true,
+        diagnostics: [],
+        output: {
+          ir: { name: basename(filePath, ".ts") },
+          outputPath: join(options.outDir, `${basename(filePath, ".ts")}.swift`),
+          swiftCode: `// compiled from ${basename(filePath)}`,
+        },
+      })
+    );
+
+    const program = new Command();
+    registerWatch(program);
+    await run(program, ["watch", srcDir, "-o", outDir]);
+
+    expect(harness.compileFile).toHaveBeenCalledTimes(1);
+    expect(harness.compileFile).toHaveBeenCalledWith(
+      join(srcDir, "first.ts"),
+      expect.objectContaining({ outDir })
+    );
+    expect(harness.watchers).toHaveLength(1);
+
+    const watcher = harness.watchers[0];
+    watcher.callback("change", "types.d.ts");
+    await vi.advanceTimersByTimeAsync(200);
+    expect(harness.compileFile).toHaveBeenCalledTimes(1);
+
+    watcher.callback("change", "first.ts");
+    await vi.advanceTimersByTimeAsync(200);
+    expect(harness.compileFile).toHaveBeenCalledTimes(2);
+    expect(readFileSync(join(outDir, "first.swift"), "utf-8")).toContain(
+      "compiled from first.ts"
+    );
+  });
+});

--- a/tests/core/axint-dsl/lowering.test.ts
+++ b/tests/core/axint-dsl/lowering.test.ts
@@ -1,0 +1,486 @@
+import { describe, expect, it } from "vitest";
+import { lower, parse } from "../../../src/core/axint-dsl/index.js";
+import type { Diagnostic } from "../../../src/core/axint-dsl/index.js";
+import type { IRIntent } from "../../../src/core/types.js";
+
+function lowerSource(source: string, sourceFile = "test.axint") {
+  const { file, diagnostics: parseDiags } = parse(source, { sourceFile });
+  if (parseDiags.length > 0) {
+    const lines = parseDiags
+      .map((d) => `${d.code} @ ${d.span.start.line}:${d.span.start.column}  ${d.message}`)
+      .join("\n");
+    throw new Error(`parse produced unexpected diagnostics:\n${lines}`);
+  }
+  return lower(file, { sourceFile });
+}
+
+function codesOf(diagnostics: readonly Diagnostic[]): string[] {
+  return diagnostics.map((d) => d.code);
+}
+
+describe("axint-dsl lowering — happy path", () => {
+  it("lowers a minimal intent to an IRIntent with a default string return type", () => {
+    const { intents, entities, diagnostics } = lowerSource(`
+      intent Hello {
+        title: "Hello"
+        description: "A minimal App Intent that says hello."
+      }
+    `);
+
+    expect(diagnostics).toHaveLength(0);
+    expect(entities).toHaveLength(0);
+    expect(intents).toHaveLength(1);
+
+    const [intent] = intents;
+    expect(intent.name).toBe("Hello");
+    expect(intent.title).toBe("Hello");
+    expect(intent.description).toBe("A minimal App Intent that says hello.");
+    expect(intent.parameters).toHaveLength(0);
+    expect(intent.returnType).toEqual({ kind: "primitive", value: "string" });
+    expect(intent.sourceFile).toBe("test.axint");
+  });
+
+  it("copies meta clauses onto the IRIntent", () => {
+    const { intents, diagnostics } = lowerSource(`
+      intent Ping {
+        title: "Ping"
+        description: "Pings a service."
+        domain: "network"
+        category: "diagnostics"
+        discoverable: true
+        donateOnPerform: false
+      }
+    `);
+
+    expect(diagnostics).toHaveLength(0);
+    const [intent] = intents;
+    expect(intent.domain).toBe("network");
+    expect(intent.category).toBe("diagnostics");
+    expect(intent.isDiscoverable).toBe(true);
+    expect(intent.donateOnPerform).toBe(false);
+  });
+
+  it("lowers params with primitive and optional types", () => {
+    const { intents, diagnostics } = lowerSource(`
+      intent SendMessage {
+        title: "Send Message"
+        description: "Send a message."
+        param recipient: string {
+          description: "Who to send the message to"
+        }
+        param note: string? {
+          description: "Optional note"
+        }
+      }
+    `);
+
+    expect(diagnostics).toHaveLength(0);
+    const [intent] = intents;
+    expect(intent.parameters).toHaveLength(2);
+    expect(intent.parameters[0]).toMatchObject({
+      name: "recipient",
+      type: { kind: "primitive", value: "string" },
+      title: "Who to send the message to",
+      description: "Who to send the message to",
+      isOptional: false,
+    });
+    expect(intent.parameters[1]).toMatchObject({
+      name: "note",
+      type: { kind: "optional", innerType: { kind: "primitive", value: "string" } },
+      isOptional: true,
+    });
+  });
+
+  it("lowers enum param types inline with their cases", () => {
+    const { intents, diagnostics } = lowerSource(`
+      enum Priority { low medium high }
+
+      intent FlagTask {
+        title: "Flag Task"
+        description: "Flags a task with a priority level."
+        param taskId: string {
+          description: "Task identifier"
+        }
+        param priority: Priority {
+          description: "Priority level"
+          default: medium
+        }
+      }
+    `);
+
+    expect(diagnostics).toHaveLength(0);
+    const priority = intents[0]!.parameters[1]!;
+    expect(priority.type).toEqual({
+      kind: "enum",
+      name: "Priority",
+      cases: ["low", "medium", "high"],
+    });
+    expect(priority.defaultValue).toBe("medium");
+  });
+
+  it("wraps dynamic options around the inner value type", () => {
+    const { intents, diagnostics } = lowerSource(`
+      intent Plan {
+        title: "Plan"
+        description: "Plan an activity."
+        param activity: string {
+          description: "Activity"
+          options: dynamic ActivityOptions
+        }
+      }
+    `);
+
+    expect(diagnostics).toHaveLength(0);
+    expect(intents[0]!.parameters[0]!.type).toEqual({
+      kind: "dynamicOptions",
+      valueType: { kind: "primitive", value: "string" },
+      providerName: "ActivityOptions",
+    });
+  });
+
+  it("attaches referenced entities and lowers entity params to entity IR", () => {
+    const { intents, entities, diagnostics } = lowerSource(`
+      entity Trail {
+        display {
+          title: name
+          subtitle: region
+          image: "figure.hiking"
+        }
+        property id: string {
+          description: "Trail identifier"
+        }
+        property name: string {
+          description: "Trail name"
+        }
+        property region: string {
+          description: "Trail region"
+        }
+        query: property
+      }
+
+      intent OpenTrail {
+        title: "Open Trail"
+        description: "Opens a trail."
+        param trail: Trail {
+          description: "Trail to open"
+        }
+      }
+    `);
+
+    expect(diagnostics).toHaveLength(0);
+    expect(entities).toHaveLength(1);
+    expect(entities[0]).toMatchObject({
+      name: "Trail",
+      displayRepresentation: {
+        title: "name",
+        subtitle: "region",
+        image: "figure.hiking",
+      },
+      queryType: "property",
+    });
+    expect(entities[0]!.properties.map((p) => p.name)).toEqual(["id", "name", "region"]);
+
+    const intent = intents[0]!;
+    expect(intent.parameters[0]!.type).toMatchObject({
+      kind: "entity",
+      entityName: "Trail",
+    });
+    expect(intent.entities).toHaveLength(1);
+    expect(intent.entities?.[0]?.name).toBe("Trail");
+  });
+
+  it("lowers returns clauses — primitives, entity, and array of entity", () => {
+    const { intents, diagnostics } = lowerSource(`
+      entity Contact {
+        display { title: name image: "person.circle" }
+        property id: string { description: "id" }
+        property name: string { description: "name" }
+        query: property
+      }
+
+      intent FindContact {
+        title: "Find"
+        description: "Finds a contact."
+        param name: string { description: "Contact name" }
+        returns: Contact
+      }
+
+      intent ListContacts {
+        title: "List"
+        description: "Lists contacts."
+        param limit: int { description: "Max contacts" default: 10 }
+        returns: [Contact]
+      }
+    `);
+
+    expect(diagnostics).toHaveLength(0);
+    expect(intents[0]!.returnType).toMatchObject({
+      kind: "entity",
+      entityName: "Contact",
+    });
+    expect(intents[1]!.returnType).toEqual({
+      kind: "array",
+      elementType: expect.objectContaining({ kind: "entity", entityName: "Contact" }),
+    });
+  });
+
+  it("lowers a simple summary template", () => {
+    const { intents, diagnostics } = lowerSource(`
+      intent Greet {
+        title: "Greet"
+        description: "Greet someone."
+        param name: string { description: "Name" }
+        summary: "Hello \${name}"
+      }
+    `);
+
+    expect(diagnostics).toHaveLength(0);
+    expect(intents[0]!.parameterSummary).toEqual({
+      kind: "summary",
+      template: "Hello ${name}",
+    });
+  });
+
+  it("lowers a summary switch with a default into IRParameterSummary", () => {
+    const { intents, diagnostics } = lowerSource(`
+      intent SetBrightness {
+        title: "Set Brightness"
+        description: "Adjust brightness."
+        param mode: string { description: "Mode" }
+        param value: int { description: "Value" }
+        summary switch mode {
+          case "manual": "Set brightness to \${value}"
+          case "auto": "Switch brightness to automatic"
+          default: "Adjust brightness"
+        }
+      }
+    `);
+
+    expect(diagnostics).toHaveLength(0);
+    const summary = intents[0]!.parameterSummary!;
+    expect(summary.kind).toBe("switch");
+    if (summary.kind !== "switch") throw new Error("unreachable");
+    expect(summary.parameter).toBe("mode");
+    expect(summary.cases).toHaveLength(2);
+    expect(summary.default).toEqual({ kind: "summary", template: "Adjust brightness" });
+  });
+});
+
+describe("axint-dsl lowering — validator diagnostics", () => {
+  it("AX001 fires when the file has zero declarations", () => {
+    const { diagnostics, intents, entities } = lowerSource("");
+    expect(intents).toHaveLength(0);
+    expect(entities).toHaveLength(0);
+    expect(codesOf(diagnostics)).toEqual(["AX001"]);
+    expect(diagnostics[0]!.fix?.kind).toBe("insert_required_clause");
+  });
+
+  it("AX005 fires on an unknown lowercase primitive-ish type", () => {
+    const { diagnostics } = lowerSource(`
+      intent Broken {
+        title: "Broken"
+        description: "Uses an unknown type."
+        param count: integer { description: "Count" }
+      }
+    `);
+    const ax005 = diagnostics.find((d) => d.code === "AX005");
+    expect(ax005).toBeDefined();
+    expect(ax005!.fix?.kind).toBe("change_type");
+    expect(ax005!.fix?.candidates).toContain("int");
+  });
+
+  it("AX020 fires when a param references an undeclared entity", () => {
+    const { diagnostics } = lowerSource(`
+      intent OpenTrail {
+        title: "Open Trail"
+        description: "Opens a trail."
+        param trail: Trail { description: "Trail" }
+      }
+    `);
+    const ax020 = diagnostics.find((d) => d.code === "AX020");
+    expect(ax020).toBeDefined();
+    expect(ax020!.fix?.kind).toBe("replace_identifier");
+  });
+
+  it("AX021 fires when display.title names a property that does not exist", () => {
+    const { diagnostics } = lowerSource(`
+      entity Trail {
+        display {
+          title: label
+          image: "figure.hiking"
+        }
+        property id: string { description: "id" }
+        property name: string { description: "name" }
+        query: property
+      }
+    `);
+    const ax021 = diagnostics.find((d) => d.code === "AX021");
+    expect(ax021).toBeDefined();
+    expect(ax021!.fix?.candidates).toEqual(expect.arrayContaining(["id", "name"]));
+  });
+
+  it("AX023 fires when a summary template references an unknown param", () => {
+    const { diagnostics } = lowerSource(`
+      intent SendMessage {
+        title: "Send Message"
+        description: "Send a message."
+        param recipient: string { description: "Recipient" }
+        param body: string { description: "Body" }
+        summary: "Send \${body} to \${destination}"
+      }
+    `);
+    const ax023 = diagnostics.find((d) => d.code === "AX023");
+    expect(ax023).toBeDefined();
+    expect(ax023!.message).toContain("destination");
+    expect(ax023!.fix?.candidates).toEqual(["body", "recipient"]);
+  });
+
+  it("AX100 fires when the intent name is not PascalCase", () => {
+    const { diagnostics } = lowerSource(`
+      intent send_message {
+        title: "Send"
+        description: "Send."
+      }
+    `);
+    const ax100 = diagnostics.find((d) => d.code === "AX100");
+    expect(ax100).toBeDefined();
+    expect(ax100!.fix?.kind).toBe("rename_identifier");
+  });
+
+  it("AX103 fires on duplicate param names", () => {
+    const { diagnostics } = lowerSource(`
+      intent SendMessage {
+        title: "Send"
+        description: "Send."
+        param recipient: string { description: "Who" }
+        param recipient: string { description: "Who again" }
+      }
+    `);
+    expect(codesOf(diagnostics)).toContain("AX103");
+  });
+
+  it("AX106 fires when a default value doesn't match the declared type", () => {
+    const { diagnostics } = lowerSource(`
+      intent SetBrightness {
+        title: "Set Brightness"
+        description: "Adjust."
+        param level: int {
+          description: "Percentage"
+          default: "one hundred"
+        }
+      }
+    `);
+    const ax106 = diagnostics.find((d) => d.code === "AX106");
+    expect(ax106).toBeDefined();
+    expect(ax106!.fix?.kind).toBe("replace_literal");
+  });
+
+  it("AX107 fires when an optional param carries a default value", () => {
+    const { diagnostics } = lowerSource(`
+      intent SendMessage {
+        title: "Send"
+        description: "Send."
+        param urgent: boolean? {
+          description: "Urgent"
+          default: true
+        }
+      }
+    `);
+    const ax107 = diagnostics.find((d) => d.code === "AX107");
+    expect(ax107).toBeDefined();
+    expect(ax107!.fix?.kind).toBe("remove_field");
+  });
+
+  it("AX109 fires when a boolean summary switch omits the default and doesn't cover both cases", () => {
+    const { diagnostics } = lowerSource(`
+      intent SendMessage {
+        title: "Send"
+        description: "Send."
+        param recipient: string { description: "Who" }
+        param urgent: boolean {
+          description: "Urgent"
+          default: false
+        }
+        summary switch urgent {
+          case true: "URGENT: send to \${recipient}"
+        }
+      }
+    `);
+    const ax109 = diagnostics.find((d) => d.code === "AX109");
+    expect(ax109).toBeDefined();
+    expect(ax109!.fix?.kind).toBe("insert_required_clause");
+  });
+
+  it("accepts an exhaustive boolean switch without a default", () => {
+    const { diagnostics } = lowerSource(`
+      intent SendMessage {
+        title: "Send"
+        description: "Send."
+        param recipient: string { description: "Who" }
+        param urgent: boolean {
+          description: "Urgent"
+          default: false
+        }
+        summary switch urgent {
+          case true: "URGENT: send to \${recipient}"
+          case false: "Send to \${recipient}"
+        }
+      }
+    `);
+    expect(diagnostics.filter((d) => d.code === "AX109")).toHaveLength(0);
+  });
+
+  it("accepts an exhaustive enum switch without a default", () => {
+    const { diagnostics } = lowerSource(`
+      enum Priority { low medium high }
+
+      intent Flag {
+        title: "Flag"
+        description: "Flag."
+        param priority: Priority { description: "Priority" }
+        summary switch priority {
+          case low: "Low"
+          case medium: "Medium"
+          case high: "High"
+        }
+      }
+    `);
+    expect(diagnostics.filter((d) => d.code === "AX109")).toHaveLength(0);
+  });
+});
+
+describe("axint-dsl lowering — diagnostic shape", () => {
+  it("every diagnostic carries the v1 schema version and the reported file path", () => {
+    const { diagnostics } = lowerSource(
+      `intent broken { title: "X" description: "X" }`,
+      "broken.axint"
+    );
+    expect(diagnostics.length).toBeGreaterThan(0);
+    for (const d of diagnostics) {
+      expect(d.schemaVersion).toBe(1);
+      expect(d.file).toBe("broken.axint");
+    }
+  });
+});
+
+describe("axint-dsl lowering — IR contract", () => {
+  it("produces an IRIntent whose shape matches the TS surface (structural check)", () => {
+    const { intents } = lowerSource(`
+      intent Hello {
+        title: "Hello"
+        description: "A minimal App Intent that says hello."
+      }
+    `);
+    const [intent] = intents;
+    // Structural assertions mirror the TS surface's defineIntent output.
+    const expected: IRIntent = {
+      name: "Hello",
+      title: "Hello",
+      description: "A minimal App Intent that says hello.",
+      parameters: [],
+      returnType: { kind: "primitive", value: "string" },
+      sourceFile: "test.axint",
+    };
+    expect(intent).toEqual(expected);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
     "types": ["node"],
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
     "types": ["node"],
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
Lowers the .axint AST into the same IRIntent/IREntity shape the TS SDK produces. Ten validator codes fire with spec-shaped Fix records: AX001, AX005, AX020, AX021, AX023, AX100, AX103, AX106, AX107, AX109. 23 new tests, all green.