### PR TITLE
housekeeping: gitignore local tooling, wire docs and roadmap scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       - run: npm audit --audit-level=moderate
       - run: npm run versions:check
       - run: npm run metrics:check
+      - run: npm run docs:check
       - run: npm run boundary:check
       - run: npm run typecheck
       - run: npm run typecheck:examples

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,12 @@ SUBMISSIONS.md
 
 # Smithery build artifacts
 .smithery/
+
+# Python coverage (pytest-cov artifacts)
+python/.coverage
+python/coverage.json
+python/coverage.lcov
+
+# Local Claude plugin setup (not shipped)
+.agents/
+plugins/

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.3.9 · 11 MCP tools + 3 prompts · 134 diagnostic codes · 713 tests · 14 live packages · 28 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.3.9 · 11 MCP tools + 3 prompts · 139 diagnostic codes · 794 tests · 8 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,9 @@
     "metrics:emit": "node scripts/emit-metrics.mjs",
     "metrics:check": "node scripts/check-metrics.mjs",
     "boundary:check": "node scripts/check-public-boundary.mjs",
-    "prepublishOnly": "npm run versions:check && npm run metrics:check && npm run clean && npm run build",
+    "docs:check": "node scripts/check-readme-mcp-docs.mjs",
+    "roadmap:sync": "node scripts/sync-roadmap-metrics.mjs",
+    "prepublishOnly": "npm run versions:check && npm run metrics:check && npm run docs:check && npm run clean && npm run build",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/python/typings/mcp/__init__.pyi
+++ b/python/typings/mcp/__init__.pyi
@@ -1,0 +1,1 @@
+# Local stubs for the optional `mcp` dependency used by the Python MCP server.

--- a/python/typings/mcp/server/__init__.pyi
+++ b/python/typings/mcp/server/__init__.pyi
@@ -1,0 +1,20 @@
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+class Server:
+    name: str
+
+    def __init__(self, name: str) -> None: ...
+    def list_tools(self) -> Callable[[_F], _F]: ...
+    def call_tool(self) -> Callable[[_F], _F]: ...
+    async def connect(self, transport: Any) -> None: ...
+    async def __aenter__(self) -> Server: ...
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: Any,
+    ) -> None: ...

--- a/python/typings/mcp/server/stdio.pyi
+++ b/python/typings/mcp/server/stdio.pyi
@@ -1,0 +1,8 @@
+class StdioServerTransport:
+    async def __aenter__(self) -> StdioServerTransport: ...
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object | None,
+    ) -> None: ...

--- a/python/typings/mcp/types.pyi
+++ b/python/typings/mcp/types.pyi
@@ -1,0 +1,32 @@
+from typing import Any
+
+class ToolAnnotations:
+    readOnlyHint: bool
+    destructiveHint: bool
+    idempotentHint: bool
+    openWorldHint: bool
+
+    def __init__(
+        self,
+        *,
+        readOnlyHint: bool,
+        destructiveHint: bool,
+        idempotentHint: bool,
+        openWorldHint: bool,
+    ) -> None: ...
+
+
+class Tool:
+    name: str
+    description: str
+    annotations: ToolAnnotations
+    inputSchema: dict[str, Any]
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str,
+        annotations: ToolAnnotations,
+        inputSchema: dict[str, Any],
+    ) -> None: ...

--- a/scripts/check-readme-mcp-docs.mjs
+++ b/scripts/check-readme-mcp-docs.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Verify the README's public MCP docs still match the compiler surface.
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const README = resolve(ROOT, "README.md");
+const METRICS = resolve(ROOT, "metrics.json");
+const PUBLIC_TRUTH = resolve(ROOT, "..", "public-truth", "public-truth.json");
+
+const readme = readFileSync(README, "utf-8");
+const metrics = JSON.parse(readFileSync(METRICS, "utf-8"));
+const publicTruth = existsSync(PUBLIC_TRUTH)
+  ? JSON.parse(readFileSync(PUBLIC_TRUTH, "utf-8"))
+  : null;
+const failures = [];
+
+for (const toolName of metrics.mcpToolNames ?? []) {
+  if (!readme.includes(`\`${toolName}\``)) {
+    failures.push(`README is missing MCP tool reference: ${toolName}`);
+  }
+}
+
+for (const promptName of metrics.mcpPromptNames ?? []) {
+  if (!readme.includes(`\`${promptName}\``)) {
+    failures.push(`README is missing MCP prompt reference: ${promptName}`);
+  }
+}
+
+const proofMatch = readme.match(
+  /<!-- truth:readme-proof-line:start -->([\s\S]*?)<!-- truth:readme-proof-line:end -->/,
+);
+
+if (!proofMatch) {
+  failures.push("README public-truth proof line markers are missing");
+} else {
+  const proofLine = proofMatch[1].trim();
+  const expectedVersion = publicTruth?.axint?.versionTag ?? `v${metrics.version}`;
+  const expectedMcp =
+    publicTruth?.axint?.mcp?.summary
+    ?? `${metrics.mcpTools} MCP tools + ${metrics.mcpPrompts} prompts`;
+  const expectedDiagnostics =
+    publicTruth?.axint?.diagnostics?.summary
+    ?? `${metrics.diagnostics} diagnostic codes`;
+  const totalTests = (metrics.tests?.typescript ?? 0) + (metrics.tests?.python ?? 0);
+  const expectedTests =
+    publicTruth?.axint?.tests?.summary
+    ?? `${totalTests} tests`;
+  const expectedPackages =
+    publicTruth?.axint?.registryPackages?.summary
+    ?? `${metrics.registryPackages} live packages`;
+  const expectedTemplates =
+    publicTruth?.axint?.templates?.summary
+    ?? `${metrics.bundledTemplates} bundled templates`;
+
+  if (!proofLine.includes(expectedVersion)) {
+    failures.push(`README proof line should include ${expectedVersion}`);
+  }
+  if (!proofLine.includes(expectedMcp)) {
+    failures.push(`README proof line should include ${expectedMcp}`);
+  }
+  if (!proofLine.includes(expectedDiagnostics)) {
+    failures.push(`README proof line should include ${expectedDiagnostics}`);
+  }
+  if (!proofLine.includes(expectedTests)) {
+    failures.push(`README proof line should include ${expectedTests}`);
+  }
+  if (!proofLine.includes(expectedPackages)) {
+    failures.push(`README proof line should include ${expectedPackages}`);
+  }
+  if (!proofLine.includes(expectedTemplates)) {
+    failures.push(`README proof line should include ${expectedTemplates}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("README MCP docs are stale:\n");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("README MCP docs match metrics.json");

--- a/scripts/sync-roadmap-metrics.mjs
+++ b/scripts/sync-roadmap-metrics.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Keep ROADMAP release references and current snapshot tied to metrics.json.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const ROADMAP = resolve(ROOT, "ROADMAP.md");
+const METRICS = resolve(ROOT, "metrics.json");
+const CHECK = process.argv.includes("--check");
+
+const metrics = JSON.parse(readFileSync(METRICS, "utf-8"));
+const totalTests = Number(metrics.tests?.typescript ?? 0) + Number(metrics.tests?.python ?? 0);
+
+const releaseLink = `[v${metrics.version}](https://github.com/agenticempire/axint/releases/tag/v${metrics.version})`;
+const snapshotLine =
+  `Current compiler snapshot: v${metrics.version} · ${metrics.mcpTools} MCP tools + ` +
+  `${metrics.mcpPrompts} prompts · ${metrics.bundledTemplates} templates · ` +
+  `${metrics.diagnostics} diagnostic codes · ${totalTests} tests.`;
+
+const current = readFileSync(ROADMAP, "utf-8");
+const next = replaceBetween(
+  replaceBetween(
+    current,
+    "<!-- metrics:roadmap-release:start -->",
+    "<!-- metrics:roadmap-release:end -->",
+    releaseLink,
+  ),
+  "<!-- metrics:roadmap-snapshot:start -->",
+  "<!-- metrics:roadmap-snapshot:end -->",
+  snapshotLine,
+);
+
+if (CHECK) {
+  if (next !== current) {
+    console.error("ROADMAP.md metrics are stale — run: node scripts/sync-roadmap-metrics.mjs");
+    process.exit(1);
+  }
+  console.log("ROADMAP.md matches metrics.json");
+  process.exit(0);
+}
+
+writeFileSync(ROADMAP, next, "utf-8");
+console.log("ROADMAP.md synced from metrics.json");
+
+function replaceBetween(source, startMarker, endMarker, content) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker);
+
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(`Missing markers: ${startMarker} ... ${endMarker}`);
+  }
+
+  const before = source.slice(0, start + startMarker.length);
+  const after = source.slice(end);
+  return `${before}${content}${after}`;
+}


### PR DESCRIPTION
Cleans up the working tree:

- .gitignore picks up pytest-cov artifacts (python/.coverage, python/coverage.json, python/coverage.lcov) and local Claude plugin descriptors (.agents/, plugins/) that aren't for the public repo
- scripts/check-readme-mcp-docs.mjs (new): guards against README drift when MCP tool/prompt names change in metrics.json — wired into CI between metrics:check and boundary:check, and into prepublishOnly
- scripts/sync-roadmap-metrics.mjs (new): manual-only sync from metrics.json into ROADMAP.md via marker comments (no CI gate yet — ROADMAP needs markers added first)
- python/typings/mcp/*.pyi: pyright stubs for the MCP SDK, auto-discovered via convention

Follow-up PR will land the spec/language/*.md drop.