### PR TITLE
add language spec under spec/language/

### DIFF
--- a/spec/language/README.md
+++ b/spec/language/README.md
@@ -1,0 +1,49 @@
+# Axint App-Definition Language — Specification
+
+Axint adds a compact declarative authoring surface for App Intents and App Entities that compiles 1:1 into the existing IR and validated Swift. That is the whole pitch. It is not a general-purpose programming language, not a replacement for the TypeScript or Python surfaces, and not an attempt to grow a new ecosystem. It is a capture mechanism — a low-entropy syntax that agents can write, read, diff, and correct in a single prompt — pointed at the same compiler, the same diagnostics, and the same validated Swift output everything else already targets.
+
+The existing TS and Python SDKs remain the primary authoring surfaces. The app-definition language is a third surface sitting next to them. All three lower to the same `IRIntent` / `IREntity` nodes, so every intent written in any surface is fungible with every intent written in every other surface.
+
+This directory is the specification. The language itself ships as part of `@axint/compiler` starting in `v0.4.0-alpha`, behind an experimental flag.
+
+## Status
+
+- **Version:** draft 1 (pre-implementation)
+- **Scope v1:** `intent`, `entity`, and `enum` declarations. An enum is a closed set of named cases used as a param type. Files may contain any combination of the three; a file with only enums is valid and compiles to the enum's Swift form with no intent output.
+- **IR target:** existing `IRIntent`, `IREntity`, and the inline `enum` IR form — no new IR nodes
+- **Diagnostics v1:** reuses existing `AX001`–`AX113` and `AX200`–`AX202` codes — no new codes
+- **File extension:** `.axint`
+- **Reserved for later:** additional top-level surfaces (`view`, `widget`, `app`) and cross-file composition (`use`, `from`) — deferred to v0.5.0+. User-defined functions, types beyond `entity` and `enum`, and macros are permanent non-goals (see [`non-goals.md`](./non-goals.md)).
+
+## Contents
+
+- [`why-agents.md`](./why-agents.md) — the thesis: smallest valid search space, measured on seven metrics
+- [`principles.md`](./principles.md) — design principles and the seven agent-first criteria
+- [`grammar.md`](./grammar.md) — lexical rules and full EBNF
+- [`parser-recovery.md`](./parser-recovery.md) — single-pass recovery contract: one parse, all diagnostics
+- [`keywords.md`](./keywords.md) — keyword and type catalog
+- [`ir-mapping.md`](./ir-mapping.md) — every production mapped to an IR node
+- [`non-goals.md`](./non-goals.md) — what the language deliberately refuses to express
+- [`diagnostics.md`](./diagnostics.md) — which AX codes a `.axint` file can trigger
+- [`diagnostic-protocol.md`](./diagnostic-protocol.md) — machine-readable diagnostic schema and fix-kind taxonomy
+- [`benchmark.md`](./benchmark.md) — 20-task agent benchmark matrix across `.axint`, TS, Python, and raw Swift
+- [`failures.md`](./failures.md) — canonical broken-input corpus, one entry per author-side AX code
+- [`examples/`](./examples) — canonical `.axint` files with paired Swift outputs
+
+## Versioning
+
+The spec ships three version lines. Most releases touch one; they bump independently.
+
+| Line                         | Lives in                           | Bumps when                                                                                   |
+|------------------------------|------------------------------------|----------------------------------------------------------------------------------------------|
+| Language spec                | this directory                     | Grammar, keyword set, IR mapping, or field-order rules change                                  |
+| Diagnostic protocol          | `schemaVersion` in `diagnostic-protocol.md` (pinned to `1`) | JSON record shape, the closed fix-kind set, or `Fix` object fields change       |
+| Parser recovery boundaries   | `parser-recovery.md`               | The closed four-point boundary set gains or loses a recovery point                            |
+
+Diagnostic wording changes bump nothing.
+
+## One rule above everything else
+
+> The language is not the product. The language is the capture mechanism.
+
+Every decision in this spec is evaluated against that frame. If a feature makes the surface richer but harder for an agent to emit correctly, it does not ship. The compiler's IR, the validator, and the Swift generator are the product. The language exists so a model can hand us a single file and we can hand back a working Apple feature.

--- a/spec/language/benchmark.md
+++ b/spec/language/benchmark.md
@@ -1,0 +1,174 @@
+# Benchmark Matrix
+
+The claim in `why-agents.md` is empirical: authoring in `.axint` moves seven measurable metrics the right way compared to raw Swift, the TS SDK, and the Python SDK. This doc specifies the benchmark that proves or disproves that claim on every release. A spec or grammar change that moves any metric the wrong way rolls back.
+
+The benchmark is deliberately small. Twenty tasks, not two hundred. A small matrix that runs on every PR is more useful than a large matrix that runs once a quarter. The tasks are chosen to cover the grammar's decision points, not to stress-test throughput.
+
+## The four surfaces under test
+
+| Surface     | What the agent emits                                   |
+|-------------|--------------------------------------------------------|
+| `.axint`    | A `.axint` source file                                 |
+| TS SDK      | A `.ts` file using `defineIntent` / `defineEntity`     |
+| Python SDK  | A `.py` file using the `axint` package                 |
+| Raw Swift   | A `.swift` file targeting the Apple `AppIntents` framework directly |
+
+All four flow through the same downstream pipeline: the first three lower to IR and emit Swift via the compiler; raw Swift is measured directly. The comparison is at the agent-authored artifact level: what did the model produce on turn 1, and how far was it from a Swift binary that compiles against the Apple SDK.
+
+## The seven metrics
+
+Named the same way as `why-agents.md` so the two docs read together. Every task contributes one data point per metric per surface.
+
+| # | Metric                          | Definition                                                                 | Unit      |
+|---|---------------------------------|----------------------------------------------------------------------------|-----------|
+| 1 | First-pass parse rate           | Share of turn-1 outputs that parse without syntax error                    | %         |
+| 2 | First-pass validator pass rate  | Share of parsed turn-1 outputs that clear every semantic check (AX001–AX113) | %        |
+| 3 | First-pass Swift compile rate   | Share of validated turn-1 outputs whose emitted Swift compiles against the Apple SDK | %   |
+| 4 | Turns to green                  | Mean agent turns from first broken output to valid-compiling, capped at 5  | turns     |
+| 5 | Lines changed per repair        | Mean unified-diff lines between consecutive repair turns                    | lines     |
+| 6 | Tokens per successful feature   | Mean generated tokens to reach a valid compiling feature (sum across turns) | tokens    |
+| 7 | Output variance                 | Mean pairwise tree-edit distance over the normalized IR across runs         | unitless  |
+
+Metric 7 is measured on IR, not source, so a purely stylistic difference (whitespace, field order that the formatter normalizes) contributes zero. Two agents producing textually different files that lower to byte-identical IR score perfectly on variance.
+
+## Harness shape
+
+For each `(task, surface)` pair, the harness runs `N = 10` independent generations per model, across `M = 3` models (Sonnet-class, Opus-class, one open-weight peer pinned at release time). Models and temperatures are pinned in `benchmark.config.json`; the pin changes in a version-bump PR, not silently.
+
+One generation is:
+
+1. **Prompt.** Fixed prompt per task. Prompts are identical across surfaces except for the surface-specific preamble — which names the surface, gives one 10-line example, and links the spec. No few-shot beyond the preamble.
+2. **Turn 1 output.** Recorded. Metrics 1, 2, 3 are computed here.
+3. **Repair loop.** If turn 1 failed, the harness feeds the compiler diagnostics back to the agent and records turn 2, then turn 3, up to turn 5. Metrics 4, 5 are computed over this loop.
+4. **Tokens.** Every turn's generated-token count is summed into metric 6.
+5. **Variance.** After all `N × M` runs for a task complete, metric 7 is the mean pairwise tree-edit distance across the successful IRs.
+
+The loop caps at 5 turns because in practice agents either converge in ≤3 or diverge. A cap keeps one bad run from dominating the mean.
+
+## Repair-loop contract
+
+The repair loop uses the machine-readable diagnostic protocol in `diagnostic-protocol.md`. The harness feeds the agent exactly what an automated caller would receive: the JSON diagnostic record, with `code`, `message`, `span`, `fix.kind`, and `fix.suggestedEdit.text` where present. No additional human-written hints. If `.axint` wins metric 4 (turns to green), it wins it on the merit of the protocol, not on richer prompting.
+
+Raw Swift has no diagnostic protocol. The harness feeds the agent the first `swiftc` error verbatim, one error per turn. This is the realistic counterfactual — `swiftc` does not emit structured repair suggestions.
+
+## The 20 tasks
+
+Three buckets — authoring, repair, transformation. Every task has a fixed prompt, a fixed success criterion, and a reference IR so the harness can score structural correctness beyond "it compiled."
+
+### Authoring (10 tasks)
+
+New file from scratch.
+
+| # | Task                                                                                                           | Grammar surface exercised               |
+|---|----------------------------------------------------------------------------------------------------------------|------------------------------------------|
+| A1 | Send a message to a recipient. One string param.                                                              | Minimum viable intent                    |
+| A2 | Set brightness to a percentage. Int param with a default of 100.                                              | Default values                           |
+| A3 | Toggle a boolean setting. Single optional boolean param.                                                      | Optional primitives                      |
+| A4 | Start a workout with a chosen activity from a fixed list (Run, Bike, Swim).                                   | Enum param                               |
+| A5 | Open a trail. Param is a `Trail` entity with five properties and `query: property`.                           | Entity declaration + entity param        |
+| A6 | Schedule a calendar event. Title, start date, optional duration. Requires calendar entitlement + `NSCalendarsUsageDescription`. | entitlements + infoPlistKeys |
+| A7 | Plan activity on a trail near a region. Summary with `when` on the optional region param.                     | `summary when`                           |
+| A8 | Plan activity on a trail with nested `switch` on `includeNearby` and inner `when` on `region`.                 | Nested `summary switch`/`when`           |
+| A9 | Find tracks matching a search. String param with `options: dynamic TrackSearchOptions`.                       | Dynamic options provider                 |
+| A10 | Return a list of recent trails. `returns: [Trail]`.                                                           | Entity array return type                 |
+
+### Repair (6 tasks)
+
+Start from a deliberately broken file, reach green.
+
+| # | Task                                                                                       | Diagnostic exercised  | Corpus entry                              |
+|---|--------------------------------------------------------------------------------------------|-----------------------|-------------------------------------------|
+| R1 | `description` is missing from an otherwise valid intent.                                  | AX004                 | `ax004-missing-description/`              |
+| R2 | An `intent-body` has `description` before `title`.                                        | AX007                 | `ax007-clause-out-of-order/`              |
+| R3 | A `param` name is `Recipient` (PascalCase) instead of `recipient` (camelCase).            | AX105                 | `ax105-param-not-camel/`                  |
+| R4 | An `entity` `display { title: propName }` references a property that doesn't exist.       | AX021                 | `ax021-display-unknown-property/`         |
+| R5 | An `entity` has `display { image: "trail-icon" }` with an SF Symbol that isn't in the catalog. | AX113             | `ax113-invalid-sf-symbol/`                |
+| R6 | An `entity` is missing its `query` clause entirely.                                        | AX017                 | `ax017-entity-missing-query/`             |
+
+Every row pulls its starting `broken.axint` from the corpus entry in the rightmost column — the benchmark does not define its own broken fixtures. This keeps repair-task diagnostics and corpus diagnostics byte-for-byte in sync.
+
+### Transformation (4 tasks)
+
+Start from a valid file, apply a change.
+
+| # | Task                                                                                                          | Edit surface                |
+|---|---------------------------------------------------------------------------------------------------------------|-----------------------------|
+| T1 | Rename a param from `activity` to `sport`. Summary template references must update.                          | Cross-clause identifier     |
+| T2 | Add a new required `priority: Priority` enum param to an existing intent that already has a `summary switch`. | Summary + param coupling    |
+| T3 | Add HealthKit entitlement and `NSHealthShareUsageDescription` to an existing intent that has neither block.  | Block insertion             |
+| T4 | Change a `region` param from `string` to an enum of `{ north south east west }`.                              | Type change                 |
+
+### Why this split
+
+The authoring bucket exercises every non-trivial grammar production. The repair bucket exercises the diagnostic protocol and the fix-kind taxonomy end-to-end. The transformation bucket exercises something no other benchmark tests: whether a constrained language is as easy to *edit* as it is to *write*. Metrics 5 and 7 live or die on transformation tasks.
+
+## Reference IR and scoring
+
+Every task ships with a reference IR in `examples/benchmark/<task-id>/reference.ir.json`. Scoring:
+
+- **Structural correctness:** tree-edit distance from the agent's IR to the reference IR, normalized by reference IR size. Zero means structurally identical. This is scored alongside metric 3 — a file that compiles but lowers to a structurally wrong IR does not count as a success for authoring tasks.
+- **Repair tasks:** the reference IR is the *fixed* form. The broken source ships in `broken.<surface>`. Success is the agent reaching an IR that equals the reference IR within tree-edit distance tolerance.
+- **Transformation tasks:** two reference IRs — `before.ir.json` and `after.ir.json`. The agent is given the before state and a plain-English instruction; success is reaching `after.ir.json`.
+
+## Regression budgets
+
+Every release runs the benchmark and publishes the seven metric deltas against the last release. Budgets:
+
+| Metric                      | Regression budget per release           |
+|-----------------------------|-----------------------------------------|
+| First-pass parse rate       | No regression                           |
+| First-pass validator pass   | −2 percentage points maximum             |
+| First-pass Swift compile    | −2 percentage points maximum             |
+| Turns to green              | +0.3 turns maximum                       |
+| Lines changed per repair    | +1 line maximum                          |
+| Tokens per feature          | +10% maximum                             |
+| Output variance             | +5% maximum                              |
+
+A PR that breaches any budget on `.axint` rolls back. A PR that breaches any budget on TS or Python (shared compiler pipeline) gets escalated to the same review. Raw Swift numbers are recorded but not budgeted — Apple owns that surface, we don't.
+
+## What the benchmark does not measure
+
+- **Human ergonomics.** If Axint is worse for humans than Swift, that's fine — `why-agents.md` is explicit about the target. A human-ergonomics benchmark would need a different harness.
+- **Runtime performance of emitted Swift.** The generator is the same across all three SDK surfaces, so there's no differential signal. If there's a regression in the generated Swift, it's caught by the Swift compile rate, not by a performance bench.
+- **Cross-surface mixing.** A project that writes some intents in `.axint` and others in TS is a real-world case, but it doesn't belong in the per-surface bench. A separate integration suite covers it.
+- **Long-context authoring.** Every benchmark file is one intent or one small cluster. Multi-file, multi-feature authoring isn't a v1 concern.
+
+## Source-of-truth layout
+
+```
+spec/language/
+  benchmark.md              # this file
+  examples/benchmark/
+    a1-send-message/
+      prompt.txt
+      reference.ir.json
+      reference.axint
+      reference.ts
+      reference.py
+      reference.swift
+    a2-set-brightness/
+      ...
+    r1-missing-description/
+      prompt.txt
+      broken.axint
+      broken.ts
+      broken.py
+      broken.swift
+      reference.ir.json
+    t1-rename-param/
+      prompt.txt
+      before.axint
+      before.ts
+      before.py
+      before.swift
+      after.ir.json
+    ...
+```
+
+Every task has reference artifacts for all four surfaces. The reference is what a principal engineer would write — it anchors the scoring and doubles as the corpus for `examples/`.
+
+## Cadence
+
+The benchmark runs on every PR that touches `spec/`, `compiler/`, or `runtime/`. A scheduled nightly run against pinned-tip model versions catches model drift. Results land in `benchmark/results/<date>.json`, and the README badge on the compiler repo links the latest.
+
+A release is blocked until the benchmark passes the regression budgets. There is no "we'll fix it in the next one."

--- a/spec/language/diagnostic-protocol.md
+++ b/spec/language/diagnostic-protocol.md
@@ -1,0 +1,207 @@
+# Diagnostic Protocol
+
+Every diagnostic the compiler emits against a `.axint` file is machine-readable and repair-oriented. A diagnostic does not just tell an agent *what* is wrong — it tells the agent *where* to edit, *what kind* of edit, and, when possible, *exactly what* to write. This turns criterion #4 in `principles.md` ("easy to correct") and metrics #4–#5 in `why-agents.md` (turns to green, lines per repair) from aspirations into a protocol.
+
+Human-readable diagnostics still ship — they are the default output of `axint check` and what a developer sees in an editor. The machine-readable form is additive, emitted under `axint check --format=json`.
+
+## The diagnostic record
+
+Every diagnostic is a JSON object of this shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "code": "AX021",
+  "severity": "error",
+  "message": "Display field names a property that doesn't exist on the entity.",
+  "file": "intents/trail.axint",
+  "span": {
+    "start": { "line": 5, "column": 12 },
+    "end":   { "line": 5, "column": 17 }
+  },
+  "fix": {
+    "kind": "replace_identifier",
+    "targetSpan": {
+      "start": { "line": 5, "column": 12 },
+      "end":   { "line": 5, "column": 17 }
+    },
+    "suggestedEdit": { "text": "name" },
+    "candidates": ["name", "region"]
+  }
+}
+```
+
+Top-level fields:
+
+| Field            | Type                                  | Required | Meaning                                                            |
+|------------------|---------------------------------------|----------|--------------------------------------------------------------------|
+| `schemaVersion`  | integer                               | yes      | Pinned to `1` in v1. Consumers must check and reject unknown versions. |
+| `code`           | string                                | yes      | `AX###`. One of the codes in `diagnostics.md`.                      |
+| `severity`       | `"error"` \| `"warning"`              | yes      | Matches the catalog in `diagnostics.md`.                            |
+| `message`        | string                                | yes      | Human-readable. One sentence. No trailing period convention.        |
+| `file`           | string                                | yes      | Path relative to the project root.                                  |
+| `span`           | `Span`                                | yes      | Where the problem is. Used for editor highlighting.                  |
+| `fix`            | `Fix` \| `null`                       | yes      | `null` when there is no principled author-side fix (compiler/registry codes). |
+
+## Spans
+
+```ts
+type Position = { line: number; column: number }  // both 1-indexed
+type Span     = { start: Position; end: Position } // end is exclusive
+```
+
+Line and column are 1-indexed. `end` is exclusive — `{start:(5,12), end:(5,17)}` covers five characters on line 5 starting at column 12. A zero-width span (`start == end`) denotes an insertion point, used by the insert-class fix kinds below.
+
+Spans always point at the narrowest meaningful range. For an identifier error, the span is the identifier, not the enclosing clause. For a missing clause, the span is the empty range at the point the clause would appear.
+
+## Fix kinds
+
+Six kinds. Closed set — the TypeScript union type is exhaustive and the compiler emits a `never` default. Adding a new kind is a minor version bump of `schemaVersion`.
+
+| Kind                      | What it does                                                                  | Canonical triggers                                           |
+|---------------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `insert_required_clause`  | Insert a missing required clause or block.                                    | AX001, AX003, AX004, AX015, AX016, AX017, AX019, AX109, AX112 |
+| `remove_field`            | Delete a field that is syntactically valid but contradictory, unknown, or out of order. | AX107, AX007 (see §AX007 below)                      |
+| `replace_literal`         | Replace a literal value with another of the correct type or from a closed set. | AX101, AX102, AX106, AX113                                    |
+| `change_type`             | Change a declared type annotation to match the surrounding constraint.         | AX005, AX007 (see §AX007 below)                              |
+| `rename_identifier`       | Rename an identifier to match a naming convention, resolve a duplicate, or correct a close-match typo. | AX100, AX103, AX105, AX110, AX111, AX007 (see §AX007 below) |
+| `replace_identifier`      | Rewrite an identifier reference to point at a different declaration that exists. | AX002, AX018, AX020, AX021, AX022, AX023                    |
+
+The kind is a hint about the *shape* of the edit. It does not replace the `suggestedEdit.text` field — it tells the agent what class of mistake this is, which is useful for repair priority, for training, and for cases where the text field is absent and the agent has to synthesize the edit itself.
+
+### AX007 fix-kind resolution
+
+AX007 is the one code that maps to more than one fix kind. The code itself is narrow — "parser saw a token it doesn't expect at this position" — but it fires on three distinct parser-position errors, and the repair shape differs per sub-case. The parser knows which sub-case it is at emission time, so the emitted `fix.kind` is deterministic.
+
+| Sub-case                                                 | Fix kind               | Example and repair                                                                                  |
+|----------------------------------------------------------|------------------------|-----------------------------------------------------------------------------------------------------|
+| Unknown field keyword, close match to a valid one         | `rename_identifier`    | `titel: "..."` → the compiler emits `rename_identifier` with `suggestedEdit.text: "title"`          |
+| Unknown field keyword, no close match                     | `remove_field`         | `frobnicate: 42` inside an `intent-body` → delete the line (`suggestedEdit.text: ""`)               |
+| Clause declared out of the fixed order                    | `remove_field`         | `description` before `title` → delete the out-of-order line; the next `axint check` fires AX003/AX004 with `insert_required_clause` at the correct position. Two passes, each a single-line edit. |
+| Malformed type syntax (generics, unrecognized form)       | `change_type`          | `param foo: Map<string, int>` → change to a supported primitive, entity, or array form              |
+
+The closed fix-kind set does not grow to accommodate AX007. The code stays overloaded on purpose — the parser's notion of "this token doesn't belong here" is one concept, even if the repair shape splits. The two axes (codes describe what went wrong, fix kinds describe what shape the repair takes) are intentionally orthogonal. Agents that read `fix.kind` get a single-edit repair path regardless of which sub-case fired.
+
+A later release can split AX007 into three distinct codes if implementation shows the overload is confusing in practice. That is a `schemaVersion` bump and a catalog migration, not a v1 concern.
+
+## The `Fix` object
+
+```ts
+type Fix = {
+  kind:           FixKind
+  targetSpan:     Span
+  suggestedEdit?: { text: string }
+  candidates?:    string[]
+}
+```
+
+| Field           | Type        | Required | Meaning                                                              |
+|-----------------|-------------|----------|----------------------------------------------------------------------|
+| `kind`          | `FixKind`   | yes      | One of the six kinds above.                                          |
+| `targetSpan`    | `Span`      | yes      | The exact range the edit replaces. For inserts, a zero-width span at the insertion point. |
+| `suggestedEdit` | `{ text }`  | no       | When the compiler can synthesize a complete fix, the replacement text. Applying this text at `targetSpan` resolves the diagnostic. |
+| `candidates`    | `string[]`  | no       | For identifier-replacement kinds, the set of valid alternatives. The agent picks one; `suggestedEdit.text`, when present, is the compiler's top pick. |
+
+A `suggestedEdit` is present when:
+
+- The target is a closed set (`replace_literal` for `AX018` query-kind, `AX113` SF Symbol, `replace_identifier` for `AX020`/`AX021`/`AX023` where only one plausible target exists).
+- The target is mechanical (`remove_field` for `AX107`: `text: ""`).
+- The convention is unambiguous (`rename_identifier` for `AX100`/`AX105`/`AX110`/`AX111`: PascalCase ↔ camelCase is a pure transform).
+
+A `suggestedEdit` is absent when:
+
+- The correct text depends on domain knowledge (`insert_required_clause` for `AX003` missing title: the compiler can insert `title: ""` but the string itself is up to the agent).
+- Multiple candidates are equally valid and no heuristic picks one.
+
+In the absent case, the agent synthesizes the text. `kind` and `targetSpan` still narrow the task to a one-line edit.
+
+## Applying an edit
+
+The edit operation is textual, not semantic. Given a diagnostic with `fix.targetSpan = s` and `fix.suggestedEdit.text = t`:
+
+1. Read the source bytes between `s.start` and `s.end`.
+2. Replace them with `t`.
+3. Rerun `axint check`.
+
+If the diagnostic was the only blocker and the suggested edit is present, the file is now valid. If there are more diagnostics, the agent processes the next one. If the edit introduced a new diagnostic, the agent backs off to the next candidate or asks for help.
+
+The protocol makes no promise that all diagnostics are suggestedEdit-complete in v1. The promise is that every diagnostic has a `kind` and a `targetSpan`, so every fix is local and bounded.
+
+## Catalog
+
+Every code in `diagnostics.md` mapped to its fix kind. Suggested edits marked ✅ where the compiler can synthesize the full text, ✱ where it can only insert a scaffold, and — where the agent must supply the text.
+
+| Code  | Severity | Fix kind                   | Suggested |
+|-------|----------|----------------------------|-----------|
+| AX001 | error    | `insert_required_clause`   | ✱         |
+| AX002 | error    | `replace_identifier`       | —         |
+| AX003 | error    | `insert_required_clause`   | ✱         |
+| AX004 | error    | `insert_required_clause`   | ✱         |
+| AX005 | error    | `change_type`              | —         |
+| AX007 | error    | context-sensitive †        | varies    |
+| AX015 | error    | `insert_required_clause`   | ✱         |
+| AX016 | error    | `insert_required_clause`   | ✱         |
+| AX017 | error    | `insert_required_clause`   | ✱         |
+| AX018 | error    | `replace_literal`          | ✅        |
+| AX019 | error    | `insert_required_clause`   | ✱         |
+| AX020 | error    | `replace_identifier`       | ✅        |
+| AX021 | error    | `replace_identifier`       | ✅        |
+| AX022 | error    | `replace_identifier`       | —         |
+| AX023 | error    | `replace_identifier`       | ✅        |
+| AX100 | error    | `rename_identifier`        | ✅        |
+| AX101 | error    | `replace_literal`          | —         |
+| AX102 | error    | `replace_literal`          | —         |
+| AX103 | error    | `rename_identifier`        | —         |
+| AX104 | error    | `insert_required_clause` \| `replace_literal` | — |
+| AX105 | error    | `rename_identifier`        | ✅        |
+| AX106 | error    | `replace_literal`          | —         |
+| AX107 | error    | `remove_field`             | ✅        |
+| AX108 | warning  | `insert_required_clause`   | ✱         |
+| AX109 | error    | `insert_required_clause`   | ✱         |
+| AX110 | error    | `rename_identifier`        | ✅        |
+| AX111 | error    | `rename_identifier`        | ✅        |
+| AX112 | error    | `insert_required_clause`   | ✱         |
+| AX113 | error    | `replace_literal`          | ✅        |
+| AX200 | error    | — (compiler bug)           | —         |
+| AX201 | error    | — (compiler bug)           | —         |
+| AX202 | error    | — (compiler bug)           | —         |
+| AX600 | error    | — (registry, not author-side) | —      |
+
+The codes without an author-side fix (`AX200`–`AX202`, `AX600`) emit `"fix": null`. These surface as tool errors — a compiler bug, a registry mismatch — and the repair path is "file an issue" or "republish," not "edit the file."
+
+† AX007's fix kind depends on the sub-case. See [§AX007 fix-kind resolution](#ax007-fix-kind-resolution) above.
+
+## The agent repair loop
+
+```
+while True:
+    result = axint_check(file, format="json")
+    if result.diagnostics == []:
+        break
+
+    d = pick_highest_priority(result.diagnostics)
+
+    if d.fix is None:
+        escalate_to_user(d)
+        break
+
+    if d.fix.suggestedEdit is not None:
+        file = apply_edit(file, d.fix.targetSpan, d.fix.suggestedEdit.text)
+    else:
+        text = synthesize_text(d.code, d.fix.kind, d.fix.candidates, context=file)
+        file = apply_edit(file, d.fix.targetSpan, text)
+```
+
+`pick_highest_priority` in v1 is "first-file, first-line, first-column." Diagnostics do not block each other — fixing them in source order converges.
+
+## Versioning
+
+`schemaVersion: 1` is pinned for the life of v1. If the shape of the emitted record changes — new required field, renamed field, new fix kind added to the closed set — the version increments. Consumers must refuse records with a `schemaVersion` they do not recognize rather than silently dropping unknown fields.
+
+The fix-kind set is closed. Adding a new fix kind is a version bump. Changing which AX code maps to which fix kind is a patch — the semantics of an edit don't change, only the label.
+
+## Why this schema and not LSP diagnostics
+
+LSP's `Diagnostic` is a superset shape designed for general-purpose language servers. It carries `code`, `message`, `range`, and a free-form `data` field that every server uses differently. That freedom is precisely what we are trying to remove. The Axint diagnostic protocol is a closed schema built around a closed fix-kind set, because the whole point is that an agent consuming diagnostics from Axint can write repair logic once and have it work against every diagnostic the compiler will ever emit.
+
+The protocol is serializable to LSP — the `code`, `message`, `range`, and a subset of `data` map cleanly — and the `axint-lsp` server does that translation. But the canonical machine-readable form is this document, not LSP.

--- a/spec/language/diagnostics.md
+++ b/spec/language/diagnostics.md
@@ -1,0 +1,88 @@
+# Diagnostics
+
+v1 ships with zero new diagnostic codes. Every validation path a `.axint` file can hit already has an AX code from the TS/Python surfaces. This document catalogs which codes fire, in which parser stage, and what triggers them.
+
+## Parser stage — lexing and syntax
+
+These fire before validation, while tokenizing or parsing the file.
+
+| Code   | Severity | Trigger in `.axint`                                            |
+|--------|----------|----------------------------------------------------------------|
+| AX001  | error    | File contains no top-level declarations. A file with only comments, or an empty file, fails. A file with only `enum` declarations is valid. |
+| AX002  | error    | An `intent` or `entity` declaration is missing a name.         |
+| AX003  | error    | An `intent` is missing a `title` clause.                       |
+| AX004  | error    | An `intent` is missing a `description` clause.                 |
+| AX005  | error    | A `param` or `property` uses an unknown type.                  |
+| AX007  | error    | A clause or token the parser does not recognize at its position — covers unknown field keyword inside an `intent-body` or `entity-body` (e.g. `titel: "..."`), a clause declared out of the fixed order, or a type syntax form the parser does not recognize (e.g. generics). |
+| AX015  | error    | An `entity` is missing a `display` block.                      |
+| AX016  | error    | An `entity` `display` block is missing `title`.                |
+| AX017  | error    | An `entity` is missing a `query` clause.                       |
+| AX018  | error    | An `entity` `query` uses an unknown kind.                      |
+| AX019  | error    | An `entity` has zero `property` declarations.                  |
+| AX020  | error    | A `param` references an entity not declared in the file.       |
+| AX021  | error    | A `display` field names a property that doesn't exist.         |
+| AX022  | error    | A `param options: dynamic` names a provider that cannot be resolved at bundle time. Note: this is a build-time concern, not an authoring-surface dependency. The `.axint` file itself remains single-file; provider resolution happens when the CLI assembles the bundle from `.axint` + sibling TS/Python files. |
+| AX023  | error    | A `summary` template references a param that doesn't exist on the intent. |
+
+Note: the parser reuses the same AX015–AX023 range the TS parser uses for entity errors. The surface is different, the errors are the same.
+
+## Validator stage — semantic checks
+
+After the parser produces IR, the same `IRIntent` and `IREntity` validators the TS surface runs are run against the DSL-produced IR. No DSL-specific logic.
+
+| Code   | Severity | Trigger                                                        |
+|--------|----------|----------------------------------------------------------------|
+| AX100  | error    | Intent name is not `PascalCase`.                               |
+| AX101  | error    | Intent `title` is empty.                                       |
+| AX102  | error    | Intent `description` is empty.                                 |
+| AX103  | error    | Intent has duplicate param names.                              |
+| AX104  | error    | Param or entity property is missing its `description` field, or the description string is empty. The grammar requires the field; the validator rejects an empty string. |
+| AX105  | error    | Param name is not `camelCase`.                                 |
+| AX106  | error    | Param `default` value type does not match the declared type.   |
+| AX107  | error    | Optional param has a non-null default — contradictory.         |
+| AX108  | warning  | Intent has no params (allowed but unusual).                    |
+| AX109  | error    | `summary` `switch` has no `default` and the param type is not exhaustively covered. |
+| AX110  | error    | Entity name is not `PascalCase`.                               |
+| AX111  | error    | Entity property name is not `camelCase`.                       |
+| AX112  | error    | Entity `query: property` but no property has `description`.    |
+| AX113  | error    | Entity `display.image` is not a valid SF Symbol or asset name. |
+
+## Generator stage — Swift emission
+
+These should not fire against a well-formed IR from the parser. If any of these triggers, there is a bug in the DSL → IR lowering.
+
+| Code   | Severity | Trigger                                                        |
+|--------|----------|----------------------------------------------------------------|
+| AX200  | error    | Generator received an unknown IR type kind.                    |
+| AX201  | error    | Generator could not synthesize a required conformance.         |
+| AX202  | error    | Generator tried to emit a platform-specific type unsupported on the target. |
+
+The DSL parser has a property test ensuring every IR it produces is well-formed relative to the IR type schema in `src/core/types.ts`. If the generator emits AX200+, the parser test suite has a gap.
+
+## Registry / bundle
+
+| Code   | Severity | Trigger                                                        |
+|--------|----------|----------------------------------------------------------------|
+| AX600  | error    | A `.axint` file is publishable to the registry and the bundle hash does not match. |
+
+This only fires during `axint publish`. Authoring a `.axint` file never triggers AX600.
+
+## What does *not* need new codes
+
+- Recursive `summary` structures: if an inner `summary when` references a missing param, AX023 fires with a nested path.
+- Entity references in `returns`: same AX020 path as param entity references.
+- Enum case references in `summary switch case`: validated by the same literal-type checker that enforces `default` values. If `case purple:` appears under a `switch priority` where `Priority` is `{ low medium high }`, the validator rejects it with AX106 — the same "literal does not match declared type" code used for defaults, because semantically that is the same class of error (a literal the type can't accept).
+
+## Agent fix-path expectation
+
+For each diagnostic above, an agent receiving the error should be able to fix the file by editing one line or one block. Example:
+
+```
+# AX107: Optional param has a non-null default — contradictory.
+param urgent: boolean? {
+  description: "Mark as urgent"
+  default: true    # ← remove this line, or change type to `boolean`
+}
+```
+
+The validator emits the line and column. The fix is a single-line edit. That is the agent-first criterion #4 in `principles.md`.

--- a/spec/language/failures.md
+++ b/spec/language/failures.md
@@ -1,0 +1,317 @@
+# Canonical Failures Corpus
+
+The failures corpus is the set of deliberately broken `.axint` inputs that every author-side diagnostic code (`AX001`–`AX113`) must have an entry for. Each entry pins the input, the exact diagnostic record the compiler emits, and the one-edit repair. The corpus is what the benchmark's repair bucket (`benchmark.md` §Repair) draws from, what the diagnostic-protocol test suite regressions against, and what a new agent repair-loop learns from.
+
+It also enforces a contract: a new diagnostic code cannot ship without a corpus entry. If the compiler can emit it, the corpus shows what triggers it and what fixes it.
+
+## What an entry contains
+
+Each entry lives under `spec/language/examples/failures/<ax-code>/` and has exactly five files. No more, no less.
+
+| File              | Purpose                                                                 |
+|-------------------|-------------------------------------------------------------------------|
+| `broken.axint`    | The minimal `.axint` source that triggers this code and only this code. |
+| `diagnostic.json` | The exact diagnostic record the compiler emits, matching the schema in `diagnostic-protocol.md`. Used as the gold output for protocol tests. |
+| `fixed.axint`     | The repaired file, identical to `broken.axint` outside the repair span. |
+| `repair.diff`     | Unified diff `broken.axint` → `fixed.axint`. Must be ≤3 lines changed — any entry that requires more is a sign the diagnostic or the repair is too broad. |
+| `notes.md`        | One paragraph. Why this is the canonical form of this failure, what near-variants are *not* canonical, and what the fix demonstrates about the fix kind. |
+
+"Minimal" means the surrounding `.axint` is the smallest valid-except-for-this-error file. An `AX107` entry is a valid intent with one param whose only flaw is a non-null default on an optional — nothing else in the file is redundant or decorative.
+
+"And only this code" means a fresh `axint check --format=json` on `broken.axint` returns exactly one diagnostic. Multi-error test files have their place in the benchmark's authoring corpus; they do not belong here. The failures corpus is one-to-one with codes.
+
+## Layout
+
+```
+spec/language/examples/failures/
+  ax001-empty-file/
+    broken.axint
+    diagnostic.json
+    fixed.axint
+    repair.diff
+    notes.md
+  ax003-missing-title/
+    ...
+  ax007-clause-out-of-order/
+    ...
+  ax021-display-unknown-property/
+    ...
+  ax107-optional-with-default/
+    ...
+```
+
+Directory names are `<ax-code>-<kebab-case-summary>`. The summary is the phrase a developer would grep for, not the full diagnostic message.
+
+## Representative entries
+
+Six entries written in full, one per fix kind from `diagnostic-protocol.md`. The rest of the 29 author-side codes follow the same shape.
+
+### AX003 — missing title (`insert_required_clause`)
+
+`broken.axint`:
+
+```
+intent SendMessage {
+  description: "Send a message to a recipient"
+  param recipient: string {
+    description: "Who to send to"
+  }
+}
+```
+
+`diagnostic.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "code": "AX003",
+  "severity": "error",
+  "message": "Intent is missing a title clause",
+  "file": "broken.axint",
+  "span": { "start": { "line": 2, "column": 3 }, "end": { "line": 2, "column": 3 } },
+  "fix": {
+    "kind": "insert_required_clause",
+    "targetSpan": { "start": { "line": 2, "column": 3 }, "end": { "line": 2, "column": 3 } },
+    "suggestedEdit": { "text": "title: \"\"\n  " }
+  }
+}
+```
+
+`fixed.axint` fills in `title: "Send Message"` on the inserted line. `notes.md` notes that the suggested edit is a scaffold (`✱`), not a finished string — the agent supplies the human-readable title.
+
+### AX107 — optional param with non-null default (`remove_field`)
+
+`broken.axint`:
+
+```
+intent MarkUrgent {
+  title: "Mark Urgent"
+  description: "Flag an item as urgent"
+  param urgent: boolean? {
+    description: "Mark as urgent"
+    default: true
+  }
+}
+```
+
+`diagnostic.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "code": "AX107",
+  "severity": "error",
+  "message": "Optional param has a non-null default",
+  "file": "broken.axint",
+  "span": { "start": { "line": 6, "column": 5 }, "end": { "line": 6, "column": 18 } },
+  "fix": {
+    "kind": "remove_field",
+    "targetSpan": { "start": { "line": 6, "column": 5 }, "end": { "line": 6, "column": 18 } },
+    "suggestedEdit": { "text": "" }
+  }
+}
+```
+
+`repair.diff` is a one-line deletion. `notes.md` notes that the alternative fix (drop `?` from the type) is *not* the canonical repair — the semantics of optional-with-default are contradictory, and the remove-field path preserves the author's intent that the param is optional.
+
+### AX113 — invalid SF Symbol (`replace_literal`)
+
+`broken.axint`:
+
+```
+entity Trail {
+  display {
+    title: name
+    image: "trail-icon"
+  }
+  property id: string { description: "Identifier" }
+  property name: string { description: "Trail name" }
+  query: id
+}
+```
+
+`diagnostic.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "code": "AX113",
+  "severity": "error",
+  "message": "Display image is not a valid SF Symbol",
+  "file": "broken.axint",
+  "span": { "start": { "line": 4, "column": 12 }, "end": { "line": 4, "column": 25 } },
+  "fix": {
+    "kind": "replace_literal",
+    "targetSpan": { "start": { "line": 4, "column": 12 }, "end": { "line": 4, "column": 25 } },
+    "suggestedEdit": { "text": "\"figure.hiking\"" },
+    "candidates": ["figure.hiking", "figure.walk", "map"]
+  }
+}
+```
+
+The compiler synthesized the top pick from the SF Symbol catalog's fuzzy match. `candidates` carries the runner-ups so the agent can override if the top pick is wrong in context.
+
+### AX005 — unknown type (`change_type`)
+
+`broken.axint`:
+
+```
+intent SetTimer {
+  title: "Set Timer"
+  description: "Start a timer"
+  param length: timespan {
+    description: "Timer length"
+  }
+}
+```
+
+`diagnostic.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "code": "AX005",
+  "severity": "error",
+  "message": "Unknown type 'timespan'",
+  "file": "broken.axint",
+  "span": { "start": { "line": 4, "column": 17 }, "end": { "line": 4, "column": 25 } },
+  "fix": {
+    "kind": "change_type",
+    "targetSpan": { "start": { "line": 4, "column": 17 }, "end": { "line": 4, "column": 25 } }
+  }
+}
+```
+
+No `suggestedEdit` — the correct type depends on intent (`duration`, `int`, an enum). `notes.md` enumerates the three plausible replacements and explains why each is wrong for this particular intent, ending with `duration` as the right answer.
+
+### AX100 — intent name not PascalCase (`rename_identifier`)
+
+`broken.axint`:
+
+```
+intent sendMessage {
+  title: "Send Message"
+  description: "Send a message"
+}
+```
+
+`diagnostic.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "code": "AX100",
+  "severity": "error",
+  "message": "Intent name must be PascalCase",
+  "file": "broken.axint",
+  "span": { "start": { "line": 1, "column": 8 }, "end": { "line": 1, "column": 19 } },
+  "fix": {
+    "kind": "rename_identifier",
+    "targetSpan": { "start": { "line": 1, "column": 8 }, "end": { "line": 1, "column": 19 } },
+    "suggestedEdit": { "text": "SendMessage" }
+  }
+}
+```
+
+Pure mechanical transform, `suggestedEdit` is complete (`✅`).
+
+### AX021 — display references unknown property (`replace_identifier`)
+
+`broken.axint`:
+
+```
+entity Trail {
+  display {
+    title: label
+  }
+  property name: string { description: "Trail name" }
+  property region: string { description: "Trail region" }
+  query: string
+}
+```
+
+`diagnostic.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "code": "AX021",
+  "severity": "error",
+  "message": "Display field names a property that doesn't exist on the entity",
+  "file": "broken.axint",
+  "span": { "start": { "line": 3, "column": 12 }, "end": { "line": 3, "column": 17 } },
+  "fix": {
+    "kind": "replace_identifier",
+    "targetSpan": { "start": { "line": 3, "column": 12 }, "end": { "line": 3, "column": 17 } },
+    "suggestedEdit": { "text": "name" },
+    "candidates": ["name", "region"]
+  }
+}
+```
+
+Classic identifier-replacement case. The compiler's top pick is the closest-string-distance declared property; `candidates` carries the full set so an agent whose semantic intent was `region` can override without guessing.
+
+## Coverage
+
+Every author-side code in `diagnostics.md` has a corpus entry. The table below is the canonical coverage map — if a PR adds a new code, it must add a row here and ship the directory in the same commit.
+
+| Code   | Directory                                 | Fix kind                     |
+|--------|-------------------------------------------|------------------------------|
+| AX001  | `ax001-empty-file/`                       | `insert_required_clause`     |
+| AX002  | `ax002-missing-name/`                     | `replace_identifier`         |
+| AX003  | `ax003-missing-title/`                    | `insert_required_clause`     |
+| AX004  | `ax004-missing-description/`              | `insert_required_clause`     |
+| AX005  | `ax005-unknown-type/`                     | `change_type`                |
+| AX007  | `ax007-clause-out-of-order/`              | `remove_field` †             |
+| AX015  | `ax015-entity-missing-display/`           | `insert_required_clause`     |
+| AX016  | `ax016-display-missing-title/`            | `insert_required_clause`     |
+| AX017  | `ax017-entity-missing-query/`             | `insert_required_clause`     |
+| AX018  | `ax018-unknown-query-kind/`               | `replace_literal`            |
+| AX019  | `ax019-entity-no-properties/`             | `insert_required_clause`     |
+| AX020  | `ax020-unknown-entity-ref/`               | `replace_identifier`         |
+| AX021  | `ax021-display-unknown-property/`         | `replace_identifier`         |
+| AX022  | `ax022-unknown-options-provider/`         | `replace_identifier`         |
+| AX023  | `ax023-summary-unknown-param/`            | `replace_identifier`         |
+| AX100  | `ax100-intent-not-pascal/`                | `rename_identifier`          |
+| AX101  | `ax101-empty-title/`                      | `replace_literal`            |
+| AX102  | `ax102-empty-description/`                | `replace_literal`            |
+| AX103  | `ax103-duplicate-param/`                  | `rename_identifier`          |
+| AX104  | `ax104-empty-field-description/`          | `replace_literal`            |
+| AX105  | `ax105-param-not-camel/`                  | `rename_identifier`          |
+| AX106  | `ax106-default-type-mismatch/`            | `replace_literal`            |
+| AX107  | `ax107-optional-with-default/`            | `remove_field`               |
+| AX108  | `ax108-intent-no-params/`                 | `insert_required_clause`     |
+| AX109  | `ax109-switch-missing-default/`           | `insert_required_clause`     |
+| AX110  | `ax110-entity-not-pascal/`                | `rename_identifier`          |
+| AX111  | `ax111-property-not-camel/`               | `rename_identifier`          |
+| AX112  | `ax112-query-property-no-descriptions/`   | `insert_required_clause`     |
+| AX113  | `ax113-invalid-sf-symbol/`                | `replace_literal`            |
+
+Generator bugs (`AX200`–`AX202`) and registry errors (`AX600`) are not in the corpus — they are not author-side failures. They are covered by the compiler's own regression tests.
+
+† AX007 is context-sensitive — see [`diagnostic-protocol.md` §AX007 fix-kind resolution](./diagnostic-protocol.md#ax007-fix-kind-resolution). This corpus entry pins the clause-out-of-order sub-case, which emits `remove_field`. The unknown-field-keyword and malformed-type-syntax sub-cases share the code but emit `rename_identifier` / `remove_field` / `change_type` depending on which one fires. The corpus rule is one entry per code, not per sub-case — the entry above is the representative form of AX007 for CI and benchmark purposes. Adding sub-case entries becomes worthwhile only if implementation proves they drift from each other in practice.
+
+## Maintenance contract
+
+Three rules, enforced by CI:
+
+1. **Every code in `diagnostics.md` has a matching directory.** CI walks `spec/language/examples/failures/` and compares the code prefixes against `diagnostics.md`. Missing or orphaned entries fail the build.
+
+2. **Every `broken.axint` triggers exactly its code.** CI runs `axint check --format=json` on every `broken.axint` and diffs the output against that directory's `diagnostic.json`. Any divergence fails the build. Extra diagnostics, a different code, a different span — all failures.
+
+3. **Every `fixed.axint` is clean.** CI runs `axint check` on every `fixed.axint`. Any diagnostic fails the build. This catches the case where someone "fixes" an entry in a way that introduces a new error.
+
+A fourth soft rule, not CI-enforced but watched: `repair.diff` should be ≤3 lines changed. An entry that needs more is a signal that either the diagnostic is imprecise (it should have fired on a narrower span) or the repair is not canonical.
+
+## How this feeds the benchmark
+
+`benchmark.md` §Repair pulls six tasks (`R1`–`R6`) directly from this corpus. Each benchmark repair task reuses the corresponding `broken.axint` as its starting point and the corresponding `fixed.axint` as the reference target. The benchmark harness only has to add the agent-facing prompt and the repair-loop wiring; the broken input, the expected diagnostic, and the repair are already pinned here.
+
+This means a diagnostic regression — the compiler starts emitting a different span, or a different fix kind, for an existing failure — shows up in both the corpus CI and the benchmark delta on the next run. The two signals are redundant on purpose. The corpus catches changes in the diagnostic protocol's output; the benchmark catches changes in how agents perform against that output.
+
+## What this corpus is not
+
+- **Not a tutorial.** The examples are minimal and surgical. `examples/` has the canonical demonstration files for showing authors what a well-written `.axint` looks like.
+- **Not a fuzz corpus.** Every entry is a human-written minimal case. Fuzz coverage is the parser's own property tests, not this directory.
+- **Not a multi-error corpus.** By construction, one code per entry. Multi-error files are the benchmark's authoring bucket, not here.
+- **Not versioned by model.** The corpus is the compiler's output contract. Agent behavior against the corpus is measured in the benchmark; the corpus itself is model-agnostic.

--- a/spec/language/grammar.md
+++ b/spec/language/grammar.md
@@ -1,0 +1,333 @@
+# Grammar
+
+## Lexical rules
+
+### Whitespace
+
+Spaces, tabs, and newlines separate tokens. Whitespace is never significant to meaning. Indentation is a formatter convention, not a grammar rule.
+
+### Comments
+
+```
+# Single-line comment — extends to end of line.
+```
+
+`#` is the only comment syntax. No block comments.
+
+### Identifiers
+
+```
+identifier    = letter { letter | digit | "_" }
+letter        = "A".."Z" | "a".."z" | "_"
+digit         = "0".."9"
+```
+
+Conventions (enforced by validator, not by grammar):
+
+- `intent` and `entity` names are `PascalCase`: `SendMessage`, `Trail`
+- `param` and `property` names are `camelCase`: `recipient`, `distanceKm`
+- `enum` names are `PascalCase`; `enum` case names are `camelCase`
+
+### Keywords
+
+Reserved words — cannot be used as identifiers:
+
+```
+intent  entity  enum  param  property  summary  display  query
+title   description  domain  category  default  options  dynamic
+case    default  when    then  otherwise  switch
+string  int  double  float  boolean  date  duration  url
+true   false
+entitlements  infoPlistKeys  discoverable  donateOnPerform  returns
+use  from
+```
+
+`use` and `from` are reserved in v1 even though the grammar does not use them. They are held for the v0.5 cross-file composition story described in `non-goals.md`. Declaring them reserved now means a v0.5 upgrade is grammar-additive, not grammar-breaking.
+
+### String literals
+
+```
+string-literal = "\"" { character } "\""
+```
+
+Only double-quoted strings. Standard backslash escapes: `\"`, `\\`, `\n`, `\t`.
+
+Inside a `summary` template string, `${identifier}` references a declared param. No other interpolation anywhere.
+
+No multi-line strings in v1. If a description is long, put it on one line. Agents don't care about line length.
+
+### Number literals
+
+```
+number-literal = [ "-" ] digit { digit } [ "." digit { digit } ]
+```
+
+Integers and decimals only. No hex, no binary, no exponent notation, no underscores.
+
+### Boolean literals
+
+```
+boolean-literal = "true" | "false"
+```
+
+## Syntactic grammar (EBNF)
+
+### File
+
+```
+file = { top-level-decl } .
+
+top-level-decl = enum-decl
+               | entity-decl
+               | intent-decl .
+```
+
+A file may contain zero or more top-level declarations in any order, except that an entity referenced by an intent must be declared in the same file (v1 is single-file). Convention: entities first, then intents.
+
+### Enum declaration
+
+```
+enum-decl = "enum" identifier "{" enum-case { enum-case } "}" .
+enum-case = identifier .
+```
+
+Example:
+
+```
+enum Priority { low medium high }
+```
+
+Cases may also be placed one per line.
+
+### Entity declaration
+
+```
+entity-decl      = "entity" identifier "{" entity-body "}" .
+entity-body      = display-block
+                   { property-decl }
+                   query-clause .
+display-block    = "display" "{" display-field { display-field } "}" .
+display-field    = display-property-ref
+                 | display-image .
+display-property-ref = ( "title" | "subtitle" ) ":" identifier .
+display-image    = "image" ":" string-literal .
+property-decl    = "property" identifier ":" type "{" property-body "}" .
+property-body    = description-field .
+query-clause     = "query" ":" query-kind .
+query-kind       = "all" | "id" | "string" | "property" .
+```
+
+Four query kinds are supported. Each picks a different `EntityQuery` conformance in the generated Swift:
+
+| Kind         | When to use                                                                  |
+|--------------|------------------------------------------------------------------------------|
+| `query: all` | The app exposes a small, fixed set and Shortcuts should list them all.       |
+| `query: id`  | Entities are resolved by their declared `id` property.                       |
+| `query: string` | Entities are resolved by a freeform string match against the display `title` property. |
+| `query: property` | Every property with a `description` becomes a Shortcuts-selectable filter (property-based lookup). |
+
+Example:
+
+```
+entity Trail {
+  display {
+    title: name
+    subtitle: region
+    image: "figure.hiking"
+  }
+
+  property id: string {
+    description: "Trail identifier"
+  }
+
+  property name: string {
+    description: "Trail name"
+  }
+
+  property region: string {
+    description: "Trail region"
+  }
+
+  property distanceKm: double {
+    description: "Distance in kilometers"
+  }
+
+  property openNow: boolean {
+    description: "Whether the trail is open"
+  }
+
+  query: property
+}
+```
+
+### Intent declaration
+
+```
+intent-decl      = "intent" identifier "{" intent-body "}" .
+intent-body      = title-clause
+                   description-clause
+                   { intent-meta }
+                   { param-decl }
+                   [ summary-decl ]
+                   [ returns-clause ]
+                   [ entitlements-block ]
+                   [ info-plist-block ] .
+
+title-clause       = "title" ":" string-literal .
+description-clause = "description" ":" string-literal .
+
+intent-meta      = "domain" ":" string-literal
+                 | "category" ":" string-literal
+                 | "discoverable" ":" boolean-literal
+                 | "donateOnPerform" ":" boolean-literal .
+
+returns-clause   = "returns" ":" return-type .
+return-type      = return-type-atom | "[" return-type-atom "]" .
+return-type-atom = primitive-type | identifier .
+```
+
+`returns` does not accept `?` in v1. A `returns-clause` is a primitive, a declared entity, an array of either, or it is omitted entirely. "Sometimes returns nothing" is expressed by omitting `returns`, returning an empty array, or surfacing the condition via dialog/error — not by declaring `T?` as the return. This is a deliberate search-space narrowing: the DSL is not trying to match every shape Apple's `ReturnsValue` can carry, it is trying to collapse marginally-different forms into one canonical one.
+
+The EBNF fixes the clause order. `title` comes first, then `description`, then zero or more `intent-meta` clauses (`domain`, `category`, `discoverable`, `donateOnPerform`), then zero or more `param` declarations, then an optional `summary`, then an optional `returns`, then an optional `entitlements` block, then an optional `infoPlistKeys` block. Every `.axint` file in the corpus follows this order, and the formatter enforces it. A clause out of order is a syntax error (AX007) — no recovery, no re-ordering, no "we'll figure out what you meant." This makes ten different agents produce textually identical files, which is criterion #1 in `principles.md`.
+
+### Parameter declaration
+
+```
+param-decl       = "param" identifier ":" type "{" param-body "}" .
+param-body       = description-field { other-param-field } .
+description-field = "description" ":" string-literal .
+other-param-field = "default" ":" literal
+                  | "options" ":" "dynamic" identifier .
+```
+
+A param block is required. Inside it, `description` is required and must be the first field — it becomes the `@Parameter(title: …)` string in the emitted Swift, and the Shortcuts UI will not render without it. `default` and `options` are optional and may follow in any order. The same rule applies to `property` inside an `entity`: the body is required, `description` is required and comes first, no other fields ship in v1.
+
+Example:
+
+```
+param recipient: string {
+  description: "Who to send the message to"
+}
+
+param urgent: boolean? {
+  description: "Mark as urgent"
+}
+
+param brightness: int {
+  description: "Brightness percentage (0-100)"
+  default: 100
+}
+
+param activity: string {
+  description: "Activity type"
+  options: dynamic ActivityOptions
+}
+
+param trail: Trail {
+  description: "Trail to open"
+}
+```
+
+### Types
+
+```
+type             = type-atom [ "?" ] .
+type-atom        = primitive-type
+                 | array-type
+                 | identifier .
+primitive-type   = "string" | "int" | "double" | "float"
+                 | "boolean" | "date" | "duration" | "url" .
+array-type       = "[" type "]" .
+```
+
+`identifier` as a type refers to a declared entity or enum in the same file.
+
+Optionality is expressed by a trailing `?`. An optional array is `[string]?`. Arrays of optionals are not supported in v1 — that is a TS surface concern if it ever matters.
+
+Optionality applies to `param` and `property` types. It does **not** apply to `returns` (see `returns-clause` above). A param may be `string?`; a return may not be `Trail?`.
+
+### Summary declaration
+
+```
+summary-decl     = "summary" summary-form .
+summary-form     = ":" string-literal
+                 | "when" identifier "{" when-body "}"
+                 | "switch" identifier "{" switch-body "}" .
+
+when-body        = "then" ":" summary-value
+                   [ "otherwise" ":" summary-value ] .
+
+switch-body      = switch-case { switch-case }
+                   [ "default" ":" summary-value ] .
+
+switch-case      = "case" literal ":" summary-value .
+
+summary-value    = string-literal
+                 | "summary" summary-form .
+```
+
+The recursion on `summary-value` allows nested switch/when structures without ambiguity.
+
+Example (simple):
+
+```
+summary: "Plan ${activity} on ${trail}"
+```
+
+Example (when):
+
+```
+summary when region {
+  then: "Plan ${activity} on ${trail} near ${region}"
+  otherwise: "Plan ${activity} on ${trail} near me"
+}
+```
+
+Example (nested switch + when):
+
+```
+summary switch includeNearby {
+  case true: summary when region {
+    then: "Plan ${activity} on ${trail} near ${region}"
+    otherwise: "Plan ${activity} on ${trail} near me"
+  }
+  case false: "Plan ${activity} on ${trail}"
+  default: "Plan trail"
+}
+```
+
+### Entitlements and Info.plist
+
+```
+entitlements-block = "entitlements" "{" { string-literal } "}" .
+info-plist-block   = "infoPlistKeys" "{" { info-plist-entry } "}" .
+info-plist-entry   = string-literal ":" string-literal .
+```
+
+Example:
+
+```
+entitlements {
+  "com.apple.developer.siri"
+}
+
+infoPlistKeys {
+  "NSCalendarsUsageDescription": "Axint needs calendar access to create events."
+}
+```
+
+### Literals
+
+```
+literal = string-literal | number-literal | boolean-literal | identifier .
+```
+
+An `identifier` literal is only valid as a `case` value in a `summary switch`, where it refers to an enum case. All other literal uses require a typed primitive.
+
+## Grammar decisions worth calling out
+
+- **`:` everywhere.** Every key-to-value binding uses `:`. Every type annotation uses `:`. No `=`. One symbol, one job (at the lexer level), two closely related jobs (at the semantic level).
+- **Braces, not indentation.** Indentation is never semantic. A formatter writes two-space indent; a parser ignores it.
+- **No semicolons, no commas.** Declarations end when the next declaration begins or when a `}` closes the enclosing block. Inside blocks, newlines separate fields; whitespace between fields is not required.
+- **No trailing punctuation.** A block body ends at `}`. No trailing comma. No trailing semicolon.
+- **Keywords are reserved globally.** Even inside string literals, keywords have no special meaning — but the literal is treated as opaque text. A param cannot be named `title` or `query`.

--- a/spec/language/ir-mapping.md
+++ b/spec/language/ir-mapping.md
@@ -1,0 +1,157 @@
+# IR Mapping
+
+Every production in the grammar compiles to a node or field in the existing IR. No new IR nodes ship in v1. This file is the canonical mapping.
+
+## Intent
+
+```
+intent Name {
+  title: "..."
+  description: "..."
+  domain: "..."
+  category: "..."
+  discoverable: true
+  donateOnPerform: true
+  ...
+}
+```
+
+| DSL form                         | IR field on `IRIntent`          |
+|----------------------------------|---------------------------------|
+| `intent Name { ... }`            | `name: "Name"`                  |
+| `title: "..."`                   | `title: "..."`                  |
+| `description: "..."`             | `description: "..."`            |
+| `domain: "..."`                  | `domain?: "..."`                |
+| `category: "..."`                | `category?: "..."`              |
+| `discoverable: bool`             | `isDiscoverable?: bool`         |
+| `donateOnPerform: bool`          | `donateOnPerform?: bool`        |
+| `returns: T`                     | `returnType: IRType` — `T` is a non-optional primitive, entity, or array (see grammar `return-type`) |
+| `returns: CustomType`            | `customResultType?: "CustomType"` (when `T` is not a known primitive or entity) |
+| `param name: T { ... }`          | appends an `IRParameter` to `parameters` |
+| `summary ...`                    | `parameterSummary?: IRParameterSummary` |
+| `entitlements { "..." }`         | appends to `entitlements?: string[]`    |
+| `infoPlistKeys { "k": "v" }`     | merges into `infoPlistKeys?: Record<string, string>` |
+| Entities declared in the file    | `entities?: IREntity[]` (auto-collected when referenced by any param) |
+| The source `.axint` file path    | `sourceFile: "..."`             |
+
+## Entity
+
+```
+entity Name {
+  display { title: propName subtitle: propName image: "sf.symbol" }
+  property id: string { description: "..." }
+  ...
+  query: property
+}
+```
+
+| DSL form                                   | IR field on `IREntity`                          |
+|--------------------------------------------|-------------------------------------------------|
+| `entity Name { ... }`                      | `name: "Name"`                                  |
+| `display { title: propName }`              | `displayRepresentation.title: "propName"` (bare identifier, must match a declared `property`) |
+| `display { subtitle: propName }`           | `displayRepresentation.subtitle?: "propName"` (bare identifier, must match a declared `property`) |
+| `display { image: "sf.symbol" }`           | `displayRepresentation.image?: "sf.symbol"` (quoted literal — SF Symbol name or asset identifier) |
+| `property name: T { description: "..." }`  | appends an `IRParameter` to `properties`        |
+| `query: all \| id \| string \| property`   | `queryType: "all" \| "id" \| "string" \| "property"` |
+
+The grammar disambiguates on token type: bare identifiers in `title`/`subtitle` are property references, a quoted string in `image` is a literal asset name. The validator resolves the identifier against the entity's declared properties and raises `AX021` if the name doesn't exist.
+
+## Parameters
+
+A `param` in an intent and a `property` on an entity both compile to `IRParameter`. They use the same grammar productions.
+
+```
+param name: T {
+  description: "..."
+  default: <literal>
+  options: dynamic ProviderName
+}
+```
+
+| DSL form                         | IR field on `IRParameter`                                  |
+|----------------------------------|------------------------------------------------------------|
+| `param name: T`                  | `name: "name"`, `type: <mapped IRType>`, `isOptional: false` |
+| `param name: T?`                 | same, with `isOptional: true` and type wrapped as needed   |
+| `{ description: "..." }`         | `description: "..."`, `title: "..."` (defaults to description when no explicit title) |
+| `{ default: <literal> }`         | `defaultValue: <literal>`                                  |
+| `{ options: dynamic Provider }`  | `type: { kind: "dynamicOptions", valueType: <inner>, providerName: "Provider" }` |
+
+## Types
+
+| DSL type              | IRType                                                                     |
+|-----------------------|----------------------------------------------------------------------------|
+| `string`              | `{ kind: "primitive", value: "string" }`                                   |
+| `int`                 | `{ kind: "primitive", value: "int" }`                                      |
+| `double`              | `{ kind: "primitive", value: "double" }`                                   |
+| `float`               | `{ kind: "primitive", value: "float" }`                                    |
+| `boolean`             | `{ kind: "primitive", value: "boolean" }`                                  |
+| `date`                | `{ kind: "primitive", value: "date" }`                                     |
+| `duration`            | `{ kind: "primitive", value: "duration" }`                                 |
+| `url`                 | `{ kind: "primitive", value: "url" }`                                      |
+| `T?`                  | `{ kind: "optional", innerType: <T> }`                                     |
+| `[T]`                 | `{ kind: "array", elementType: <T> }`                                      |
+| `EntityName` (declared entity)  | `{ kind: "entity", entityName: "...", properties: [...] }`       |
+| `EnumName` (declared enum)      | `{ kind: "enum", name: "...", cases: [...] }`                    |
+
+Entity references inside a `param` or a `returns` clause lower to `entity` IR nodes whose `properties` field carries the same IR shape the entity declaration produces — the reference and the declaration share the same property list in IR, so downstream consumers (validator, generator, TS emit) don't need to look the entity up by name. This matches the existing SDK behavior where `param.entity("Trail", ...)` resolves against the registered entity and writes an annotated `entity` IR node.
+
+## Summary
+
+```
+summary: "template"
+```
+→ `{ kind: "summary", template: "template" }`
+
+```
+summary when p { then: A otherwise: B }
+```
+→ `{ kind: "when", parameter: "p", then: <A>, otherwise: <B> }`
+
+```
+summary switch p {
+  case v1: A
+  case v2: B
+  default: C
+}
+```
+→ `{ kind: "switch", parameter: "p", cases: [{ value: v1, summary: <A> }, ...], default: <C> }`
+
+A `summary-value` is either a string literal (a leaf `{ kind: "summary", template: "..." }`) or a nested `summary ...` form, which recurses.
+
+## Enum
+
+```
+enum Name { case1 case2 case3 }
+```
+→ `{ kind: "enum", name: "Name", cases: ["case1", "case2", "case3"] }`
+
+Enums in v1 are used as param types. They do not get their own top-level IR node — they're embedded wherever referenced. This matches the existing IR's `kind: "enum"` inline form.
+
+## Entitlements and Info.plist
+
+```
+entitlements { "com.apple.developer.siri" "com.apple.developer.healthkit" }
+```
+→ `entitlements: ["com.apple.developer.siri", "com.apple.developer.healthkit"]`
+
+```
+infoPlistKeys {
+  "NSCalendarsUsageDescription": "..."
+  "NSMicrophoneUsageDescription": "..."
+}
+```
+→ `infoPlistKeys: { "NSCalendarsUsageDescription": "...", "NSMicrophoneUsageDescription": "..." }`
+
+## File to `IRIntent[]`
+
+Compiling a `.axint` file produces an array of `IRIntent` (one per `intent` declaration) and an array of `IREntity` (one per `entity` declaration), attached via each intent's `entities?` field where referenced. The resulting IR is byte-identical to what the TS surface would produce for the equivalent `defineIntent` / `defineEntity` calls.
+
+## Round-trip invariant
+
+For every valid `.axint` file `F`:
+
+1. `parse(F) = IR`
+2. `emitTs(IR) = T` (a TypeScript source string using the `@axint/compiler` SDK)
+3. `parseTs(T) = IR`
+
+The IR round-trips. This is the migration contract referenced in `principles.md`. The test suite enforces it with property tests.

--- a/spec/language/keywords.md
+++ b/spec/language/keywords.md
@@ -1,0 +1,96 @@
+# Keywords and Types
+
+Every reserved word in the language, with a one-line semantic.
+
+## Top-level declarations
+
+| Keyword    | Role                                                                     |
+|------------|--------------------------------------------------------------------------|
+| `intent`   | Declares an App Intent. Compiles to an `AppIntent` struct.               |
+| `entity`   | Declares an App Entity. Compiles to an `AppEntity` struct + `EntityQuery`. |
+| `enum`     | Declares a closed enum. Compiles to a Swift `enum` conforming to `AppEnum`. |
+
+## Intent body keywords
+
+| Keyword           | Role                                                                                |
+|-------------------|-------------------------------------------------------------------------------------|
+| `title`           | Required display title shown in Shortcuts and Siri.                                 |
+| `description`     | Required human-readable description.                                                |
+| `domain`          | Optional App Intents domain (e.g. `"messaging"`, `"health"`).                       |
+| `category`        | Optional category hint for Shortcuts organization.                                  |
+| `discoverable`    | Whether to expose the intent to Spotlight indexing. Defaults to framework default.  |
+| `donateOnPerform` | Whether to donate this intent to Siri/Spotlight when performed.                     |
+| `param`           | Declares an input parameter.                                                        |
+| `summary`         | Declares the Shortcuts parameter summary.                                           |
+| `returns`         | Declares the intent's return type. Accepts a primitive (`string`, `int`, `url`, …), a declared entity (`Trail`), or an array of either (`[Trail]`). Optional return types (`Trail?`) are **not** supported in v1 — omit `returns` when the intent returns nothing, or return an empty array for maybe-empty collections. |
+| `entitlements`    | Declares entitlements required by this intent.                                      |
+| `infoPlistKeys`   | Declares Info.plist keys required by this intent (key-to-description mapping).      |
+
+## Entity body keywords
+
+| Keyword     | Role                                                                              |
+|-------------|-----------------------------------------------------------------------------------|
+| `display`   | Opens the display representation block (title, subtitle, image).                  |
+| `property`  | Declares a property on the entity.                                                |
+| `query`     | Declares the query kind. Four kinds are allowed: `all` returns every entity; `id` resolves an entity by its `id` property; `string` resolves by freeform string match against the `title` property; `property` exposes every property with a `description` as a Shortcuts-selectable filter. |
+| `title`     | Inside `display`: takes a bare property identifier to render as the title.        |
+| `subtitle`  | Inside `display`: takes a bare property identifier to render as the subtitle.     |
+| `image`     | Inside `display`: takes a quoted string naming the SF Symbol or asset to render.  |
+
+## Param / property body keywords
+
+| Keyword       | Role                                                                          |
+|---------------|-------------------------------------------------------------------------------|
+| `description` | Required first field in every param and property body. Compiles to the `@Parameter(title:)` / `@Property(title:)` string in the emitted Swift. |
+| `default`     | Optional. Default value of a param. Must be a literal whose type matches the param's declared type. Not supported on entity properties in v1. |
+| `options`     | Optional. Specifies a dynamic options provider: `options: dynamic ProviderName`. |
+| `dynamic`     | Modifier on `options` indicating a runtime options provider.                  |
+
+## Summary keywords
+
+| Keyword     | Role                                                                               |
+|-------------|------------------------------------------------------------------------------------|
+| `summary`   | Opens a summary declaration or a nested recursive summary value.                   |
+| `when`      | Branch on whether a specific param has a value.                                    |
+| `then`      | Summary used when the `when` param has a value.                                    |
+| `otherwise` | Summary used when the `when` param has no value.                                   |
+| `switch`    | Branch on the value of a specific param.                                           |
+| `case`      | A branch of a `switch`. Followed by a literal value then `:` then a summary-value. |
+| `default`   | The fallback case of a `switch`, or a param's default value.                       |
+
+## Type keywords
+
+| Keyword    | Swift type                     | Notes                                            |
+|------------|--------------------------------|--------------------------------------------------|
+| `string`   | `String`                       | UTF-8 text.                                      |
+| `int`      | `Int`                          | 64-bit signed integer.                           |
+| `double`   | `Double`                       | 64-bit floating point.                           |
+| `float`    | `Float`                        | 32-bit floating point.                           |
+| `boolean`  | `Bool`                         |                                                  |
+| `date`     | `Date`                         | Foundation `Date`.                               |
+| `duration` | `Measurement<UnitDuration>`    | Durations use Foundation units.                  |
+| `url`      | `URL`                          | Foundation `URL`.                                |
+
+## Type syntax
+
+| Syntax       | Meaning                                                                 |
+|--------------|-------------------------------------------------------------------------|
+| `T?`         | Optional `T`.                                                           |
+| `[T]`        | Array of `T`.                                                           |
+| `[T]?`       | Optional array of `T`.                                                  |
+| `EntityName` | Reference to a declared entity. The entity must be declared in the file. |
+| `EnumName`   | Reference to a declared enum. The enum must be declared in the file.     |
+
+## Literals
+
+| Literal   | Example                              | Notes                                            |
+|-----------|--------------------------------------|--------------------------------------------------|
+| String    | `"Send Message"`                     | Double-quoted, standard escapes.                 |
+| Integer   | `100`, `-3`                          | No underscores, no hex.                          |
+| Decimal   | `3.14`, `-0.5`                       | Simple decimal form only.                        |
+| Boolean   | `true`, `false`                      |                                                  |
+| Identifier| `low`, `medium`                      | Only valid as a `case` value for an enum switch. |
+
+## Not reserved — available as identifiers
+
+Everything not listed above is available as a user-chosen identifier. Examples of names that are **not** reserved and are fine to use: `recipient`, `trail`, `region`, `includeNearby`, `distanceKm`, `openNow`.

--- a/spec/language/non-goals.md
+++ b/spec/language/non-goals.md
@@ -1,0 +1,92 @@
+# Non-goals
+
+What the language deliberately refuses to express, and where to go instead.
+
+## No imports
+
+v1 is single-file. If you need an entity, declare it in the same file as the intent that uses it. If two intents share an entity, declare the entity in both files — the redundancy is cheap, and the resulting Swift is deduplicated by the generator.
+
+If you need cross-file composition, use the TypeScript or Python surface.
+
+## No expressions
+
+No arithmetic, no string concatenation, no conditionals, no comparisons. The one interpolation form is `${paramName}` inside a `summary` template string, which looks up a declared param by name. Nothing else.
+
+A default value is a literal, not an expression. `default: 100` is valid; `default: 50 * 2` is not.
+
+## No user-defined functions or types
+
+No `func`, no `struct`, no `class`, no type aliases, no generics, no protocols. The only types available are the eight primitives, declared entities, declared enums, and the array/optional modifiers over those.
+
+If you want abstraction, use TypeScript.
+
+## No perform / implementation body
+
+A `.axint` file declares the shape of an App Intent. It does not implement `perform()`. The generated Swift contains a stub that calls into an implementation resolved at link time — typically a Swift Package target provided by the app author, or a generated bridge to the TS/Python runtime via Axint's IPC layer.
+
+If you want to write the `perform` logic in TypeScript and have Axint bridge it, use the TS surface directly. The `.axint` surface is strictly declarative.
+
+## No inline Swift
+
+There is no `raw` or `swift { ... }` escape hatch. If you need Swift, you have three options, in order of preference:
+
+1. Use the TS surface's `customResultType` to point at a Swift type you author separately.
+2. `axint eject` your file to TypeScript and modify from there.
+3. Edit the generated Swift directly and stop using the DSL for this intent.
+
+The language does not try to be a thin wrapper over Swift. It is a target-agnostic declaration that happens to compile to Swift today.
+
+## No macros
+
+No compile-time metaprogramming. No generation-time substitution beyond the `${paramName}` rule in summary templates. If you find yourself wanting a macro, you have outgrown the DSL — move to the TS surface.
+
+## No significant whitespace
+
+A formatter will indent consistently. The parser ignores indentation. You can write an entire intent on one line if you want — the validator won't complain (though the formatter will fix it).
+
+## No multiple intents per file (v1 convention)
+
+The grammar allows multiple `intent` declarations per file. The v1 convention is one intent per file, with supporting entities declared above it. This is a convention the formatter and the `axint init` template enforce — not a grammar rule. Advanced authors can put several intents in one file; the compiler emits one Swift file per intent regardless.
+
+## No views, widgets, or apps
+
+v1 ships `intent` and `entity` only. Views, widgets, and apps stay on the TS and Python surfaces until v0.5.0. The vocabulary for those surfaces (`@State`, `@Binding`, `@Environment`, `WindowGroup`, `Settings`, timeline providers) is large enough that it needs its own grammar pass. Doing it badly would contaminate v1.
+
+When v0.5.0 ships, the top-level decls `view`, `widget`, and `app` become available. The grammar described here does not change for existing intent and entity forms.
+
+## No enums beyond flat string cases
+
+v1 enums are flat: `enum Priority { low medium high }`. No associated values, no raw values, no methods, no conformances. They compile to Swift `enum Priority: String, AppEnum` with one case per identifier.
+
+If you need associated values, use the TS surface.
+
+## No schema extensions
+
+No `extends`, no `mixin`, no trait composition. Each entity and each intent is self-contained. If two entities share ten properties, write the ten properties twice. The validator will tell you when the shapes drift — which is usually what you want.
+
+## Future composition story
+
+Several non-goals above are v1 scope decisions, not permanent language limits. They are called out here so a v0.5 or v0.6 can relax them without a breaking grammar change.
+
+**Shared entities across files (v0.5 target).** The v1 rule is single-file: declare the entity next to the intent that uses it. This is correct for a first release — it keeps resolution trivial and the round-trip invariant easy to prove. But real apps re-use the same entity across dozens of intents, and asking authors to duplicate `entity Contact` into every file gets annoying fast. The v0.5 path is a minimal `use` clause at the top of a file:
+
+```
+use Contact from "./entities/contact.axint"
+use Trail, Region from "./entities/trail.axint"
+
+intent OpenTrail { ... }
+```
+
+No wildcard imports. No renaming. No transitive resolution through third-party packages. A `use` clause names one or more entities from a relative path, and the resolver inlines those entities' IR into the importing file at compile time. The resulting IR is still single-file shape — the composition happens entirely at the parser/resolver layer, so every downstream stage (validator, generator, round-trip) sees the same IR shape it sees today.
+
+This is additive: v1 `.axint` files remain valid under v0.5 with no changes, because they don't have `use` clauses. The reserved keyword `use` is the only piece we need to hold back in v1's lexer to keep the door open.
+
+**Shared enums follow the same pattern.** `use Priority from "./enums/priority.axint"` lowers to the same IR-inlining resolver.
+
+**Intent packages (v0.6 target, speculative).** If and only if `use` proves insufficient, a later version may introduce a package manifest (`axint.toml` or similar) that lets the CLI resolve `use Contact from @myorg/shared-entities`. This is explicitly out of v0.5 scope — we ship relative-path imports first, learn what breaks, then decide whether a package system earns its complexity.
+
+**What stays non-goal forever.** Expressions, user-defined functions, user-defined types beyond entities/enums, inline Swift, macros, and significant whitespace remain permanent non-goals. The grammar never grows those. If an author needs them, they have the TS and Python surfaces.
+
+## What this list buys
+
+Every non-goal here is a production the parser doesn't need, a branch the validator doesn't need, a codegen path the generator doesn't need, and a failure mode an agent can't trigger. The cost of excluding all of this is near zero: the TS surface is already rich enough that power users have somewhere to go. The value is a DSL that fits in a single prompt.

--- a/spec/language/parser-recovery.md
+++ b/spec/language/parser-recovery.md
@@ -1,0 +1,149 @@
+# Parser Recovery
+
+A `.axint` parser runs once and returns every diagnostic it can find in one pass. A file with three broken declarations produces three diagnostics, not one. This doc specifies how the parser gets there — the fixed set of recovery boundaries it resyncs at, and the contract that recovery never invents meaning the source didn't have.
+
+The motivation is metric #4 in `why-agents.md` — turns to green. If an agent has to rerun the compiler to discover each error serially, the repair loop is O(n) in the number of mistakes. Reporting all errors per parse makes it O(1). The grammar is restricted enough (`principles.md`, criterion #3) that a single-pass recursive-descent parser can resync at a small closed set of points without guessing.
+
+## The contract
+
+1. **One parse, all diagnostics.** The parser never aborts on the first error. It emits a diagnostic, resyncs at the nearest documented boundary, and continues.
+2. **Recovery is structural, not semantic.** The parser resyncs at tokens — not at inferred meaning. It does not guess what the author "meant" and continue as if that were the source.
+3. **Resynced regions produce no downstream diagnostics.** Once the parser skips bytes to reach a recovery point, it does not emit further syntax errors for the skipped range. The original diagnostic covers it.
+4. **Recovery is idempotent.** Running the parser twice on the same file produces the same diagnostic set in the same order.
+
+## Recovery boundaries
+
+The closed set. Four points. The parser resyncs at whichever comes first:
+
+| Boundary                            | Used at                                      |
+|-------------------------------------|----------------------------------------------|
+| `}` closing the enclosing block     | Inside an `intent`, `entity`, `enum`, `display`, `entitlements`, `infoPlistKeys`, or nested `summary` block |
+| Next top-level keyword at column 1  | Between top-level declarations               |
+| Next field-starting keyword inside a block | Between fields in an `intent-body`, `entity-body`, `param-body`, `property-body`, `display-block`, or `switch-body` |
+| End of line                         | Inside a single-line field like `title: "..."` or `description: "..."` |
+
+Closed set. The parser resyncs at one of these four points and nowhere else. Adding a new recovery boundary is a grammar change and a version bump.
+
+### Top-level keywords
+
+`intent`, `entity`, `enum`. When the parser is recovering at the file level, it scans forward for one of these three tokens appearing at column 1 and resumes parsing from there.
+
+### Field-starting keywords
+
+Inside an `intent-body`: `title`, `description`, `domain`, `category`, `discoverable`, `donateOnPerform`, `param`, `summary`, `returns`, `entitlements`, `infoPlistKeys`.
+
+Inside an `entity-body`: `display`, `property`, `query`.
+
+Inside a `param-body` or `property-body`: `description`, `default`, `options`.
+
+Inside a `display-block`: `title`, `subtitle`, `image`.
+
+Inside a `switch-body`: `case`, `default`.
+
+The parser only accepts these as recovery points when they appear in a position the grammar expects them — a stray `title` keyword inside a `switch-body` is not a valid recovery point for an `intent-body`. This is enforced by context: the parser tracks which block it is recovering inside and matches only against that block's field set.
+
+### End of line
+
+Only used for single-line fields (`title: "..."`, `description: "..."`, `domain: "..."`, etc.). If the right-hand side of `:` is malformed, the parser emits a diagnostic spanning the malformed region and resumes at the next newline. Multi-line constructs (blocks, `summary switch`, nested blocks) never use end-of-line recovery — they use `}` or the next field keyword.
+
+## What gets skipped
+
+Between the point of the error and the recovery boundary, the parser discards tokens without further parsing. No AST nodes are constructed for the skipped region. No diagnostics are emitted from inside it. If the skipped region contained a structurally valid nested block that the parser would otherwise have descended into, that block is still skipped — recovery does not second-guess its own boundary.
+
+This means a malformed top-level declaration can hide a valid declaration nested inside it. That is acceptable. The agent fixes the outer error, reruns, and sees the inner error on the next pass. The alternative — reparsing the skipped region hoping for salvage — reintroduces the O(n) repair loop this whole contract exists to prevent.
+
+## Worked examples
+
+### Example 1: two broken intents
+
+```
+intent SendMessage {
+  titel: "Send Message"                # AX007: unknown field "titel"
+  description: "Send a message"
+  param recipient: string {
+    description: "Who to send to"
+  }
+}
+
+intent OpenTrail {
+  title: "Open Trail"
+  # missing description — AX003
+  param trail: Trail {
+    description: "Trail to open"
+  }
+}
+```
+
+One parse. Two diagnostics. `AX007` at `SendMessage`, span on `titel`. `AX003` at `OpenTrail`, zero-width span after `title:`. Recovery #1 at the next field-starting keyword (`description`). Recovery #2 at the `}` closing `OpenTrail`.
+
+### Example 2: malformed field recovers at end of line
+
+```
+intent Foo {
+  title: @@@broken@@@                  # AX101: invalid string literal
+  description: "A valid description"
+}
+```
+
+One diagnostic. `AX101`, span on `@@@broken@@@`. Recovery at end of line. The next line (`description: "..."`) parses normally. No cascade errors.
+
+### Example 3: unclosed block falls through to top-level keyword
+
+```
+intent Foo {
+  title: "Foo"
+  description: "Missing close brace"
+
+intent Bar {
+  title: "Bar"
+  description: "Next intent"
+}
+```
+
+One diagnostic at the point `intent Bar` is encountered: `AX001` "unexpected `intent` inside intent-body, expected `}`", with a fix of `insert_required_clause` inserting `}` before the `intent` token. Recovery at the top-level keyword `intent`. `Bar` parses cleanly.
+
+The diagnostic's `targetSpan` is the zero-width insertion point before `intent Bar`. The `suggestedEdit.text` is `"}\n"`. Applying the edit resolves the diagnostic in one edit.
+
+### Example 4: `summary switch` with a malformed case
+
+```
+intent Foo {
+  title: "Foo"
+  description: "..."
+  param mode: string { description: "..." }
+  summary switch mode {
+    case: "missing case value"           # AX007: case requires a literal
+    case "b": "valid"
+    default: "fallback"
+  }
+}
+```
+
+One diagnostic. Recovery at the next `case` keyword. The `case "b"` branch and `default` branch both parse. The file is invalid for one reason, not three.
+
+## What recovery is not
+
+The parser does not:
+
+- **Correct typos.** `titel` is an unknown field, not a misspelled `title`. The validator's `rename_identifier` fix kind can offer `title` as a candidate — that is an author-side suggestion, not a parser-side interpretation.
+- **Insert missing braces silently.** A missing `}` is always a diagnostic. Recovery uses the next top-level keyword to bound the damage, but the author still has to add the brace.
+- **Reorder fields.** If `description` appears before `title`, that is `AX007` clause-out-of-order. The parser doesn't swap them.
+- **Guess intent from adjacent tokens.** If the parser can't decide whether a block is inside an `intent-body` or an `entity-body`, it doesn't guess — it resyncs at the nearest enclosing `}` and reports the structural error.
+
+## Interaction with the diagnostic protocol
+
+Every error the parser emits has a `code`, a `severity`, a `span`, and a `fix` per `diagnostic-protocol.md`. Recovery does not degrade the diagnostic — a syntax error at line 5 still carries the same protocol payload as a semantic error at line 20. The protocol is uniform across parse-time and validate-time.
+
+The protocol's first-file, first-line, first-column priority order is what the parser emits in. The order is natural — the parser walks the file top-to-bottom and emits as it goes. Agents consuming the JSON output process diagnostics in the order they appear.
+
+## Worst-case behavior
+
+A file consisting entirely of garbage (no valid top-level keyword anywhere) emits exactly one diagnostic: `AX001` "expected `intent`, `entity`, or `enum`" with a span covering the first token. No recovery point is reachable, so parsing terminates after that one diagnostic. This is the only case where the parser returns without reaching end-of-file.
+
+A file with a valid first declaration followed by garbage recovers at the next top-level keyword. If there is no next top-level keyword, parsing terminates after the valid declaration and the trailing garbage emits one `AX001`.
+
+## Why this recovery strategy and not panic mode or incremental
+
+Panic mode (skip-until-synchronizing-token) is what this is, restricted to a closed four-point set. The restriction matters — generic panic mode is non-deterministic under grammar evolution, because adding a new keyword silently changes recovery behavior. The closed set makes recovery versioned: a grammar change that adds a new field-starting keyword has to declare whether that keyword is a recovery point, and the test suite catches regressions.
+
+Incremental parsing (reparse only dirty ranges) is overkill for single-file `.axint` sizes. The files the corpus targets are tens of lines, not tens of thousands. A full reparse per `axint check` is fast enough that incrementality adds complexity for no measured win on the seven metrics.

--- a/spec/language/principles.md
+++ b/spec/language/principles.md
@@ -1,0 +1,54 @@
+# Design Principles
+
+## The capture mechanism frame
+
+Axint already has two authoring surfaces: TypeScript (`@axint/compiler`) and Python (`axint` on PyPI). Both compile to the same IR. Both produce identical Swift. The app-definition language is a third surface with one specific job: be the surface an agent reaches for by default.
+
+TypeScript and Python carry ambient cognitive load — imports, async functions, builder calls, helper overloads, language idioms. An agent emitting a TS intent must keep a mental model of the surrounding TS runtime. A `.axint` file has no runtime. It declares data. That is the entire advantage.
+
+## Seven agent-first criteria
+
+Every grammar production must satisfy all seven:
+
+1. **Predictable.** Given the same intent, ten different agents should produce textually identical or near-identical files. If the grammar admits ten valid stylistic variants, the grammar is wrong.
+
+2. **Low-entropy.** One obvious way to express each concept. No expressions, no interpolation rules except the one in summary templates, no inline computation, no escape hatches for "just this once."
+
+3. **Easy to parse.** A single-pass recursive-descent parser should handle the entire grammar without backtracking. If the parser needs lookahead greater than one token, the grammar needs simplifying.
+
+4. **Easy to correct.** When the validator emits a diagnostic, the agent should be able to fix the file by editing one line. No file-wide restructuring. Within a declaration, the grammar fixes field order (title → description → meta → params → summary → returns → entitlements → infoPlistKeys) so a "clause out of order" error always points at a single misplaced block. At the file level, the only order rule is convention: entities appear above intents that reference them.
+
+5. **Easy to teach in one prompt.** The full language — every keyword, every production — must fit in 200 lines of prompt context. If it doesn't, the language is too big.
+
+6. **Easy to diff.** Declarations are line-oriented where possible. Renaming a param or changing a description changes one line. No multi-line restructuring for semantic edits.
+
+7. **Easy to format.** A formatter written in an afternoon should produce canonical output. No significant whitespace. No alignment rules. Braces close on their own line. Done.
+
+## What this rules out
+
+- User-defined functions, types, or macros
+- Expressions of any kind outside string literals
+- Template interpolation except in `summary` strings, where `${paramName}` references a declared param
+- Conditionals, loops, or control flow
+- Imports (v1 is single-file; entities used by an intent are declared in the same file)
+- Inline Swift escape hatches (if you need Swift, use the TS surface's `customResultType`)
+- Metaprogramming of any kind
+
+## What this rules in
+
+- Declaration of `intent`, `entity`, and `enum`
+- Declaration of parameters, their types, their descriptions, their defaults, their optionality
+- Declaration of entity properties and display representations
+- Declaration of parameterSummary in simple, `when`, and `switch` forms
+- Declaration of entitlements and Info.plist keys required by an intent
+- Declaration of dynamic options providers by name (provider implementations live in the TS or Python surface)
+
+## The no-user-abstractions rule
+
+v1 has no mechanism for user-defined abstractions. No functions, no types beyond the built-in primitives and declared entities, no macros, no extensions. This is deliberate. Abstractions are where grammars go to die: every new abstraction is new entropy for an agent, new syntax for the parser, new surface area for the validator, new room for mistakes.
+
+If a user wants abstraction, they have TypeScript and Python already. The `.axint` surface is for declaring the finite, well-known shape of an App Intent. That shape is enumerated by Apple's `AppIntents` framework. It is not infinite. It does not need user extension.
+
+## The migration contract
+
+A `.axint` file is always lowerable to its equivalent TS file with no loss. The `axint eject` command will emit the TS form. This is not a promise about tooling. It is a design constraint: every grammar production must have a faithful TS representation, and the IR round-trips in both directions. If a production cannot round-trip, it does not ship in v1.

--- a/spec/language/why-agents.md
+++ b/spec/language/why-agents.md
@@ -1,0 +1,82 @@
+# Why Axint for Agents
+
+The thesis in one line:
+
+> For AI agents generating Apple-native software, the best authoring surface is not the most expressive one. It is the one with the smallest valid search space that still captures the intent.
+
+Swift is more expressive than Axint. That is not a point in Swift's favor when the author is an agent. Expressiveness means more valid programs, more distinct ways to say the same thing, more grammar paths a model can wander down incorrectly, and more invalid programs that look almost valid. The dial that matters is not "how much can the author say." It is "how close is the author's output, on the first try, to a working Apple feature."
+
+## What "better for agents" means
+
+It means seven measurable things, not one vague one.
+
+1. **First-pass parse rate.** Percent of generated files that parse without error on the first try.
+2. **First-pass validator pass rate.** Percent of parsed files that clear all AX semantic checks on the first try.
+3. **First-pass Swift compile rate.** Percent of validated files whose emitted Swift compiles against the Apple SDKs on the first try.
+4. **Turns to green.** Number of agent turns required to go from first-broken to valid-compiling.
+5. **Lines changed per repair.** Size of the diff an agent makes to fix a diagnostic. A well-designed diagnostic produces a one-line fix, not a file rewrite.
+6. **Tokens per successful feature.** Generated-token cost per valid Apple feature shipped.
+7. **Output variance.** Structural similarity across repeated runs of the same prompt. Ten agents given the same task should produce close-to-identical files.
+
+Every design choice downstream of this doc is evaluated against those seven. The grammar is strict so variance stays low. The formatter is canonical so repair diffs stay small. The diagnostics catalog is keyed to one-line fixes so turns-to-green stays low. The IR lowers identically from TS, Python, and `.axint` so a model trained on one surface transfers to the others. Nothing in the language exists to feel elegant to humans. Everything exists to push those seven numbers.
+
+## Why constrained surfaces beat expressive surfaces for agents
+
+An expressive language gives a model a larger valid search space. A larger valid search space means more plausible-looking outputs per prompt, more stylistic variance, more ambiguity about which form is idiomatic, and more room for a small mistake to drift into a catastrophically wrong program.
+
+A constrained language narrows that space at the cost of expressiveness the author does not need for this domain. App Intents are declarative by shape. They are metadata plus a small perform body. Swift's generics, protocol extensions, property wrappers, and macros are expressive superpowers that an agent generating an App Intent does not need and will use incorrectly. Taking those tools out of the author's hand is not a restriction. It is pruning.
+
+The same logic is why the perform body lives in a sibling TS or Python file rather than inside `.axint`. The declarative shape is the part agents are reliably good at. The logic body is the part they are less reliably good at, and it belongs in a surface where the rest of the language, the tests, and the ecosystem already exist.
+
+## How the criteria and the metrics relate
+
+The seven agent-first criteria in `principles.md` are the design side of the same story the seven metrics above measure. Each criterion is written to move one or more metrics in the right direction:
+
+| Criterion (`principles.md`) | Metric it targets |
+|-----------------------------|-------------------|
+| Predictable                 | Output variance   |
+| Low-entropy                 | Output variance, first-pass parse rate |
+| Easy to parse               | First-pass parse rate |
+| Easy to correct             | Turns to green, lines per repair |
+| Easy to teach in one prompt | First-pass validator pass rate, tokens per feature |
+| Easy to diff                | Lines per repair  |
+| Easy to format              | Output variance   |
+
+If a proposed spec change improves a criterion but regresses a metric, the change does not ship.
+
+## The claim Axint makes
+
+Against raw Swift, against the TypeScript SDK, and against the Python SDK, an agent authoring in `.axint` for the same Apple-native task will:
+
+- parse correctly more often on the first try,
+- validate correctly more often on the first try,
+- compile to working Swift more often on the first try,
+- need fewer turns and fewer lines to repair a broken file,
+- emit fewer generated tokens per valid feature,
+- and produce lower-variance output across repeated runs of the same prompt.
+
+The benchmark harness that proves this runs on every release. A change to the spec, the grammar, the validator, or the generator that moves any of the seven metrics the wrong way is rolled back. The harness feeds off the paired corpus in `examples/` — prompt, `.axint`, IR snapshot, emitted Swift, broken variant, repaired variant — and runs the same task matrix across all three authoring surfaces plus raw Swift as the baseline.
+
+## The claims Axint does not make
+
+Axint is not a better language for humans than Swift. It is not a replacement for Swift. It is not more expressive. It is not general-purpose. It is not a DSL for writing application logic — the perform body lives in a sibling TS or Python file, which is the third surface's job. The language does not try to remove Swift from anyone's toolchain. It gives an agent a path to validated Swift output that does not require fluency in the full Swift and Apple-platform surface area.
+
+If the benchmark numbers ever say raw Swift beats `.axint` for agents on the seven metrics above, the language is wrong and gets fixed. The claim is empirical, not aesthetic.
+
+## Why this frames every other doc in the spec
+
+Every file in this directory is downstream of the thesis above.
+
+- `principles.md` — the seven criteria are the design-side counterparts of the seven metrics.
+- `grammar.md` — fixed clause order, no escape hatches, braces-not-indentation, one canonical punctuation rule. Every choice exists to reduce one form of variance.
+- `keywords.md` — the reserved set is minimal. Unfamiliar keywords are a tax an agent pays on every generation.
+- `ir-mapping.md` — every production lowers to an existing IR node. No new IR means no new invalid states and no new surface to validate.
+- `diagnostics.md` — every error is designed to be fixable by one line. That is metric (5).
+- `non-goals.md` — everything Axint refuses to express exists to keep the search space small.
+- `examples/` — the paired corpus is the benchmark harness feedstock.
+
+## One rule above everything else
+
+> The language is not the product. The language is the capture mechanism.
+
+An agent hands us a single file. We hand back a working Apple feature, reliably, cheaply, and with a repair loop that closes fast when something goes wrong. That is the product. Every decision in the rest of this spec is evaluated against it.


### PR DESCRIPTION
Drops the .axint language spec into the repo as its own folder so the grammar, diagnostics, and parser contracts live next to the compiler that implements them.

Contents:
- grammar.md — full .axint grammar
- keywords.md — reserved words
- diagnostics.md — AX001–AX113 + AX600 catalog
- diagnostic-protocol.md — machine-readable diagnostic envelope
- parser-recovery.md — four-point deterministic recovery rules
- ir-mapping.md — surface syntax → IRIntent / IREntity lowering
- principles.md — language design principles
- non-goals.md — what .axint deliberately isn't
- failures.md — canonical failure corpus
- benchmark.md — 20-task agent benchmark matrix
- why-agents.md — thesis for agent-authored code
- README.md — index

No code changes — spec-only drop. The parser, lexer, and diagnostic emitter already built against these docs land in follow-up PRs (tasks #30–33).