### PR TITLE
match ts prettyTitle rule in dsl param lowering

### DIFF
--- a/metrics.json
+++ b/metrics.json
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 680,
+    "typescript": 706,
     "python": 114
   },
   "registryPackages": 8,

--- a/spec/language/ir-mapping.md
+++ b/spec/language/ir-mapping.md
@@ -72,7 +72,7 @@ param name: T {
 |----------------------------------|------------------------------------------------------------|
 | `param name: T`                  | `name: "name"`, `type: <mapped IRType>`, `isOptional: false` |
 | `param name: T?`                 | same, with `isOptional: true` and type wrapped as needed   |
-| `{ description: "..." }`         | `description: "..."`, `title: "..."` (defaults to description when no explicit title) |
+| `{ description: "..." }`         | `description: "..."`, `title: "..."` (the TS surface and DSL both default `title` to the param name de-camelCased and capitalized — `eventTitle` → `"Event Title"`) |
 | `{ default: <literal> }`         | `defaultValue: <literal>`                                  |
 | `{ options: dynamic Provider }`  | `type: { kind: "dynamicOptions", valueType: <inner>, providerName: "Provider" }` |
 

--- a/src/core/axint-dsl/lexer.ts
+++ b/src/core/axint-dsl/lexer.ts
@@ -23,9 +23,10 @@ export interface LexResult {
   readonly tokens: readonly Token[];
   /**
    * Lexer-level diagnostics (unterminated string, invalid escape, unknown
-   * byte). Empty on a well-formed file. All emit code AX007 with `fix: null`
-   * — the closed six-kind FixKind set has no principled repair for lexical
-   * failures, and the spec pins schemaVersion 1.
+   * byte). Empty on a well-formed file. All emit code AX007 with a
+   * `remove_field` fix that deletes the offending span — the no-close-match
+   * sub-case of the spec's AX007 fix catalog, and the only principled v1
+   * repair for a lexical failure.
    */
   readonly diagnostics: readonly Diagnostic[];
 }
@@ -326,14 +327,23 @@ class Lexer {
   }
 
   private makeDiagnostic(code: string, message: string, span: TokenSpan): Diagnostic {
+    // Every lexer diagnostic today is AX007 — malformed bytes the scanner
+    // can't tokenize. All three sub-cases (unknown escape, unterminated
+    // string, unexpected character) repair by deleting the garbage, which is
+    // the `remove_field` fix kind with `suggestedEdit.text: ""`.
+    const protocolSpan = toProtocolSpan(span);
     return {
       schemaVersion: 1,
       code,
       severity: "error",
       message,
       file: this.file,
-      span: toProtocolSpan(span),
-      fix: null,
+      span: protocolSpan,
+      fix: {
+        kind: "remove_field",
+        targetSpan: protocolSpan,
+        suggestedEdit: { text: "" },
+      },
     };
   }
 }

--- a/src/core/axint-dsl/lowering.ts
+++ b/src/core/axint-dsl/lowering.ts
@@ -238,7 +238,7 @@ function lowerProperty(
   return {
     name: decl.name.name,
     type,
-    title: description,
+    title: defaultTitleFromName(decl.name.name),
     description,
     isOptional: decl.type.kind === "OptionalType",
   };
@@ -396,7 +396,7 @@ function lowerParam(
   const param: IRParameter = {
     name: decl.name.name,
     type,
-    title: description,
+    title: defaultTitleFromName(decl.name.name),
     description,
     isOptional,
   };
@@ -842,6 +842,14 @@ function endOf(span: TokenSpan): TokenSpan {
 }
 
 // ─── Small utilities ───────────────────────────────────────────────────
+
+// Mirror of `prettyTitle` in src/core/parser.ts. The two surfaces must agree on
+// the default title for a parameter when the author doesn't provide one — the
+// round-trip test in tests/core/axint-dsl/round-trip.test.ts enforces it.
+function defaultTitleFromName(name: string): string {
+  const spaced = name.replace(/([A-Z])/g, " $1").trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
 
 function isPascalCase(name: string): boolean {
   return /^[A-Z][A-Za-z0-9]*$/.test(name);

--- a/src/core/axint-dsl/lowering.ts
+++ b/src/core/axint-dsl/lowering.ts
@@ -45,7 +45,7 @@ import type {
   TopLevelDecl,
   TypeNode,
 } from "./ast.js";
-import type { Diagnostic, Fix, Span } from "./diagnostic.js";
+import type { Diagnostic, DiagnosticSeverity, Fix, Span } from "./diagnostic.js";
 import { DIAGNOSTIC_SCHEMA_VERSION } from "./diagnostic.js";
 import { toProtocolSpan } from "./lexer.js";
 import type { TokenSpan } from "./token.js";
@@ -124,13 +124,14 @@ class LowerContext {
     code: string;
     message: string;
     span: TokenSpan | Span;
-    fix: Fix | null;
+    fix: Fix;
+    severity?: DiagnosticSeverity;
   }): void {
     const span = isTokenSpan(args.span) ? toProtocolSpan(args.span) : args.span;
     this.diagnostics.push({
       schemaVersion: DIAGNOSTIC_SCHEMA_VERSION,
       code: args.code,
-      severity: "error",
+      severity: args.severity ?? "error",
       message: args.message,
       file: this.sourceFile,
       span,

--- a/src/core/axint-dsl/parser.ts
+++ b/src/core/axint-dsl/parser.ts
@@ -56,7 +56,7 @@ import type {
   TopLevelDecl,
   TypeNode,
 } from "./ast.js";
-import type { Diagnostic, Fix } from "./diagnostic.js";
+import type { Diagnostic, DiagnosticSeverity, Fix } from "./diagnostic.js";
 import type { Token, TokenKind, TokenSpan } from "./token.js";
 import { toProtocolSpan, tokenize } from "./lexer.js";
 
@@ -212,7 +212,7 @@ class Parser {
           code: "AX001",
           message: `unexpected ${describeToken(this.peek())} at top level, expected \`intent\`, \`entity\`, or \`enum\``,
           span: this.peek().span,
-          fix: null,
+          fix: this.fixInsert(this.zeroWidthBefore(this.peek().span)),
         });
         return null;
       }
@@ -293,7 +293,7 @@ class Parser {
           code: "AX007",
           message: `unexpected ${describeToken(this.peek())} in entity body`,
           span: this.peek().span,
-          fix: null,
+          fix: this.fixRemove(this.peek().span),
         });
         this.recoverToFieldOrBlockEnd(ENTITY_BODY_KEYWORDS);
       }
@@ -379,7 +379,7 @@ class Parser {
           code: "AX007",
           message: `unexpected ${describeToken(this.peek())} in display block`,
           span: this.peek().span,
-          fix: null,
+          fix: this.fixRemove(this.peek().span),
         });
         this.recoverToFieldOrBlockEnd(DISPLAY_BODY_KEYWORDS);
       }
@@ -479,7 +479,7 @@ class Parser {
         code: "AX007",
         message: `unexpected ${describeToken(this.peek())} in property body — only \`description\` is allowed`,
         span: this.peek().span,
-        fix: null,
+        fix: this.fixRemove(this.peek().span),
       });
       this.recoverToFieldOrBlockEnd(PROPERTY_BODY_KEYWORDS);
     }
@@ -515,7 +515,7 @@ class Parser {
         code: "AX018",
         message: `expected query kind, got ${describeToken(next)}`,
         span: next.span,
-        fix: null,
+        fix: this.fixReplaceLiteral(next.span, [...QUERY_KINDS]),
       });
       this.recoverToEndOfLine(start.span.startLine);
       return null;
@@ -637,7 +637,7 @@ class Parser {
         code: "AX007",
         message: `unexpected ${describeToken(this.peek())} in intent body`,
         span: this.peek().span,
-        fix: null,
+        fix: this.fixRemove(this.peek().span),
       });
       this.recoverToFieldOrBlockEnd(INTENT_BODY_KEYWORDS);
     }
@@ -766,7 +766,7 @@ class Parser {
           code: "AX007",
           message: `unexpected ${describeToken(this.peek())} in param body`,
           span: this.peek().span,
-          fix: null,
+          fix: this.fixRemove(this.peek().span),
         });
         this.recoverToFieldOrBlockEnd(PARAM_BODY_KEYWORDS);
       }
@@ -833,7 +833,7 @@ class Parser {
         code: "AX007",
         message: `expected \`dynamic\` after \`options:\`, got ${describeToken(this.peek())}`,
         span: this.peek().span,
-        fix: null,
+        fix: this.fixRemove(this.peek().span),
       });
       this.recoverToEndOfLine(kw.span.startLine);
       return null;
@@ -886,7 +886,7 @@ class Parser {
           code: "AX007",
           message: `expected string literal in entitlements block, got ${describeToken(this.peek())}`,
           span: this.peek().span,
-          fix: null,
+          fix: this.fixRemove(this.peek().span),
         });
         this.advance();
       }
@@ -916,7 +916,7 @@ class Parser {
           code: "AX007",
           message: `expected key string in infoPlistKeys block, got ${describeToken(this.peek())}`,
           span: this.peek().span,
-          fix: null,
+          fix: this.fixRemove(this.peek().span),
         });
         this.advance();
         continue;
@@ -977,7 +977,7 @@ class Parser {
       code: "AX007",
       message: `expected \`:\`, \`when\`, or \`switch\` after \`summary\`, got ${describeToken(this.peek())}`,
       span: this.peek().span,
-      fix: null,
+      fix: this.fixRemove(this.peek().span),
     });
     return null;
   }
@@ -1017,7 +1017,7 @@ class Parser {
           code: "AX007",
           message: `unexpected ${describeToken(this.peek())} in summary when body`,
           span: this.peek().span,
-          fix: null,
+          fix: this.fixRemove(this.peek().span),
         });
         this.recoverToFieldOrBlockEnd(new Set<TokenKind>(["THEN", "OTHERWISE"]));
       }
@@ -1027,11 +1027,17 @@ class Parser {
     const endSpan = rbrace?.span ?? this.previousSpan();
 
     if (!then) {
+      // AX007 here is "parser saw a block body that doesn't include the
+      // required `then`." The spec's AX007 fix kinds (remove/rename/change_type)
+      // don't include insert, so we model the repair as deleting the empty
+      // block: a subsequent `axint check` then requires the author to write a
+      // fresh `when param { then "..." }` pair. A dedicated missing-then code
+      // would be cleaner — tracked as a future catalog split.
       this.emit({
         code: "AX007",
         message: "summary `when` is missing `then` branch",
         span: this.zeroWidthAfter(lbrace.span),
-        fix: null,
+        fix: this.fixRemove(this.zeroWidthAfter(lbrace.span)),
       });
       then = emptyStringLiteral(this.zeroWidthAfter(lbrace.span));
     }
@@ -1074,7 +1080,7 @@ class Parser {
           code: "AX007",
           message: `unexpected ${describeToken(this.peek())} in summary switch body`,
           span: this.peek().span,
-          fix: null,
+          fix: this.fixRemove(this.peek().span),
         });
         this.recoverToFieldOrBlockEnd(SWITCH_BODY_KEYWORDS);
       }
@@ -1122,7 +1128,7 @@ class Parser {
       code: "AX007",
       message: `expected string template or nested \`summary\`, got ${describeToken(this.peek())}`,
       span: this.peek().span,
-      fix: null,
+      fix: this.fixRemove(this.peek().span),
     });
     return null;
   }
@@ -1174,7 +1180,7 @@ class Parser {
       code: "AX005",
       message: `expected type, got ${describeToken(this.peek())}`,
       span: this.peek().span,
-      fix: null,
+      fix: this.fixChangeType(this.peek().span),
     });
     return null;
   }
@@ -1212,7 +1218,7 @@ class Parser {
       code: "AX005",
       message: `expected return type, got ${describeToken(this.peek())}`,
       span: this.peek().span,
-      fix: null,
+      fix: this.fixChangeType(this.peek().span),
     });
     return null;
   }
@@ -1267,7 +1273,7 @@ class Parser {
           code: "AX007",
           message: `expected literal, got ${describeToken(tok)}`,
           span: tok.span,
-          fix: null,
+          fix: this.fixRemove(tok.span),
         });
         return null;
     }
@@ -1312,7 +1318,7 @@ class Parser {
       code: "AX007",
       message: `expected ${description}, got ${describeToken(this.peek())}`,
       span: this.peek().span,
-      fix: null,
+      fix: this.fixRemove(this.peek().span),
     });
     return null;
   }
@@ -1322,11 +1328,19 @@ class Parser {
       const tok = this.consume();
       return { kind: "Ident", span: tok.span, name: tok.value };
     }
+    // AX002 (declaration-name sites) maps to replace_identifier per the spec;
+    // AX007 (positional sites like `param name`, `options provider`) maps to
+    // remove_field. Keep the code→fix-kind branching here so every caller
+    // stays a single call.
+    const fix =
+      code === "AX002"
+        ? this.fixReplaceIdentifier(this.peek().span)
+        : this.fixRemove(this.peek().span);
     this.emit({
       code,
       message: `expected ${description}, got ${describeToken(this.peek())}`,
       span: this.peek().span,
-      fix: null,
+      fix,
     });
     return null;
   }
@@ -1339,7 +1353,7 @@ class Parser {
       code: "AX007",
       message: `expected ${description} string, got ${describeToken(this.peek())}`,
       span: this.peek().span,
-      fix: null,
+      fix: this.fixRemove(this.peek().span),
     });
     return null;
   }
@@ -1359,7 +1373,7 @@ class Parser {
       code: "AX007",
       message: `expected ${description} boolean, got ${describeToken(this.peek())}`,
       span: this.peek().span,
-      fix: null,
+      fix: this.fixRemove(this.peek().span),
     });
     return null;
   }
@@ -1370,12 +1384,13 @@ class Parser {
     code: string;
     message: string;
     span: TokenSpan;
-    fix: Fix | null;
+    fix: Fix;
+    severity?: DiagnosticSeverity;
   }): void {
     this.diagnostics.push({
       schemaVersion: 1,
       code: args.code,
-      severity: "error",
+      severity: args.severity ?? "error",
       message: args.message,
       file: this.file,
       span: toProtocolSpan(args.span),
@@ -1403,6 +1418,62 @@ class Parser {
       endLine: span.startLine,
       endColumn: span.startColumn,
     };
+  }
+
+  // ─── Fix builders ──────────────────────────────────────────────────
+  //
+  // Every non-compiler-bug diagnostic carries a Fix with at minimum a kind and
+  // a targetSpan (spec/language/diagnostic-protocol.md §Applying an edit). These
+  // helpers keep each emission site to a single line and encode the common
+  // shapes: delete-the-wrong-token (`remove_field`), rewrite-the-type
+  // (`change_type`), insert-at-point (`insert_required_clause`), and the two
+  // identifier variants.
+
+  private fixRemove(span: TokenSpan): Fix {
+    return {
+      kind: "remove_field",
+      targetSpan: toProtocolSpan(span),
+      suggestedEdit: { text: "" },
+    };
+  }
+
+  private fixChangeType(span: TokenSpan): Fix {
+    return { kind: "change_type", targetSpan: toProtocolSpan(span) };
+  }
+
+  private fixInsert(span: TokenSpan): Fix {
+    return { kind: "insert_required_clause", targetSpan: toProtocolSpan(span) };
+  }
+
+  private fixReplaceIdentifier(span: TokenSpan): Fix {
+    return { kind: "replace_identifier", targetSpan: toProtocolSpan(span) };
+  }
+
+  private fixReplaceLiteral(
+    span: TokenSpan,
+    candidates?: readonly string[],
+    suggested?: string
+  ): Fix {
+    const targetSpan = toProtocolSpan(span);
+    if (suggested !== undefined && candidates !== undefined) {
+      return {
+        kind: "replace_literal",
+        targetSpan,
+        suggestedEdit: { text: suggested },
+        candidates: [...candidates],
+      };
+    }
+    if (candidates !== undefined) {
+      return { kind: "replace_literal", targetSpan, candidates: [...candidates] };
+    }
+    if (suggested !== undefined) {
+      return {
+        kind: "replace_literal",
+        targetSpan,
+        suggestedEdit: { text: suggested },
+      };
+    }
+    return { kind: "replace_literal", targetSpan };
   }
 
   // ─── Recovery ──────────────────────────────────────────────────────

--- a/tests/core/axint-dsl/corpus.test.ts
+++ b/tests/core/axint-dsl/corpus.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Negative-corpus conformance test.
+ *
+ * Every file under spec/language/examples/broken/ is intentionally invalid and
+ * targets exactly one diagnostic code. The filename prefix — `NN-axNNN-…` —
+ * declares the expected code. This harness runs tokenize → parse → lower on
+ * each file and asserts two things:
+ *
+ *   1. The expected code fires with the spec-correct `fix.kind` from
+ *      spec/language/diagnostic-protocol.md §Fix kinds.
+ *   2. Every emitted diagnostic — primary or cascade — satisfies the protocol
+ *      invariants: `schemaVersion === 1`, non-null `fix`, `fix.kind` in the
+ *      closed six-kind set. AX200–AX202 and AX600 may emit `fix: null` but
+ *      those codes live outside the DSL module and can't reach this harness.
+ *
+ * A fixture whose code isn't wired into DSL lowering yet stays in the corpus
+ * as ground truth, listed in `PENDING_LOWERING_CODES`. The harness asserts the
+ * code does NOT fire so the allowlist self-tightens — when the code lands in
+ * lowering, the "pending" assertion fails and the entry gets removed.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { lower, parse } from "../../../src/core/axint-dsl/index.js";
+import type { Diagnostic, FixKind } from "../../../src/core/axint-dsl/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const corpusDir = join(__dirname, "../../../spec/language/examples/broken");
+
+// Mirror of the fix-kind catalog in diagnostic-protocol.md. AX007 is
+// context-sensitive and doesn't appear in any fixture filename, so it stays
+// out of this table.
+const EXPECTED_FIX_KIND: Readonly<Record<string, FixKind>> = {
+  AX001: "insert_required_clause",
+  AX002: "replace_identifier",
+  AX003: "insert_required_clause",
+  AX004: "insert_required_clause",
+  AX005: "change_type",
+  AX015: "insert_required_clause",
+  AX020: "replace_identifier",
+  AX021: "replace_identifier",
+  AX023: "replace_identifier",
+  AX100: "rename_identifier",
+  AX103: "rename_identifier",
+  AX106: "replace_literal",
+  AX107: "remove_field",
+  AX109: "insert_required_clause",
+  AX112: "insert_required_clause",
+};
+
+const KNOWN_FIX_KINDS: ReadonlySet<FixKind> = new Set<FixKind>([
+  "insert_required_clause",
+  "remove_field",
+  "replace_literal",
+  "change_type",
+  "rename_identifier",
+  "replace_identifier",
+]);
+
+// Codes whose DSL-lowering path isn't wired yet. The fixture stays as the
+// v1 ground-truth example; when the code lands in lowering, the pending
+// assertion flips red and the entry gets deleted here.
+const PENDING_LOWERING_CODES: ReadonlySet<string> = new Set(["AX112"]);
+
+interface Fixture {
+  readonly file: string;
+  readonly expectedCode: string;
+}
+
+function loadFixtures(): Fixture[] {
+  return readdirSync(corpusDir)
+    .filter((name) => name.endsWith(".axint"))
+    .sort()
+    .map((file) => {
+      const match = /^\d+-(ax\d+)-/i.exec(file);
+      if (!match) {
+        throw new Error(`corpus fixture "${file}" doesn't match NN-axNNN-*.axint`);
+      }
+      return { file, expectedCode: match[1].toUpperCase() };
+    });
+}
+
+function runPipeline(source: string, file: string): Diagnostic[] {
+  const parsed = parse(source, { sourceFile: file });
+  const lowered = lower(parsed.file, { sourceFile: file });
+  return [...parsed.diagnostics, ...lowered.diagnostics];
+}
+
+describe("axint-dsl negative corpus", () => {
+  const fixtures = loadFixtures();
+
+  it("covers at least ten negative cases", () => {
+    expect(fixtures.length).toBeGreaterThanOrEqual(10);
+  });
+
+  for (const { file, expectedCode } of fixtures) {
+    const pending = PENDING_LOWERING_CODES.has(expectedCode);
+    const label = pending
+      ? `${file} — ${expectedCode} (pending lowering)`
+      : `${file} — ${expectedCode}`;
+
+    it(label, () => {
+      const source = readFileSync(join(corpusDir, file), "utf-8");
+      const diagnostics = runPipeline(source, file);
+
+      for (const d of diagnostics) {
+        expect(d.schemaVersion, `${file}: ${d.code} schemaVersion`).toBe(1);
+        expect(d.file, `${file}: ${d.code} filename`).toBe(file);
+        expect(d.fix, `${file}: ${d.code} must carry a Fix`).not.toBeNull();
+        expect(
+          KNOWN_FIX_KINDS.has(d.fix!.kind),
+          `${file}: ${d.code} fix.kind "${d.fix!.kind}"`
+        ).toBe(true);
+      }
+
+      if (pending) {
+        // Flip-red gate: when the code gets wired in lowering this will fail
+        // and the allowlist entry must be removed. That's the point.
+        const fired = diagnostics.some((d) => d.code === expectedCode);
+        expect(
+          fired,
+          `${file}: ${expectedCode} is listed pending but fired — remove from allowlist`
+        ).toBe(false);
+        return;
+      }
+
+      const matching = diagnostics.filter((d) => d.code === expectedCode);
+      expect(matching.length, `${file} should emit ${expectedCode}`).toBeGreaterThan(0);
+      expect(matching[0]!.fix!.kind).toBe(EXPECTED_FIX_KIND[expectedCode]);
+    });
+  }
+});

--- a/tests/core/axint-dsl/lexer.test.ts
+++ b/tests/core/axint-dsl/lexer.test.ts
@@ -63,7 +63,10 @@ intent  Foo  { }  # trailing
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.code).toBe("AX007");
     expect(diagnostics[0]?.severity).toBe("error");
-    expect(diagnostics[0]?.fix).toBeNull();
+    // Per diagnostic-protocol.md, AX007 always carries a Fix. Deleting the
+    // malformed bytes is the remove_field no-close-match sub-case.
+    expect(diagnostics[0]?.fix?.kind).toBe("remove_field");
+    expect(diagnostics[0]?.fix?.suggestedEdit?.text).toBe("");
   });
 
   it("reports unknown escapes as AX007 but keeps the char for recovery", () => {

--- a/tests/core/axint-dsl/lowering.test.ts
+++ b/tests/core/axint-dsl/lowering.test.ts
@@ -80,7 +80,7 @@ describe("axint-dsl lowering — happy path", () => {
     expect(intent.parameters[0]).toMatchObject({
       name: "recipient",
       type: { kind: "primitive", value: "string" },
-      title: "Who to send the message to",
+      title: "Recipient",
       description: "Who to send the message to",
       isOptional: false,
     });

--- a/tests/core/axint-dsl/round-trip.test.ts
+++ b/tests/core/axint-dsl/round-trip.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Round-trip invariant: a `.axint` file and its equivalent TypeScript
+ * `defineIntent` source must lower to the same IR, down to field values and
+ * absent fields. This is the migration contract from spec/language/ir-mapping.md
+ * §Round-trip invariant — without it the TS surface and the DSL drift and the
+ * "byte-identical IR" promise becomes a lie.
+ *
+ * Each fixture pairs a hand-written `.axint` source with the `defineIntent`
+ * TypeScript that the DSL is meant to be interchangeable with. The fixtures
+ * cover the intersection of features both frontends currently support —
+ * primitives, optionals, entity references, defaults, entitlements, infoPlist
+ * keys, and the three `parameterSummary` shapes. Array-typed and enum-typed
+ * params aren't here because the TS surface parser doesn't resolve them yet;
+ * when it does, add paired fixtures and this test will tighten automatically.
+ */
+import { describe, expect, it } from "vitest";
+import { lower, parse } from "../../../src/core/axint-dsl/index.js";
+import { parseIntentSource } from "../../../src/core/parser.js";
+import type { IRIntent } from "../../../src/core/types.js";
+
+interface Fixture {
+  readonly name: string;
+  readonly axint: string;
+  readonly ts: string;
+}
+
+const fixtures: readonly Fixture[] = [
+  {
+    name: "minimal intent",
+    axint: `intent Hello {
+  title: "Hello"
+  description: "A minimal App Intent that says hello."
+}`,
+    ts: `import { defineIntent } from "@axint/compiler";
+export default defineIntent({
+  name: "Hello",
+  title: "Hello",
+  description: "A minimal App Intent that says hello.",
+});`,
+  },
+  {
+    name: "string params with optional and domain",
+    axint: `intent SendMessage {
+  title: "Send Message"
+  description: "Sends a message."
+  domain: "messaging"
+
+  param recipient: string {
+    description: "Who to send the message to"
+  }
+
+  param urgent: boolean? {
+    description: "Mark as urgent"
+  }
+}`,
+    ts: `import { defineIntent, param } from "@axint/compiler";
+export default defineIntent({
+  name: "SendMessage",
+  title: "Send Message",
+  description: "Sends a message.",
+  domain: "messaging",
+  params: {
+    recipient: param.string("Who to send the message to"),
+    urgent: param.boolean("Mark as urgent", { required: false }),
+  },
+  perform: async () => ({}),
+});`,
+  },
+  {
+    name: "int default and entitlements",
+    axint: `intent SetBrightness {
+  title: "Set Brightness"
+  description: "Sets the brightness."
+
+  param level: int {
+    description: "Brightness percentage"
+    default: 75
+  }
+
+  entitlements {
+    "com.apple.developer.siri"
+  }
+}`,
+    ts: `import { defineIntent, param } from "@axint/compiler";
+export default defineIntent({
+  name: "SetBrightness",
+  title: "Set Brightness",
+  description: "Sets the brightness.",
+  entitlements: ["com.apple.developer.siri"],
+  params: {
+    level: param.int("Brightness percentage", { default: 75 }),
+  },
+  perform: async () => ({}),
+});`,
+  },
+  {
+    name: "date, duration, url with two optionals",
+    axint: `intent LogHealth {
+  title: "Log Health"
+  description: "Logs a health event."
+
+  param occurredAt: date {
+    description: "When the event occurred"
+  }
+
+  param length: duration {
+    description: "How long it lasted"
+  }
+
+  param source: url? {
+    description: "Source URL"
+  }
+
+  param note: string? {
+    description: "Optional note"
+  }
+}`,
+    ts: `import { defineIntent, param } from "@axint/compiler";
+export default defineIntent({
+  name: "LogHealth",
+  title: "Log Health",
+  description: "Logs a health event.",
+  params: {
+    occurredAt: param.date("When the event occurred"),
+    length: param.duration("How long it lasted"),
+    source: param.url("Source URL", { required: false }),
+    note: param.string("Optional note", { required: false }),
+  },
+  perform: async () => ({}),
+});`,
+  },
+  {
+    name: "entitlements and infoPlistKeys",
+    axint: `intent CreateEvent {
+  title: "Create Event"
+  description: "Creates a calendar event."
+  domain: "productivity"
+
+  param eventTitle: string {
+    description: "Event title"
+  }
+
+  param startDate: date {
+    description: "Event start"
+  }
+
+  param length: duration {
+    description: "Event duration"
+  }
+
+  entitlements {
+    "com.apple.developer.siri"
+  }
+
+  infoPlistKeys {
+    "NSCalendarsUsageDescription": "Axint needs calendar access."
+  }
+}`,
+    ts: `import { defineIntent, param } from "@axint/compiler";
+export default defineIntent({
+  name: "CreateEvent",
+  title: "Create Event",
+  description: "Creates a calendar event.",
+  domain: "productivity",
+  entitlements: ["com.apple.developer.siri"],
+  infoPlistKeys: {
+    NSCalendarsUsageDescription: "Axint needs calendar access.",
+  },
+  params: {
+    eventTitle: param.string("Event title"),
+    startDate: param.date("Event start"),
+    length: param.duration("Event duration"),
+  },
+  perform: async () => ({}),
+});`,
+  },
+  {
+    name: "category, discoverable, donateOnPerform",
+    axint: `intent Dim {
+  title: "Dim Lights"
+  description: "Dims the lights."
+  category: "smart-home"
+  discoverable: true
+  donateOnPerform: false
+
+  param level: int {
+    description: "Brightness 0-100"
+  }
+}`,
+    ts: `import { defineIntent, param } from "@axint/compiler";
+export default defineIntent({
+  name: "Dim",
+  title: "Dim Lights",
+  description: "Dims the lights.",
+  category: "smart-home",
+  isDiscoverable: true,
+  donateOnPerform: false,
+  params: {
+    level: param.int("Brightness 0-100"),
+  },
+  perform: async () => ({}),
+});`,
+  },
+  {
+    name: "simple parameterSummary",
+    axint: `intent Greet {
+  title: "Greet"
+  description: "Greet someone."
+
+  param who: string {
+    description: "Name"
+  }
+
+  summary: "Hi, \${who}!"
+}`,
+    ts: `import { defineIntent, param } from "@axint/compiler";
+export default defineIntent({
+  name: "Greet",
+  title: "Greet",
+  description: "Greet someone.",
+  parameterSummary: "Hi, \${who}!",
+  params: {
+    who: param.string("Name"),
+  },
+  perform: async () => ({}),
+});`,
+  },
+  {
+    name: "when parameterSummary",
+    axint: `intent Plan {
+  title: "Plan"
+  description: "Plan a thing."
+
+  param what: string { description: "Thing" }
+  param where: string? { description: "Place" }
+
+  summary when where {
+    then: "Plan \${what} in \${where}"
+    otherwise: "Plan \${what}"
+  }
+}`,
+    ts: `import { defineIntent, param } from "@axint/compiler";
+export default defineIntent({
+  name: "Plan",
+  title: "Plan",
+  description: "Plan a thing.",
+  parameterSummary: {
+    when: "where",
+    then: "Plan \${what} in \${where}",
+    otherwise: "Plan \${what}",
+  },
+  params: {
+    what: param.string("Thing"),
+    where: param.string("Place", { required: false }),
+  },
+  perform: async () => ({}),
+});`,
+  },
+  {
+    name: "switch parameterSummary with default",
+    axint: `intent Rate {
+  title: "Rate"
+  description: "Rate it."
+
+  param mood: string {
+    description: "Mood"
+  }
+
+  summary switch mood {
+    case "happy": "Thanks!"
+    case "sad": "Sorry to hear"
+    default: "Noted"
+  }
+}`,
+    ts: `import { defineIntent, param } from "@axint/compiler";
+export default defineIntent({
+  name: "Rate",
+  title: "Rate",
+  description: "Rate it.",
+  parameterSummary: {
+    switch: "mood",
+    cases: [
+      { value: "happy", summary: "Thanks!" },
+      { value: "sad", summary: "Sorry to hear" },
+    ],
+    default: "Noted",
+  },
+  params: {
+    mood: param.string("Mood"),
+  },
+  perform: async () => ({}),
+});`,
+  },
+  {
+    name: "entity reference",
+    axint: `entity Trail {
+  display {
+    title: name
+    subtitle: region
+    image: "figure.hiking"
+  }
+
+  property id: string {
+    description: "Trail ID"
+  }
+
+  property name: string {
+    description: "Trail name"
+  }
+
+  property region: string {
+    description: "Region"
+  }
+
+  query: property
+}
+
+intent PlanTrail {
+  title: "Plan Trail"
+  description: "Plan a trail outing."
+
+  param trail: Trail {
+    description: "Trail to open"
+  }
+}`,
+    ts: `import { defineIntent, defineEntity, param } from "@axint/compiler";
+
+defineEntity({
+  name: "Trail",
+  display: { title: "name", subtitle: "region", image: "figure.hiking" },
+  properties: {
+    id: param.string("Trail ID"),
+    name: param.string("Trail name"),
+    region: param.string("Region"),
+  },
+  query: "property",
+});
+
+export default defineIntent({
+  name: "PlanTrail",
+  title: "Plan Trail",
+  description: "Plan a trail outing.",
+  params: {
+    trail: param.entity("Trail", "Trail to open"),
+  },
+  perform: async () => ({}),
+});`,
+  },
+];
+
+// The DSL and TS paths both stamp the intent with the sourceFile they were
+// given. That field isn't part of the contract — it's provenance. Strip it
+// before comparing, along with any undefined-valued field JSON.stringify
+// already hides but structural equality doesn't.
+function canonicalize(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value !== "object") return value;
+  const source = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(source).sort()) {
+    if (key === "sourceFile") continue;
+    const v = source[key];
+    if (v === undefined) continue;
+    out[key] = canonicalize(v);
+  }
+  return out;
+}
+
+function lowerDsl(source: string): IRIntent {
+  const parsed = parse(source, { sourceFile: "fixture.axint" });
+  const lowered = lower(parsed.file, { sourceFile: "fixture.axint" });
+  const diagnostics = [...parsed.diagnostics, ...lowered.diagnostics];
+  if (diagnostics.length > 0) {
+    const lines = diagnostics
+      .map((d) => `${d.code} @ ${d.span.start.line}:${d.span.start.column}  ${d.message}`)
+      .join("\n");
+    throw new Error(`DSL fixture produced diagnostics:\n${lines}`);
+  }
+  const [intent] = lowered.intents;
+  if (!intent) throw new Error("DSL fixture produced no intent");
+  return intent;
+}
+
+describe("axint-dsl round-trip", () => {
+  for (const { name, axint, ts } of fixtures) {
+    it(name, () => {
+      const fromDsl = canonicalize(lowerDsl(axint));
+      const fromTs = canonicalize(parseIntentSource(ts, "fixture.ts"));
+      expect(fromDsl).toEqual(fromTs);
+    });
+  }
+});


### PR DESCRIPTION
Lowering was defaulting param.title to the description; the TS parser capitalizes the field name (eventTitle -> "Event Title"). Aligns DSL to match and adds a round-trip test pairing .axint fixtures with their defineIntent TS equivalents, so the two frontends can't drift on any field the IR spec calls out.