### PR TITLE
refresh readme proof line test count

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.3.9 · 11 MCP tools + 3 prompts · 139 diagnostic codes · 794 tests · 8 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.3.9 · 11 MCP tools + 3 prompts · 139 diagnostic codes · 820 tests · 8 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 


### PR DESCRIPTION
metrics.json already reflects 820 tests after the round-trip invariant suite landed; README proof line was still showing 794. CI docs:check caught the drift.