### PR TITLE
canonical formatter for the .axint DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.3.9 · 11 MCP tools + 3 prompts · 139 diagnostic codes · 820 tests · 8 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.3.9 · 11 MCP tools + 3 prompts · 139 diagnostic codes · 903 tests · 8 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/metrics.json
+++ b/metrics.json
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 706,
+    "typescript": 789,
     "python": 114
   },
   "registryPackages": 8,

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -1,0 +1,51 @@
+import type { Command } from "commander";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse, printDsl } from "../core/axint-dsl/index.js";
+
+export function registerFormat(program: Command) {
+  program
+    .command("format")
+    .description("Format a .axint file in canonical style (prints to stdout by default)")
+    .argument("<file>", "Path to the .axint source file")
+    .option("-w, --write", "Rewrite the file in place instead of printing to stdout")
+    .action(async (file: string, options: { write?: boolean }) => {
+      const filePath = resolve(file);
+
+      let source: string;
+      try {
+        source = readFileSync(filePath, "utf-8");
+      } catch {
+        console.error(`\x1b[31merror:\x1b[0m Cannot read file: ${filePath}`);
+        process.exit(1);
+      }
+
+      const parsed = parse(source, { sourceFile: filePath });
+
+      const errors = parsed.diagnostics.filter((d) => d.severity === "error");
+      if (errors.length > 0) {
+        for (const d of errors) {
+          const where = `${d.span.start.line}:${d.span.start.column}`;
+          console.error(
+            `\x1b[31merror\x1b[0m[${d.code}] ${filePath}:${where}  ${d.message}`
+          );
+          const hint = d.fix?.suggestedEdit?.text;
+          if (hint) console.error(`  = help: ${hint}`);
+        }
+        console.error(
+          `\x1b[31mformat:\x1b[0m refusing to format a file with parse errors — fix the errors above and retry`
+        );
+        process.exit(1);
+      }
+
+      const output = printDsl(parsed.file);
+
+      if (options.write) {
+        if (output === source) return;
+        writeFileSync(filePath, output, "utf-8");
+        return;
+      }
+
+      process.stdout.write(output);
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@
  *   axint validate <file>         Validate a compiled intent
  *   axint validate-swift <path>   Validate existing Swift sources against Axint's build-time rules
  *   axint eject <file>            Eject intent to standalone Swift (no vendor lock-in)
+ *   axint format <file>           Format a .axint source file in canonical style
  *   axint templates               List bundled intent templates
  *   axint login                   Authenticate with the Axint Registry and unlock fuller repair reports
  *   axint publish                 Publish an intent to the Registry
@@ -37,6 +38,7 @@ import { registerCompile } from "./compile.js";
 import { registerValidate } from "./validate.js";
 import { registerValidateSwift } from "./validate-swift.js";
 import { registerEject } from "./eject.js";
+import { registerFormat } from "./format.js";
 import { registerTemplates } from "./templates.js";
 import { registerLogin } from "./login.js";
 import { registerPublish } from "./publish.js";
@@ -141,6 +143,7 @@ registerCompile(program);
 registerValidate(program);
 registerValidateSwift(program);
 registerEject(program);
+registerFormat(program);
 registerTemplates(program);
 registerLogin(program);
 registerPublish(program, VERSION);

--- a/src/core/axint-dsl/index.ts
+++ b/src/core/axint-dsl/index.ts
@@ -17,6 +17,8 @@ export type { LexResult } from "./lexer.js";
 export { lower } from "./lowering.js";
 export type { LowerResult, LowerOptions } from "./lowering.js";
 
+export { printDsl } from "./printer.js";
+
 export type { Token, TokenKind, TokenSpan } from "./token.js";
 export { KEYWORDS, PRIMITIVE_TYPE_KINDS } from "./token.js";
 

--- a/src/core/axint-dsl/printer.ts
+++ b/src/core/axint-dsl/printer.ts
@@ -1,0 +1,351 @@
+/**
+ * Axint DSL — canonical printer
+ *
+ * Turns a parsed `FileNode` back into source text. The output obeys the
+ * principles in spec/language/principles.md §7 "easy to format": two-space
+ * indent, braces on their own closing line, no alignment, no trailing
+ * punctuation, one obvious shape per construct.
+ *
+ * The printer is a pure AST walk. It assumes the input is a well-formed AST
+ * produced by the parser — no repair, no reordering, no validation. An AST
+ * with clauses out of order is a parser bug (AX007), not something the
+ * formatter silently fixes up. Grammar optional fields that are omitted in
+ * the AST stay omitted in the output.
+ *
+ * Idempotence: `printDsl(parse(printDsl(parse(x))))` equals
+ * `printDsl(parse(x))` for any input the parser accepts. Semantic
+ * equivalence: lowering the reprinted source produces an IR equal to the
+ * original modulo spans.
+ *
+ * Comments: the lexer accepts `#` line comments (grammar §Comments) and the
+ * AST intentionally drops them. A reprint therefore discards comments in v1.
+ * This is a language decision — the canonical form has no room for free-form
+ * prose — not a printer shortcut.
+ */
+
+import type {
+  EntityDecl,
+  EnumDecl,
+  FileNode,
+  IntentDecl,
+  LiteralNode,
+  MetaClause,
+  ParamDecl,
+  PropertyDecl,
+  ReturnTypeNode,
+  SummaryDecl,
+  SummaryValue,
+  TypeNode,
+} from "./ast.js";
+
+/** Produce canonical `.axint` source for a parsed AST. Output ends with `\n`. */
+export function printDsl(file: FileNode): string {
+  const w = new Writer();
+  file.declarations.forEach((decl, i) => {
+    if (i > 0) w.blank();
+    switch (decl.kind) {
+      case "IntentDecl":
+        printIntent(w, decl);
+        break;
+      case "EntityDecl":
+        printEntity(w, decl);
+        break;
+      case "EnumDecl":
+        printEnum(w, decl);
+        break;
+    }
+  });
+  return w.toString();
+}
+
+// ─── Writer ──────────────────────────────────────────────────────────
+
+class Writer {
+  private readonly lines: string[] = [];
+  private depth = 0;
+
+  indent() {
+    this.depth += 1;
+  }
+
+  dedent() {
+    this.depth -= 1;
+  }
+
+  line(text: string) {
+    this.lines.push("  ".repeat(this.depth) + text);
+  }
+
+  blank() {
+    this.lines.push("");
+  }
+
+  toString() {
+    return this.lines.join("\n") + "\n";
+  }
+}
+
+// ─── Intent ──────────────────────────────────────────────────────────
+
+function printIntent(w: Writer, node: IntentDecl) {
+  w.line(`intent ${node.name.name} {`);
+  w.indent();
+  w.line(`title: ${encodeString(node.title.value)}`);
+  w.line(`description: ${encodeString(node.description.value)}`);
+  for (const meta of node.meta) printMeta(w, meta);
+
+  for (const param of node.params) {
+    w.blank();
+    printParam(w, param);
+  }
+
+  if (node.summary) {
+    w.blank();
+    printSummary(w, node.summary);
+  }
+
+  if (node.returns) {
+    w.blank();
+    w.line(`returns: ${renderReturnType(node.returns.type)}`);
+  }
+
+  if (node.entitlements) {
+    w.blank();
+    w.line("entitlements {");
+    w.indent();
+    for (const value of node.entitlements.values) w.line(encodeString(value.value));
+    w.dedent();
+    w.line("}");
+  }
+
+  if (node.infoPlistKeys) {
+    w.blank();
+    w.line("infoPlistKeys {");
+    w.indent();
+    for (const entry of node.infoPlistKeys.entries) {
+      w.line(`${encodeString(entry.key.value)}: ${encodeString(entry.value.value)}`);
+    }
+    w.dedent();
+    w.line("}");
+  }
+
+  w.dedent();
+  w.line("}");
+}
+
+function printMeta(w: Writer, meta: MetaClause) {
+  switch (meta.kind) {
+    case "DomainMeta":
+      w.line(`domain: ${encodeString(meta.value.value)}`);
+      return;
+    case "CategoryMeta":
+      w.line(`category: ${encodeString(meta.value.value)}`);
+      return;
+    case "DiscoverableMeta":
+      w.line(`discoverable: ${meta.value.value}`);
+      return;
+    case "DonateOnPerformMeta":
+      w.line(`donateOnPerform: ${meta.value.value}`);
+      return;
+  }
+}
+
+function printParam(w: Writer, node: ParamDecl) {
+  w.line(`param ${node.name.name}: ${renderType(node.type)} {`);
+  w.indent();
+  w.line(`description: ${encodeString(node.description.value)}`);
+  if (node.defaultValue) w.line(`default: ${renderLiteral(node.defaultValue)}`);
+  if (node.options) w.line(`options: dynamic ${node.options.provider.name}`);
+  w.dedent();
+  w.line("}");
+}
+
+// ─── Entity ──────────────────────────────────────────────────────────
+
+function printEntity(w: Writer, node: EntityDecl) {
+  w.line(`entity ${node.name.name} {`);
+  w.indent();
+
+  w.line("display {");
+  w.indent();
+  w.line(`title: ${node.display.title.property.name}`);
+  if (node.display.subtitle) {
+    w.line(`subtitle: ${node.display.subtitle.property.name}`);
+  }
+  if (node.display.image) {
+    w.line(`image: ${encodeString(node.display.image.asset.value)}`);
+  }
+  w.dedent();
+  w.line("}");
+
+  for (const prop of node.properties) {
+    w.blank();
+    printProperty(w, prop);
+  }
+
+  w.blank();
+  w.line(`query: ${node.query.queryKind}`);
+
+  w.dedent();
+  w.line("}");
+}
+
+function printProperty(w: Writer, node: PropertyDecl) {
+  w.line(`property ${node.name.name}: ${renderType(node.type)} {`);
+  w.indent();
+  w.line(`description: ${encodeString(node.description.value)}`);
+  w.dedent();
+  w.line("}");
+}
+
+// ─── Enum ────────────────────────────────────────────────────────────
+
+function printEnum(w: Writer, node: EnumDecl) {
+  const cases = node.cases.map((c) => c.name).join(" ");
+  w.line(`enum ${node.name.name} { ${cases} }`);
+}
+
+// ─── Summary ─────────────────────────────────────────────────────────
+
+function printSummary(w: Writer, node: SummaryDecl) {
+  switch (node.kind) {
+    case "SummaryTemplate":
+      w.line(`summary: ${encodeString(node.template.value)}`);
+      return;
+    case "SummaryWhen":
+      w.line(`summary when ${node.param.name} {`);
+      w.indent();
+      printSummaryField(w, "then", node.then);
+      if (node.otherwise) printSummaryField(w, "otherwise", node.otherwise);
+      w.dedent();
+      w.line("}");
+      return;
+    case "SummarySwitch":
+      w.line(`summary switch ${node.param.name} {`);
+      w.indent();
+      for (const c of node.cases) {
+        printSummaryField(w, `case ${renderLiteral(c.value)}`, c.body);
+      }
+      if (node.default) printSummaryField(w, "default", node.default);
+      w.dedent();
+      w.line("}");
+      return;
+  }
+}
+
+/**
+ * Emit a labelled summary value — a leaf string or a nested summary block.
+ * For a nested block the opener becomes `${label}: summary when …` with the
+ * block body indented one level deeper.
+ */
+function printSummaryField(w: Writer, label: string, value: SummaryValue) {
+  if (value.kind === "StringLiteral") {
+    w.line(`${label}: ${encodeString(value.value)}`);
+    return;
+  }
+
+  switch (value.kind) {
+    case "SummaryTemplate":
+      w.line(`${label}: ${encodeString(value.template.value)}`);
+      return;
+    case "SummaryWhen":
+      w.line(`${label}: summary when ${value.param.name} {`);
+      w.indent();
+      printSummaryField(w, "then", value.then);
+      if (value.otherwise) printSummaryField(w, "otherwise", value.otherwise);
+      w.dedent();
+      w.line("}");
+      return;
+    case "SummarySwitch":
+      w.line(`${label}: summary switch ${value.param.name} {`);
+      w.indent();
+      for (const c of value.cases) {
+        printSummaryField(w, `case ${renderLiteral(c.value)}`, c.body);
+      }
+      if (value.default) printSummaryField(w, "default", value.default);
+      w.dedent();
+      w.line("}");
+      return;
+  }
+}
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+function renderType(node: TypeNode): string {
+  switch (node.kind) {
+    case "PrimitiveType":
+      return node.primitive;
+    case "NamedType":
+      return node.name;
+    case "ArrayType":
+      return `[${renderType(node.element)}]`;
+    case "OptionalType":
+      return `${renderType(node.inner)}?`;
+  }
+}
+
+function renderReturnType(node: ReturnTypeNode): string {
+  switch (node.kind) {
+    case "PrimitiveType":
+      return node.primitive;
+    case "NamedType":
+      return node.name;
+    case "ReturnArrayType":
+      return `[${renderReturnType(node.element)}]`;
+  }
+}
+
+// ─── Literals ────────────────────────────────────────────────────────
+
+function renderLiteral(node: LiteralNode): string {
+  switch (node.kind) {
+    case "StringLiteral":
+      return encodeString(node.value);
+    case "IntegerLiteral":
+      return String(node.value);
+    case "DecimalLiteral":
+      return formatDecimal(node.value);
+    case "BooleanLiteral":
+      return node.value ? "true" : "false";
+    case "IdentLiteral":
+      return node.name;
+  }
+}
+
+/**
+ * Re-encode a decoded string value with the escape set the grammar supports:
+ * `\"`, `\\`, `\n`, `\t`. Everything else is written literally — the grammar
+ * forbids multi-line strings but we still escape raw control chars so a bad
+ * string can't break the reprint.
+ */
+function encodeString(value: string): string {
+  let out = '"';
+  for (const ch of value) {
+    switch (ch) {
+      case "\\":
+        out += "\\\\";
+        break;
+      case '"':
+        out += '\\"';
+        break;
+      case "\n":
+        out += "\\n";
+        break;
+      case "\t":
+        out += "\\t";
+        break;
+      default:
+        out += ch;
+    }
+  }
+  return out + '"';
+}
+
+/**
+ * Keep a decimal literal's decimal point visible so it can't be round-tripped
+ * back as an integer. `1.0` stays `1.0`, `3.14` stays `3.14`.
+ */
+function formatDecimal(value: number): string {
+  const text = String(value);
+  return text.includes(".") ? text : `${text}.0`;
+}

--- a/tests/core/axint-dsl/printer.test.ts
+++ b/tests/core/axint-dsl/printer.test.ts
@@ -235,8 +235,8 @@ const productions: readonly { readonly name: string; readonly source: string }[]
   title: "A"
   description: "a"
 
-  param when: date {
-    description: "When"
+  param dueOn: date {
+    description: "Due"
   }
 }
 `,
@@ -546,7 +546,7 @@ intent A {
 `,
   },
   {
-    name: "entity with static query",
+    name: "entity with all query",
     source: `entity Thing {
   display {
     title: name
@@ -560,7 +560,7 @@ intent A {
     description: "Name"
   }
 
-  query: static
+  query: all
 }
 `,
   },

--- a/tests/core/axint-dsl/printer.test.ts
+++ b/tests/core/axint-dsl/printer.test.ts
@@ -1,0 +1,681 @@
+/**
+ * Canonical printer tests.
+ *
+ * Four contracts the formatter holds:
+ *
+ *   1. Grammar productions — each canonical shape in spec/language/grammar.md
+ *      round-trips byte-for-byte through `printDsl(parse(x))` when the input
+ *      is already canonical. Each production gets its own tiny fixture so a
+ *      regression points at exactly one construct.
+ *
+ *   2. Idempotence — `format(format(x)) === format(x)` for everything in the
+ *      canonical corpus. Formatting twice must not drift.
+ *
+ *   3. Semantic equivalence — lowering the reprinted source produces an IR
+ *      equal to the original modulo provenance spans. The formatter may
+ *      rewrite shapes (inline `{ … }` → multi-line block), but it must never
+ *      change meaning.
+ *
+ *   4. Canonical examples — every `spec/language/examples/*.axint` file is
+ *      round-tripped byte-for-byte. This is the strongest form of the
+ *      grammar-production check, and `readdirSync` auto-enrolls new examples.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { lower, parse, printDsl } from "../../../src/core/axint-dsl/index.js";
+import type { Diagnostic } from "../../../src/core/axint-dsl/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const examplesDir = join(__dirname, "../../../spec/language/examples");
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+function format(source: string, sourceFile = "fixture.axint"): string {
+  const parsed = parse(source, { sourceFile });
+  const errors = parsed.diagnostics.filter((d) => d.severity === "error");
+  if (errors.length > 0) {
+    const lines = errors
+      .map((d) => `${d.code} @ ${d.span.start.line}:${d.span.start.column}  ${d.message}`)
+      .join("\n");
+    throw new Error(`parse errors:\n${lines}`);
+  }
+  return printDsl(parsed.file);
+}
+
+/**
+ * Strip `sourceFile` provenance and `undefined` holes, then sort keys so
+ * `toEqual` compares structure only. Mirrors the canonicalizer in
+ * round-trip.test.ts — inlined to keep this file self-contained.
+ */
+function canonicalize(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value !== "object") return value;
+  const source = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(source).sort()) {
+    if (key === "sourceFile") continue;
+    const v = source[key];
+    if (v === undefined) continue;
+    out[key] = canonicalize(v);
+  }
+  return out;
+}
+
+interface LowerSnapshot {
+  readonly intents: unknown;
+  readonly entities: unknown;
+  readonly diagnostics: readonly DiagnosticSummary[];
+}
+
+interface DiagnosticSummary {
+  readonly code: string;
+  readonly severity: string;
+  readonly message: string;
+}
+
+function loweredSnapshot(source: string): LowerSnapshot {
+  const parsed = parse(source, { sourceFile: "fixture.axint" });
+  const lowered = lower(parsed.file, { sourceFile: "fixture.axint" });
+  return {
+    intents: canonicalize(lowered.intents),
+    entities: canonicalize(lowered.entities),
+    diagnostics: [...parsed.diagnostics, ...lowered.diagnostics].map(summarize),
+  };
+}
+
+function summarize(d: Diagnostic): DiagnosticSummary {
+  return { code: d.code, severity: d.severity, message: d.message };
+}
+
+// ─── production fixtures ─────────────────────────────────────────────
+
+// Each entry's `source` is already in canonical form. The test asserts
+// `format(parse(source)) === source`, so any regression in a single
+// construct fails its own named test rather than one omnibus fixture.
+const productions: readonly { readonly name: string; readonly source: string }[] = [
+  {
+    name: "minimal intent",
+    source: `intent Hello {
+  title: "Hello"
+  description: "Say hello."
+}
+`,
+  },
+  {
+    name: "domain meta",
+    source: `intent A {
+  title: "A"
+  description: "a"
+  domain: "messaging"
+}
+`,
+  },
+  {
+    name: "category meta",
+    source: `intent A {
+  title: "A"
+  description: "a"
+  category: "focus"
+}
+`,
+  },
+  {
+    name: "discoverable meta",
+    source: `intent A {
+  title: "A"
+  description: "a"
+  discoverable: true
+}
+`,
+  },
+  {
+    name: "donateOnPerform meta",
+    source: `intent A {
+  title: "A"
+  description: "a"
+  donateOnPerform: false
+}
+`,
+  },
+  {
+    name: "all meta clauses in grammar order",
+    source: `intent A {
+  title: "A"
+  description: "a"
+  domain: "productivity"
+  category: "focus"
+  discoverable: true
+  donateOnPerform: false
+}
+`,
+  },
+  {
+    name: "string param",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param who: string {
+    description: "Name"
+  }
+}
+`,
+  },
+  {
+    name: "int param with default",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param level: int {
+    description: "Level"
+    default: 75
+  }
+}
+`,
+  },
+  {
+    name: "double param with decimal default",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param ratio: double {
+    description: "Ratio"
+    default: 1.5
+  }
+}
+`,
+  },
+  {
+    name: "decimal default keeps trailing zero",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param ratio: double {
+    description: "Ratio"
+    default: 1.0
+  }
+}
+`,
+  },
+  {
+    name: "float param",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param pitch: float {
+    description: "Pitch"
+  }
+}
+`,
+  },
+  {
+    name: "boolean param with default",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param on: boolean {
+    description: "On"
+    default: true
+  }
+}
+`,
+  },
+  {
+    name: "date param",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param when: date {
+    description: "When"
+  }
+}
+`,
+  },
+  {
+    name: "duration param with string default",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param length: duration {
+    description: "Length"
+    default: "1h"
+  }
+}
+`,
+  },
+  {
+    name: "url param",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param href: url {
+    description: "Link"
+  }
+}
+`,
+  },
+  {
+    name: "optional param",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param note: string? {
+    description: "Note"
+  }
+}
+`,
+  },
+  {
+    name: "array param",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param tags: [string] {
+    description: "Tags"
+  }
+}
+`,
+  },
+  {
+    name: "optional array param",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param tags: [string]? {
+    description: "Tags"
+  }
+}
+`,
+  },
+  {
+    name: "enum-typed param with identifier default",
+    source: `enum Priority { low medium high }
+
+intent A {
+  title: "A"
+  description: "a"
+
+  param level: Priority {
+    description: "Priority"
+    default: medium
+  }
+}
+`,
+  },
+  {
+    name: "enum with single case",
+    source: `enum Mode { single }
+`,
+  },
+  {
+    name: "dynamic options provider",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param region: string {
+    description: "Region"
+    options: dynamic RegionOptions
+  }
+}
+`,
+  },
+  {
+    name: "summary template",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param who: string {
+    description: "Name"
+  }
+
+  summary: "Hi, \${who}!"
+}
+`,
+  },
+  {
+    name: "summary when with otherwise",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param who: string {
+    description: "Who"
+  }
+
+  param note: string? {
+    description: "Note"
+  }
+
+  summary when note {
+    then: "Hi \${who} — \${note}"
+    otherwise: "Hi \${who}"
+  }
+}
+`,
+  },
+  {
+    name: "summary switch with default",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param mood: string {
+    description: "Mood"
+  }
+
+  summary switch mood {
+    case "happy": "Yay"
+    case "sad": "Oh"
+    default: "Noted"
+  }
+}
+`,
+  },
+  {
+    name: "summary switch with boolean case and nested when",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  param flag: boolean {
+    description: "Flag"
+  }
+
+  param note: string? {
+    description: "Note"
+  }
+
+  summary switch flag {
+    case true: summary when note {
+      then: "On with \${note}"
+      otherwise: "On"
+    }
+    case false: "Off"
+    default: "Unknown"
+  }
+}
+`,
+  },
+  {
+    name: "returns primitive",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  returns: string
+}
+`,
+  },
+  {
+    name: "returns named entity",
+    source: `entity Contact {
+  display {
+    title: name
+  }
+
+  property id: string {
+    description: "ID"
+  }
+
+  property name: string {
+    description: "Name"
+  }
+
+  query: property
+}
+
+intent A {
+  title: "A"
+  description: "a"
+
+  returns: Contact
+}
+`,
+  },
+  {
+    name: "returns array of entity",
+    source: `entity Contact {
+  display {
+    title: name
+  }
+
+  property id: string {
+    description: "ID"
+  }
+
+  property name: string {
+    description: "Name"
+  }
+
+  query: property
+}
+
+intent A {
+  title: "A"
+  description: "a"
+
+  returns: [Contact]
+}
+`,
+  },
+  {
+    name: "entitlements block",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  entitlements {
+    "com.apple.developer.siri"
+    "com.apple.developer.healthkit"
+  }
+}
+`,
+  },
+  {
+    name: "infoPlistKeys block",
+    source: `intent A {
+  title: "A"
+  description: "a"
+
+  infoPlistKeys {
+    "NSCalendarsUsageDescription": "Needs calendar access."
+    "NSLocationWhenInUseUsageDescription": "Needs location."
+  }
+}
+`,
+  },
+  {
+    name: "entity with display title only",
+    source: `entity Thing {
+  display {
+    title: name
+  }
+
+  property id: string {
+    description: "ID"
+  }
+
+  property name: string {
+    description: "Name"
+  }
+
+  query: property
+}
+`,
+  },
+  {
+    name: "entity with display subtitle and image",
+    source: `entity Thing {
+  display {
+    title: name
+    subtitle: region
+    image: "figure.hiking"
+  }
+
+  property id: string {
+    description: "ID"
+  }
+
+  property name: string {
+    description: "Name"
+  }
+
+  property region: string {
+    description: "Region"
+  }
+
+  query: property
+}
+`,
+  },
+  {
+    name: "entity with static query",
+    source: `entity Thing {
+  display {
+    title: name
+  }
+
+  property id: string {
+    description: "ID"
+  }
+
+  property name: string {
+    description: "Name"
+  }
+
+  query: static
+}
+`,
+  },
+  {
+    name: "multiple declarations separated by one blank line",
+    source: `enum Priority { low high }
+
+intent A {
+  title: "A"
+  description: "a"
+}
+
+intent B {
+  title: "B"
+  description: "b"
+}
+`,
+  },
+];
+
+describe("printer grammar productions", () => {
+  for (const { name, source } of productions) {
+    it(`${name} round-trips byte-for-byte`, () => {
+      expect(format(source)).toBe(source);
+    });
+  }
+});
+
+// ─── canonical example corpus ────────────────────────────────────────
+
+const exampleFiles = readdirSync(examplesDir)
+  .filter((f) => f.endsWith(".axint"))
+  .sort();
+
+describe("printer canonical examples", () => {
+  for (const file of exampleFiles) {
+    it(`${file} round-trips byte-for-byte`, () => {
+      const source = readFileSync(join(examplesDir, file), "utf-8");
+      expect(format(source, file)).toBe(source);
+    });
+  }
+});
+
+// ─── idempotence ─────────────────────────────────────────────────────
+
+// Formatting twice must match formatting once. Covers the canonical
+// examples plus a couple of deliberately-messy inputs (inline single-line
+// param block, extra blank lines) to prove the formatter converges on a
+// single shape rather than tracking the input layout.
+const messyInputs: readonly { readonly name: string; readonly source: string }[] = [
+  {
+    name: "inline single-line param body",
+    source: `intent Plan {
+  title: "Plan"
+  description: "Plan a thing."
+
+  param what: string { description: "Thing" }
+  param where: string? { description: "Place" }
+}
+`,
+  },
+  {
+    name: "extra blank lines around clauses",
+    source: `intent Hello {
+
+
+  title: "Hello"
+
+  description: "Say hello."
+
+
+}
+`,
+  },
+];
+
+describe("printer idempotence", () => {
+  for (const file of exampleFiles) {
+    it(`${file} is stable under repeated formatting`, () => {
+      const source = readFileSync(join(examplesDir, file), "utf-8");
+      const once = format(source, file);
+      const twice = format(once, file);
+      expect(twice).toBe(once);
+    });
+  }
+
+  for (const { name, source } of messyInputs) {
+    it(`${name} converges after one pass`, () => {
+      const once = format(source);
+      const twice = format(once);
+      expect(twice).toBe(once);
+    });
+  }
+});
+
+// ─── semantic equivalence ────────────────────────────────────────────
+
+// The formatter may rewrite layout — it must never change meaning. For
+// every input source we lower both the original and the reprint, then
+// compare the IR modulo provenance. Diagnostics must match in code +
+// severity + message (spans are allowed to drift since reprints are
+// re-numbered).
+describe("printer preserves semantics", () => {
+  for (const file of exampleFiles) {
+    it(`${file} lowers to the same IR after reprinting`, () => {
+      const source = readFileSync(join(examplesDir, file), "utf-8");
+      const reprinted = format(source, file);
+      expect(loweredSnapshot(reprinted)).toEqual(loweredSnapshot(source));
+    });
+  }
+
+  for (const { name, source } of messyInputs) {
+    it(`${name} lowers to the same IR after reprinting`, () => {
+      const reprinted = format(source);
+      expect(loweredSnapshot(reprinted)).toEqual(loweredSnapshot(source));
+    });
+  }
+});


### PR DESCRIPTION
Adds a canonical printer for the .axint DSL and wires it up as `axint format <file>`.

The printer is a pure AST walk over `FileNode`. It emits the shape established in `spec/language/examples` — two-space indent, braces on their own line, header clauses packed, blank lines before params/summary/returns/entitlements/infoPlistKeys. Clause order is whatever the parser accepted; the formatter never silently reorders, because out-of-order clauses are AX007's job, not the printer's. Comments are dropped by design — the AST drops them and v1's canonical form has no room for free-form prose.

The CLI prints to stdout by default and takes `-w` / `--write` to rewrite in place. If the source has parse errors, `axint format` refuses to touch it and surfaces the diagnostics with fix hints so the user fixes the source first.

Tests cover the grammar productions byte-for-byte, auto-enrol every file under `spec/language/examples/*.axint` for the same round-trip check, verify idempotence (including against messy inputs with extra blank lines and single-line param bodies), and verify semantic equivalence by comparing `lower()` output modulo spans.