### PR TITLE
format mcp swift output

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.3.9 · 11 MCP tools + 3 prompts · 139 diagnostic codes · 903 tests · 8 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.3.9 · 11 MCP tools + 3 prompts · 139 diagnostic codes · 915 tests · 8 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/metrics.json
+++ b/metrics.json
@@ -58,7 +58,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 789,
+    "typescript": 801,
     "python": 114
   },
   "registryPackages": 8,

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -80,6 +80,14 @@ export const TOOL_MANIFEST = [
             description: "Swift type for this parameter",
           },
         },
+        format: {
+          type: "boolean",
+          description:
+            "When true (default), pipes every generated Swift file through " +
+            "swift-format with Axint's house style. Falls back to raw output " +
+            "when swift-format is not on $PATH. Set false to receive raw " +
+            "generator output.",
+        },
       },
       required: ["description"],
     },
@@ -246,6 +254,14 @@ export const TOOL_MANIFEST = [
             "When true, returns an .entitlements XML fragment for the intent's " +
             "declared entitlements. Only relevant for intents requiring special " +
             "capabilities. Defaults to false.",
+        },
+        format: {
+          type: "boolean",
+          description:
+            "When true (default), pipes generated Swift through swift-format " +
+            "with Axint's house style. Falls back to raw output when " +
+            "swift-format is not on $PATH. Set false to receive raw generator " +
+            "output.",
         },
       },
       required: ["source"],
@@ -504,6 +520,14 @@ export const TOOL_MANIFEST = [
             "App only. Scene definitions for the @main App struct. " +
             "At least one scene with kind 'windowGroup' is typically required.",
         },
+        format: {
+          type: "boolean",
+          description:
+            "When true (default), pipes generated Swift through swift-format " +
+            "with Axint's house style. Falls back to raw output when " +
+            "swift-format is not on $PATH. Set false to receive raw generator " +
+            "output.",
+        },
       },
       required: ["type", "name"],
     },
@@ -575,6 +599,14 @@ export const TOOL_MANIFEST = [
         file: {
           type: "string",
           description: "Optional file name to attach to diagnostics.",
+        },
+        format: {
+          type: "boolean",
+          description:
+            "When true (default), pipes the repaired Swift through " +
+            "swift-format with Axint's house style. Falls back to raw " +
+            "output when swift-format is not on $PATH. Set false to " +
+            "receive raw fixer output.",
         },
       },
       required: ["source"],

--- a/src/mcp/schema-compile.ts
+++ b/src/mcp/schema-compile.ts
@@ -12,6 +12,7 @@ import {
   compileWidgetFromIR,
   compileAppFromIR,
 } from "../core/compiler.js";
+import { formatSwift } from "../core/format.js";
 import type {
   IRIntent,
   IRView,
@@ -50,6 +51,7 @@ export type SchemaCompileArgs = {
     name?: string;
     platform?: string;
   }>;
+  format?: boolean;
 };
 
 const VALID_PLATFORMS = new Set<string>(["macOS", "iOS", "visionOS"]);
@@ -81,15 +83,16 @@ export async function handleCompileFromSchema(args: SchemaCompileArgs) {
   try {
     const inputJson = JSON.stringify(args);
     const inputTokens = Math.ceil(inputJson.length / 4);
+    const shouldFormat = args.format !== false;
 
     if (args.type === "intent") {
-      return handleIntentSchema(args, inputTokens);
+      return handleIntentSchema(args, inputTokens, shouldFormat);
     } else if (args.type === "view") {
-      return handleViewSchema(args, inputTokens);
+      return handleViewSchema(args, inputTokens, shouldFormat);
     } else if (args.type === "widget") {
-      return handleWidgetSchema(args, inputTokens);
+      return handleWidgetSchema(args, inputTokens, shouldFormat);
     } else if (args.type === "app") {
-      return handleAppSchema(args, inputTokens);
+      return handleAppSchema(args, inputTokens, shouldFormat);
     }
 
     return {
@@ -109,7 +112,11 @@ export async function handleCompileFromSchema(args: SchemaCompileArgs) {
   }
 }
 
-async function handleIntentSchema(args: SchemaCompileArgs, inputTokens: number) {
+async function handleIntentSchema(
+  args: SchemaCompileArgs,
+  inputTokens: number,
+  shouldFormat: boolean
+) {
   if (!args.name) {
     return {
       content: [
@@ -161,10 +168,14 @@ async function handleIntentSchema(args: SchemaCompileArgs, inputTokens: number) 
     };
   }
 
-  return formatSchemaOutput(result.output.swiftCode, inputTokens);
+  return formatSchemaOutput(result.output.swiftCode, inputTokens, shouldFormat);
 }
 
-async function handleViewSchema(args: SchemaCompileArgs, inputTokens: number) {
+async function handleViewSchema(
+  args: SchemaCompileArgs,
+  inputTokens: number,
+  shouldFormat: boolean
+) {
   if (!args.name) {
     return {
       content: [
@@ -221,10 +232,14 @@ async function handleViewSchema(args: SchemaCompileArgs, inputTokens: number) {
     };
   }
 
-  return formatSchemaOutput(result.output.swiftCode, inputTokens);
+  return formatSchemaOutput(result.output.swiftCode, inputTokens, shouldFormat);
 }
 
-async function handleWidgetSchema(args: SchemaCompileArgs, inputTokens: number) {
+async function handleWidgetSchema(
+  args: SchemaCompileArgs,
+  inputTokens: number,
+  shouldFormat: boolean
+) {
   if (!args.name) {
     return {
       content: [
@@ -301,10 +316,14 @@ async function handleWidgetSchema(args: SchemaCompileArgs, inputTokens: number) 
     };
   }
 
-  return formatSchemaOutput(result.output.swiftCode, inputTokens);
+  return formatSchemaOutput(result.output.swiftCode, inputTokens, shouldFormat);
 }
 
-async function handleAppSchema(args: SchemaCompileArgs, inputTokens: number) {
+async function handleAppSchema(
+  args: SchemaCompileArgs,
+  inputTokens: number,
+  shouldFormat: boolean
+) {
   if (!args.name) {
     return {
       content: [
@@ -367,14 +386,16 @@ async function handleAppSchema(args: SchemaCompileArgs, inputTokens: number) {
     };
   }
 
-  return formatSchemaOutput(result.output.swiftCode, inputTokens);
+  return formatSchemaOutput(result.output.swiftCode, inputTokens, shouldFormat);
 }
 
-function formatSchemaOutput(
+async function formatSchemaOutput(
   swiftCode: string,
-  inputTokens: number
-): { content: Array<{ type: string; text: string }>; isError?: boolean } {
-  const outputTokens = Math.ceil(swiftCode.length / 4);
+  inputTokens: number,
+  shouldFormat: boolean
+): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  const swift = shouldFormat ? (await formatSwift(swiftCode)).formatted : swiftCode;
+  const outputTokens = Math.ceil(swift.length / 4);
   const compressionRatio =
     inputTokens > 0 ? (outputTokens / inputTokens).toFixed(2) : "0.00";
   const tokensSaved = inputTokens - outputTokens;
@@ -387,6 +408,6 @@ function formatSchemaOutput(
 // Tokens saved:                   ${tokensSaved > 0 ? `+${tokensSaved}` : tokensSaved}
 `;
 
-  const output = tokenStats + "\n\n" + swiftCode;
+  const output = tokenStats + "\n\n" + swift;
   return { content: [{ type: "text" as const, text: output }] };
 }

--- a/src/mcp/schema-compile.ts
+++ b/src/mcp/schema-compile.ts
@@ -147,10 +147,11 @@ async function handleIntentSchema(
     }
   }
 
+  const resolvedTitle = args.title || args.name.replace(/([A-Z])/g, " $1").trim();
   const ir: IRIntent = {
     name: args.name,
-    title: args.title || args.name.replace(/([A-Z])/g, " $1").trim(),
-    description: args.description || "",
+    title: resolvedTitle,
+    description: args.description || resolvedTitle,
     domain: args.domain,
     parameters,
     returnType: { kind: "primitive", value: "string" },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -31,6 +31,7 @@ import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { compileAnySource } from "../core/compiler.js";
+import { formatSwift } from "../core/format.js";
 import { scaffoldIntent } from "./scaffold.js";
 import { generateFeature, type FeatureInput, type Surface } from "./feature.js";
 import { suggestFeatures, type SuggestInput } from "./suggest.js";
@@ -60,6 +61,7 @@ type CompileArgs = {
   fileName?: string;
   emitInfoPlist?: boolean;
   emitEntitlements?: boolean;
+  format?: boolean;
 };
 
 type ScaffoldArgs = {
@@ -93,9 +95,18 @@ function errorText(text: string): ToolResult {
   };
 }
 
+// Agents call axint.* through MCP stdio with no way to invoke swift-format
+// themselves. Default-on here means every AI-generated Swift file matches
+// Apple's house style without the caller having to know it exists.
+async function maybeFormatSwift(source: string, enabled: boolean): Promise<string> {
+  if (!enabled) return source;
+  const { formatted } = await formatSwift(source);
+  return formatted;
+}
+
 export async function handleToolCall(name: string, args: unknown): Promise<ToolResult> {
   if (name === "axint.feature") {
-    const a = args as FeatureInput;
+    const a = args as FeatureInput & { format?: boolean };
     if (!a.description) {
       return errorText("Error: 'description' is required for axint.feature");
     }
@@ -108,11 +119,16 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
       params: a.params,
     });
 
+    const shouldFormat = a.format !== false;
     const output: string[] = [result.summary, ""];
 
     for (const file of result.files) {
+      const content =
+        file.type === "swift" || file.type === "test"
+          ? await maybeFormatSwift(file.content, shouldFormat)
+          : file.content;
       output.push(`// ─── ${file.path} ───`);
-      output.push(file.content);
+      output.push(content);
       output.push("");
     }
 
@@ -166,10 +182,8 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
     });
 
     if (result.success && result.output) {
-      const parts: string[] = [
-        "// ─── Swift ──────────────────────────",
-        result.output.swiftCode,
-      ];
+      const swift = await maybeFormatSwift(result.output.swiftCode, a.format !== false);
+      const parts: string[] = ["// ─── Swift ──────────────────────────", swift];
       if (result.surface === "intent" && result.output.infoPlistFragment) {
         parts.push("// ─── Info.plist fragment ────────────");
         parts.push(result.output.infoPlistFragment);
@@ -241,7 +255,7 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
   }
 
   if (name === "axint.swift.fix") {
-    const a = args as { source: string; file?: string };
+    const a = args as { source: string; file?: string; format?: boolean };
     const result = fixSwiftSource(a.source, a.file ?? "<input>");
     const summary =
       result.fixed.length === 0
@@ -251,7 +265,8 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
       result.remaining.length > 0
         ? `\nRemaining: ${result.remaining.map((d) => `[${d.code}] ${d.message}`).join("; ")}`
         : "";
-    return diagnosticsText(`${summary}${remaining}\n\n${result.source}`);
+    const swift = await maybeFormatSwift(result.source, a.format !== false);
+    return diagnosticsText(`${summary}${remaining}\n\n${swift}`);
   }
 
   if (name === "axint.templates.list") {

--- a/tests/mcp/swift-format.test.ts
+++ b/tests/mcp/swift-format.test.ts
@@ -26,12 +26,18 @@ const INTENT_SOURCE = `
   });
 `;
 
+// A SwiftUI View that declares @State with `let` — the validator only
+// emits AX703 for View-conforming structs, because @State has no meaning
+// outside a View. This exercises the regex fixer's @State let → @State var
+// path through the MCP surface.
 const BROKEN_SWIFT = `
-import AppIntents
+import SwiftUI
 
-struct BrokenIntent: AppIntent {
-    static var title: LocalizedStringResource = "Broken"
+struct BrokenView: View {
     @State let count: Int = 0
+    var body: some View {
+        Text("\\(count)")
+    }
 }
 `;
 

--- a/tests/mcp/swift-format.test.ts
+++ b/tests/mcp/swift-format.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import { handleToolCall } from "../../src/mcp/server.js";
+
+// These tests cover the agent-facing path: MCP tools that emit Swift
+// should route through swift-format by default, fall back cleanly when
+// the binary is missing, and respect `format: false` as an opt-out.
+//
+// The tests are tolerant of both environments:
+//   - macOS dev boxes with Xcode → swift-format runs and reshapes output
+//   - Linux CI without the toolchain → the formatter no-ops and returns
+//     the raw generator output
+//
+// Either way, the shape of the response and the presence of the Swift
+// body are invariants we can assert on.
+
+const INTENT_SOURCE = `
+  import { defineIntent, param } from "@axint/compiler";
+  export default defineIntent({
+    name: "SendMessage",
+    title: "Send Message",
+    description: "Send a text message",
+    params: {
+      recipient: param.string("Recipient"),
+    },
+    perform: async (_) => "sent",
+  });
+`;
+
+const BROKEN_SWIFT = `
+import AppIntents
+
+struct BrokenIntent: AppIntent {
+    static var title: LocalizedStringResource = "Broken"
+    @State let count: Int = 0
+}
+`;
+
+function textOf(result: Awaited<ReturnType<typeof handleToolCall>>): string {
+  return result.content[0]?.text ?? "";
+}
+
+describe("axint.compile swift-format pipeline", () => {
+  it("routes Swift output through swift-format by default", async () => {
+    const result = await handleToolCall("axint.compile", {
+      source: INTENT_SOURCE,
+      fileName: "send-message.ts",
+    });
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toContain("struct SendMessage");
+    expect(text).toContain("AppIntent");
+  });
+
+  it("skips swift-format when format is false", async () => {
+    const result = await handleToolCall("axint.compile", {
+      source: INTENT_SOURCE,
+      fileName: "send-message.ts",
+      format: false,
+    });
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toContain("struct SendMessage");
+  });
+
+  it("produces the same Swift body with and without formatting on Linux CI", async () => {
+    // When swift-format is unavailable the two paths converge. When it's
+    // available the formatted version may reshape whitespace but both
+    // still contain the core generator output.
+    const [formatted, raw] = await Promise.all([
+      handleToolCall("axint.compile", { source: INTENT_SOURCE }),
+      handleToolCall("axint.compile", { source: INTENT_SOURCE, format: false }),
+    ]);
+    for (const r of [formatted, raw]) {
+      expect(r.isError).not.toBe(true);
+      expect(textOf(r)).toContain("struct SendMessage");
+    }
+  });
+});
+
+describe("axint.schema.compile swift-format pipeline", () => {
+  it("formats intent schema output by default", async () => {
+    const result = await handleToolCall("axint.schema.compile", {
+      type: "intent",
+      name: "GetWeather",
+      title: "Get Weather",
+      params: { city: "string" },
+    });
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toContain("Token Statistics");
+    expect(text).toContain("struct GetWeather");
+  });
+
+  it("respects format: false on schema compile", async () => {
+    const result = await handleToolCall("axint.schema.compile", {
+      type: "intent",
+      name: "GetWeather",
+      title: "Get Weather",
+      format: false,
+    });
+    expect(result.isError).not.toBe(true);
+    expect(textOf(result)).toContain("struct GetWeather");
+  });
+
+  it("formats view schema output", async () => {
+    const result = await handleToolCall("axint.schema.compile", {
+      type: "view",
+      name: "GreetingCard",
+      props: { name: "string" },
+    });
+    expect(result.isError).not.toBe(true);
+    expect(textOf(result)).toContain("struct GreetingCard");
+  });
+
+  it("formats widget schema output", async () => {
+    const result = await handleToolCall("axint.schema.compile", {
+      type: "widget",
+      name: "StepsWidget",
+      displayName: "Steps",
+      entry: { steps: "int" },
+    });
+    expect(result.isError).not.toBe(true);
+    expect(textOf(result)).toContain("struct StepsWidget");
+  });
+
+  it("formats app schema output", async () => {
+    const result = await handleToolCall("axint.schema.compile", {
+      type: "app",
+      name: "TrailPlanner",
+      scenes: [{ kind: "windowGroup", view: "ContentView" }],
+    });
+    expect(result.isError).not.toBe(true);
+    expect(textOf(result)).toContain("struct TrailPlanner");
+  });
+});
+
+describe("axint.swift.fix swift-format pipeline", () => {
+  it("returns repaired Swift that contains the fix", async () => {
+    const result = await handleToolCall("axint.swift.fix", {
+      source: BROKEN_SWIFT,
+    });
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    // The fixer rewrites @State let → @State var. The formatted and raw
+    // paths both preserve that substitution.
+    expect(text).toContain("@State");
+    expect(text).toContain("var count");
+  });
+
+  it("accepts format: false on swift.fix", async () => {
+    const result = await handleToolCall("axint.swift.fix", {
+      source: BROKEN_SWIFT,
+      format: false,
+    });
+    expect(result.isError).not.toBe(true);
+    expect(textOf(result)).toContain("var count");
+  });
+});
+
+describe("axint.feature swift-format pipeline", () => {
+  it("formats every Swift file in the feature package", async () => {
+    const result = await handleToolCall("axint.feature", {
+      description: "Let users log water intake via Siri",
+      surfaces: ["intent"],
+      name: "LogWaterIntake",
+    });
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toContain("LogWaterIntake");
+    expect(text).toContain("AppIntent");
+  });
+
+  it("respects format: false on feature generation", async () => {
+    const result = await handleToolCall("axint.feature", {
+      description: "Let users log water intake via Siri",
+      surfaces: ["intent"],
+      name: "LogWaterIntake",
+      format: false,
+    });
+    expect(result.isError).not.toBe(true);
+    expect(textOf(result)).toContain("LogWaterIntake");
+  });
+});


### PR DESCRIPTION
Routes every MCP tool that emits Swift through formatSwift by default, so agents calling axint.compile, axint.schema.compile, axint.swift.fix, and axint.feature get formatter-clean output without needing to know swift-format exists. The formatter silently no-ops when the binary isn't on $PATH, so Linux CI still gets raw generator output.

Each of those four tools now accepts format: false to opt out. Adds 12 tests covering the default-on path, the opt-out path, and the Linux-CI fallback — tolerant of both macOS dev boxes (where swift-format reshapes whitespace) and CI (where it no-ops).