### PR TITLE
Refresh Axint brand assets

### DIFF
--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000" width="256" height="256" role="img" aria-label="Axint favicon">
+  <rect width="1000" height="1000" fill="#0A0A0C"></rect>
+  
+    
+    <polyline points="340,240 140,500 340,760" fill="none" stroke="#F4F1EA" stroke-width="64" stroke-linecap="square" stroke-linejoin="miter"></polyline>
+    
+    <polyline points="660,240 860,500 660,760" fill="none" stroke="#F4F1EA" stroke-width="64" stroke-linecap="square" stroke-linejoin="miter"></polyline>
+    
+    <rect x="470" y="470" width="60" height="60" fill="#F05138"></rect>
+  
+</svg>

--- a/docs/assets/mark.svg
+++ b/docs/assets/mark.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000" width="1000" height="1000" role="img" aria-label="Axint mark — on light">
-  <title>Axint mark — on light</title>
-  <rect width="1000" height="1000" fill="#F4F1EA"></rect>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="100 200 800 600" width="800" height="600" role="img" aria-label="Axint mark — tight crop on light">
+  <title>Axint mark — tight crop on light</title>
+  
   
     
     <polyline points="340,240 140,500 340,760" fill="none" stroke="#0A0A0C" stroke-width="64" stroke-linecap="square" stroke-linejoin="miter"></polyline>

--- a/docs/assets/wordmark.svg
+++ b/docs/assets/wordmark.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 240" width="800" height="240" role="img" aria-label="Axint wordmark">
+  <title>Axint wordmark</title>
+  
+  <text x="400" y="175" font-family="&#39;Archivo&#39;,&#39;Neue Haas Grotesk Display&#39;,&#39;Inter&#39;,&#39;Söhne&#39;,&#39;GT America&#39;,Helvetica,Arial,sans-serif" font-size="200" font-weight="600" letter-spacing="-7" text-anchor="middle" fill="#0A0A0C">axint</text>
+</svg>


### PR DESCRIPTION
Updates the public Axint brand files used by the README and shared brand surfaces.

Changes:
- replace the old logo asset with the new bracket mark and orange center square
- add favicon, mark, and wordmark SVG assets under docs/assets
