### PR TITLE
Use branded Axint header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="docs/assets/logo.svg" alt="Axint" width="96" height="96" />
+  <img src="docs/assets/mark-dark.svg" alt="Axint mark" width="52" height="52" valign="middle" />
+  &nbsp;
+  <img src="docs/assets/wordmark-dark.svg" alt="Axint" height="32" valign="middle" />
 </p>
-
-<h1 align="center">Axint</h1>
 
 <p align="center">
   <strong>Axint turns TypeScript and Python into validated Swift for Apple-native features.</strong>

--- a/docs/assets/mark-dark.svg
+++ b/docs/assets/mark-dark.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="100 200 800 600" width="800" height="600" role="img" aria-label="Axint mark">
+  <title>Axint mark</title>
+  <polyline points="340,240 140,500 340,760" fill="none" stroke="#F4F1EA" stroke-width="64" stroke-linecap="square" stroke-linejoin="miter"></polyline>
+  <polyline points="660,240 860,500 660,760" fill="none" stroke="#F4F1EA" stroke-width="64" stroke-linecap="square" stroke-linejoin="miter"></polyline>
+  <rect x="470" y="470" width="60" height="60" fill="#F05138"></rect>
+</svg>

--- a/docs/assets/wordmark-dark.svg
+++ b/docs/assets/wordmark-dark.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 240" width="800" height="240" role="img" aria-label="Axint wordmark">
+  <title>Axint wordmark</title>
+  <text x="400" y="175" font-family="'Archivo','Neue Haas Grotesk Display','Inter','Söhne','GT America',Helvetica,Arial,sans-serif" font-size="200" font-weight="600" letter-spacing="-7" text-anchor="middle" fill="#F4F1EA">axint</text>
+</svg>


### PR DESCRIPTION
## Summary
- replace the stacked README logo plus heading with a side-by-side branded Axint header row
- add a transparent dark-surface mark asset for GitHub rendering
- add a light Axint wordmark asset for the README header

## Testing
- static README review