### PR TITLE
fix stale mcp tool count in extension readmes

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -34,13 +34,14 @@ Any tool that speaks MCP over stdio can connect to Axint:
 
 ## Tools Provided
 
-All integrations expose the same ten MCP tools plus three built-in prompts:
+All integrations expose the same 11 MCP tools plus three built-in prompts:
 
 - `axint.feature` — generate a complete feature package from a description
 - `axint.suggest` — suggest Apple-native features for a domain
 - `axint.scaffold` — generate a TypeScript intent from a description
 - `axint.compile` — compile TypeScript → Swift
 - `axint.validate` — validate and return diagnostics
+- `axint.fix-packet` — read the latest Fix Packet for an AI repair loop
 - `axint.schema.compile` — minimal JSON → Swift (token-saving mode)
 - `axint.swift.validate` — validate existing Swift against build-time rules
 - `axint.swift.fix` — auto-fix mechanical Swift errors

--- a/extensions/claude-desktop/README.md
+++ b/extensions/claude-desktop/README.md
@@ -8,11 +8,12 @@ Double-click the `.mcpb` file, or drag it onto Claude Desktop.
 
 ## What It Does
 
-Axint gives Claude ten MCP tools plus three built-in prompts for working with Apple-native capabilities:
+Axint gives Claude 11 MCP tools plus three built-in prompts for working with Apple-native capabilities:
 
 - **Scaffold** — Describe what you want, get a TypeScript intent file
 - **Compile** — Turn TypeScript into production-ready Swift
 - **Validate** — Catch issues before you touch Xcode
+- **Fix Packet** — Read the latest Fix Packet for an AI repair loop
 - **List Templates** — Browse bundled reference templates
 - **Get Template** — Pull a complete working example
 - **Feature** — Generate a complete feature package from a description

--- a/extensions/codex/README.md
+++ b/extensions/codex/README.md
@@ -17,11 +17,12 @@ Add to your Codex MCP configuration:
 }
 ```
 
-Codex will discover ten Axint tools plus three built-in prompts automatically:
+Codex will discover 11 Axint tools plus three built-in prompts automatically:
 
 - `axint.scaffold` — generate a TypeScript intent from a description
 - `axint.compile` — compile TypeScript → Swift
 - `axint.validate` — validate and return diagnostics
+- `axint.fix-packet` — read the latest Fix Packet for an AI repair loop
 - `axint.templates.list` — list pre-built templates
 - `axint.templates.get` — get a template's full source
 - `axint.feature` — generate a complete feature package from a description


### PR DESCRIPTION
Three extension READMEs still said "ten MCP tools" after axint.fix-packet was added as the 11th tool. Bumps the count and adds the missing fix-packet bullet in each list.