### PR TITLE
Sync public Axint proof metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.3.9 · 11 MCP tools + 3 prompts · 170 diagnostic codes · 992 tests · 8 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.3.9 · 11 MCP tools + 3 prompts · 170 diagnostic codes · 992 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/metrics.json
+++ b/metrics.json
@@ -61,6 +61,6 @@
     "typescript": 878,
     "python": 114
   },
-  "registryPackages": 8,
+  "registryPackages": 14,
   "distributionSurfaces": 4
 }

--- a/scripts/metrics.mjs
+++ b/scripts/metrics.mjs
@@ -31,7 +31,7 @@ export function computeMetrics({ countTests = true } = {}) {
       : { typescript: 0, python: 0 },
     // Kept as explicit constants — both depend on repos outside the compiler tree.
     // Update these when the corresponding surface ships a new package.
-    registryPackages: 8,
+    registryPackages: 14,
     distributionSurfaces: 4,
   };
 }


### PR DESCRIPTION
## What changed

- Updates the public proof line in `README.md` from 8 to 14 live packages.
- Updates `metrics.json` and `scripts/metrics.mjs` so generated proof stays aligned with the Registry count.

## Why

The public-facing Axint surfaces now refer to the current Registry package count. This keeps the compiler repo truth layer aligned with the website and docs proof pass.

## Validation

- `npm run metrics:check`
- `npm run docs:check`
