### PR TITLE
Add trademark and notice files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,29 @@
+Axint
+Copyright 2026 Agentic Empire.
+
+This product includes software developed by Agentic Empire and the Axint
+contributors.
+
+Axint is licensed under the Apache License, Version 2.0. See LICENSE for the
+license terms that apply to the source code and other licensed materials.
+
+Trademark notice
+----------------
+
+Axint, the Axint name, the Axint wordmark, the Axint axis mark, the Axint logo,
+Agentic Empire, the Agentic Empire name, and related product names, service
+names, domain names, graphics, badges, and brand identifiers are trademarks or
+trade dress of Agentic Empire or its affiliates.
+
+The Apache License, Version 2.0 does not grant trademark rights. Permission to
+use, copy, modify, or distribute the Apache-licensed source code does not grant
+permission to use Axint or Agentic Empire marks in a way that suggests
+sponsorship, endorsement, official status, or confusing source affiliation.
+
+Forks, redistributions, and derivative works should use a distinct project name
+and branding unless Agentic Empire gives prior written permission. Accurate
+nominative references such as "based on Axint" or "compatible with Axint" are
+allowed when they are truthful, limited to what is necessary, and do not imply
+endorsement or official status.
+
+For the project trademark policy, see TRADEMARKS.md.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@
 
 ---
 
+## License and trademarks
+
+Axint is open-source software licensed under Apache-2.0. The Axint name,
+wordmark, axis mark, logo, hosted service names, domains, and related Agentic
+Empire brand assets are not licensed for use by forks or unaffiliated products.
+
+Forks are welcome under the Apache-2.0 license, but they should use distinct
+names and branding. See [NOTICE](NOTICE) and [TRADEMARKS.md](TRADEMARKS.md).
+
+---
+
 ## Why Axint
 
 Apple's API surfaces — App Intents, SwiftUI, WidgetKit — are verbose. A single widget needs a TimelineEntry, a TimelineProvider, an EntryView, and a Widget struct before you've written a line of business logic. AI coding agents pay per token, and all that boilerplate adds up fast.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,150 @@
+# Axint Trademark Policy
+
+Axint is open source. The source code is licensed under the Apache License,
+Version 2.0. The Axint identity is not.
+
+This policy explains how the Axint name, marks, and brand assets may be used by
+forks, redistributors, package maintainers, writers, companies, and community
+projects. It is intended to reduce confusion while keeping the open-source
+compiler easy to adopt, study, modify, and redistribute.
+
+This policy is not a separate software license. It does not change the rights
+granted under the Apache License, Version 2.0.
+
+## Protected marks
+
+The following are trademarks, service marks, trade names, or trade dress of
+Agentic Empire or its affiliates:
+
+- Axint
+- Agentic Empire
+- The Axint wordmark
+- The Axint axis mark
+- The Axint logo and favicon
+- Axint Cloud
+- Axint Registry
+- Axint MCP
+- The `axint.ai`, `docs.axint.ai`, `cloud.axint.ai`, `registry.axint.ai`, and
+  `mcp.axint.ai` domains
+- The `@axint` package scope and official package names controlled by Agentic
+  Empire
+- Any confusingly similar name, logo, mark, badge, package name, domain name, or
+  visual identity
+
+## What the Apache license covers
+
+The Apache License, Version 2.0 covers the source code and other materials in
+this repository that are expressly licensed under Apache-2.0.
+
+It does not grant permission to use Axint or Agentic Empire trademarks, service
+marks, trade names, product names, logos, hosted-service names, domains, or
+brand assets, except as needed for reasonable and customary references to the
+origin of the software.
+
+## Allowed uses
+
+You may use the Axint name when the use is truthful, limited, and not confusing.
+Examples:
+
+- Saying that your project is "based on Axint."
+- Saying that your package is "compatible with Axint."
+- Linking to `https://github.com/agenticempire/axint` as the upstream project.
+- Referring to Axint in documentation, articles, benchmarks, tutorials,
+  security reports, talks, or academic work.
+- Preserving required copyright, license, attribution, and NOTICE references.
+
+These uses should not imply that Agentic Empire sponsors, endorses, maintains,
+certifies, or operates your project unless that is true and you have written
+permission.
+
+## Uses that require permission
+
+You need prior written permission from Agentic Empire before you:
+
+- Use Axint, Agentic Empire, or a confusingly similar name as the name of a fork,
+  product, service, company, package, app, website, registry, cloud service, or
+  developer tool.
+- Use the Axint wordmark, axis mark, logo, favicon, badge style, or brand
+  system in your own project branding.
+- Publish a fork or derivative work under a name that suggests it is the
+  official Axint project.
+- Use Axint marks in a domain name, subdomain, social handle, package scope,
+  extension marketplace listing, app-store listing, or paid service.
+- Operate a hosted compiler, registry, validation service, cloud product,
+  compatibility service, or MCP endpoint in a way that suggests it is operated
+  by, endorsed by, or affiliated with Agentic Empire.
+- Use Axint marks in advertising, fundraising, sales, investor materials,
+  sponsorship materials, or press outreach for an unaffiliated product.
+
+## Forks and derivative works
+
+You may fork the Apache-licensed code, modify it, and distribute your fork under
+the terms of the Apache License, Version 2.0.
+
+If you distribute a fork or derivative work, use a different project name and a
+different visual identity. You may include a clear attribution statement such as:
+
+> This project is based on Axint, an open-source compiler by Agentic Empire.
+
+Do not call the fork "Axint", "Axint Pro", "Axint Cloud", "Axint Registry",
+"Axint-compatible Registry", or any name that makes users reasonably think your
+project is official, endorsed, or operated by Agentic Empire.
+
+## Hosted services
+
+The open-source compiler does not grant rights to operate a service under Axint
+branding.
+
+The official Axint hosted services currently include Axint Cloud, Axint
+Registry, hosted MCP endpoints, official docs, compatibility reports, package
+trust signals, hosted validation reports, and any service running under an
+official Axint or Agentic Empire domain.
+
+Forks may operate their own services, but they must use their own names,
+domains, marks, and branding.
+
+## Package and extension marketplaces
+
+Do not publish packages, plugins, extensions, or marketplace listings using
+Axint marks in a way that suggests official status unless Agentic Empire has
+approved the listing.
+
+Acceptable:
+
+- `example-tool-for-axint`
+- "An unofficial extension for Axint"
+- "Works with Axint"
+
+Not acceptable without permission:
+
+- `@axint/...`
+- `axint-cloud`
+- `axint-registry`
+- "Official Axint extension"
+- Any listing using the Axint logo or wordmark as its own primary brand
+
+## Brand assets
+
+Brand assets in this repository or related Agentic Empire repositories are
+provided for identification of the official Axint project. They are not licensed
+for use as the branding of an unaffiliated fork, service, product, or company.
+
+Do not remove, recolor, modify, animate, combine, or republish Axint brand
+assets as your own identity without written permission.
+
+## How to ask for permission
+
+For trademark or brand permission, contact Agentic Empire through the official
+project channels listed at:
+
+- https://axint.ai
+- https://agenticempire.co
+
+Include what you want to use, where it will appear, whether the use is
+commercial, and how you will avoid confusion with the official Axint project.
+
+## Reservation of rights
+
+Agentic Empire reserves all rights in the Axint and Agentic Empire marks,
+including rights not expressly granted in this policy. Agentic Empire may update
+this policy as the project, hosted services, and brand system evolve.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "NOTICE",
+    "TRADEMARKS.md"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## What changed

- Adds a root `NOTICE` file with copyright, attribution, and trademark notice language.
- Adds `TRADEMARKS.md` describing protected Axint and Agentic Empire marks, allowed nominative uses, fork naming expectations, hosted-service boundaries, and marketplace guidance.
- Adds both files to the npm package allowlist so the notices ship with published compiler packages.
- Links the license and trademark guidance from the README.

## Validation

- `npm run docs:check`
- `npm run versions:check`
- `npm run metrics:check`
- `npm run boundary:check`
- `npm pack --dry-run --json`
