### PR TITLE
Release Axint 0.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,9 @@ jobs:
       - run: npm ci
       - run: npm run typecheck
       - run: npm run lint
+      - run: npm run build
       - run: npm test
       - run: npm audit --audit-level=moderate
-      - run: npm run build
 
       - name: Verify CLI works
         run: |

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.0 · 13 MCP tools + 3 prompts · 173 diagnostic codes · 1020 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.1 · 13 MCP tools + 3 prompts · 173 diagnostic codes · 1020 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.4.1",
   "mcpTools": 13,
   "mcpToolNames": [
     "axint.feature",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/agenticempire/axint",
     "source": "github"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "remotes": [
     {
       "type": "streamable-http",
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "transport": {
         "type": "stdio"
       }
@@ -26,7 +26,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "transport": {
         "type": "stdio"
       }

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -68,7 +68,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.0";
+const VERSION = "0.4.1";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary
- bump Axint release surfaces to 0.4.1 after the 0.4.0 NPM-only publish
- fix the release workflow ordering so `dist/cli/index.js` exists before CLI tests execute
- resync metrics and README public truth for the coordinated NPM/PyPI release

## Validation
- npm run versions:check
- npm run metrics:check
- npm run docs:check
- npm run gen:swift-fixer:check
- npm run release:check
- npm run typecheck
- npm test
- npm run build
- node dist/cli/index.js xcode verify
- python3 -m pytest
- python3 -m build
