### PR TITLE
Release Axint 0.4.2 generation upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.1 · 13 MCP tools + 3 prompts · 173 diagnostic codes · 1020 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.2 · 13 MCP tools + 3 prompts · 173 diagnostic codes · 1025 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.1",
+  "version": "0.4.2",
   "mcpTools": 13,
   "mcpToolNames": [
     "axint.feature",
@@ -60,7 +60,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 906,
+    "typescript": 911,
     "python": 114
   },
   "registryPackages": 14,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.1"
+version = "0.4.2"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/agenticempire/axint",
     "source": "github"
   },
-  "version": "0.4.1",
+  "version": "0.4.2",
   "remotes": [
     {
       "type": "streamable-http",
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "transport": {
         "type": "stdio"
       }
@@ -26,7 +26,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/cli/feature.ts
+++ b/src/cli/feature.ts
@@ -1,0 +1,166 @@
+import type { Command } from "commander";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import {
+  generateFeature,
+  type FeatureInput,
+  type FeatureResult,
+  type Surface,
+} from "../mcp/feature.js";
+
+const SURFACES = ["intent", "view", "widget"] as const;
+const PLATFORMS = ["iOS", "macOS", "visionOS", "all"] as const;
+
+export function registerFeature(program: Command) {
+  program
+    .command("feature")
+    .description("Generate an Apple-native feature package from a description")
+    .argument("<description...>", "Feature description")
+    .option("--surface <surfaces>", "Comma-separated surfaces: intent,view,widget")
+    .option("--name <name>", "Base Swift type name")
+    .option("--app-name <name>", "App name for generated metadata")
+    .option("--domain <domain>", "Domain hint")
+    .option("--platform <platform>", "Target platform", parsePlatform)
+    .option("--token-namespace <name>", "Swift design-token namespace")
+    .option(
+      "--param <name:type>",
+      "Explicit parameter. Repeat for multiple params.",
+      collectParam,
+      [] as string[]
+    )
+    .option("--write <dir>", "Write generated files into a directory")
+    .option("--json", "Emit the full feature result as JSON")
+    .action((descriptionParts: string[], options: FeatureOptions) => {
+      try {
+        const input = buildFeatureInput(descriptionParts, options);
+        const result = generateFeature(input);
+
+        if (options.write) {
+          writeFeatureFiles(result, options.write);
+        }
+
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              {
+                ...result,
+                writtenRoot: options.write ? resolve(options.write) : null,
+              },
+              null,
+              2
+            )
+          );
+          return;
+        }
+
+        console.log(formatFeatureResult(result, options.write));
+      } catch (err: unknown) {
+        console.error(`\x1b[31merror:\x1b[0m ${(err as Error).message ?? err}`);
+        process.exit(1);
+      }
+    });
+}
+
+type FeatureOptions = {
+  surface?: string;
+  name?: string;
+  appName?: string;
+  domain?: string;
+  platform?: FeatureInput["platform"];
+  tokenNamespace?: string;
+  param: string[];
+  write?: string;
+  json?: boolean;
+};
+
+function buildFeatureInput(
+  descriptionParts: string[],
+  options: FeatureOptions
+): FeatureInput {
+  const description = descriptionParts.join(" ").trim();
+  if (!description) {
+    throw new Error("feature requires a description");
+  }
+
+  return {
+    description,
+    surfaces: parseSurfaces(options.surface),
+    name: options.name,
+    appName: options.appName,
+    domain: options.domain,
+    params: parseParams(options.param),
+    platform: options.platform,
+    tokenNamespace: options.tokenNamespace,
+  };
+}
+
+function parseSurfaces(value: string | undefined): Surface[] | undefined {
+  if (!value) return undefined;
+  const surfaces = value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  for (const surface of surfaces) {
+    if (!(SURFACES as readonly string[]).includes(surface)) {
+      throw new Error(`invalid surface: ${surface}`);
+    }
+  }
+
+  return surfaces as Surface[];
+}
+
+function parseParams(entries: string[]): Record<string, string> | undefined {
+  if (entries.length === 0) return undefined;
+  const params: Record<string, string> = {};
+
+  for (const entry of entries) {
+    const [name, type, ...rest] = entry.split(":");
+    if (!name || !type || rest.length > 0) {
+      throw new Error(`invalid param: ${entry} (expected name:type)`);
+    }
+    params[name] = type;
+  }
+
+  return params;
+}
+
+function collectParam(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+function parsePlatform(value: string): FeatureInput["platform"] {
+  if ((PLATFORMS as readonly string[]).includes(value)) {
+    return value as FeatureInput["platform"];
+  }
+  throw new Error(`invalid platform: ${value}`);
+}
+
+function writeFeatureFiles(result: FeatureResult, root: string) {
+  const targetRoot = resolve(root);
+  for (const file of result.files) {
+    const targetPath = resolve(targetRoot, file.path);
+    mkdirSync(dirname(targetPath), { recursive: true });
+    writeFileSync(targetPath, file.content, "utf-8");
+  }
+}
+
+function formatFeatureResult(
+  result: FeatureResult,
+  writeRoot: string | undefined
+): string {
+  const lines = [
+    result.summary,
+    writeRoot ? `Written: ${resolve(writeRoot)}` : null,
+    result.diagnostics.length ? "Diagnostics:" : null,
+    ...result.diagnostics.map((diagnostic) => `  ${diagnostic}`),
+  ].filter(Boolean) as string[];
+
+  if (writeRoot) return lines.join("\n");
+
+  return [
+    ...lines,
+    "",
+    ...result.files.map((file) => `--- ${file.path} ---\n${file.content.trimEnd()}\n`),
+  ].join("\n");
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,8 @@
  *   axint cloud check --source    Run an agent-callable Cloud Check on a file
  *   axint cloud status            Show Cloud sign-in and Pro repair-check allowance
  *   axint tokens ingest --source  Convert design tokens into SwiftUI token enums
+ *   axint schema compile <file>   Compile compact JSON schemas into Swift
+ *   axint feature <description>   Generate a multi-file feature package
  *   axint publish                 Publish an intent to the Registry
  *   axint add <package>           Install a template from the Registry
  *   axint search [query]          Search the Axint Registry for intent templates
@@ -46,6 +48,8 @@ import { registerTemplates } from "./templates.js";
 import { registerLogin } from "./login.js";
 import { registerCloud } from "./cloud.js";
 import { registerTokens } from "./tokens.js";
+import { registerSchema } from "./schema.js";
+import { registerFeature } from "./feature.js";
 import { registerPublish } from "./publish.js";
 import { registerAdd } from "./add.js";
 import { registerSearch } from "./search.js";
@@ -153,6 +157,8 @@ registerTemplates(program);
 registerLogin(program);
 registerCloud(program);
 registerTokens(program);
+registerSchema(program);
+registerFeature(program);
 registerPublish(program, VERSION);
 registerAdd(program, VERSION);
 registerSearch(program, VERSION);

--- a/src/cli/schema.ts
+++ b/src/cli/schema.ts
@@ -1,0 +1,143 @@
+import type { Command } from "commander";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import {
+  handleCompileFromSchema,
+  type SchemaCompileArgs,
+} from "../mcp/schema-compile.js";
+
+type SchemaType = SchemaCompileArgs["type"];
+type SchemaPlatform = NonNullable<SchemaCompileArgs["platform"]>;
+
+const SCHEMA_TYPES = ["intent", "view", "widget", "app", "component"] as const;
+const PLATFORMS = ["iOS", "macOS", "visionOS", "all"] as const;
+
+export function registerSchema(program: Command) {
+  const schema = program
+    .command("schema")
+    .description("Compile compact JSON schemas into Swift surfaces");
+
+  schema
+    .command("compile")
+    .description("Compile an intent, view, widget, app, or component schema")
+    .argument("<file>", "JSON schema file, or - for stdin")
+    .option("--type <type>", "Override schema type", parseSchemaType)
+    .option("--name <name>", "Override generated Swift type name")
+    .option("--platform <platform>", "Target platform", parsePlatform)
+    .option("--token-namespace <name>", "Swift design-token namespace")
+    .option("--component-kind <kind>", "Component blueprint kind")
+    .option("--out <file>", "Write Swift output to a file")
+    .option("--json", "Emit a JSON envelope instead of raw Swift")
+    .option("--raw", "Skip Swift formatting")
+    .action(async (file: string, options: SchemaCompileOptions) => {
+      try {
+        const input = readSchemaInput(file);
+        const parsed = parseSchemaInput(input);
+        const args = buildSchemaArgs(parsed, options);
+        const result = await handleCompileFromSchema(args);
+        const output = result.content[0]?.text ?? "";
+
+        if (result.isError) {
+          console.error(output);
+          process.exit(1);
+        }
+
+        if (options.out) {
+          const outPath = resolve(options.out);
+          mkdirSync(dirname(outPath), { recursive: true });
+          writeFileSync(outPath, output, "utf-8");
+        }
+
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              {
+                ok: true,
+                type: args.type,
+                name: args.name,
+                output,
+                written: options.out ? resolve(options.out) : null,
+              },
+              null,
+              2
+            )
+          );
+          return;
+        }
+
+        if (options.out) {
+          console.log(`Wrote ${resolve(options.out)}`);
+          return;
+        }
+
+        console.log(output);
+      } catch (err: unknown) {
+        console.error(`\x1b[31merror:\x1b[0m ${(err as Error).message ?? err}`);
+        process.exit(1);
+      }
+    });
+}
+
+type SchemaCompileOptions = {
+  type?: SchemaType;
+  name?: string;
+  platform?: SchemaPlatform;
+  tokenNamespace?: string;
+  componentKind?: string;
+  out?: string;
+  json?: boolean;
+  raw?: boolean;
+};
+
+function readSchemaInput(file: string): string {
+  if (file === "-") {
+    return readFileSync(0, "utf-8");
+  }
+  return readFileSync(resolve(file), "utf-8");
+}
+
+function parseSchemaInput(input: string): Record<string, unknown> {
+  const parsed = JSON.parse(input) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("schema input must be a JSON object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function buildSchemaArgs(
+  parsed: Record<string, unknown>,
+  options: SchemaCompileOptions
+): SchemaCompileArgs {
+  const args = { ...parsed } as Partial<SchemaCompileArgs>;
+
+  if (options.type) args.type = options.type;
+  if (options.name) args.name = options.name;
+  if (options.platform) args.platform = options.platform;
+  if (options.tokenNamespace) args.tokenNamespace = options.tokenNamespace;
+  if (options.componentKind) args.componentKind = options.componentKind;
+  if (options.raw) args.format = false;
+  else if (typeof args.format !== "boolean") args.format = true;
+
+  if (!args.type) {
+    throw new Error("schema requires a type: intent, view, widget, app, or component");
+  }
+  if (!SCHEMA_TYPES.includes(args.type)) {
+    throw new Error(`invalid schema type: ${String(args.type)}`);
+  }
+
+  return args as SchemaCompileArgs;
+}
+
+function parseSchemaType(value: string): SchemaType {
+  if ((SCHEMA_TYPES as readonly string[]).includes(value)) {
+    return value as SchemaType;
+  }
+  throw new Error(`invalid schema type: ${value}`);
+}
+
+function parsePlatform(value: string): SchemaPlatform {
+  if ((PLATFORMS as readonly string[]).includes(value)) {
+    return value as SchemaPlatform;
+  }
+  throw new Error(`invalid platform: ${value}`);
+}

--- a/src/mcp/feature.ts
+++ b/src/mcp/feature.ts
@@ -460,8 +460,11 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
     "health",
     "fitness",
     "workout",
+    "workouts",
     "step",
+    "steps",
     "calorie",
+    "calories",
     "heart",
     "sleep",
     "water",
@@ -563,7 +566,15 @@ function resolveDomain(
 
 function domainScore(domain: string, lowerDescription: string): number {
   const keywords = DOMAIN_KEYWORDS[domain] ?? [];
-  return keywords.filter((kw) => lowerDescription.includes(kw)).length;
+  return keywords.filter((kw) => wordAppears(kw, lowerDescription)).length;
+}
+
+function wordAppears(keyword: string, lowerDescription: string): boolean {
+  return new RegExp(`\\b${escapeRegExp(keyword)}\\b`).test(lowerDescription);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function inferName(description: string): string {
@@ -701,9 +712,13 @@ function shouldEmitDomainArtifacts(
     "health",
     "healthkit",
     "workout",
+    "workouts",
     "exercise",
+    "exercises",
     "step",
+    "steps",
     "calorie",
+    "calories",
     "heart",
     "sleep",
     "water",

--- a/src/mcp/schema-compile.ts
+++ b/src/mcp/schema-compile.ts
@@ -333,19 +333,42 @@ function buildComponentProps(args: SchemaCompileArgs): IRViewProp[] {
         ? { value: "double", label: "string" }
         : kind === "missionCard"
           ? { title: "string", subtitle: "string", progress: "double", status: "string" }
-          : kind === "channelRow"
-            ? { title: "string", unreadCount: "int", isSelected: "boolean" }
-            : kind === "sidebarRail"
-              ? { selectedIndex: "int" }
-              : kind === "profileCard"
+          : kind === "contextPanel"
+            ? {
+                northStar: "string",
+                syncStatus: "string",
+                suggestedUpdates: "int",
+              }
+            : kind === "contextUpdateCard"
+              ? { summary: "string" }
+              : kind === "decisionLog"
                 ? {
-                    photoURL: "url",
-                    name: "string",
-                    age: "int",
-                    bio: "string",
-                    workoutPreferences: "string",
+                    title: "string",
+                    owner: "string",
+                    decision: "string",
+                    impact: "string",
                   }
-                : { title: "string" };
+                : kind === "approvalCard"
+                  ? { missionTitle: "string", risk: "string", costEstimate: "string" }
+                  : kind === "agentRow"
+                    ? { name: "string", role: "string", status: "string" }
+                    : kind === "roleCard"
+                      ? { title: "string", description: "string", status: "string" }
+                      : kind === "signalCard"
+                        ? { sourceTitle: "string", insight: "string" }
+                        : kind === "channelRow"
+                          ? { title: "string", unreadCount: "int", isSelected: "boolean" }
+                          : kind === "sidebarRail"
+                            ? { selectedIndex: "int" }
+                            : kind === "profileCard"
+                              ? {
+                                  photoURL: "url",
+                                  name: "string",
+                                  age: "int",
+                                  bio: "string",
+                                  workoutPreferences: "string",
+                                }
+                              : { title: "string" };
 
   return Object.entries(defaults).map(([name, typeStr]) => ({
     name,
@@ -394,6 +417,15 @@ function inferComponentKind(args: SchemaCompileArgs): string {
   if (lower.includes("avatar")) return "avatar";
   if (lower.includes("statusring")) return "statusRing";
   if (lower.includes("missioncard")) return "missionCard";
+  if (lower.includes("contextpanel") || lower.includes("projectcontext"))
+    return "contextPanel";
+  if (lower.includes("contextupdate") || lower.includes("stalecontext"))
+    return "contextUpdateCard";
+  if (lower.includes("decisionlog")) return "decisionLog";
+  if (lower.includes("approvalcard")) return "approvalCard";
+  if (lower.includes("agentrow")) return "agentRow";
+  if (lower.includes("rolecard")) return "roleCard";
+  if (lower.includes("signalcard")) return "signalCard";
   if (lower.includes("channelrow")) return "channelRow";
   if (lower.includes("sidebarrail")) return "sidebarRail";
   if (lower.includes("profilecard") || lower.includes("datingprofile"))
@@ -402,7 +434,14 @@ function inferComponentKind(args: SchemaCompileArgs): string {
 }
 
 function defaultValueForType(typeStr: string, name: string): unknown {
-  if (typeStr === "int") return name === "age" ? 29 : name === "unreadCount" ? 3 : 0;
+  if (typeStr === "int")
+    return name === "age"
+      ? 29
+      : name === "unreadCount"
+        ? 3
+        : name === "suggestedUpdates"
+          ? 2
+          : 0;
   if (typeStr === "double" || typeStr === "float")
     return name === "progress" || name === "value" ? 0.72 : 0;
   if (typeStr === "boolean") return name === "isSelected";
@@ -414,6 +453,21 @@ function defaultValueForType(typeStr: string, name: string): unknown {
   if (name === "label") return "Ready";
   if (name === "title") return "Mission";
   if (name === "subtitle") return "Design the agent loop";
+  if (name === "northStar") return "The project room where context never gets lost.";
+  if (name === "syncStatus") return "synced 12m ago";
+  if (name === "summary") return "This thread changed the onboarding strategy.";
+  if (name === "owner") return "Nima";
+  if (name === "decision")
+    return "Make Context the default tab and primary product invariant.";
+  if (name === "impact")
+    return "Missions, agents, and onboarding now reference the North Star.";
+  if (name === "missionTitle") return "Build native Mac shell";
+  if (name === "risk") return "Touches layout and local files. Human approval required.";
+  if (name === "costEstimate") return "$0.42-$0.86";
+  if (name === "role") return "Keeps context sharp";
+  if (name === "sourceTitle") return "Apple expands App Intents at WWDC";
+  if (name === "insight")
+    return "Potential roadmap impact. Create a research mission before the next SDK beta.";
   if (name === "name") return "Alex";
   if (name === "bio") return "Strength training, early mornings, clean handoffs.";
   if (name === "workoutPreferences") return "Hypertrophy · Mobility · Coffee walks";

--- a/src/mcp/tokens.ts
+++ b/src/mcp/tokens.ts
@@ -18,16 +18,22 @@ interface TokenRecord {
   swiftName: string;
   kind: "color" | "layout" | "spacing" | "radius" | "typography" | "shadow" | "value";
   value: string | number | boolean;
+  aliasOf?: string;
 }
 
 export function handleTokenIngest(args: TokenIngestArgs) {
   const { source, fileName } = readTokenSource(args);
   const namespace = sanitizeTypeName(args.namespace || "AxintDesignTokens");
   const value = parseTokenSource(source, fileName);
-  const records = flattenTokens(value).map((record) => ({
+  const baseRecords = flattenTokens(value).map((record) => ({
     ...record,
     kind: classifyToken(record),
   }));
+  const records = enrichTokenRecords(baseRecords, {
+    source,
+    fileName,
+    namespace,
+  });
 
   const result = {
     namespace,
@@ -215,6 +221,7 @@ function classifyToken(record: Omit<TokenRecord, "kind">): TokenRecord["kind"] {
   }
   if (/\b(color|brand|accent|background|surface|text|border|fill)\b/.test(name))
     return "color";
+  if (/(^|\.)r(?:input|card|modal|[0-9]+)$/i.test(record.name)) return "radius";
   if (/\b(sidebar|rail|column|width|height|size|layout)\b/.test(name)) return "layout";
   if (/\b(space|spacing|gap|padding|margin|inset)\b/.test(name)) return "spacing";
   if (/\b(radius|radii|corner|rounded)\b/.test(name)) return "radius";
@@ -225,6 +232,129 @@ function classifyToken(record: Omit<TokenRecord, "kind">): TokenRecord["kind"] {
     return "typography";
   if (/\b(shadow|elevation|blur)\b/.test(name)) return "shadow";
   return "value";
+}
+
+function enrichTokenRecords(
+  records: TokenRecord[],
+  context: { source: string; fileName: string; namespace: string }
+): TokenRecord[] {
+  const enriched = [...records];
+  const swarmLike = isSwarmLikeTokenSet(records, context);
+
+  addAlias(enriched, "color", "surfaceRaised", ["elevated", "surface"]);
+  addAlias(enriched, "color", "panel", ["surface", "elevated"]);
+  addAlias(enriched, "color", "textPrimary", ["text"]);
+  addAlias(enriched, "color", "textSecondary", ["text2", "text"]);
+  addAlias(enriched, "color", "textMuted", ["text3", "text2"]);
+  addAlias(enriched, "color", "borderMuted", ["border"]);
+  addAlias(enriched, "radius", "row", ["rInput", "r2", "r1"]);
+  addAlias(enriched, "radius", "input", ["rInput", "r2"]);
+  addAlias(enriched, "radius", "card", ["rCard", "rInput"]);
+  addAlias(enriched, "radius", "modal", ["rModal", "rCard"]);
+
+  if (swarmLike) {
+    addNumericToken(enriched, "layout", "sidebarRail", 56);
+    addNumericToken(enriched, "layout", "channelsColumn", 244);
+    addNumericToken(enriched, "layout", "rightContextPane", 308);
+    addNumericToken(enriched, "layout", "statusBar", 32);
+    addNumericToken(enriched, "layout", "floatingWindowWidth", 340);
+  }
+
+  return enriched;
+}
+
+function isSwarmLikeTokenSet(
+  records: TokenRecord[],
+  context: { source: string; fileName: string; namespace: string }
+): boolean {
+  const marker = `${context.fileName} ${context.namespace} ${context.source.slice(0, 500)}`;
+  if (/swarm/i.test(marker)) return true;
+
+  const names = new Set(records.map((record) => record.swiftName.toLowerCase()));
+  return (
+    names.has("rinput") &&
+    names.has("rcard") &&
+    names.has("shadowwin") &&
+    names.has("membercolors")
+  );
+}
+
+function addAlias(
+  records: TokenRecord[],
+  kind: TokenRecord["kind"],
+  aliasName: string,
+  sourceCandidates: string[]
+) {
+  if (hasSwiftName(records, kind, aliasName)) return;
+  const target = sourceCandidates
+    .map((candidate) => findBySwiftName(records, kind, candidate))
+    .find(Boolean);
+  if (!target) return;
+
+  records.push({
+    path: [groupPathName(kind), aliasName],
+    name: `${groupPathName(kind)}.${aliasName}`,
+    swiftName: swiftIdentifier([groupPathName(kind), aliasName]),
+    kind,
+    value: target.value,
+    aliasOf: withGroupSwiftName(target).swiftName,
+  });
+}
+
+function addNumericToken(
+  records: TokenRecord[],
+  kind: TokenRecord["kind"],
+  swiftName: string,
+  value: number
+) {
+  if (hasSwiftName(records, kind, swiftName)) return;
+  records.push({
+    path: [groupPathName(kind), swiftName],
+    name: `${groupPathName(kind)}.${swiftName}`,
+    swiftName: swiftIdentifier([groupPathName(kind), swiftName]),
+    kind,
+    value,
+  });
+}
+
+function hasSwiftName(
+  records: TokenRecord[],
+  kind: TokenRecord["kind"],
+  swiftName: string
+): boolean {
+  return Boolean(findBySwiftName(records, kind, swiftName));
+}
+
+function findBySwiftName(
+  records: TokenRecord[],
+  kind: TokenRecord["kind"],
+  swiftName: string
+): TokenRecord | undefined {
+  const normalized = swiftName.toLowerCase();
+  return records.find(
+    (record) =>
+      record.kind === kind &&
+      withGroupSwiftName(record).swiftName.toLowerCase() === normalized
+  );
+}
+
+function groupPathName(kind: TokenRecord["kind"]): string {
+  switch (kind) {
+    case "color":
+      return "colors";
+    case "layout":
+      return "layout";
+    case "spacing":
+      return "spacing";
+    case "radius":
+      return "radii";
+    case "typography":
+      return "typography";
+    case "shadow":
+      return "shadows";
+    default:
+      return "values";
+  }
 }
 
 function renderSwiftTokens(namespace: string, records: TokenRecord[]): string {
@@ -285,6 +415,7 @@ function renderSwiftTokens(namespace: string, records: TokenRecord[]): string {
 }
 
 function swiftLiteral(record: TokenRecord): string {
+  if (record.aliasOf) return record.aliasOf;
   if (record.kind === "color") return colorLiteral(String(record.value));
   if (typeof record.value === "number") return `CGFloat(${record.value})`;
   if (typeof record.value === "boolean") return record.value ? "true" : "false";
@@ -301,8 +432,32 @@ function swiftLiteral(record: TokenRecord): string {
 
 function colorLiteral(value: string): string {
   if (value.startsWith("#")) return `Color(hex: "${escapeSwiftString(value)}")`;
-  if (/^(rgb|rgba|hsl|hsla)\(/i.test(value)) return `"${escapeSwiftString(value)}"`;
+  const rgb = parseRgbColor(value);
+  if (rgb) {
+    return `Color(.sRGB, red: ${rgb.red}, green: ${rgb.green}, blue: ${rgb.blue}, opacity: ${rgb.opacity})`;
+  }
+  if (/^(hsl|hsla)\(/i.test(value)) return `"${escapeSwiftString(value)}"`;
   return `"${escapeSwiftString(value)}"`;
+}
+
+function parseRgbColor(
+  value: string
+): { red: string; green: string; blue: string; opacity: string } | undefined {
+  const match = value.match(
+    /^rgba?\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)(?:\s*,\s*(\d?(?:\.\d+)?|1(?:\.0)?))?\s*\)$/i
+  );
+  if (!match) return undefined;
+
+  return {
+    red: decimal(Number(match[1]) / 255),
+    green: decimal(Number(match[2]) / 255),
+    blue: decimal(Number(match[3]) / 255),
+    opacity: decimal(match[4] === undefined ? 1 : Number(match[4])),
+  };
+}
+
+function decimal(value: number): string {
+  return Number(value.toFixed(4)).toString();
 }
 
 function renderMarkdown(result: {

--- a/src/mcp/view-blueprints.ts
+++ b/src/mcp/view-blueprints.ts
@@ -55,6 +55,18 @@ function inferComponentKind(name: string, description: string): string | undefin
     return "statusRing";
   if (haystack.includes("mission card") || haystack.includes("missioncard"))
     return "missionCard";
+  if (haystack.includes("context panel") || haystack.includes("projectcontext"))
+    return "contextPanel";
+  if (haystack.includes("context update") || haystack.includes("stale context"))
+    return "contextUpdateCard";
+  if (haystack.includes("decision log") || haystack.includes("decisionlog"))
+    return "decisionLog";
+  if (haystack.includes("approval card") || haystack.includes("approvalcard"))
+    return "approvalCard";
+  if (haystack.includes("agent row") || haystack.includes("agentrow")) return "agentRow";
+  if (haystack.includes("role card") || haystack.includes("rolecard")) return "roleCard";
+  if (haystack.includes("signal card") || haystack.includes("signalcard"))
+    return "signalCard";
   if (haystack.includes("channel row") || haystack.includes("channelrow"))
     return "channelRow";
   if (haystack.includes("sidebar rail") || haystack.includes("sidebarrail"))
@@ -70,6 +82,14 @@ function normalizeKind(kind: string | undefined): string | undefined {
   if (lower === "avatar") return "avatar";
   if (lower === "statusring") return "statusRing";
   if (lower === "missioncard") return "missionCard";
+  if (lower === "contextpanel" || lower === "projectcontextpanel") return "contextPanel";
+  if (lower === "contextupdatecard" || lower === "contextupdate")
+    return "contextUpdateCard";
+  if (lower === "decisionlog" || lower === "decisionlogcard") return "decisionLog";
+  if (lower === "approvalcard" || lower === "approval") return "approvalCard";
+  if (lower === "agentrow") return "agentRow";
+  if (lower === "rolecard") return "roleCard";
+  if (lower === "signalcard") return "signalCard";
   if (lower === "channelrow") return "channelRow";
   if (lower === "sidebarrail") return "sidebarRail";
   if (lower === "profilecard") return "profileCard";
@@ -141,6 +161,221 @@ function buildComponentBody(kind: string, input: ViewBlueprintInput): string {
         .padding(16)
         .background(${colorRef(input.tokenNamespace, "surface", "Color.secondary.opacity(0.08)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "16")}, style: .continuous))`;
 
+    case "contextPanel":
+      return `VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Project Context")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+                    .textCase(.uppercase)
+                Spacer()
+                Text(${textExpr(input, "syncStatus", "synced 12m ago")})
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "success", ".green")})
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("North Star")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "textMuted", ".secondary")})
+                    .textCase(.uppercase)
+                Text(${textExpr(input, "northStar", "Keep the project room aligned while humans and agents move fast.")})
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "textPrimary", ".primary")})
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                ${contextFileRow("NORTH_STAR.md", "synced")}
+                ${contextFileRow("PROJECT_CONTEXT.md", "synced")}
+                ${contextFileRow("DECISIONS.md", "updated")}
+                ${contextFileRow("ROADMAP.md", "2 pending")}
+            }
+
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "warning", ".orange")})
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\\(${numericExpr(input, "suggestedUpdates", "2")}) suggested updates")
+                        .font(.caption.weight(.semibold))
+                    Text("Review context changes from #general before the next run.")
+                        .font(.caption2)
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+                }
+                Spacer()
+            }
+            .padding(12)
+            .background(${colorRef(input.tokenNamespace, "warningSoft", "Color.orange.opacity(0.12)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "12")}, style: .continuous))
+
+            Spacer()
+        }
+        .padding(16)
+        .background(${colorRef(input.tokenNamespace, "surface", "Color.secondary.opacity(0.08)")})`;
+
+    case "contextUpdateCard":
+      return `VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "warning", ".orange")})
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Context may be stale")
+                        .font(.subheadline.weight(.semibold))
+                    Text(${textExpr(input, "summary", "This thread changed the onboarding strategy.")})
+                        .font(.caption)
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+                }
+                Spacer()
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Label("Update PROJECT_CONTEXT.md", systemImage: "doc.text")
+                Label("Add decision to DECISIONS.md", systemImage: "checkmark.seal")
+                Label("Revise current sprint in ROADMAP.md", systemImage: "map")
+            }
+            .font(.caption)
+            .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+
+            HStack {
+                Button("Apply updates") {}
+                    .buttonStyle(.borderedProminent)
+                Button("Review diff") {}
+                    .buttonStyle(.bordered)
+                Spacer()
+            }
+            .controlSize(.small)
+        }
+        .padding(14)
+        .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.12)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "12")}, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "12")}, style: .continuous)
+                .strokeBorder(${colorRef(input.tokenNamespace, "warningSoft", "Color.orange.opacity(0.24)")}, lineWidth: 1)
+        }`;
+
+    case "decisionLog":
+      return `VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(${textExpr(input, "title", "Choose context-first positioning")})
+                    .font(.headline)
+                Spacer()
+                Text(${textExpr(input, "owner", "Nima")})
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Decision")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "textMuted", ".secondary")})
+                Text(${textExpr(input, "decision", "Make Context the default tab and primary product invariant.")})
+                    .font(.callout)
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "textPrimary", ".primary")})
+            }
+
+            Text(${textExpr(input, "impact", "Missions, agents, and onboarding now reference the North Star.")})
+                .font(.caption)
+                .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+        }
+        .padding(14)
+        .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.12)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "12")}, style: .continuous))`;
+
+    case "approvalCard":
+      return `VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(${textExpr(input, "missionTitle", "Build native Mac shell")})
+                    .font(.headline)
+                Spacer()
+                Text(${textExpr(input, "costEstimate", "$0.42-$0.86")})
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "accent", "Color.accentColor")})
+            }
+
+            Label(${textExpr(input, "risk", "Touches layout and local files. Human approval required.")}, systemImage: "shield.lefthalf.filled")
+                .font(.caption)
+                .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+
+            HStack {
+                Button("Approve") {}
+                    .buttonStyle(.borderedProminent)
+                Button("Run cheap") {}
+                    .buttonStyle(.bordered)
+                Button("Not yet") {}
+                    .buttonStyle(.plain)
+                Spacer()
+            }
+            .controlSize(.small)
+        }
+        .padding(14)
+        .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.12)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "12")}, style: .continuous))`;
+
+    case "agentRow":
+      return `HStack(spacing: 10) {
+            Circle()
+                .fill(${colorRef(input.tokenNamespace, "accentSoft", "Color.accentColor.opacity(0.16)")})
+                .overlay {
+                    Text(String(${textExpr(input, "name", "Product Agent")}.prefix(1)))
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "accent", "Color.accentColor")})
+                }
+                .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(${textExpr(input, "name", "Product Agent")})
+                    .font(.subheadline.weight(.semibold))
+                Text(${textExpr(input, "role", "Keeps context sharp")})
+                    .font(.caption)
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+            }
+
+            Spacer()
+
+            Text(${textExpr(input, "status", "awake")})
+                .font(.caption2.weight(.bold))
+                .padding(.horizontal, 7)
+                .padding(.vertical, 4)
+                .background(${colorRef(input.tokenNamespace, "successSoft", "Color.green.opacity(0.14)")}, in: Capsule())
+                .foregroundStyle(${colorRef(input.tokenNamespace, "success", ".green")})
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.10)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "row", "10")}, style: .continuous))`;
+
+    case "roleCard":
+      return `VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text(${textExpr(input, "title", "Context Guardian")})
+                    .font(.headline)
+                Spacer()
+                Text(${textExpr(input, "status", "suggested")})
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "accent", "Color.accentColor")})
+            }
+            Text(${textExpr(input, "description", "Detects stale context, summarizes decisions, and keeps Markdown current.")})
+                .font(.caption)
+                .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.12)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "12")}, style: .continuous))`;
+
+    case "signalCard":
+      return `VStack(alignment: .leading, spacing: 12) {
+            Text(${textExpr(input, "sourceTitle", "Apple expands App Intents at WWDC")})
+                .font(.headline)
+            Text(${textExpr(input, "insight", "Potential roadmap impact. Create a research mission before the next SDK beta.")})
+                .font(.caption)
+                .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+
+            HStack(spacing: 8) {
+                Button("Discuss") {}
+                Button("Ask Agent") {}
+                Button("Create Mission") {}
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .padding(14)
+        .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.12)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "12")}, style: .continuous))`;
+
     case "channelRow":
       return `HStack(spacing: 10) {
             Circle()
@@ -197,6 +432,12 @@ function buildThreePaneBody(input: ViewBlueprintInput): string {
     /(channels? column|channel list|channels?)[^\d]*(\d+)/i,
     "244"
   );
+  const rightPane = extractDimension(
+    input.description ?? "",
+    /(right(?: context)? pane|context pane|right column|right rail)[^\d]*(\d+)/i,
+    "308"
+  );
+  const includeRightPane = wantsRightContextPane(input.description ?? "");
 
   return `HStack(spacing: 0) {
             VStack(spacing: 12) {
@@ -242,7 +483,55 @@ function buildThreePaneBody(input: ViewBlueprintInput): string {
             }
             .padding(24)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        }`;
+${
+  includeRightPane
+    ? `\n            VStack(alignment: .leading, spacing: 14) {
+                HStack {
+                    Text("Context")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+                    Spacer()
+                    Text("Synced")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "success", ".green")})
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("North Star")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textMuted", ".secondary")})
+                    Text("The project room where context never gets lost.")
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textPrimary", ".primary")})
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Context Files")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textMuted", ".secondary")})
+                    ${contextFileRow("NORTH_STAR.md", "synced")}
+                    ${contextFileRow("PROJECT_CONTEXT.md", "synced")}
+                    ${contextFileRow("DECISIONS.md", "updated")}
+                    ${contextFileRow("ROADMAP.md", "2 pending")}
+                }
+
+                Spacer()
+            }
+            .padding(14)
+            .frame(width: ${layoutRef(input.tokenNamespace, "rightContextPane", rightPane)}, maxHeight: .infinity, alignment: .topLeading)
+            .background(${colorRef(input.tokenNamespace, "surface", "Color.secondary.opacity(0.08)")})
+            .overlay(alignment: .leading) {
+                Rectangle()
+                    .fill(${colorRef(input.tokenNamespace, "border", "Color.secondary.opacity(0.18)")})
+                    .frame(width: 1)
+            }`
+    : ""
+}
+        }
+        .background(${colorRef(input.tokenNamespace, "bg", "Color.clear")})`;
 }
 
 function buildProfileCardBody(platform: BlueprintPlatform | undefined): string {
@@ -355,6 +644,50 @@ function layoutRef(
   fallback: string
 ): string {
   return namespace ? `${namespace}.Layout.${name}` : fallback;
+}
+
+function contextFileRow(name: string, status: string): string {
+  return `HStack(spacing: 8) {
+                    Image(systemName: "doc.text")
+                        .foregroundStyle(.secondary)
+                    Text("${name}")
+                        .font(.caption)
+                    Spacer()
+                    Text("${status}")
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.secondary)
+                }`;
+}
+
+function wantsRightContextPane(description: string): boolean {
+  const lower = description.toLowerCase();
+  return (
+    lower.includes("right pane") ||
+    lower.includes("context pane") ||
+    lower.includes("right context") ||
+    lower.includes("project context") ||
+    lower.includes("300") ||
+    lower.includes("308")
+  );
+}
+
+function textExpr(input: ViewBlueprintInput, name: string, fallback: string): string {
+  return hasValue(input, name) ? name : `"${escapeSwiftString(fallback)}"`;
+}
+
+function numericExpr(input: ViewBlueprintInput, name: string, fallback: string): string {
+  return hasValue(input, name) ? name : fallback;
+}
+
+function hasValue(input: ViewBlueprintInput, name: string): boolean {
+  return Boolean(
+    input.props?.some((prop) => prop.name === name) ||
+    input.state?.some((state) => state.name === name)
+  );
+}
+
+function escapeSwiftString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
 function extractDimension(

--- a/tests/cli/generation.test.ts
+++ b/tests/cli/generation.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerFeature } from "../../src/cli/feature.js";
+import { registerSchema } from "../../src/cli/schema.js";
+
+async function run(program: Command, args: string[]) {
+  program.name("axint");
+  await program.parseAsync(["node", "axint", ...args], { from: "node" });
+}
+
+describe("agent-facing generation CLI commands", () => {
+  const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  let tempRoot = "";
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), "axint-generation-cli-"));
+    logSpy.mockClear();
+    errorSpy.mockClear();
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("compiles a Swarm component schema from the CLI", async () => {
+    const schemaPath = join(tempRoot, "project-context-panel.json");
+    writeFileSync(
+      schemaPath,
+      JSON.stringify({
+        type: "component",
+        name: "ProjectContextPanel",
+        componentKind: "contextPanel",
+        tokenNamespace: "SwarmTokens",
+        format: false,
+      }),
+      "utf-8"
+    );
+
+    const program = new Command();
+    registerSchema(program);
+    await run(program, ["schema", "compile", schemaPath]);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("struct ProjectContextPanel: View");
+    expect(output).toContain("NORTH_STAR.md");
+    expect(output).toContain("SwarmTokens");
+  });
+
+  it("writes a Swarm shell feature package from the CLI", async () => {
+    const outDir = join(tempRoot, "generated");
+    const program = new Command();
+    registerFeature(program);
+    await run(program, [
+      "feature",
+      "A three-pane Swarm shell with a 56px sidebar rail, 244px channels column, flexible content area, and right project context pane",
+      "--surface",
+      "view",
+      "--name",
+      "SwarmShellView",
+      "--platform",
+      "macOS",
+      "--token-namespace",
+      "SwarmTokens",
+      "--write",
+      outDir,
+    ]);
+
+    const generatedPath = join(outDir, "Sources/Views/SwarmShellView.swift");
+    expect(existsSync(generatedPath)).toBe(true);
+    const swift = readFileSync(generatedPath, "utf-8");
+    expect(swift).toContain("SwarmTokens.Layout.sidebarRail");
+    expect(swift).toContain("SwarmTokens.Layout.rightContextPane");
+    expect(swift).toContain("NORTH_STAR.md");
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Written:");
+    expect(output).not.toContain("Domain: messaging");
+  });
+});

--- a/tests/mcp/feature.test.ts
+++ b/tests/mcp/feature.test.ts
@@ -212,7 +212,7 @@ describe("axint.feature", () => {
   it("generates a Swarm-style three-pane macOS shell from the description", () => {
     const result = generateFeature({
       description:
-        "A three-pane layout with a 56px sidebar rail, 244px channels column, and a flex content area for Swarm agent activity.",
+        "A three-pane layout with a 56px sidebar rail, 244px channels column, a flex content area for Swarm agent activity, and a 308px right Project Context pane.",
       surfaces: ["view"],
       name: "SwarmShellView",
       platform: "macOS",
@@ -225,6 +225,8 @@ describe("axint.feature", () => {
     expect(viewFile!.content).toContain("HStack(spacing: 0)");
     expect(viewFile!.content).toContain("SwarmTokens.Layout.sidebarRail");
     expect(viewFile!.content).toContain("SwarmTokens.Layout.channelsColumn");
+    expect(viewFile!.content).toContain("SwarmTokens.Layout.rightContextPane");
+    expect(viewFile!.content).toContain("NORTH_STAR.md");
     expect(viewFile!.content).toContain(".frame(maxWidth: .infinity");
   });
 

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -473,6 +473,26 @@ describe("axint.schema.compile — view", () => {
     expect(result.content[0].text).toContain("SwarmTokens.Layout.channelsColumn");
     expect(result.content[0].text).not.toContain('Text("VStack {}")');
   });
+
+  it("adds the Swarm context pane when the shell asks for one", async () => {
+    const result = await handleToolCall("axint.schema.compile", {
+      type: "view",
+      name: "SwarmShellView",
+      description:
+        "A three-pane layout with a 56px sidebar rail, 244px channels column, flex content area, and a 308px right Project Context pane.",
+      platform: "macOS",
+      tokenNamespace: "SwarmTokens",
+      format: false,
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.content[0].text).toContain("SwarmTokens.Layout.rightContextPane");
+    expect(result.content[0].text).toContain(
+      "The project room where context never gets lost."
+    );
+    expect(result.content[0].text).toContain("NORTH_STAR.md");
+    expect(result.content[0].text).not.toContain("ContextFileRow");
+  });
 });
 
 // ── axint.schema.compile (component) ───────────────────────────────
@@ -492,6 +512,23 @@ describe("axint.schema.compile — component", () => {
     expect(result.content[0].text).toContain("var title: String");
     expect(result.content[0].text).toContain("ProgressView(value: progress)");
     expect(result.content[0].text).toContain("SwarmTokens.Colors.accent");
+  });
+
+  it("compiles a reusable Swarm project context panel component", async () => {
+    const result = await handleToolCall("axint.schema.compile", {
+      type: "component",
+      name: "ProjectContextPanel",
+      componentKind: "contextPanel",
+      tokenNamespace: "SwarmTokens",
+      format: false,
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.content[0].text).toContain("struct ProjectContextPanel: View");
+    expect(result.content[0].text).toContain("var northStar: String");
+    expect(result.content[0].text).toContain("var suggestedUpdates: Int");
+    expect(result.content[0].text).toContain("PROJECT_CONTEXT.md");
+    expect(result.content[0].text).not.toContain("ContextFileRow");
   });
 });
 
@@ -513,6 +550,50 @@ describe("axint.tokens.ingest", () => {
     expect(result.content[0].text).toContain("enum SwarmTokens");
     expect(result.content[0].text).toContain('static let accent = Color(hex: "#FF5A3D")');
     expect(result.content[0].text).toContain("static let sidebarRail = CGFloat(56)");
+  });
+
+  it("turns Swarm V4 tokens into usable SwiftUI aliases and layout constants", async () => {
+    const result = await handleToolCall("axint.tokens.ingest", {
+      source: `
+        // Swarm design tokens
+        window.SW = {
+          bg: "#0A0A0B",
+          surface: "#111113",
+          elevated: "#17171A",
+          border: "#1F1F22",
+          text: "#EDEDEE",
+          text2: "#9B9BA1",
+          text3: "#6A6A6F",
+          accent: "#6366F1",
+          accentSoft: "rgba(99,102,241,0.15)",
+          warning: "#F59E0B",
+          warningSoft: "rgba(245,158,11,0.15)",
+          success: "#10B981",
+          successSoft: "rgba(16,185,129,0.15)",
+          memberColors: ["#6366F1", "#EC4899"],
+          r1: 4,
+          r2: 6,
+          rInput: 8,
+          rCard: 12,
+          rModal: 14,
+          shadowWin: "0 24px 80px rgba(0,0,0,0.5)"
+        }
+      `,
+      namespace: "SwarmTokens",
+      format: "swift",
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.content[0].text).toContain("static let accentSoft = Color(.sRGB");
+    expect(result.content[0].text).toContain("opacity: 0.15");
+    expect(result.content[0].text).toContain("static let surfaceRaised = elevated");
+    expect(result.content[0].text).toContain("static let textPrimary = text");
+    expect(result.content[0].text).toContain("static let sidebarRail = CGFloat(56)");
+    expect(result.content[0].text).toContain("static let channelsColumn = CGFloat(244)");
+    expect(result.content[0].text).toContain(
+      "static let rightContextPane = CGFloat(308)"
+    );
+    expect(result.content[0].text).toContain("static let row = rInput");
   });
 });
 

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -68,7 +68,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.1";
+const VERSION = "0.4.2";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary
- adds CLI fallback commands for schema compilation and feature package generation
- upgrades Swarm-oriented token ingestion, view blueprints, and component schema generation
- fixes domain matching so context-heavy layouts do not get mislabeled as messaging
- syncs public proof/version surfaces for 0.4.2

## Validation
- npm test
- npm run typecheck
- npm run build
- npm run metrics:check
- npm run docs:check
- npm run versions:check
- npm run release:check
- python3 -m pytest -q
- npm pack --dry-run