### PR TITLE
Release Axint 0.4.6 MCP status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+## [0.4.6] — 2026-04-25
+
+### Added
+
+- **`axint.status` MCP tool** — reports the exact running MCP server version, package path, uptime, tool count, and Xcode restart/update instructions so agents can prove which Axint process they are connected to.
+
+### Changed
+
+- **Xcode startup prompts** now tell agents to call `axint.status` before editing code and stop if the running MCP server is older than expected.
+- **`axint xcode verify`** now treats a missing `axint.status` tool as an old MCP server and prints the update/restart path.
+
 ## [0.4.5] — 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.5 · 13 MCP tools + 4 prompts · 175 diagnostic codes · 1039 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.6 · 14 MCP tools + 4 prompts · 175 diagnostic codes · 1042 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -257,6 +257,7 @@ MCP tools and built-in prompts:
 
 | Tool | What it does |
 | --- | --- |
+| `axint.status` | Report the running MCP server version, package path, uptime, and Xcode restart/update instructions |
 | `axint.compile` | Full pipeline: TypeScript → Swift + plist + entitlements |
 | `axint.schema.compile` | Minimal JSON → Swift (token-saving mode for agents) |
 | `axint.validate` | Dry-run validation with diagnostics |

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,7 +1,8 @@
 {
-  "version": "0.4.5",
-  "mcpTools": 13,
+  "version": "0.4.6",
+  "mcpTools": 14,
   "mcpToolNames": [
+    "axint.status",
     "axint.feature",
     "axint.suggest",
     "axint.scaffold",
@@ -61,7 +62,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 925,
+    "typescript": 928,
     "python": 114
   },
   "registryPackages": 14,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.5"
+version = "0.4.6"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/agenticempire/axint",
     "source": "github"
   },
-  "version": "0.4.5",
+  "version": "0.4.6",
   "remotes": [
     {
       "type": "streamable-http",
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "transport": {
         "type": "stdio"
       }
@@ -26,7 +26,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "transport": {
         "type": "stdio"
       }

--- a/src/cli/xcode-setup.ts
+++ b/src/cli/xcode-setup.ts
@@ -31,6 +31,8 @@ const START_PROMPT = [
   "6. https://docs.axint.ai/reference/cli/",
   "",
   "Then list MCP servers and confirm both xcode-tools and axint are available.",
+  "Call axint.status and report the running MCP server version before editing code.",
+  "If the version is older than expected, stop and tell me to update Axint, rerun `axint xcode setup --agent claude`, and restart the Xcode agent chat.",
   "Use Axint before guessing App Intents, widgets, SwiftUI scaffolds, entitlements, Info.plist keys, or repair prompts.",
   "Work in short checkpoints. Do not spend 20+ minutes on a task without running Axint and Xcode validation.",
   "After each generated Apple surface, run axint.cloud.check or axint cloud check <file> --feedback, then build in Xcode.",
@@ -162,14 +164,20 @@ export async function verifyXcode(): Promise<void> {
       throw result.error;
     }
 
-    if (output.includes("axint.feature")) {
+    if (output.includes("axint.feature") && output.includes("axint.status")) {
       console.log(`  ${GREEN}✓${RESET} MCP server responds`);
+      console.log(`  ${GREEN}✓${RESET} axint.status tool available`);
       console.log(`  ${GREEN}✓${RESET} axint.feature tool available`);
 
       const toolCount = (output.match(/"name":\s*"axint\./g) || []).length;
       console.log(`  ${GREEN}✓${RESET} ${toolCount} tools registered`);
       console.log();
       console.log(`  ${GREEN}All checks passed.${RESET} Axint is ready for Xcode.`);
+    } else if (output.includes("axint.feature")) {
+      console.log(`  ${RED}✗${RESET} MCP server is old: axint.status not found`);
+      console.log(
+        `  ${DIM}  Update Axint, rerun: axint xcode setup --agent claude, then restart the Xcode agent chat${RESET}`
+      );
     } else {
       console.log(`  ${RED}✗${RESET} Server responded but axint.feature not found`);
       console.log(`  ${DIM}  Try updating: npm install -g @axint/compiler${RESET}`);

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -7,6 +7,33 @@
 
 export const TOOL_MANIFEST = [
   {
+    name: "axint.status",
+    description:
+      "Report the exact running Axint MCP server version, package path, uptime, " +
+      "registered tool count, and Xcode restart/update instructions. Use this " +
+      "as the first tool in a new Xcode agent chat to prove which Axint process " +
+      "the agent is actually connected to. This answers the running MCP server, " +
+      "not a guessed npm, PyPI, or docs version.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        format: {
+          type: "string",
+          enum: ["markdown", "json", "prompt"],
+          description:
+            "Output format. markdown is human-readable, json is structured, " +
+            "and prompt is a short instruction an agent can repeat back before editing.",
+        },
+      },
+    },
+  },
+  {
     name: "axint.feature",
     description:
       "Generate a scaffolded Apple-native feature package from a description. " +

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -127,13 +127,14 @@ export function getPromptMessages(
               "   - https://docs.axint.ai/guides/fix-packets/\n" +
               "   - https://docs.axint.ai/reference/cli/\n" +
               "2. List the available MCP servers and confirm both xcode-tools and axint are present.\n" +
-              "3. If axint is missing in Xcode, tell me to run `axint xcode setup --agent claude`, restart the Xcode agent session, and ask again for available MCP servers.\n" +
-              "4. Use Axint tools before guessing App Intents, widgets, SwiftUI scaffolds, entitlements, Info.plist keys, or repair prompts.\n" +
-              "5. Work in short checkpoints. Do not spend 20+ minutes on a task without running Axint and Xcode validation.\n" +
-              "6. After each generated Apple surface, run `axint.cloud.check` or `axint cloud check <file> --feedback` and then build in Xcode.\n" +
-              "7. Do not claim there is no bug from Axint alone. Cloud Check is static; Xcode build, unit tests, UI tests, accessibility flows, and runtime behavior are separate evidence.\n" +
-              "8. If Axint passes but Xcode/tests/runtime fails, report the exact failure as an Axint validator or runtime-coverage gap before continuing.\n\n" +
-              "Once that is done, summarize which docs you read, which MCP servers are available, and the first Axint command you will use.",
+              "3. Call `axint.status` and report the running MCP server version before editing code. If the version is older than expected, stop and tell me to update Axint, rerun `axint xcode setup --agent claude`, and restart the Xcode agent chat.\n" +
+              "4. If axint is missing in Xcode, tell me to run `axint xcode setup --agent claude`, restart the Xcode agent session, and ask again for available MCP servers.\n" +
+              "5. Use Axint tools before guessing App Intents, widgets, SwiftUI scaffolds, entitlements, Info.plist keys, or repair prompts.\n" +
+              "6. Work in short checkpoints. Do not spend 20+ minutes on a task without running Axint and Xcode validation.\n" +
+              "7. After each generated Apple surface, run `axint.cloud.check` or `axint cloud check <file> --feedback` and then build in Xcode.\n" +
+              "8. Do not claim there is no bug from Axint alone. Cloud Check is static; Xcode build, unit tests, UI tests, accessibility flows, and runtime behavior are separate evidence.\n" +
+              "9. If Axint passes but Xcode/tests/runtime fails, report the exact failure as an Axint validator or runtime-coverage gap before continuing.\n\n" +
+              "Once that is done, summarize which docs you read, the running Axint MCP version, which MCP servers are available, and the first Axint command you will use.",
           },
         },
       ],

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,6 +19,7 @@
  *   - axint.swift.fix:        Auto-fix mechanical Swift validator errors
  *   - axint.templates.list:   List bundled reference templates
  *   - axint.templates.get:    Return the source of a specific template
+ *   - axint.status:           Report the running MCP server version + restart help
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -59,14 +60,28 @@ import {
   type TokenOutputFormat,
 } from "./tokens.js";
 
-// Read version from package.json so it stays in sync
-let pkg = { version: "0.3.9" };
+type PackageInfo = {
+  name?: string;
+  version: string;
+  mcpName?: string;
+};
+
+type StatusArgs = {
+  format?: "markdown" | "json" | "prompt";
+};
+
+// Read version from package.json so it stays in sync.
+let pkg: PackageInfo = { version: "0.3.9" };
+let packageJsonPath = "<bundled>";
 try {
   const __dirname = dirname(fileURLToPath(import.meta.url));
-  pkg = JSON.parse(readFileSync(resolve(__dirname, "../../package.json"), "utf-8"));
+  packageJsonPath = resolve(__dirname, "../../package.json");
+  pkg = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as PackageInfo;
 } catch {
   // fallback version used when bundled outside repo (e.g. Smithery scan)
 }
+
+const serverStartedAt = new Date();
 
 type CompileArgs = {
   source: string;
@@ -117,6 +132,77 @@ function errorText(text: string): ToolResult {
   };
 }
 
+function renderStatus(format: StatusArgs["format"] = "markdown"): string {
+  const uptimeSeconds = Math.max(
+    0,
+    Math.round((Date.now() - serverStartedAt.getTime()) / 1000)
+  );
+  const status = {
+    server: "axint-mcp",
+    packageName: pkg.name ?? "@axint/compiler",
+    mcpName: pkg.mcpName ?? "io.github.agenticempire/axint",
+    version: pkg.version,
+    packageJsonPath,
+    node: process.version,
+    pid: process.pid,
+    startedAt: serverStartedAt.toISOString(),
+    uptimeSeconds,
+    argv: process.argv,
+    toolsRegistered: TOOL_MANIFEST.length,
+    promptsRegistered: PROMPT_MANIFEST.length,
+    restartRequiredAfterUpdate: true,
+    updateCommand: "npm install -g @axint/compiler@latest",
+    xcodeSetupCommand: "axint xcode setup --agent claude",
+    xcodeRestartInstruction:
+      "Restart the Xcode Claude Agent chat or MCP server after updating. MCP clients keep the old Node process alive until it is restarted.",
+  };
+
+  if (format === "json") return JSON.stringify(status, null, 2);
+
+  if (format === "prompt") {
+    return [
+      `The running Axint MCP server is v${status.version}.`,
+      "If this is older than the version the user expects, stop before editing code.",
+      "Tell the user to update Axint, rerun `axint xcode setup --agent claude`, and restart the Xcode Claude Agent chat.",
+    ].join("\n");
+  }
+
+  return [
+    "# Axint MCP Status",
+    "",
+    `- Server: ${status.server}`,
+    `- Running version: v${status.version}`,
+    `- Package: ${status.packageName}`,
+    `- Package path: ${status.packageJsonPath}`,
+    `- Node: ${status.node}`,
+    `- PID: ${status.pid}`,
+    `- Started: ${status.startedAt}`,
+    `- Uptime: ${status.uptimeSeconds}s`,
+    `- Tools registered: ${status.toolsRegistered}`,
+    `- Prompts registered: ${status.promptsRegistered}`,
+    "",
+    "## Updating Axint for Xcode",
+    "",
+    "MCP servers are long-running processes. Installing a newer package does not update the already-running server inside Xcode.",
+    "",
+    "1. Update Axint:",
+    "",
+    "```sh",
+    status.updateCommand,
+    "```",
+    "",
+    "2. Rewrite the Xcode Claude Agent MCP config with durable paths:",
+    "",
+    "```sh",
+    status.xcodeSetupCommand,
+    "```",
+    "",
+    "3. Restart the Xcode Claude Agent chat or MCP server.",
+    "",
+    "4. In the new chat, ask: `Call axint.status and tell me the running version.`",
+  ].join("\n");
+}
+
 // Agents call axint.* through MCP stdio with no way to invoke swift-format
 // themselves. Default-on here means every AI-generated Swift file matches
 // Apple's house style without the caller having to know it exists.
@@ -127,6 +213,11 @@ async function maybeFormatSwift(source: string, enabled: boolean): Promise<strin
 }
 
 export async function handleToolCall(name: string, args: unknown): Promise<ToolResult> {
+  if (name === "axint.status") {
+    const a = args as StatusArgs | undefined;
+    return diagnosticsText(renderStatus(a?.format ?? "markdown"));
+  }
+
   if (name === "axint.feature") {
     const a = args as FeatureInput & { format?: boolean };
     if (!a.description) {

--- a/tests/cli/xcode.test.ts
+++ b/tests/cli/xcode.test.ts
@@ -82,6 +82,7 @@ describe("xcode CLI smoke coverage", () => {
     spawnSyncMock.mockReturnValue({
       stdout: JSON.stringify({
         tools: [
+          { name: "axint.status" },
           { name: "axint.feature" },
           { name: "axint.compile" },
           { name: "axint.validate" },

--- a/tests/mcp/http-transport.test.ts
+++ b/tests/mcp/http-transport.test.ts
@@ -89,6 +89,29 @@ describe("axint HTTP MCP transport", () => {
     );
   });
 
+  it("reports the running remote MCP server version through axint.status", async () => {
+    const response = await request({
+      jsonrpc: "2.0",
+      id: 11,
+      method: "tools/call",
+      params: {
+        name: "axint.status",
+        arguments: { format: "json" },
+      },
+    });
+    const payload = await response.json();
+    const text = payload.result.content[0].text as string;
+    const status = JSON.parse(text) as {
+      server: string;
+      version: string;
+      restartRequiredAfterUpdate: boolean;
+    };
+
+    expect(status.server).toBe("axint-mcp");
+    expect(status.version).toBe(packageVersion);
+    expect(status.restartRequiredAfterUpdate).toBe(true);
+  });
+
   it("lists built-in prompts and resolves prompt content", async () => {
     const listResponse = await request({ jsonrpc: "2.0", id: 1, method: "prompts/list" });
     const listPayload = await listResponse.json();

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -12,6 +12,32 @@ import { TEMPLATES, getTemplate } from "../../src/templates/index.js";
 import { validateSwiftSource } from "../../src/core/swift-validator.js";
 import { fixSwiftSource } from "../../src/core/swift-fixer.js";
 
+describe("axint.status tool", () => {
+  it("reports the running MCP server version and restart instructions", async () => {
+    const result = await handleToolCall("axint.status", { format: "json" });
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      server: string;
+      version: string;
+      restartRequiredAfterUpdate: boolean;
+      xcodeSetupCommand: string;
+    };
+    expect(payload.server).toBe("axint-mcp");
+    expect(payload.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(payload.restartRequiredAfterUpdate).toBe(true);
+    expect(payload.xcodeSetupCommand).toBe("axint xcode setup --agent claude");
+  });
+
+  it("returns a human-readable Xcode update path", async () => {
+    const result = await handleToolCall("axint.status", {});
+
+    expect(result.content[0].text).toContain("# Axint MCP Status");
+    expect(result.content[0].text).toContain("Call axint.status");
+    expect(result.content[0].text).toContain("Restart the Xcode Claude Agent");
+  });
+});
+
 const VIEW_SOURCE = `
   import { defineView, prop, state, view } from "@axint/sdk";
 

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -22,6 +22,7 @@
  *   - axint.swift.fix:        Auto-fix mechanical Swift errors
  *   - axint.templates.list:   List bundled reference templates
  *   - axint.templates.get:    Return template source by id
+ *   - axint.status:           Report remote MCP server version + restart help
  *
  * Endpoint: POST /mcp
  * Health:   GET /health
@@ -68,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.5";
+const VERSION = "0.4.6";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 
@@ -192,6 +193,57 @@ function textResult(text: string, isError = false) {
   return isError
     ? { content: [{ type: "text", text }], isError: true }
     : { content: [{ type: "text", text }] };
+}
+
+function statusResult(args: Record<string, unknown>) {
+  const format = typeof args.format === "string" ? args.format : "markdown";
+  const status = {
+    server: "axint-mcp",
+    transport: "http",
+    packageName: "@axint/compiler",
+    version: VERSION,
+    toolsRegistered: TOOL_MANIFEST.length,
+    promptsRegistered: PROMPT_MANIFEST.length,
+    restartRequiredAfterUpdate: true,
+    updateCommand: "npm install -g @axint/compiler@latest",
+    xcodeSetupCommand: "axint xcode setup --agent claude",
+    xcodeRestartInstruction:
+      "Restart the Xcode Claude Agent chat or MCP server after updating. MCP clients keep the old process alive until it is restarted.",
+  };
+
+  if (format === "json") return textResult(JSON.stringify(status, null, 2));
+
+  if (format === "prompt") {
+    return textResult(
+      [
+        `The running Axint MCP server is v${VERSION}.`,
+        "If this is older than the version the user expects, stop before editing code.",
+        "Tell the user to update Axint, rerun `axint xcode setup --agent claude`, and restart the Xcode Claude Agent chat.",
+      ].join("\n")
+    );
+  }
+
+  return textResult(
+    [
+      "# Axint MCP Status",
+      "",
+      "- Server: axint-mcp",
+      "- Transport: http",
+      `- Running version: v${VERSION}`,
+      "- Package: @axint/compiler",
+      `- Tools registered: ${TOOL_MANIFEST.length}`,
+      `- Prompts registered: ${PROMPT_MANIFEST.length}`,
+      "",
+      "## Updating Axint for Xcode",
+      "",
+      "MCP servers are long-running processes. Installing a newer package does not update an already-running server inside Xcode.",
+      "",
+      "1. Run `npm install -g @axint/compiler@latest`.",
+      "2. Run `axint xcode setup --agent claude`.",
+      "3. Restart the Xcode Claude Agent chat or MCP server.",
+      "4. In the new chat, ask: `Call axint.status and tell me the running version.`",
+    ].join("\n")
+  );
 }
 
 
@@ -536,6 +588,10 @@ function compileFromSchema(args: SchemaArgs) {
 }
 
 function handleTool(name: string, args: Record<string, unknown>) {
+  if (name === "axint.status") {
+    return statusResult(args);
+  }
+
   if (name === "axint.feature") {
     const a = args as unknown as FeatureInput;
     if (!a.description)


### PR DESCRIPTION
Adds axint.status so Xcode agents can report the exact running MCP server version, package path, uptime, and update/restart instructions before editing code.\n\nAlso updates the Xcode project-start prompt and xcode verify path to catch old MCP servers that do not expose axint.status.\n\nChecks run:\n- npm test\n- npm test -- tests/mcp/server.test.ts tests/mcp/http-transport.test.ts tests/cli/xcode.test.ts\n- npm run docs:check && npm run metrics:check && npm run versions:check && npm run typecheck\n- npm run prepublishOnly\n- python3 -m pytest\n- python3 -m build && python3 -m twine check dist/*