### PR TITLE
Treat MCP registry duplicate publishes as no-op

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -32,4 +32,17 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       - name: Publish server.json
-        run: ./mcp-publisher publish
+        run: |
+          set -euo pipefail
+          if output=$(./mcp-publisher publish 2>&1); then
+            echo "$output"
+            exit 0
+          fi
+
+          echo "$output"
+          if grep -qi "duplicate version" <<<"$output"; then
+            echo "::notice::This server.json version is already published in the official MCP Registry."
+            exit 0
+          fi
+
+          exit 1


### PR DESCRIPTION
Makes the registry publish workflow idempotent so manual reruns do not show a red failure when the current server.json version is already live.\n\nValidation:\n- official registry already shows io.github.agenticempire/axint v0.4.8 as latest active