### PR TITLE
Add guarded Xcode Axint run loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.9 · 20 MCP tools + 5 prompts · 182 diagnostic codes · 1098 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.9 · 23 MCP tools + 5 prompts · 182 diagnostic codes · 1107 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -230,6 +230,33 @@ Recompiles on every save with 150ms debounce, inline errors, and optional `swift
 axint watch ./intents/ --out ios/Intents/ --emit-info-plist --emit-entitlements
 axint watch my-intent.ts --out ios/Intents/ --format --swift-build
 ```
+
+---
+
+## Axint Run
+
+`axint run` is the local/BYO-Mac build loop for Apple projects. It exists so agents do not have to remember separate Axint steps after a long chat or context compaction.
+
+```bash
+axint xcode setup --agent claude --guarded --project /path/to/MyApp --name MyApp
+axint xcode setup --agent claude --guarded --local-build --project /path/to/MyApp --name MyApp
+axint xcode guard --dir /path/to/MyApp --stage context-recovery
+axint run --dir /path/to/MyApp --scheme MyApp --destination "platform=macOS"
+axint run --dir /path/to/MyApp --scheme MyApp --runtime
+axint runner once --dir /path/to/MyApp --scheme MyApp
+```
+
+`axint xcode setup --guarded` configures the Xcode Claude Agent with durable MCP paths, writes the project memory pack, starts a session, and creates `.axint/guard/latest.json` plus `.axint/guard/latest.md`. That guard report is the audit trail for the problem where an Xcode agent works for a long block, compacts context, and silently stops using Axint.
+
+Use `--local-build` only while dogfooding this checkout before publishing; it points Xcode at the built local MCP server instead of the npm package.
+
+When an MCP agent is creating a new Swift file, use `axint.xcode.write` instead of a raw file write. The tool writes inside the project root, validates Swift, runs Cloud Check, and updates the guard proof in one call.
+
+The run starts an Axint session, refreshes the project recovery context, validates changed Swift, runs Cloud Check, executes `xcodebuild build` and `xcodebuild test`, optionally launches a macOS app for runtime proof, and writes `.axint/run/latest.json` plus `.axint/run/latest.md`.
+
+Use `--dry-run` to prove the harness and planned `xcodebuild` commands before letting a local or BYO Mac runner execute the job.
+
+This open-source repository does not include the proprietary hosted Axint Cloud control plane: job queues, Mac fleet orchestration, billing, signed-in Pro entitlements, stored report history, or learning pipelines live outside the compiler package.
 
 ---
 
@@ -259,6 +286,8 @@ MCP tools and built-in prompts:
 | --- | --- |
 | `axint.status` | Report the running MCP server version, package path, uptime, and Xcode restart/update instructions |
 | `axint.doctor` | Audit version truth, Node/npm/npx paths, project MCP wiring, and agent start-pack files |
+| `axint.xcode.guard` | Guard Xcode agent sessions against context compaction and Axint drift, then write `.axint/guard/latest.*` proof artifacts |
+| `axint.xcode.write` | Write a project file through Axint, then validate Swift, run Cloud Check, and update guard proof for Swift files |
 | `axint.session.start` | Start an enforced agent session, refresh `.axint/AXINT_REHYDRATE.md`, write `.axint/session/current.json`, and return the token required by workflow gates |
 | `axint.compile` | Full pipeline: TypeScript → Swift + plist + entitlements |
 | `axint.schema.compile` | Minimal JSON → Swift (token-saving mode for agents) |
@@ -274,6 +303,7 @@ MCP tools and built-in prompts:
 | `axint.swift.fix` | Auto-fix mechanical Swift errors (concurrency, Live Activities) |
 | `axint.fix-packet` | Read the latest AI-ready repair packet from a local compile or watch run |
 | `axint.cloud.check` | Run an agent-callable Cloud Check report against Swift or TypeScript source |
+| `axint.run` | Run the enforced Apple build loop: session, workflow gate, Swift validation, Cloud Check, xcodebuild build/test, optional runtime launch, and `.axint/run` artifacts |
 | `axint.tokens.ingest` | Convert design tokens into SwiftUI token enums for generated views |
 | `axint.templates.list` | List bundled reference templates |
 | `axint.templates.get` | Return the source of a specific template |

--- a/metrics.json
+++ b/metrics.json
@@ -1,9 +1,11 @@
 {
   "version": "0.4.9",
-  "mcpTools": 20,
+  "mcpTools": 23,
   "mcpToolNames": [
     "axint.status",
     "axint.doctor",
+    "axint.xcode.guard",
+    "axint.xcode.write",
     "axint.session.start",
     "axint.feature",
     "axint.project.pack",
@@ -16,6 +18,7 @@
     "axint.validate",
     "axint.fix-packet",
     "axint.cloud.check",
+    "axint.run",
     "axint.tokens.ingest",
     "axint.schema.compile",
     "axint.swift.validate",
@@ -70,7 +73,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 984,
+    "typescript": 993,
     "python": 114
   },
   "registryPackages": 14,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,9 +24,12 @@
  *   axint doctor                  Audit version truth, MCP wiring, and project start files
  *   axint project init            Write Axint project-start files for agent workflows
  *   axint session start           Start an enforced Axint agent session and refresh context
+ *   axint run                     Run Axint's enforced Apple build/test/runtime loop
+ *   axint runner once             Execute one BYO-Mac runner Axint job
  *   axint mcp                     Start the MCP server (stdio)
  *   axint mcp status              Show local MCP launch command and Xcode restart steps
  *   axint xcode setup             Configure Axint for Xcode agentic coding
+ *   axint xcode guard             Check/write the Axint Xcode drift guard
  *   axint xcode verify            Verify the MCP connection is working
  *   axint xcode fix <path>        Auto-fix mechanical Swift validator errors
  *   axint xcode doctor            Audit environment for Apple-platform agentic coding
@@ -63,6 +66,8 @@ import { registerStatus, renderCliStatus } from "./status.js";
 import { registerDoctor } from "./doctor.js";
 import { registerProject } from "./project.js";
 import { registerSession } from "./session.js";
+import { registerRun } from "./run.js";
+import { registerXcodeGuard } from "./xcode-guard.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(resolve(__dirname, "../../package.json"), "utf-8"));
@@ -176,6 +181,7 @@ registerStatus(program, VERSION);
 registerDoctor(program, VERSION);
 registerProject(program, VERSION);
 registerSession(program, VERSION);
+registerRun(program, VERSION);
 
 // ─── mcp ─────────────────────────────────────────────────────────────
 
@@ -208,10 +214,31 @@ xcode
   .description("Configure Axint as an MCP server for Xcode's agentic coding workflow")
   .option("--agent <agent>", "Which agent to configure (claude, codex, all)", "all")
   .option("--remote", "Use the hosted remote MCP endpoint instead of local stdio")
-  .action(async (options: { agent: string; remote: boolean }) => {
-    const { setupXcode } = await import("./xcode-setup.js");
-    await setupXcode(options);
-  });
+  .option(
+    "--guarded",
+    "Also write project Axint memory and an Xcode guard proof file for this project"
+  )
+  .option(
+    "--local-build",
+    "Use this checkout's built dist/mcp/register.js instead of the npm package"
+  )
+  .option("--project <dir>", "Project directory for guarded setup", ".")
+  .option("--name <name>", "Project name for guarded setup")
+  .action(
+    async (options: {
+      agent: string;
+      remote: boolean;
+      guarded?: boolean;
+      localBuild?: boolean;
+      project?: string;
+      name?: string;
+    }) => {
+      const { setupXcode } = await import("./xcode-setup.js");
+      await setupXcode(options);
+    }
+  );
+
+registerXcodeGuard(xcode);
 
 xcode
   .command("verify")

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,0 +1,172 @@
+import type { Command } from "commander";
+import {
+  renderAxintRunReport,
+  runAxintProject,
+  type AxintRunFormat,
+  type AxintRunPlatform,
+} from "../run/project-runner.js";
+
+export function registerRun(program: Command, version: string) {
+  program
+    .command("run")
+    .description(
+      "Run the enforced Axint Apple build loop: session, workflow gate, validate, Cloud Check, xcodebuild, and optional runtime proof"
+    )
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--scheme <scheme>", "Xcode scheme")
+    .option("--workspace <path>", "Path to .xcworkspace")
+    .option("--project <path>", "Path to .xcodeproj")
+    .option("--destination <destination>", "xcodebuild destination")
+    .option("--configuration <configuration>", "Xcode build configuration")
+    .option("--derived-data <path>", "xcodebuild -derivedDataPath")
+    .option("--test-plan <name>", "xcodebuild -testPlan")
+    .option(
+      "--platform <platform>",
+      "Target platform: macOS, iOS, watchOS, visionOS, all",
+      parsePlatform
+    )
+    .option("--changed <file...>", "Changed Swift files to validate/check")
+    .option("--skip-build", "Skip xcodebuild build")
+    .option("--skip-tests", "Skip xcodebuild test")
+    .option("--runtime", "Launch the built macOS app and capture runtime evidence")
+    .option("--runtime-timeout <seconds>", "Runtime launch timeout", parsePositiveInt)
+    .option("--timeout <seconds>", "Build/test timeout", parsePositiveInt)
+    .option("--expected <text>", "Expected runtime or UI behavior")
+    .option("--actual <text>", "Actual runtime or UI behavior")
+    .option("--runtime-failure <text>", "Runtime, freeze, crash, or hang evidence")
+    .option("--dry-run", "Plan the xcodebuild commands without executing them")
+    .option("--no-write-report", "Do not write .axint/run/latest artifacts")
+    .option("--json", "Shortcut for --format json")
+    .option("--prompt", "Shortcut for --format prompt")
+    .option(
+      "--format <format>",
+      "Output format: markdown, json, or prompt",
+      parseFormat,
+      "markdown" as AxintRunFormat
+    )
+    .action(
+      async (options: {
+        dir: string;
+        scheme?: string;
+        workspace?: string;
+        project?: string;
+        destination?: string;
+        configuration?: string;
+        derivedData?: string;
+        testPlan?: string;
+        platform?: AxintRunPlatform;
+        changed?: string[];
+        skipBuild?: boolean;
+        skipTests?: boolean;
+        runtime?: boolean;
+        runtimeTimeout?: number;
+        timeout?: number;
+        expected?: string;
+        actual?: string;
+        runtimeFailure?: string;
+        dryRun?: boolean;
+        writeReport?: boolean;
+        json?: boolean;
+        prompt?: boolean;
+        format: AxintRunFormat;
+      }) => {
+        const report = await runAxintProject({
+          cwd: options.dir,
+          kind: "local",
+          expectedVersion: version,
+          platform: options.platform,
+          scheme: options.scheme,
+          workspace: options.workspace,
+          project: options.project,
+          destination: options.destination,
+          configuration: options.configuration,
+          derivedDataPath: options.derivedData,
+          testPlan: options.testPlan,
+          modifiedFiles: options.changed,
+          skipBuild: options.skipBuild,
+          skipTests: options.skipTests,
+          runtime: options.runtime,
+          runtimeTimeoutSeconds: options.runtimeTimeout,
+          timeoutSeconds: options.timeout,
+          expectedBehavior: options.expected,
+          actualBehavior: options.actual,
+          runtimeFailure: options.runtimeFailure,
+          dryRun: options.dryRun,
+          writeReport: options.writeReport,
+        });
+        const format = options.prompt ? "prompt" : options.json ? "json" : options.format;
+        console.log(renderAxintRunReport(report, format));
+        if (report.status === "fail") process.exit(1);
+      }
+    );
+
+  const runner = program
+    .command("runner")
+    .description("Run Axint jobs on a local or BYO Mac runner");
+
+  runner
+    .command("once")
+    .description(
+      "Execute one Axint Run job in the current project. This is the open-source BYO Mac runner primitive."
+    )
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--scheme <scheme>", "Xcode scheme")
+    .option("--destination <destination>", "xcodebuild destination")
+    .option("--skip-tests", "Skip xcodebuild test")
+    .option("--runtime", "Launch the built macOS app and capture runtime evidence")
+    .option("--dry-run", "Plan commands without executing them")
+    .option(
+      "--format <format>",
+      "Output format: markdown, json, or prompt",
+      parseFormat,
+      "markdown" as AxintRunFormat
+    )
+    .action(
+      async (options: {
+        dir: string;
+        scheme?: string;
+        destination?: string;
+        skipTests?: boolean;
+        runtime?: boolean;
+        dryRun?: boolean;
+        format: AxintRunFormat;
+      }) => {
+        const report = await runAxintProject({
+          cwd: options.dir,
+          kind: "byo-runner",
+          expectedVersion: version,
+          scheme: options.scheme,
+          destination: options.destination,
+          skipTests: options.skipTests,
+          runtime: options.runtime,
+          dryRun: options.dryRun,
+        });
+        console.log(renderAxintRunReport(report, options.format));
+        if (report.status === "fail") process.exit(1);
+      }
+    );
+}
+
+function parseFormat(value: string): AxintRunFormat {
+  if (value === "markdown" || value === "json" || value === "prompt") return value;
+  throw new Error(`invalid run format: ${value}`);
+}
+
+function parsePlatform(value: string): AxintRunPlatform {
+  if (
+    value === "macOS" ||
+    value === "iOS" ||
+    value === "watchOS" ||
+    value === "visionOS" ||
+    value === "all"
+  ) {
+    return value;
+  }
+  throw new Error(`invalid platform: ${value}`);
+}
+
+function parsePositiveInt(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  throw new Error(`invalid positive number: ${value}`);
+}

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -32,7 +32,7 @@ export function renderCliStatus(
     cwd: process.cwd(),
     mcpCommand: `${which("npx") ?? "npx"} -y @axint/compiler axint-mcp`,
     updateCommand: `${which("npm") ?? "npm"} install -g @axint/compiler@latest`,
-    xcodeSetupCommand: "axint xcode setup --agent claude",
+    xcodeSetupCommand: "axint xcode setup --agent claude --guarded",
     doctorCommand: "axint doctor",
     projectInitCommand: "axint project init",
     verificationPrompt:
@@ -47,6 +47,7 @@ export function renderCliStatus(
     return [
       "Use Axint before editing Apple-native code.",
       status.verificationPrompt,
+      "Call axint.xcode.guard with stage=context-recovery so this Xcode chat writes durable guard proof.",
       `Expected local package version: ${status.version}.`,
       "If axint.status reports an older version, stop and ask me to update/restart the Xcode agent chat.",
       "After each generated Swift surface, run axint.cloud.check or axint cloud check --source <file> with build/test evidence when available.",
@@ -69,6 +70,7 @@ export function renderCliStatus(
     "",
     "```text",
     status.verificationPrompt,
+    "Call axint.xcode.guard with stage=context-recovery before any long task.",
     "If Axint is not available, inspect the project .mcp.json, make sure npx uses a durable full path, then restart this Xcode agent chat.",
     "```",
     "",

--- a/src/cli/xcode-guard.ts
+++ b/src/cli/xcode-guard.ts
@@ -1,0 +1,108 @@
+import type { Command } from "commander";
+import {
+  renderXcodeGuardReport,
+  runXcodeGuard,
+  type XcodeGuardFormat,
+  type XcodeGuardStage,
+} from "../project/xcode-guard.js";
+
+const STAGES = [
+  "context-recovery",
+  "planning",
+  "before-write",
+  "after-write",
+  "pre-build",
+  "runtime",
+  "finish",
+] as const;
+
+export function registerXcodeGuard(xcode: Command): void {
+  xcode
+    .command("guard")
+    .description(
+      "Check the Axint Xcode drift guard and write .axint/guard/latest artifacts"
+    )
+    .option("--dir <dir>", "Project directory to guard", ".")
+    .option("--name <name>", "Project name")
+    .option("--expected-version <version>", "Expected Axint version")
+    .option("--platform <platform>", "Target Apple platform")
+    .option(
+      "--stage <stage>",
+      "Guard stage: context-recovery, planning, before-write, after-write, pre-build, runtime, finish",
+      parseStage,
+      "context-recovery" as XcodeGuardStage
+    )
+    .option("--session-token <token>", "Current axint.session.start token")
+    .option("--modified <files...>", "Modified files in scope")
+    .option("--notes <text>", "Agent notes or user feedback to scan for drift")
+    .option("--last-tool <tool>", "Last Axint tool used, e.g. axint.suggest")
+    .option("--last-result <text>", "Short result from the last Axint tool")
+    .option(
+      "--max-minutes <minutes>",
+      "Maximum allowed minutes since the latest Axint evidence",
+      parsePositiveNumber,
+      10
+    )
+    .option("--no-auto-start", "Do not auto-start an Axint session if missing")
+    .option("--no-write-report", "Do not write .axint/guard/latest artifacts")
+    .option(
+      "--format <format>",
+      "Output format: markdown or json",
+      parseFormat,
+      "markdown" as XcodeGuardFormat
+    )
+    .action(
+      (options: {
+        dir: string;
+        name?: string;
+        expectedVersion?: string;
+        platform?: string;
+        stage: XcodeGuardStage;
+        sessionToken?: string;
+        modified?: string[];
+        notes?: string;
+        lastTool?: string;
+        lastResult?: string;
+        maxMinutes: number;
+        autoStart?: boolean;
+        writeReport?: boolean;
+        format: XcodeGuardFormat;
+      }) => {
+        const report = runXcodeGuard({
+          cwd: options.dir,
+          projectName: options.name,
+          expectedVersion: options.expectedVersion,
+          platform: options.platform,
+          stage: options.stage,
+          sessionToken: options.sessionToken,
+          modifiedFiles: options.modified,
+          notes: options.notes,
+          lastAxintTool: options.lastTool,
+          lastAxintResult: options.lastResult,
+          maxMinutesSinceAxint: options.maxMinutes,
+          autoStartSession: options.autoStart ?? true,
+          writeReport: options.writeReport ?? true,
+        });
+        console.log(renderXcodeGuardReport(report, options.format));
+        if (report.status === "needs_action") {
+          process.exitCode = 1;
+        }
+      }
+    );
+}
+
+function parseStage(value: string): XcodeGuardStage {
+  if ((STAGES as readonly string[]).includes(value)) return value as XcodeGuardStage;
+  throw new Error(`invalid stage: ${value}`);
+}
+
+function parseFormat(value: string): XcodeGuardFormat {
+  if (value === "markdown" || value === "json") return value;
+  throw new Error(`invalid format: ${value}`);
+}
+
+function parsePositiveNumber(value: string): number {
+  const parsed = Number(value);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  throw new Error(`invalid positive number: ${value}`);
+}

--- a/src/cli/xcode-setup.ts
+++ b/src/cli/xcode-setup.ts
@@ -8,8 +8,10 @@
 import { execSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { writeProjectStartPack } from "../project/start-pack.js";
+import { renderXcodeGuardReport, runXcodeGuard } from "../project/xcode-guard.js";
 
 const ORANGE = "\x1b[38;5;208m";
 const GREEN = "\x1b[38;5;82m";
@@ -31,10 +33,12 @@ const START_PROMPT = [
   "6. https://docs.axint.ai/reference/cli/",
   "",
   "Then list MCP servers and confirm both xcode-tools and axint are available.",
+  "Call axint.xcode.guard with stage=context-recovery so the project writes .axint/guard/latest.* proof before any long task.",
   "Call axint.status and report the running MCP server version before editing code.",
-  "If the version is older than expected, stop and tell me to update Axint, rerun `axint xcode setup --agent claude`, and restart the Xcode agent chat.",
+  "If the version is older than expected, stop and tell me to update Axint, rerun `axint xcode setup --agent claude --guarded`, and restart the Xcode agent chat.",
   "Use Axint before guessing App Intents, widgets, SwiftUI scaffolds, entitlements, Info.plist keys, or repair prompts.",
   "Work in short checkpoints. Do not spend 20+ minutes on a task without running Axint and Xcode validation.",
+  "For long build/debug work, prefer axint.run or axint.xcode.guard over raw Xcode actions so Axint proof survives context compaction.",
   "After each generated Apple surface, run axint.cloud.check or axint cloud check <file> --feedback, then build in Xcode.",
   "Do not claim there is no bug from Axint alone. Cloud Check is static; Xcode build, unit tests, UI tests, accessibility flows, and runtime behavior are separate evidence.",
   "If Axint passes but Xcode/tests/runtime fails, report the exact failure as an Axint validator or runtime-coverage gap before continuing.",
@@ -64,6 +68,10 @@ interface ClaudeAgentConfig {
 interface SetupOptions {
   agent: string;
   remote: boolean;
+  guarded?: boolean;
+  localBuild?: boolean;
+  project?: string;
+  name?: string;
 }
 
 export async function setupXcode(options: SetupOptions): Promise<void> {
@@ -116,7 +124,16 @@ export async function setupXcode(options: SetupOptions): Promise<void> {
   }
 
   if (!options.remote && agents.includes("claude")) {
-    setupXcodeClaudeAgent();
+    setupXcodeClaudeAgent({ localBuild: options.localBuild ?? false });
+  }
+
+  if (options.guarded) {
+    setupGuardedProject({
+      projectDir: options.project ?? ".",
+      projectName: options.name,
+      mode: options.remote ? "remote" : "local",
+      agent: options.agent,
+    });
   }
 
   // 5. Print verification instructions
@@ -136,6 +153,48 @@ export async function setupXcode(options: SetupOptions): Promise<void> {
   console.log();
   printAgentStartPrompt();
   console.log();
+}
+
+function setupGuardedProject(input: {
+  projectDir: string;
+  projectName?: string;
+  mode: "local" | "remote";
+  agent: string;
+}): void {
+  const targetDir = resolve(input.projectDir);
+  const projectName = input.projectName ?? basename(targetDir) ?? "AppleApp";
+  console.log();
+  console.log(`  ${BOLD}Configuring guarded Axint project loop...${RESET}`);
+
+  const pack = writeProjectStartPack({
+    targetDir,
+    projectName,
+    agent:
+      input.agent === "claude" || input.agent === "codex" || input.agent === "all"
+        ? input.agent
+        : "all",
+    mode: input.mode,
+    version: readPackageVersion(),
+    force: false,
+  });
+  console.log(
+    `  ${GREEN}✓${RESET} Project guard memory checked (${pack.written.length} written, ${pack.skipped.length} existing)`
+  );
+
+  const guard = runXcodeGuard({
+    cwd: targetDir,
+    projectName,
+    expectedVersion: readPackageVersion(),
+    stage: "context-recovery",
+    autoStartSession: true,
+    writeReport: true,
+  });
+  console.log(`  ${GREEN}✓${RESET} Xcode guard proof written`);
+  console.log(`  ${DIM}  ${guard.proofFiles.markdown}${RESET}`);
+  if (guard.status === "needs_action") {
+    console.log();
+    console.log(renderXcodeGuardReport(guard));
+  }
 }
 
 export async function verifyXcode(): Promise<void> {
@@ -176,7 +235,7 @@ export async function verifyXcode(): Promise<void> {
     } else if (output.includes("axint.feature")) {
       console.log(`  ${RED}✗${RESET} MCP server is old: axint.status not found`);
       console.log(
-        `  ${DIM}  Update Axint, rerun: axint xcode setup --agent claude, then restart the Xcode agent chat${RESET}`
+        `  ${DIM}  Update Axint, rerun: axint xcode setup --agent claude --guarded, then restart the Xcode agent chat${RESET}`
       );
     } else {
       console.log(`  ${RED}✗${RESET} Server responded but axint.feature not found`);
@@ -275,6 +334,19 @@ function detectXcode(): string | null {
   }
 }
 
+function readPackageVersion(): string {
+  try {
+    const currentFile = fileURLToPath(import.meta.url);
+    const packagePath = join(dirname(dirname(currentFile)), "..", "package.json");
+    const pkg = JSON.parse(readFileSync(packagePath, "utf-8")) as {
+      version?: string;
+    };
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
 function detectMcpBridge(): boolean {
   try {
     execSync("xcrun mcpbridge --help 2>/dev/null", { timeout: 5000 });
@@ -296,12 +368,12 @@ function detectAxint(): string | null {
   }
 }
 
-function setupXcodeClaudeAgent(): void {
+function setupXcodeClaudeAgent(options: { localBuild: boolean }): void {
   console.log(`  ${BOLD}Configuring Xcode Claude Agent...${RESET}`);
 
   const configPath = join(homedir(), XCODE_CLAUDE_CONFIG);
   const command = buildLocalMcpServerCommand({
-    preferAbsoluteNpx: true,
+    preferAbsoluteNpx: !options.localBuild,
     requireAbsoluteNode: true,
   });
 
@@ -310,7 +382,7 @@ function setupXcodeClaudeAgent(): void {
       `  ${DIM}ℹ${RESET} Could not find a durable Axint MCP script. Install globally, then rerun:`
     );
     console.log(`  ${DIM}  npm install -g ${AXINT_NPM_PACKAGE}${RESET}`);
-    console.log(`  ${DIM}  axint xcode setup --agent claude${RESET}`);
+    console.log(`  ${DIM}  axint xcode setup --agent claude --guarded${RESET}`);
     return;
   }
 
@@ -511,7 +583,7 @@ function printManualClaude(remote: boolean): void {
     );
     console.log();
     console.log(
-      `  ${DIM}For Xcode's built-in Claude Agent, run: axint xcode setup --agent claude${RESET}`
+      `  ${DIM}For Xcode's built-in Claude Agent, run: axint xcode setup --agent claude --guarded${RESET}`
     );
   }
   console.log();

--- a/src/core/swift-validator.ts
+++ b/src/core/swift-validator.ts
@@ -459,6 +459,13 @@ function collectTopLevelPropertyNames(
           )
         : null;
     if (match?.[1]) names.add(match[1]);
+    const funcMatch =
+      depth === 0
+        ? rawLine.match(
+            /^\s*(?:@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?\s*)*(?:(?:public|private|fileprivate|internal|open|static|nonisolated)\s+)*func\s+([A-Za-z_][A-Za-z0-9_]*)\b/
+          )
+        : null;
+    if (funcMatch?.[1]) names.add(funcMatch[1]);
 
     for (const ch of strippedLine) {
       if (ch === "{") depth++;
@@ -471,8 +478,13 @@ function collectTopLevelPropertyNames(
 
 function collectLocalNames(bodySource: string): Set<string> {
   const names = new Set<string>();
-  for (const match of bodySource.matchAll(/\{\s*([A-Za-z_][A-Za-z0-9_]*)\s+in\b/g)) {
-    names.add(match[1]!);
+  for (const match of bodySource.matchAll(
+    /\{\s*\(?\s*((?:[A-Za-z_][A-Za-z0-9_]*|_)(?:\s*,\s*(?:[A-Za-z_][A-Za-z0-9_]*|_))*)\s*\)?\s+in\b/g
+  )) {
+    for (const part of match[1]!.split(",")) {
+      const name = part.trim();
+      if (name && name !== "_") names.add(name);
+    }
   }
   for (const match of bodySource.matchAll(
     /\b(?:if|guard)\s+(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\b/g

--- a/src/mcp/doctor.ts
+++ b/src/mcp/doctor.ts
@@ -144,7 +144,7 @@ function versionCheck(
     detail: `running ${runningVersion}, expected ${expectedVersion}`,
     fix: matches
       ? undefined
-      : "Install the expected Axint version, rerun axint xcode setup --agent claude, then restart the Xcode agent chat.",
+      : "Install the expected Axint version, rerun axint xcode setup --agent claude --guarded, then restart the Xcode agent chat.",
   };
 }
 
@@ -216,7 +216,7 @@ function mcpConfigCheck(cwd: string): MachineDoctorCheck {
       fix:
         hasAxint && durable
           ? undefined
-          : "Run axint project init --force or axint xcode setup --agent claude.",
+          : "Run axint project init --force or axint xcode setup --agent claude --guarded.",
     };
   } catch {
     return {
@@ -243,7 +243,7 @@ function agentConfigCheck(): MachineDoctorCheck {
       label: "Xcode Claude Agent config",
       status: "warn",
       detail: "not found",
-      fix: "Run axint xcode setup --agent claude after installing Axint.",
+      fix: "Run axint xcode setup --agent claude --guarded after installing Axint.",
     };
   }
   const text = readFileSync(configPath, "utf-8");
@@ -252,7 +252,7 @@ function agentConfigCheck(): MachineDoctorCheck {
     label: "Xcode Claude Agent config",
     status: hasAxint ? "ok" : "warn",
     detail: hasAxint ? "axint registered" : "config exists but axint not registered",
-    fix: hasAxint ? undefined : "Run axint xcode setup --agent claude.",
+    fix: hasAxint ? undefined : "Run axint xcode setup --agent claude --guarded.",
   };
 }
 

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -68,6 +68,172 @@ export const TOOL_MANIFEST = [
     },
   },
   {
+    name: "axint.xcode.guard",
+    description:
+      "Guard an Xcode agent session against context compaction and Axint drift. " +
+      "Checks project memory files, active Axint session, latest Axint Run or guard proof, " +
+      "and long-task freshness. Writes .axint/guard/latest.json and latest.md so the " +
+      "user can audit whether Axint was actually used during a long Xcode task. " +
+      "Use this before long Xcode tasks, after context recovery, before broad Swift edits, " +
+      "and before claiming a build/runtime fix is done.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cwd: {
+          type: "string",
+          description: "Project directory to guard. Defaults to the MCP process cwd.",
+        },
+        projectName: {
+          type: "string",
+          description: "Project name for the guard report.",
+        },
+        expectedVersion: {
+          type: "string",
+          description: "Expected Axint version for the active project.",
+        },
+        platform: {
+          type: "string",
+          description: "Target Apple platform, such as macOS, iOS, visionOS, or all.",
+        },
+        stage: {
+          type: "string",
+          enum: [
+            "context-recovery",
+            "planning",
+            "before-write",
+            "after-write",
+            "pre-build",
+            "runtime",
+            "finish",
+          ],
+          description: "Current Xcode workflow stage. Defaults to context-recovery.",
+        },
+        sessionToken: {
+          type: "string",
+          description: "Current axint.session.start token, if already known.",
+        },
+        modifiedFiles: {
+          type: "array",
+          items: { type: "string" },
+          description: "Files in scope for this task.",
+        },
+        notes: {
+          type: "string",
+          description:
+            "Agent/user notes to scan for compaction, drift, forgotten Axint usage, or long-task risk.",
+        },
+        lastAxintTool: {
+          type: "string",
+          description:
+            "Last Axint tool the agent used, e.g. axint.suggest or axint.feature.",
+        },
+        lastAxintResult: {
+          type: "string",
+          description: "Short result from the last Axint tool call.",
+        },
+        maxMinutesSinceAxint: {
+          type: "number",
+          description:
+            "Maximum allowed minutes since latest Axint evidence. Defaults to 10.",
+        },
+        autoStartSession: {
+          type: "boolean",
+          description:
+            "Whether to start axint.session.start automatically if no active session exists. Defaults to true.",
+        },
+        writeReport: {
+          type: "boolean",
+          description:
+            "Whether to write .axint/guard/latest.json and latest.md. Defaults to true.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json"],
+          description: "Output format. Defaults to markdown.",
+        },
+      },
+    },
+  },
+  {
+    name: "axint.xcode.write",
+    description:
+      "Write a file inside the Xcode project through the Axint guard path. " +
+      "For Swift files, runs axint.swift.validate and axint.cloud.check immediately, " +
+      "then records .axint/guard/latest.* proof. Use this instead of raw XcodeWrite " +
+      "when an agent is editing Apple-native files during a long task.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      required: ["path", "content"],
+      properties: {
+        cwd: {
+          type: "string",
+          description: "Project root. Defaults to the MCP process cwd.",
+        },
+        path: {
+          type: "string",
+          description:
+            "File path to write. Relative paths are resolved inside cwd; absolute paths must still be inside cwd.",
+        },
+        content: {
+          type: "string",
+          description: "Full file contents to write.",
+        },
+        projectName: {
+          type: "string",
+          description: "Project name for guard/session reports.",
+        },
+        expectedVersion: {
+          type: "string",
+          description: "Expected Axint version for this project.",
+        },
+        platform: {
+          type: "string",
+          enum: ["iOS", "macOS", "watchOS", "visionOS", "all"],
+          description: "Target Apple platform for Cloud Check.",
+        },
+        sessionToken: {
+          type: "string",
+          description: "Current axint.session.start token, if already known.",
+        },
+        createDirs: {
+          type: "boolean",
+          description:
+            "Whether to create parent directories before writing. Defaults to true.",
+        },
+        validateSwift: {
+          type: "boolean",
+          description:
+            "Whether to run Swift validation for .swift files. Defaults to true.",
+        },
+        cloudCheck: {
+          type: "boolean",
+          description: "Whether to run Cloud Check for .swift files. Defaults to true.",
+        },
+        notes: {
+          type: "string",
+          description: "Agent notes or user feedback to scan for drift while writing.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json"],
+          description: "Output format. Defaults to markdown.",
+        },
+      },
+    },
+  },
+  {
     name: "axint.session.start",
     description:
       "Start an enforced Axint agent session. Writes " +
@@ -832,6 +998,127 @@ export const TOOL_MANIFEST = [
           enum: ["markdown", "json", "prompt", "feedback"],
           description:
             "Output format. markdown returns the report, json returns structured data, prompt returns only the repair prompt, and feedback returns only the privacy-preserving learning signal.",
+        },
+      },
+    },
+  },
+  {
+    name: "axint.run",
+    description:
+      "Run the enforced Axint Apple build loop outside the Xcode UI. Starts or refreshes " +
+      "the Axint session, validates Swift, runs Cloud Check, executes xcodebuild build/test " +
+      "when a project or workspace is present, optionally launches a macOS app for runtime " +
+      "evidence, writes .axint/run/latest artifacts, and returns an agent-ready repair prompt. " +
+      "Use this when the agent might forget the Axint workflow: one tool call owns the gate.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cwd: {
+          type: "string",
+          description: "Project directory to run. Defaults to the MCP process cwd.",
+        },
+        projectName: {
+          type: "string",
+          description: "Project name for Axint session and report labels.",
+        },
+        expectedVersion: {
+          type: "string",
+          description: "Expected Axint package version for the run session.",
+        },
+        platform: {
+          type: "string",
+          enum: ["macOS", "iOS", "watchOS", "visionOS", "all"],
+          description:
+            "Target Apple platform. Defaults to macOS unless inferred from destination.",
+        },
+        scheme: {
+          type: "string",
+          description: "Xcode scheme. If omitted, Axint tries to infer one.",
+        },
+        workspace: {
+          type: "string",
+          description: "Path to .xcworkspace, relative to cwd or absolute.",
+        },
+        project: {
+          type: "string",
+          description: "Path to .xcodeproj, relative to cwd or absolute.",
+        },
+        destination: {
+          type: "string",
+          description:
+            "xcodebuild destination, e.g. platform=macOS or platform=iOS Simulator,name=iPhone 16.",
+        },
+        configuration: {
+          type: "string",
+          description: "Xcode build configuration, e.g. Debug or Release.",
+        },
+        derivedDataPath: {
+          type: "string",
+          description: "Optional xcodebuild -derivedDataPath.",
+        },
+        testPlan: {
+          type: "string",
+          description: "Optional xcodebuild -testPlan for test runs.",
+        },
+        modifiedFiles: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Changed Swift files to validate and Cloud Check. If omitted, Axint scans project Swift files.",
+        },
+        skipBuild: {
+          type: "boolean",
+          description: "Skip xcodebuild build and only run Axint static gates.",
+        },
+        skipTests: {
+          type: "boolean",
+          description: "Skip xcodebuild test.",
+        },
+        runtime: {
+          type: "boolean",
+          description:
+            "After build, launch the built macOS .app and capture runtime/timeout evidence.",
+        },
+        runtimeTimeoutSeconds: {
+          type: "number",
+          description: "Runtime launch timeout in seconds.",
+        },
+        timeoutSeconds: {
+          type: "number",
+          description: "Build/test timeout in seconds.",
+        },
+        expectedBehavior: {
+          type: "string",
+          description: "Expected runtime behavior for semantic bug checks.",
+        },
+        actualBehavior: {
+          type: "string",
+          description: "Actual runtime behavior for semantic bug checks.",
+        },
+        runtimeFailure: {
+          type: "string",
+          description: "Crash, freeze, hang, launch timeout, or UI failure evidence.",
+        },
+        dryRun: {
+          type: "boolean",
+          description: "Plan xcodebuild commands without executing them.",
+        },
+        writeReport: {
+          type: "boolean",
+          description:
+            "Whether to write .axint/run/latest.json and latest.md. Defaults to true.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json", "prompt"],
+          description:
+            "Output format. markdown returns the run report, json returns structured data, prompt returns only the repair prompt.",
         },
       },
     },

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -146,17 +146,19 @@ export function getPromptMessages(
               "   - https://docs.axint.ai/guides/fix-packets/\n" +
               "   - https://docs.axint.ai/reference/cli/\n" +
               "2. Call `axint.session.start` and keep the returned `sessionToken` visible.\n" +
-              "3. Read `.axint/AXINT_REHYDRATE.md`, `.axint/AXINT_MEMORY.md`, `.axint/AXINT_DOCS_CONTEXT.md`, `AGENTS.md`, `CLAUDE.md`, or `.axint/project.json` if present.\n" +
-              "4. List the available MCP servers and confirm both xcode-tools and axint are present.\n" +
-              "5. Call `axint.status` and report the running MCP server version before editing code. If the version is older than expected, stop and tell me to update Axint, rerun `axint xcode setup --agent claude`, and restart the Xcode agent chat.\n" +
-              "6. If axint is missing in Xcode, tell me to run `axint xcode setup --agent claude`, restart the Xcode agent session, and ask again for available MCP servers.\n" +
-              "7. Call `axint.workflow.check` with stage `context-recovery`, sessionToken, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.\n" +
-              "8. Call `axint.workflow.check` with `sessionToken` at planning, before-write, and pre-build checkpoints so you do not skip the Axint loop by accident.\n" +
-              "9. Use Axint tools before guessing App Intents, widgets, SwiftUI scaffolds, entitlements, Info.plist keys, or repair prompts.\n" +
-              "10. Work in short checkpoints. Do not spend 20+ minutes on a task without running Axint and Xcode validation.\n" +
-              "11. After each generated Apple surface, run `axint.cloud.check` or `axint cloud check <file> --feedback` and then build in Xcode.\n" +
-              "12. Do not claim there is no bug from Axint alone. Cloud Check is static; Xcode build, unit tests, UI tests, accessibility flows, and runtime behavior are separate evidence.\n" +
-              "13. If Axint passes but Xcode/tests/runtime fails, report the exact failure as an Axint validator or runtime-coverage gap before continuing.\n\n" +
+              "3. Call `axint.xcode.guard` with stage `context-recovery` so this chat writes `.axint/guard/latest.*` proof before any long task.\n" +
+              "4. Read `.axint/AXINT_REHYDRATE.md`, `.axint/AXINT_MEMORY.md`, `.axint/AXINT_DOCS_CONTEXT.md`, `AGENTS.md`, `CLAUDE.md`, or `.axint/project.json` if present.\n" +
+              "5. List the available MCP servers and confirm both xcode-tools and axint are present.\n" +
+              "6. Call `axint.status` and report the running MCP server version before editing code. If the version is older than expected, stop and tell me to update Axint, rerun `axint xcode setup --agent claude --guarded`, and restart the Xcode agent chat.\n" +
+              "7. If axint is missing in Xcode, tell me to run `axint xcode setup --agent claude --guarded`, restart the Xcode agent session, and ask again for available MCP servers.\n" +
+              "8. Call `axint.workflow.check` with stage `context-recovery`, sessionToken, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.\n" +
+              "9. Call `axint.xcode.guard` before long tasks and `axint.workflow.check` with `sessionToken` at planning, before-write, and pre-build checkpoints so you do not skip the Axint loop by accident.\n" +
+              "10. Use Axint tools before guessing App Intents, widgets, SwiftUI scaffolds, entitlements, Info.plist keys, or repair prompts.\n" +
+              "11. Prefer `axint.xcode.write` when writing new Swift files so validation, Cloud Check, and guard proof happen with the write.\n" +
+              "12. Work in short checkpoints. Do not spend 20+ minutes on a task without running Axint and Xcode validation.\n" +
+              "13. After each generated Apple surface, run `axint.cloud.check` or `axint cloud check <file> --feedback` and then build in Xcode.\n" +
+              "14. Do not claim there is no bug from Axint alone. Cloud Check is static; Xcode build, unit tests, UI tests, accessibility flows, and runtime behavior are separate evidence.\n" +
+              "15. If Axint passes but Xcode/tests/runtime fails, report the exact failure as an Axint validator or runtime-coverage gap before continuing.\n\n" +
               "If this chat was compacted or restarted, run axint.context-recovery before continuing.\n\n" +
               "Once that is done, summarize which docs you read, the running Axint MCP version, which MCP servers are available, and the first Axint command you will use.",
           },
@@ -178,14 +180,15 @@ export function getPromptMessages(
               `Recover the Axint workflow for ${projectName}.${lastTask}\n\n` +
               "Assume this chat may have lost context. Before editing code or continuing the prior task:\n\n" +
               "1. Call axint.session.start and keep the returned sessionToken.\n" +
-              "2. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json if they exist.\n" +
-              "3. If those files are missing, call axint.context.memory and axint.context.docs, then use them as the compact Axint operating memory and docs context.\n" +
-              "4. List the available MCP servers/tools and confirm axint is present.\n" +
-              "5. Call axint.status and report the running Axint MCP version.\n" +
-              "6. Call axint.workflow.check with stage `context-recovery`, sessionToken, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.\n" +
-              "7. If Axint is missing or stale, stop and give the exact setup/restart command instead of continuing by hand.\n" +
-              "8. Name the next Axint tool you will use before editing code.\n" +
-              "9. Do not claim a bug is fixed until Axint validation, Cloud Check, Xcode build, and relevant tests/runtime evidence support it.\n\n" +
+              "2. Call axint.xcode.guard with stage `context-recovery` so this chat writes `.axint/guard/latest.*` proof.\n" +
+              "3. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json if they exist.\n" +
+              "4. If those files are missing, call axint.context.memory and axint.context.docs, then use them as the compact Axint operating memory and docs context.\n" +
+              "5. List the available MCP servers/tools and confirm axint is present.\n" +
+              "6. Call axint.status and report the running Axint MCP version.\n" +
+              "7. Call axint.workflow.check with stage `context-recovery`, sessionToken, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.\n" +
+              "8. If Axint is missing or stale, stop and give the exact setup/restart command instead of continuing by hand.\n" +
+              "9. Name the next Axint tool you will use before editing code.\n" +
+              "10. Do not claim a bug is fixed until Axint validation, Cloud Check, Xcode build, and relevant tests/runtime evidence support it.\n\n" +
               "Output a short recovery report with: files read, Axint version, available MCP servers, workflow gate result, and next Axint action.",
           },
         },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,6 +7,8 @@
  *
  * Tools:
  *   - axint.doctor:           Audit version truth and project MCP wiring
+ *   - axint.xcode.guard:      Guard Xcode agent sessions against Axint drift
+ *   - axint.xcode.write:      Write files through Axint validation/guard path
  *   - axint.session.start:    Start enforced session token + rehydration context
  *   - axint.feature:          Generate a scaffolded Apple-native feature package
  *   - axint.suggest:          Suggest Apple-native features for an app domain
@@ -17,6 +19,7 @@
  *   - axint.compile:          Compile TypeScript intent → Swift App Intent
  *   - axint.fix-packet: Read the latest emitted Fix Packet / AI repair prompt
  *   - axint.cloud.check:     Run an agent-callable Cloud Check report
+ *   - axint.run:             Run enforced build/test/runtime loop outside Xcode UI
  *   - axint.tokens.ingest:    Convert design tokens into SwiftUI token enums
  *   - axint.validate:         Validate an intent definition without codegen
  *   - axint.schema.compile:   Compile minimal JSON schema → Swift (token saver)
@@ -76,6 +79,14 @@ import {
   type DoctorFormat,
 } from "./doctor.js";
 import {
+  renderXcodeGuardReport,
+  renderXcodeWriteReport,
+  runXcodeGuard,
+  runXcodeWrite,
+  type XcodeGuardFormat,
+  type XcodeGuardStage,
+} from "../project/xcode-guard.js";
+import {
   buildProjectStartPack,
   renderProjectStartPack,
   type ProjectAgent,
@@ -90,6 +101,12 @@ import {
   type AxintSessionAgent,
   type AxintSessionFormat,
 } from "../project/session.js";
+import {
+  renderAxintRunReport,
+  runAxintProject,
+  type AxintRunFormat,
+  type AxintRunPlatform,
+} from "../run/project-runner.js";
 
 type PackageInfo = {
   name?: string;
@@ -104,6 +121,36 @@ type DoctorArgs = {
   cwd?: string;
   expectedVersion?: string;
   format?: DoctorFormat;
+};
+type XcodeGuardArgs = {
+  cwd?: string;
+  projectName?: string;
+  expectedVersion?: string;
+  platform?: string;
+  stage?: XcodeGuardStage;
+  sessionToken?: string;
+  modifiedFiles?: string[];
+  notes?: string;
+  lastAxintTool?: string;
+  lastAxintResult?: string;
+  maxMinutesSinceAxint?: number;
+  autoStartSession?: boolean;
+  writeReport?: boolean;
+  format?: XcodeGuardFormat;
+};
+type XcodeWriteArgs = {
+  cwd?: string;
+  path: string;
+  content: string;
+  projectName?: string;
+  expectedVersion?: string;
+  platform?: "iOS" | "macOS" | "watchOS" | "visionOS" | "all";
+  sessionToken?: string;
+  createDirs?: boolean;
+  validateSwift?: boolean;
+  cloudCheck?: boolean;
+  notes?: string;
+  format?: XcodeGuardFormat;
 };
 type SessionStartArgs = {
   targetDir?: string;
@@ -162,6 +209,31 @@ type CloudCheckArgs = {
   actualBehavior?: string;
   format?: CloudCheckFormat;
 };
+type AxintRunArgs = {
+  cwd?: string;
+  projectName?: string;
+  expectedVersion?: string;
+  platform?: AxintRunPlatform;
+  scheme?: string;
+  workspace?: string;
+  project?: string;
+  destination?: string;
+  configuration?: string;
+  derivedDataPath?: string;
+  testPlan?: string;
+  modifiedFiles?: string[];
+  skipBuild?: boolean;
+  skipTests?: boolean;
+  runtime?: boolean;
+  runtimeTimeoutSeconds?: number;
+  timeoutSeconds?: number;
+  expectedBehavior?: string;
+  actualBehavior?: string;
+  runtimeFailure?: string;
+  dryRun?: boolean;
+  writeReport?: boolean;
+  format?: AxintRunFormat;
+};
 type TokensIngestArgs = TokenIngestArgs & {
   format?: TokenOutputFormat;
 };
@@ -218,7 +290,7 @@ function renderStatus(format: StatusArgs["format"] = "markdown"): string {
     promptsRegistered: PROMPT_MANIFEST.length,
     restartRequiredAfterUpdate: true,
     updateCommand: "npm install -g @axint/compiler@latest",
-    xcodeSetupCommand: "axint xcode setup --agent claude",
+    xcodeSetupCommand: "axint xcode setup --agent claude --guarded",
     doctorCommand: "axint doctor",
     projectInitCommand: "axint project init",
     xcodeRestartInstruction:
@@ -231,7 +303,7 @@ function renderStatus(format: StatusArgs["format"] = "markdown"): string {
     return [
       `The running Axint MCP server is v${status.version}.`,
       "If this is older than the version the user expects, stop before editing code.",
-      "Tell the user to update Axint, rerun `axint xcode setup --agent claude`, and restart the Xcode Claude Agent chat.",
+      "Tell the user to update Axint, rerun `axint xcode setup --agent claude --guarded`, and restart the Xcode Claude Agent chat.",
     ].join("\n");
   }
 
@@ -259,7 +331,7 @@ function renderStatus(format: StatusArgs["format"] = "markdown"): string {
     status.updateCommand,
     "```",
     "",
-    "2. Rewrite the Xcode Claude Agent MCP config with durable paths:",
+    "2. Rewrite the Xcode Claude Agent MCP config with durable paths and guarded project proof:",
     "",
     "```sh",
     status.xcodeSetupCommand,
@@ -303,6 +375,64 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
         {
           type: "text" as const,
           text: renderMachineDoctorReport(report, a?.format ?? "markdown"),
+        },
+      ],
+      isError: report.status === "fail",
+    };
+  }
+
+  if (name === "axint.xcode.guard") {
+    const a = args as XcodeGuardArgs | undefined;
+    const report = runXcodeGuard({
+      cwd: a?.cwd,
+      projectName: a?.projectName,
+      expectedVersion: a?.expectedVersion ?? pkg.version,
+      platform: a?.platform,
+      stage: a?.stage,
+      sessionToken: a?.sessionToken,
+      modifiedFiles: a?.modifiedFiles,
+      notes: a?.notes,
+      lastAxintTool: a?.lastAxintTool,
+      lastAxintResult: a?.lastAxintResult,
+      maxMinutesSinceAxint: a?.maxMinutesSinceAxint,
+      autoStartSession: a?.autoStartSession ?? true,
+      writeReport: a?.writeReport ?? true,
+    });
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: renderXcodeGuardReport(report, a?.format ?? "markdown"),
+        },
+      ],
+      isError: report.status === "needs_action",
+    };
+  }
+
+  if (name === "axint.xcode.write") {
+    const a = args as XcodeWriteArgs;
+    if (!a?.path || typeof a.content !== "string") {
+      return errorText("Error: 'path' and 'content' are required for axint.xcode.write");
+    }
+    const report = runXcodeWrite({
+      cwd: a.cwd,
+      path: a.path,
+      content: a.content,
+      projectName: a.projectName,
+      expectedVersion: a.expectedVersion ?? pkg.version,
+      platform: a.platform,
+      sessionToken: a.sessionToken,
+      createDirs: a.createDirs,
+      validateSwift: a.validateSwift,
+      cloudCheck: a.cloudCheck,
+      notes: a.notes,
+      format: a.format,
+    });
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: renderXcodeWriteReport(report, a.format ?? "markdown"),
         },
       ],
       isError: report.status === "fail",
@@ -520,6 +650,44 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
         {
           type: "text" as const,
           text: renderCloudCheckReport(report, a.format ?? "markdown"),
+        },
+      ],
+      isError: report.status === "fail",
+    };
+  }
+
+  if (name === "axint.run") {
+    const a = args as AxintRunArgs;
+    const report = await runAxintProject({
+      cwd: a.cwd,
+      kind: "local",
+      projectName: a.projectName,
+      expectedVersion: a.expectedVersion ?? pkg.version,
+      platform: a.platform,
+      scheme: a.scheme,
+      workspace: a.workspace,
+      project: a.project,
+      destination: a.destination,
+      configuration: a.configuration,
+      derivedDataPath: a.derivedDataPath,
+      testPlan: a.testPlan,
+      modifiedFiles: a.modifiedFiles,
+      skipBuild: a.skipBuild,
+      skipTests: a.skipTests,
+      runtime: a.runtime,
+      runtimeTimeoutSeconds: a.runtimeTimeoutSeconds,
+      timeoutSeconds: a.timeoutSeconds,
+      expectedBehavior: a.expectedBehavior,
+      actualBehavior: a.actualBehavior,
+      runtimeFailure: a.runtimeFailure,
+      dryRun: a.dryRun,
+      writeReport: a.writeReport,
+    });
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: renderAxintRunReport(report, a.format ?? "markdown"),
         },
       ],
       isError: report.status === "fail",

--- a/src/project/docs-context.ts
+++ b/src/project/docs-context.ts
@@ -27,8 +27,9 @@ When a chat is new, compacted, summarized, or confused, reload context in this o
 4. \`.axint/project.json\`: machine-readable gates and pinned version.
 5. \`AGENTS.md\` and \`CLAUDE.md\`: local instructions for the active agent.
 6. \`axint.session.start\`: writes \`.axint/session/current.json\` and returns the session token.
-7. \`axint.status\`: current MCP version and restart/setup guidance.
-8. \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
+7. \`axint.xcode.guard\`: writes \`.axint/guard/latest.*\` so the user can audit whether Axint was used after a long Xcode task.
+8. \`axint.status\`: current MCP version and restart/setup guidance.
+9. \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
 
 If any local context file is missing, call \`axint.context.memory\` and \`axint.context.docs\`, then continue from those returned documents.
 
@@ -47,6 +48,8 @@ Examples:
 - \`Axint checkpoint: runtime · axint.cloud.check with runtimeFailure · AXCLOUD-RUNTIME-FREEZE · next sample main thread\`
 
 If the agent cannot name the current checkpoint, it must stop and run \`axint.workflow.check\`.
+
+For Xcode work, prefer \`axint.xcode.guard\` as the checkpoint because it creates durable proof under \`.axint/guard/latest.*\`.
 
 ## What Axint Is
 
@@ -69,20 +72,22 @@ Use this loop before ordinary hand-written Swift:
 
 1. \`axint.status\` confirms the running MCP version.
 2. \`axint.session.start\` creates a durable token for the current agent pass.
-3. \`axint.context.memory\` reloads compact operating memory when local files are missing.
-4. \`axint.context.docs\` reloads this docs context when local files are missing.
-5. \`axint.workflow.check\` verifies the agent is at the right gate and has the active token.
-6. \`axint.suggest\` proposes relevant Apple-native surfaces from the app description.
-7. \`axint.feature\` generates a package of surfaces: intent, view, widget, component, app, store, tests, plist, and entitlements.
-8. \`axint.scaffold\` creates TypeScript \`defineIntent(...)\` source for an App Intent.
-9. \`axint.compile\` compiles TypeScript intent source to Swift + Info.plist + entitlements.
-10. \`axint.schema.compile\` compiles low-token JSON directly to Swift.
-11. \`axint.tokens.ingest\` converts design tokens into SwiftUI token enums.
-12. \`axint.swift.validate\` checks changed Swift before Xcode build.
-13. \`axint.swift.fix\` applies mechanical Swift repairs when safe.
-14. \`axint.cloud.check\` runs coverage-aware Cloud Check with source plus build/test/runtime evidence.
-15. \`axint.fix-packet\` reads the latest AI-ready repair packet.
-16. Xcode build and tests provide runtime proof.
+3. \`axint.xcode.guard\` proves the Xcode agent is still inside the Axint loop.
+4. \`axint.context.memory\` reloads compact operating memory when local files are missing.
+5. \`axint.context.docs\` reloads this docs context when local files are missing.
+6. \`axint.workflow.check\` verifies the agent is at the right gate and has the active token.
+7. \`axint.suggest\` proposes relevant Apple-native surfaces from the app description.
+8. \`axint.feature\` generates a package of surfaces: intent, view, widget, component, app, store, tests, plist, and entitlements.
+9. \`axint.xcode.write\` writes Swift files through the guard path and runs validation/Cloud Check immediately.
+10. \`axint.scaffold\` creates TypeScript \`defineIntent(...)\` source for an App Intent.
+11. \`axint.compile\` compiles TypeScript intent source to Swift + Info.plist + entitlements.
+12. \`axint.schema.compile\` compiles low-token JSON directly to Swift.
+13. \`axint.tokens.ingest\` converts design tokens into SwiftUI token enums.
+14. \`axint.swift.validate\` checks changed Swift before Xcode build.
+15. \`axint.swift.fix\` applies mechanical Swift repairs when safe.
+16. \`axint.cloud.check\` runs coverage-aware Cloud Check with source plus build/test/runtime evidence.
+17. \`axint.fix-packet\` reads the latest AI-ready repair packet.
+18. Xcode build and tests provide runtime proof.
 
 ## Axint Language And Input Surfaces
 
@@ -145,6 +150,8 @@ axint.tokens.ingest -> axint.suggest -> axint.feature with context -> axint.swif
 - \`axint.status\`: running version, uptime, package path, restart/update help.
 - \`axint.doctor\`: checks version truth, Node/npm/npx paths, MCP config, Xcode Claude config, and project memory files.
 - \`axint.session.start\`: starts the enforced session, writes \`.axint/session/current.json\`, and returns the token required by workflow gates.
+- \`axint.xcode.guard\`: checks for Xcode drift, enforces fresh Axint evidence, and writes \`.axint/guard/latest.json\` plus \`.axint/guard/latest.md\`.
+- \`axint.xcode.write\`: writes files inside the project through Axint, then runs Swift validation, Cloud Check, and guard proof for Swift files.
 - \`axint.project.pack\`: returns first-try project setup files without writing.
 - \`axint.context.memory\`: returns compact operating memory for context recovery.
 - \`axint.context.docs\`: returns this docs context for context recovery.
@@ -202,7 +209,7 @@ Typical project setup:
 
 \`\`\`bash
 npm install -g @axint/compiler
-axint xcode setup --agent claude
+axint xcode setup --agent claude --guarded
 axint project init --dir /path/to/App --name AppName --agent claude --force
 \`\`\`
 

--- a/src/project/operating-memory.ts
+++ b/src/project/operating-memory.ts
@@ -27,22 +27,26 @@ Work in Axint first:
 2. Gate each stage with \`axint.workflow.check\` and the active \`sessionToken\`.
 3. Plan with \`axint.suggest\`.
 4. Generate or scaffold with \`axint.feature\`, \`axint.scaffold\`, \`axint.compile\`, or \`axint.schema.compile\`.
-5. Validate changed Swift with \`axint.swift.validate\`.
-6. Run \`axint.cloud.check\` with source and any Xcode/test/runtime evidence.
-7. Build and test in Xcode.
-8. If Axint passes but Xcode, UI tests, accessibility, or runtime behavior fails, report that as an Axint coverage gap before continuing.
+5. Prefer \`axint.run\` when you need the whole loop in one call. It starts/refreshes the session, validates, Cloud Checks, builds/tests with \`xcodebuild\`, and writes \`.axint/run/latest.*\`.
+6. In Xcode, call \`axint.xcode.guard\` before long tasks, after context recovery, and whenever the agent might drift. It writes \`.axint/guard/latest.*\` so the user can audit whether Axint was actually used.
+7. Prefer \`axint.xcode.write\` for new Swift files so the write itself runs Swift validation, Cloud Check, and guard proof.
+8. If running tools manually, validate changed Swift with \`axint.swift.validate\`.
+9. Run \`axint.cloud.check\` with source and any Xcode/test/runtime evidence.
+10. Build and test with Xcode or \`axint run\`.
+11. If Axint passes but Xcode, UI tests, accessibility, or runtime behavior fails, report that as an Axint coverage gap before continuing.
 
 ## Context Recovery
 
 Models lose memory when chats compact. The project does not. When context is missing, compacted, or uncertain:
 
 1. Call \`axint.session.start\` and keep the returned \`sessionToken\`.
-2. Read \`.axint/AXINT_REHYDRATE.md\`, this file, \`.axint/AXINT_DOCS_CONTEXT.md\`, \`AGENTS.md\`, \`CLAUDE.md\`, and \`.axint/project.json\`.
-3. If the docs context file is missing, call \`axint.context.docs\`.
-4. List MCP servers/tools and confirm \`axint\` is present.
-5. Call \`axint.status\` and compare the running MCP version with the expected version above.
-6. Call \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
-7. Name the next Axint tool before editing code.
+2. Call \`axint.xcode.guard\` with \`stage: "context-recovery"\` so this chat writes durable guard proof.
+3. Read \`.axint/AXINT_REHYDRATE.md\`, this file, \`.axint/AXINT_DOCS_CONTEXT.md\`, \`AGENTS.md\`, \`CLAUDE.md\`, and \`.axint/project.json\`.
+4. If the docs context file is missing, call \`axint.context.docs\`.
+5. List MCP servers/tools and confirm \`axint\` is present.
+6. Call \`axint.status\` and compare the running MCP version with the expected version above.
+7. Call \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
+8. Name the next Axint tool before editing code.
 
 If Axint is missing or stale, stop. Do not continue by hand. Tell the user to reinstall/update Axint, rerun the Xcode setup, and restart the Xcode agent chat.
 
@@ -51,11 +55,14 @@ If Axint is missing or stale, stop. Do not continue by hand. Tell the user to re
 Do not spend more than 10 minutes or make broad multi-file Swift changes without an Axint checkpoint. A checkpoint means one of:
 
 - \`axint.workflow.check\`
+- \`axint.xcode.guard\`
+- \`axint.xcode.write\`
 - \`axint.session.start\`
 - \`axint.suggest\`
 - \`axint.feature\`
 - \`axint.swift.validate\`
 - \`axint.cloud.check\`
+- \`axint.run\`
 - Xcode build/test evidence tied back to the Axint report
 
 Every long-running response should keep this visible:
@@ -66,13 +73,15 @@ Axint checkpoint: <stage> · <last Axint tool> · <result> · next <proof step>
 
 If the agent cannot fill this out, it must run \`axint.workflow.check\` before continuing.
 
+For Xcode work, prefer \`axint.xcode.guard\` as the checkpoint because it writes durable proof under \`.axint/guard/latest.*\`.
+
 ## Proof Rules
 
 - Static validation is not runtime proof.
 - Cloud Check must say what it checked and what it did not check.
 - For SwiftUI and app behavior, use Xcode build, focused tests, UI smoke tests, previews, or runtime evidence.
 - Do not claim a bug is fixed until validation plus relevant runtime evidence supports it.
-- For freezes, hangs, beachballs, launch timeouts, and unresponsive UI, call \`axint.cloud.check\` with \`runtimeFailure\`, \`expectedBehavior\`, \`actualBehavior\`, platform, and the suspicious source file.
+- For freezes, hangs, beachballs, launch timeouts, and unresponsive UI, prefer \`axint run --runtime\` on macOS or call \`axint.cloud.check\` with \`runtimeFailure\`, \`expectedBehavior\`, \`actualBehavior\`, platform, and the suspicious source file.
 - If Axint returns a clean static pass but the app still freezes, the next action is runtime evidence, not more ordinary coding.
 
 ## Docs To Refresh When Needed
@@ -87,7 +96,7 @@ If the agent cannot fill this out, it must run \`axint.workflow.check\` before c
 ## Recovery Prompt
 
 \`\`\`text
-Call axint.session.start for this project and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If docs context is missing, call axint.context.docs. Then list MCP servers, call axint.status, call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true, and tell me the next Axint tool you will use before editing code.
+Call axint.xcode.guard with stage=context-recovery, then call axint.session.start if the guard asks for it and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If docs context is missing, call axint.context.docs. Then list MCP servers, call axint.status, call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true. For build/test/runtime proof, use axint.run instead of manually remembering every Axint gate.
 \`\`\`
 `;
 }

--- a/src/project/rehydration.ts
+++ b/src/project/rehydration.ts
@@ -29,10 +29,11 @@ The model's memory is not the source of truth. These project files are. If the a
 ## Rehydrate In This Exact Order
 
 1. Call \`axint.session.start\` for this project and keep the returned \`sessionToken\`.
-2. Read \`.axint/AXINT_REHYDRATE.md\`, \`.axint/AXINT_MEMORY.md\`, and \`.axint/AXINT_DOCS_CONTEXT.md\`.
-3. Read \`AGENTS.md\`, \`CLAUDE.md\`, or \`.axint/project.json\` if present.
-4. Call \`axint.status\` and report the running MCP version.
-5. Call \`axint.workflow.check\` with:
+2. Call \`axint.xcode.guard\` with \`stage: "context-recovery"\` so this chat writes \`.axint/guard/latest.*\` proof.
+3. Read \`.axint/AXINT_REHYDRATE.md\`, \`.axint/AXINT_MEMORY.md\`, and \`.axint/AXINT_DOCS_CONTEXT.md\`.
+4. Read \`AGENTS.md\`, \`CLAUDE.md\`, or \`.axint/project.json\` if present.
+5. Call \`axint.status\` and report the running MCP version.
+6. Call \`axint.workflow.check\` with:
 
 \`\`\`json
 {
@@ -46,13 +47,15 @@ The model's memory is not the source of truth. These project files are. If the a
 }
 \`\`\`
 
-6. State the next Axint tool before editing code.
+7. State the next Axint tool before editing code.
 
 ## Required Checkpoints
 
 - Planning: \`axint.workflow.check\` with \`stage: "planning"\` and \`ranSuggest: true\`.
 - New surface: \`axint.workflow.check\` with \`stage: "before-write"\`, \`ranSuggest: true\`, and either \`ranFeature: true\` or a real \`featureBypassReason\`.
-- Before build: \`axint.workflow.check\` with \`stage: "pre-build"\`, \`ranSwiftValidate: true\`, and \`ranCloudCheck: true\`.
+- Long Xcode task: \`axint.xcode.guard\` with the current \`stage\` before starting and again before claiming done.
+- New Swift file: prefer \`axint.xcode.write\` so the write runs validation, Cloud Check, and guard proof immediately.
+- Before build: prefer \`axint.run\` for the full enforced loop. If doing it manually, call \`axint.workflow.check\` with \`stage: "pre-build"\`, \`ranSwiftValidate: true\`, and \`ranCloudCheck: true\`.
 - Before done: \`axint.workflow.check\` with \`stage: "pre-commit"\`, validation, Cloud Check, build evidence, and relevant tests.
 
 ## Drift Triggers
@@ -61,7 +64,7 @@ Rehydrate immediately if any of these are true:
 
 - The chat was compacted, summarized, restarted, or opened as a new chat.
 - The agent says Axint is unavailable, stale, or it is unsure what MCP tools exist.
-- The agent has been coding for a long block without \`axint.suggest\`, \`axint.feature\`, \`axint.swift.validate\`, \`axint.cloud.check\`, or \`axint.workflow.check\`.
+- The agent has been coding for a long block without \`axint.xcode.guard\`, \`axint.xcode.write\`, \`axint.suggest\`, \`axint.feature\`, \`axint.swift.validate\`, \`axint.cloud.check\`, \`axint.run\`, or \`axint.workflow.check\`.
 - Xcode, UI tests, previews, accessibility, or runtime behavior fail after Axint returned a static pass.
 - The task touches App Intents, SwiftUI views/components, widgets, shared stores, plist, entitlements, design tokens, or Xcode repair loops.
 
@@ -73,6 +76,6 @@ Every long response should keep this visible:
 Axint checkpoint: <stage> · <last Axint tool> · <result> · next <proof step>
 \`\`\`
 
-If the agent cannot fill that line honestly, it must run \`axint.workflow.check\` before continuing.
+If the agent cannot fill that line honestly, it must run \`axint.xcode.guard\` or \`axint.workflow.check\` before continuing.
 `;
 }

--- a/src/project/start-pack.ts
+++ b/src/project/start-pack.ts
@@ -121,12 +121,15 @@ export function buildProjectStartPack(
           docs: DOCS,
           requiredLoop: [
             "axint.session.start",
+            "axint.xcode.guard",
             "axint.status",
             "axint.workflow.check",
             "axint.suggest",
             "axint.feature or axint.scaffold",
+            "axint.xcode.write for guarded file writes when available",
             "axint.swift.validate",
             "axint.cloud.check",
+            "axint.run",
             "Xcode build/test evidence",
           ],
           session: {
@@ -145,21 +148,24 @@ export function buildProjectStartPack(
             ],
             requiredActions: [
               "call axint.session.start",
+              "call axint.xcode.guard with stage=context-recovery",
               "read .axint/AXINT_REHYDRATE.md",
               "read .axint/AXINT_MEMORY.md",
               "read .axint/AXINT_DOCS_CONTEXT.md or call axint.context.docs",
               "read AGENTS.md, CLAUDE.md, or .axint/project.json",
               "call axint.status",
               "call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readDocsContext=true, readAgentInstructions=true, and ranStatus=true",
-              "state the next Axint tool that will be used",
+              "state the next Axint tool that will be used, or call axint.run for the full validation/build loop",
             ],
           },
           rules: {
             noStaticOnlyBugClaims: true,
             restartMcpAfterUpdate: true,
             cloudCheckNeedsRuntimeEvidenceForViews: true,
+            preferAxintRunForBuildTestRuntimeProof: true,
             recoverAxintAfterContextCompaction: true,
             doNotWorkLongerThanTenMinutesWithoutAxintCheckpoint: true,
+            preferXcodeGuardBeforeLongTasks: true,
           },
         },
         null,
@@ -275,19 +281,23 @@ function buildStartPrompt(input: { projectName: string; version: string }): stri
     "",
     "Then do this exact startup sequence:",
     "1. Call axint.session.start for this project. Keep the returned sessionToken visible.",
-    "2. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, or .axint/project.json if present.",
-    "3. If those files are missing, call axint.context.memory and axint.context.docs, then use those as the compact Axint operating memory and docs context.",
-    "4. List MCP servers/tools and confirm axint is available.",
-    "5. Call axint.status and report the running MCP server version.",
-    "6. Call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.",
-    `7. Expected Axint package version from this project pack: ${input.version}.`,
-    "8. If the running MCP version is stale, stop and tell me to update Axint, rerun axint xcode setup --agent claude, and restart this Xcode agent chat.",
-    "9. Call axint.workflow.check with sessionToken at planning, before-write, pre-build, and pre-commit checkpoints.",
-    "10. Before planning new Apple-native surfaces, call axint.suggest.",
-    "11. For generated surfaces, use axint.feature, axint.scaffold, axint.compile, or axint.schema.compile before hand-writing from scratch.",
-    "12. Before each build, run axint.swift.validate on changed Swift and axint.cloud.check with source plus Xcode/test/runtime evidence when available.",
-    "13. Never claim there is no bug from Axint alone. Cloud Check is static unless build, UI test, or runtime evidence is supplied.",
-    "14. If Axint passes but Xcode/tests/runtime fails, report the failure as an Axint feedback signal before continuing.",
+    "2. Call axint.xcode.guard with stage=context-recovery so this chat writes .axint/guard/latest.* proof before any long task.",
+    "3. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, or .axint/project.json if present.",
+    "4. If those files are missing, call axint.context.memory and axint.context.docs, then use those as the compact Axint operating memory and docs context.",
+    "5. List MCP servers/tools and confirm axint is available.",
+    "6. Call axint.status and report the running MCP server version.",
+    "7. Call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.",
+    `8. Expected Axint package version from this project pack: ${input.version}.`,
+    "9. If the running MCP version is stale, stop and tell me to update Axint, rerun axint xcode setup --agent claude --guarded, and restart this Xcode agent chat.",
+    "10. Call axint.xcode.guard before long tasks, before broad Swift edits, and after any context recovery.",
+    "11. Call axint.workflow.check with sessionToken at planning, before-write, pre-build, and pre-commit checkpoints.",
+    "12. Before planning new Apple-native surfaces, call axint.suggest.",
+    "13. For generated surfaces, use axint.feature, axint.scaffold, axint.compile, or axint.schema.compile before hand-writing from scratch.",
+    "14. Prefer axint.run before each build so the session, workflow gate, Swift validation, Cloud Check, xcodebuild, tests, and runtime evidence stay tied together.",
+    "15. When writing new Swift files from MCP, prefer axint.xcode.write so validation, Cloud Check, and guard proof happen with the write.",
+    "16. If you cannot use axint.run, manually run axint.swift.validate on changed Swift and axint.cloud.check with source plus Xcode/test/runtime evidence when available.",
+    "17. Never claim there is no bug from Axint alone. Cloud Check is static unless build, UI test, or runtime evidence is supplied.",
+    "18. If Axint passes but Xcode/tests/runtime fails, report the failure as an Axint feedback signal before continuing.",
     "",
     "Context recovery rule: if this chat was compacted, restarted, or you are unsure whether Axint was used recently, stop and rerun steps 1-6 before continuing.",
     "Long-task rule: do not work more than 10 minutes or make broad multi-file Swift changes without an Axint checkpoint.",
@@ -323,25 +333,29 @@ ${buildStartPrompt({ projectName: input.projectName, version: input.version })}
 If the chat was restarted, compacted, summarized, or has drifted into ordinary Xcode coding, run this before continuing:
 
 1. Call \`axint.session.start\` and keep the returned \`sessionToken\`.
-2. Read \`.axint/AXINT_REHYDRATE.md\`, \`.axint/AXINT_MEMORY.md\`, \`.axint/AXINT_DOCS_CONTEXT.md\`, \`AGENTS.md\`, \`CLAUDE.md\`, or \`.axint/project.json\`.
-3. If either Axint context file is missing, call \`axint.context.memory\` and \`axint.context.docs\`.
-4. Call \`axint.status\` and compare it with the expected version above.
-5. Call \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
-6. State the next Axint tool to use before editing code.
+2. Call \`axint.xcode.guard\` with \`stage: "context-recovery"\` so the project records \`.axint/guard/latest.*\` proof for this chat.
+3. Read \`.axint/AXINT_REHYDRATE.md\`, \`.axint/AXINT_MEMORY.md\`, \`.axint/AXINT_DOCS_CONTEXT.md\`, \`AGENTS.md\`, \`CLAUDE.md\`, or \`.axint/project.json\`.
+4. If either Axint context file is missing, call \`axint.context.memory\` and \`axint.context.docs\`.
+5. Call \`axint.status\` and compare it with the expected version above.
+6. Call \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
+7. State the next Axint tool to use before editing code. For proof passes, prefer \`axint.run\`.
 
 Do not rely on model memory alone. Rehydrate the workflow from the files.
 
 ## Required Loop
 
 1. Call \`axint.session.start\` and persist the returned token in the workflow check calls.
-2. Read the Axint docs listed in the start prompt.
-3. Call \`axint.status\`.
-4. Call \`axint.workflow.check\` with \`sessionToken\` at session start, after context recovery, before planning, before writing, before building, and before committing.
-5. Use \`axint.suggest\` for feature planning.
-6. Use \`axint.feature\`, \`axint.scaffold\`, \`axint.compile\`, or \`axint.schema.compile\` for Apple-native surfaces.
-7. Run \`axint.swift.validate\` on modified Swift.
-8. Run \`axint.cloud.check\` with Xcode build, test, runtime, or behavior evidence when available.
-9. Build in Xcode. Axint is not a replacement for Xcode proof.
+2. Call \`axint.xcode.guard\` after session start, before long tasks, and after context recovery.
+3. Read the Axint docs listed in the start prompt.
+4. Call \`axint.status\`.
+5. Call \`axint.workflow.check\` with \`sessionToken\` at session start, after context recovery, before planning, before writing, before building, and before committing.
+6. Use \`axint.suggest\` for feature planning.
+7. Use \`axint.feature\`, \`axint.scaffold\`, \`axint.compile\`, or \`axint.schema.compile\` for Apple-native surfaces.
+8. Prefer \`axint.xcode.write\` for new Swift files so Axint validation, Cloud Check, and guard proof happen as part of the write.
+9. Run \`axint.swift.validate\` on modified Swift.
+10. Run \`axint.cloud.check\` with Xcode build, test, runtime, or behavior evidence when available.
+11. Prefer \`axint.run\` when moving toward build/test/runtime proof so Axint owns the loop instead of relying on memory.
+12. Build in Xcode or via \`xcodebuild\`. Static Axint checks are not a replacement for runtime proof.
 
 ## Hard Rule
 
@@ -350,6 +364,8 @@ Do not tell the user a bug is gone because static validation passed. Say what Ax
 ## Drift Guard
 
 If you are about to spend a long uninterrupted block on implementation, first name the Axint checkpoint you just ran or the one you will run next. If no Axint checkpoint has run in the last task, stop and run one.
+
+In Xcode, the safest checkpoint is \`axint.xcode.guard\`. It writes \`.axint/guard/latest.json\` and \`.axint/guard/latest.md\`, which lets the user audit whether Axint was actually used during a long task.
 `;
 }
 
@@ -367,6 +383,8 @@ This folder stores Axint project metadata for ${input.projectName}.
 - Compact agent memory: \`.axint/AXINT_MEMORY.md\`
 - Project-local docs context: \`.axint/AXINT_DOCS_CONTEXT.md\`
 - Project workflow: \`.axint/project.json\`
+- Axint Run artifacts: \`.axint/run/latest.json\` and \`.axint/run/latest.md\`
+- Xcode Guard artifacts: \`.axint/guard/latest.json\` and \`.axint/guard/latest.md\`
 - Active session token: \`.axint/session/current.json\`
 - MCP config: \`.mcp.json\`
 - Agent instructions: \`AGENTS.md\` and \`CLAUDE.md\`
@@ -382,7 +400,8 @@ ${input.startPrompt}
 Ask it to run the Axint context recovery loop:
 
 \`\`\`text
-Call axint.session.start for this project and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If either Axint context file is missing, call axint.context.memory and axint.context.docs. Then call axint.status, call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, ranStatus=true, and tell me the next Axint tool you will use before editing code.
+Call axint.session.start for this project and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If either Axint context file is missing, call axint.context.memory and axint.context.docs. Then call axint.status, call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, ranStatus=true. For build/test/runtime proof, call axint.run so Axint owns the full loop.
+Call axint.xcode.guard with stage=context-recovery first, then call axint.session.start if the guard asks for it. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. Then call axint.status and axint.workflow.check. For build/test/runtime proof, call axint.run so Axint owns the full loop.
 \`\`\`
 
 ## CLI Session Start
@@ -390,7 +409,13 @@ Call axint.session.start for this project and keep the returned sessionToken. Re
 \`\`\`bash
 axint session start --dir /path/to/${input.projectName} --name ${input.projectName}
 \`\`\`
-`;
+
+## Full Build Loop
+
+\`\`\`bash
+axint run --dir /path/to/${input.projectName} --scheme ${input.projectName} --runtime
+\`\`\`
+	`;
 }
 
 function detectNpxPath(): string | null {

--- a/src/project/xcode-guard.ts
+++ b/src/project/xcode-guard.ts
@@ -1,0 +1,664 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, relative, resolve, sep } from "node:path";
+import { runCloudCheck, type CloudCheckReport } from "../cloud/check.js";
+import {
+  validateSwiftSource,
+  type SwiftValidationResult,
+} from "../core/swift-validator.js";
+import {
+  readCurrentAxintSession,
+  startAxintSession,
+  type AxintSessionRecord,
+} from "./session.js";
+
+export type XcodeGuardStage =
+  | "context-recovery"
+  | "planning"
+  | "before-write"
+  | "after-write"
+  | "pre-build"
+  | "runtime"
+  | "finish";
+
+export type XcodeGuardStatus = "ready" | "needs_action";
+export type XcodeGuardFormat = "markdown" | "json";
+
+export interface XcodeGuardInput {
+  cwd?: string;
+  projectName?: string;
+  expectedVersion?: string;
+  platform?: string;
+  stage?: XcodeGuardStage;
+  sessionToken?: string;
+  modifiedFiles?: string[];
+  notes?: string;
+  lastAxintTool?: string;
+  lastAxintResult?: string;
+  maxMinutesSinceAxint?: number;
+  autoStartSession?: boolean;
+  writeReport?: boolean;
+}
+
+export interface XcodeGuardEvidence {
+  kind: "session" | "run" | "guard" | "explicit-tool";
+  at: string;
+  source: string;
+  detail: string;
+}
+
+export interface XcodeGuardReport {
+  schema: "https://axint.ai/schemas/xcode-guard.v1.json";
+  id: string;
+  status: XcodeGuardStatus;
+  stage: XcodeGuardStage;
+  cwd: string;
+  projectName: string;
+  createdAt: string;
+  maxMinutesSinceAxint: number;
+  session?: {
+    token: string;
+    path: string;
+    startedAt: string;
+    autoStarted: boolean;
+  };
+  latestEvidence?: XcodeGuardEvidence & {
+    ageMinutes: number;
+  };
+  required: string[];
+  recommended: string[];
+  checked: string[];
+  nextTool: string;
+  proofFiles: {
+    json?: string;
+    markdown?: string;
+  };
+  recoveryPrompt: string;
+}
+
+export interface XcodeWriteInput {
+  cwd?: string;
+  path: string;
+  content: string;
+  projectName?: string;
+  expectedVersion?: string;
+  platform?: "iOS" | "macOS" | "watchOS" | "visionOS" | "all";
+  sessionToken?: string;
+  createDirs?: boolean;
+  validateSwift?: boolean;
+  cloudCheck?: boolean;
+  notes?: string;
+  format?: XcodeGuardFormat;
+}
+
+export interface XcodeWriteReport {
+  schema: "https://axint.ai/schemas/xcode-write.v1.json";
+  id: string;
+  status: "pass" | "needs_action" | "fail";
+  cwd: string;
+  path: string;
+  relativePath: string;
+  bytesWritten: number;
+  createdAt: string;
+  swiftValidation?: SwiftValidationResult;
+  cloudCheck?: CloudCheckReport;
+  guard: XcodeGuardReport;
+  required: string[];
+  recommended: string[];
+  checked: string[];
+  repairPrompt: string;
+}
+
+interface PreviousGuardReport {
+  createdAt?: string;
+  stage?: XcodeGuardStage;
+  status?: XcodeGuardStatus;
+}
+
+interface PreviousRunReport {
+  createdAt?: string;
+  status?: string;
+  gate?: {
+    decision?: string;
+  };
+}
+
+const REQUIRED_PROJECT_FILES = [
+  ".axint/AXINT_REHYDRATE.md",
+  ".axint/AXINT_MEMORY.md",
+  ".axint/AXINT_DOCS_CONTEXT.md",
+  ".axint/project.json",
+  "AGENTS.md",
+  "CLAUDE.md",
+];
+
+export function runXcodeGuard(input: XcodeGuardInput = {}): XcodeGuardReport {
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const projectName = input.projectName ?? basename(cwd) ?? "AppleApp";
+  const stage = input.stage ?? "context-recovery";
+  const maxMinutesSinceAxint = input.maxMinutesSinceAxint ?? 10;
+  const createdAt = new Date();
+  const required: string[] = [];
+  const recommended: string[] = [];
+  const checked: string[] = [];
+  let session = readCurrentAxintSession(cwd);
+  let autoStarted = false;
+
+  if (!session && input.autoStartSession !== false) {
+    const started = startAxintSession({
+      targetDir: cwd,
+      projectName,
+      expectedVersion: input.expectedVersion,
+      platform: input.platform,
+      agent: "xcode",
+    });
+    session = started.session;
+    autoStarted = true;
+    checked.push("axint.session.start was run automatically for guarded Xcode mode.");
+  }
+
+  if (!session) {
+    required.push(
+      "No active Axint session was found. Call axint.session.start before planning, editing, building, or debugging."
+    );
+  } else if (input.sessionToken && input.sessionToken !== session.token) {
+    required.push(
+      "The supplied sessionToken does not match .axint/session/current.json. Re-run axint.session.start and use the current token."
+    );
+  } else {
+    checked.push("Active Axint session is present for this Xcode project.");
+  }
+
+  const missingFiles = REQUIRED_PROJECT_FILES.filter(
+    (file) => !existsSync(resolve(cwd, file))
+  );
+  if (missingFiles.length > 0) {
+    required.push(
+      `Project Axint memory is incomplete: ${missingFiles.join(", ")}. Run axint project init --dir "${cwd}" --force or axint xcode setup --guarded --project "${cwd}".`
+    );
+  } else {
+    checked.push("Project Axint memory files are present.");
+  }
+
+  const latestEvidence = latestAxintEvidence({
+    cwd,
+    session,
+    lastAxintTool: input.lastAxintTool,
+    lastAxintResult: input.lastAxintResult,
+  });
+  const latestEvidenceWithAge = latestEvidence
+    ? {
+        ...latestEvidence,
+        ageMinutes: minutesBetween(new Date(latestEvidence.at), createdAt),
+      }
+    : undefined;
+
+  if (!latestEvidenceWithAge) {
+    required.push(
+      "No recent Axint evidence was found. Call axint.xcode.guard, axint.workflow.check, axint.suggest, axint.feature, axint.cloud.check, or axint.run before continuing."
+    );
+  } else if (latestEvidenceWithAge.ageMinutes > maxMinutesSinceAxint) {
+    required.push(
+      `Latest Axint evidence is ${latestEvidenceWithAge.ageMinutes.toFixed(1)} minutes old. Refresh the guard before continuing.`
+    );
+  } else {
+    checked.push(
+      `Latest Axint evidence is fresh: ${latestEvidenceWithAge.kind} from ${latestEvidenceWithAge.source}.`
+    );
+  }
+
+  if (looksLikeDrift(input.notes)) {
+    required.push(
+      "The notes mention drift, compaction, or Axint being forgotten. Run context recovery before continuing."
+    );
+  }
+
+  const modifiedSwift = (input.modifiedFiles ?? []).filter((file) =>
+    file.endsWith(".swift")
+  );
+  if (modifiedSwift.length > 0) {
+    checked.push(`Swift files in scope: ${modifiedSwift.join(", ")}.`);
+    if (stage === "pre-build" || stage === "runtime" || stage === "finish") {
+      recommended.push(
+        "Use axint.run for Swift build/test/runtime proof so validation, Cloud Check, xcodebuild, and artifacts stay tied together."
+      );
+    }
+  }
+
+  if (stage === "planning" && input.lastAxintTool !== "axint.suggest") {
+    recommended.push(
+      "For feature planning, call axint.suggest with the current app description before choosing the implementation path."
+    );
+  }
+
+  if (stage === "before-write") {
+    const lastTool = input.lastAxintTool ?? "";
+    if (
+      ![
+        "axint.feature",
+        "axint.scaffold",
+        "axint.compile",
+        "axint.schema.compile",
+      ].includes(lastTool)
+    ) {
+      recommended.push(
+        "Before writing a new Apple-native surface, use axint.feature, axint.scaffold, axint.compile, or axint.schema.compile, or record a concrete bypass reason."
+      );
+    }
+  }
+
+  if (stage === "pre-build" || stage === "runtime" || stage === "finish") {
+    if (latestEvidenceWithAge?.kind !== "run") {
+      required.push(
+        "This stage needs build/test/runtime proof. Call axint.run instead of relying on a remembered checklist."
+      );
+    }
+  }
+
+  const status: XcodeGuardStatus = required.length === 0 ? "ready" : "needs_action";
+  const report: XcodeGuardReport = {
+    schema: "https://axint.ai/schemas/xcode-guard.v1.json",
+    id: `xguard_${createdAt.getTime().toString(36)}`,
+    status,
+    stage,
+    cwd,
+    projectName,
+    createdAt: createdAt.toISOString(),
+    maxMinutesSinceAxint,
+    session: session
+      ? {
+          token: session.token,
+          path: resolve(cwd, ".axint/session/current.json"),
+          startedAt: session.startedAt,
+          autoStarted,
+        }
+      : undefined,
+    latestEvidence: latestEvidenceWithAge,
+    required: dedupe(required),
+    recommended: dedupe(recommended),
+    checked: dedupe(checked),
+    nextTool: chooseNextTool(stage, required),
+    proofFiles: {},
+    recoveryPrompt: buildGuardRecoveryPrompt(cwd, projectName),
+  };
+
+  if (input.writeReport !== false) {
+    writeGuardReport(cwd, report);
+  }
+
+  return report;
+}
+
+export function renderXcodeGuardReport(
+  report: XcodeGuardReport,
+  format: XcodeGuardFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(report, null, 2);
+
+  const lines = [
+    `# Axint Xcode Guard: ${report.status}`,
+    "",
+    `- Project: ${report.projectName}`,
+    `- Stage: ${report.stage}`,
+    `- Created: ${report.createdAt}`,
+    `- Max age: ${report.maxMinutesSinceAxint} minutes`,
+    report.latestEvidence
+      ? `- Latest Axint evidence: ${report.latestEvidence.kind} · ${report.latestEvidence.ageMinutes.toFixed(1)}m old · ${report.latestEvidence.source}`
+      : "- Latest Axint evidence: none",
+    report.session
+      ? `- Session: ${report.session.token}${report.session.autoStarted ? " (auto-started)" : ""}`
+      : "- Session: missing",
+    "",
+    "## Required",
+    ...(report.required.length > 0
+      ? report.required.map((item) => `- ${item}`)
+      : ["- None."]),
+    "",
+    "## Recommended",
+    ...(report.recommended.length > 0
+      ? report.recommended.map((item) => `- ${item}`)
+      : ["- None."]),
+    "",
+    "## Checked",
+    ...(report.checked.length > 0
+      ? report.checked.map((item) => `- ${item}`)
+      : ["- No Axint guard evidence was supplied."]),
+    "",
+    "## Next Tool",
+    `- ${report.nextTool}`,
+  ];
+
+  if (report.proofFiles.json || report.proofFiles.markdown) {
+    lines.push(
+      "",
+      "## Proof Files",
+      ...(report.proofFiles.json ? [`- JSON: ${report.proofFiles.json}`] : []),
+      ...(report.proofFiles.markdown ? [`- Markdown: ${report.proofFiles.markdown}`] : [])
+    );
+  }
+
+  lines.push("", "## Recovery Prompt", "```text", report.recoveryPrompt, "```");
+  return lines.join("\n");
+}
+
+export function runXcodeWrite(input: XcodeWriteInput): XcodeWriteReport {
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const targetPath = resolve(cwd, input.path);
+  const createdAt = new Date().toISOString();
+  const required: string[] = [];
+  const recommended: string[] = [];
+  const checked: string[] = [];
+
+  if (!isInside(cwd, targetPath)) {
+    const guard = runXcodeGuard({
+      cwd,
+      projectName: input.projectName,
+      expectedVersion: input.expectedVersion,
+      platform: input.platform,
+      stage: "before-write",
+      sessionToken: input.sessionToken,
+      notes: input.notes,
+      lastAxintTool: "axint.xcode.write",
+      lastAxintResult: "blocked path outside project",
+      autoStartSession: true,
+      writeReport: true,
+    });
+    return {
+      schema: "https://axint.ai/schemas/xcode-write.v1.json",
+      id: `xwrite_${Date.now().toString(36)}`,
+      status: "fail",
+      cwd,
+      path: targetPath,
+      relativePath: relative(cwd, targetPath),
+      bytesWritten: 0,
+      createdAt,
+      guard,
+      required: [`Refusing to write outside the project root: ${targetPath}`],
+      recommended,
+      checked,
+      repairPrompt:
+        "Pick a target path inside the Xcode project root and call axint.xcode.write again.",
+    };
+  }
+
+  if (input.createDirs !== false) {
+    mkdirSync(dirname(targetPath), { recursive: true });
+  }
+  writeFileSync(targetPath, input.content, "utf-8");
+  checked.push(`Wrote ${targetPath}.`);
+
+  const shouldValidateSwift =
+    input.validateSwift !== false && targetPath.endsWith(".swift");
+  const swiftValidation = shouldValidateSwift
+    ? validateSwiftSource(input.content, targetPath)
+    : undefined;
+  if (swiftValidation) {
+    checked.push("Ran axint.swift.validate on the written Swift source.");
+    const errors = swiftValidation.diagnostics.filter(
+      (diagnostic) => diagnostic.severity === "error"
+    );
+    if (errors.length > 0) {
+      required.push(
+        `Swift validation found ${errors.length} blocking issue${errors.length === 1 ? "" : "s"}.`
+      );
+    }
+  }
+
+  const cloudCheck =
+    input.cloudCheck !== false && targetPath.endsWith(".swift")
+      ? runCloudCheck({
+          source: input.content,
+          fileName: targetPath,
+          language: "swift",
+          platform: input.platform,
+        })
+      : undefined;
+  if (cloudCheck) {
+    checked.push("Ran axint.cloud.check on the written Swift source.");
+    if (cloudCheck.status === "fail") {
+      required.push("Cloud Check found blocking Apple-facing issues.");
+    } else if (cloudCheck.status === "needs_review") {
+      recommended.push(
+        "Cloud Check needs runtime, build, or review evidence before this can be claimed fixed."
+      );
+    }
+  }
+
+  const guard = runXcodeGuard({
+    cwd,
+    projectName: input.projectName,
+    expectedVersion: input.expectedVersion,
+    platform: input.platform,
+    stage: "after-write",
+    sessionToken: input.sessionToken,
+    modifiedFiles: [relative(cwd, targetPath)],
+    notes: input.notes,
+    lastAxintTool: "axint.xcode.write",
+    lastAxintResult:
+      required.length > 0
+        ? "write completed with required follow-up"
+        : "write completed with Axint validation",
+    autoStartSession: true,
+    writeReport: true,
+  });
+  if (guard.status === "needs_action") {
+    required.push(...guard.required);
+  }
+
+  const status =
+    required.length > 0
+      ? swiftValidation?.diagnostics.some((d) => d.severity === "error") ||
+        cloudCheck?.status === "fail"
+        ? "fail"
+        : "needs_action"
+      : "pass";
+
+  return {
+    schema: "https://axint.ai/schemas/xcode-write.v1.json",
+    id: `xwrite_${Date.now().toString(36)}`,
+    status,
+    cwd,
+    path: targetPath,
+    relativePath: relative(cwd, targetPath),
+    bytesWritten: Buffer.byteLength(input.content),
+    createdAt,
+    swiftValidation,
+    cloudCheck,
+    guard,
+    required: dedupe(required),
+    recommended: dedupe(recommended),
+    checked: dedupe(checked),
+    repairPrompt: buildWriteRepairPrompt({
+      path: targetPath,
+      status,
+      required,
+      cloudCheck,
+    }),
+  };
+}
+
+export function renderXcodeWriteReport(
+  report: XcodeWriteReport,
+  format: XcodeGuardFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(report, null, 2);
+
+  const lines = [
+    `# Axint Xcode Write: ${report.status}`,
+    "",
+    `- File: ${report.relativePath}`,
+    `- Bytes: ${report.bytesWritten}`,
+    `- Guard: ${report.guard.status}`,
+    report.swiftValidation
+      ? `- Swift diagnostics: ${report.swiftValidation.diagnostics.length}`
+      : "- Swift diagnostics: not applicable",
+    report.cloudCheck
+      ? `- Cloud Check: ${report.cloudCheck.status}`
+      : "- Cloud Check: not applicable",
+    "",
+    "## Required",
+    ...(report.required.length > 0
+      ? report.required.map((item) => `- ${item}`)
+      : ["- None."]),
+    "",
+    "## Recommended",
+    ...(report.recommended.length > 0
+      ? report.recommended.map((item) => `- ${item}`)
+      : ["- None."]),
+    "",
+    "## Checked",
+    ...(report.checked.length > 0
+      ? report.checked.map((item) => `- ${item}`)
+      : ["- No Axint write checks were recorded."]),
+    "",
+    "## Repair Prompt",
+    "```text",
+    report.repairPrompt,
+    "```",
+  ];
+
+  if (report.cloudCheck?.repairPrompt) {
+    lines.push("", "## Cloud Check Repair Prompt", "```text");
+    lines.push(report.cloudCheck.repairPrompt, "```");
+  }
+
+  return lines.join("\n");
+}
+
+function latestAxintEvidence(input: {
+  cwd: string;
+  session?: AxintSessionRecord;
+  lastAxintTool?: string;
+  lastAxintResult?: string;
+}): XcodeGuardEvidence | undefined {
+  const candidates: XcodeGuardEvidence[] = [];
+  const explicitTool = input.lastAxintTool?.trim();
+
+  if (explicitTool?.startsWith("axint.")) {
+    candidates.push({
+      kind: explicitTool === "axint.run" ? "run" : "explicit-tool",
+      at: new Date().toISOString(),
+      source: explicitTool,
+      detail:
+        input.lastAxintResult ?? "Agent supplied an explicit Axint tool checkpoint.",
+    });
+  }
+
+  if (input.session) {
+    candidates.push({
+      kind: "session",
+      at: input.session.startedAt,
+      source: ".axint/session/current.json",
+      detail: `Axint session for ${input.session.projectName}.`,
+    });
+  }
+
+  const run = readJson<PreviousRunReport>(resolve(input.cwd, ".axint/run/latest.json"));
+  if (run?.createdAt) {
+    candidates.push({
+      kind: "run",
+      at: run.createdAt,
+      source: ".axint/run/latest.json",
+      detail: `Axint Run status: ${run.status ?? "unknown"} · ${run.gate?.decision ?? "unknown gate"}.`,
+    });
+  }
+
+  const previousGuard = readJson<PreviousGuardReport>(
+    resolve(input.cwd, ".axint/guard/latest.json")
+  );
+  if (previousGuard?.createdAt) {
+    candidates.push({
+      kind: "guard",
+      at: previousGuard.createdAt,
+      source: ".axint/guard/latest.json",
+      detail: `Previous guard status: ${previousGuard.status ?? "unknown"} at ${previousGuard.stage ?? "unknown stage"}.`,
+    });
+  }
+
+  return candidates
+    .filter((candidate) => !Number.isNaN(new Date(candidate.at).getTime()))
+    .sort((a, b) => new Date(b.at).getTime() - new Date(a.at).getTime())[0];
+}
+
+function writeGuardReport(cwd: string, report: XcodeGuardReport): void {
+  const dir = resolve(cwd, ".axint/guard");
+  mkdirSync(dir, { recursive: true });
+  const jsonPath = resolve(dir, "latest.json");
+  const markdownPath = resolve(dir, "latest.md");
+  report.proofFiles.json = jsonPath;
+  report.proofFiles.markdown = markdownPath;
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf-8");
+  writeFileSync(markdownPath, `${renderXcodeGuardReport(report)}\n`, "utf-8");
+}
+
+function readJson<T>(path: string): T | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function chooseNextTool(stage: XcodeGuardStage, required: string[]): string {
+  const text = required.join(" ").toLowerCase();
+  if (text.includes("session.start")) return "axint.session.start";
+  if (text.includes("project init") || text.includes("setup --guarded")) {
+    return "axint project init or axint xcode setup --guarded";
+  }
+  if (text.includes("context recovery")) return "axint.session.start";
+  if (text.includes("axint.run") || ["pre-build", "runtime", "finish"].includes(stage)) {
+    return "axint.run";
+  }
+  if (stage === "planning") return "axint.suggest";
+  if (stage === "before-write") return "axint.feature";
+  return "axint.workflow.check";
+}
+
+function buildWriteRepairPrompt(input: {
+  path: string;
+  status: XcodeWriteReport["status"];
+  required: string[];
+  cloudCheck?: CloudCheckReport;
+}): string {
+  if (input.status === "pass") {
+    return `The file ${input.path} was written through axint.xcode.write. Continue with the next Axint checkpoint, and call axint.run before build/test/runtime proof.`;
+  }
+  return [
+    `The file ${input.path} was written through axint.xcode.write, but follow-up is required.`,
+    ...input.required.map((item) => `- ${item}`),
+    input.cloudCheck?.repairPrompt
+      ? "Use the Cloud Check repair prompt below before continuing."
+      : "Run axint.swift.validate, axint.cloud.check, or axint.run after repairing.",
+  ].join("\n");
+}
+
+function buildGuardRecoveryPrompt(cwd: string, projectName: string): string {
+  return [
+    `We are working in ${projectName}. Do not continue from memory.`,
+    `Project path: ${cwd}`,
+    "Call axint.xcode.guard with stage=context-recovery.",
+    "Then call axint.status and report the running Axint MCP version.",
+    "Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json.",
+    "For build/test/runtime proof, call axint.run so Axint owns the full loop.",
+  ].join("\n");
+}
+
+function looksLikeDrift(notes: string | undefined): boolean {
+  if (!notes) return false;
+  return /\b(compact|compaction|summarized|new chat|forgot|forget|drift|stale|not using axint|axint unavailable|long task|long block|default xcode|ordinary xcode)\b/i.test(
+    notes
+  );
+}
+
+function minutesBetween(start: Date, end: Date): number {
+  return Math.max(0, (end.getTime() - start.getTime()) / 60_000);
+}
+
+function isInside(root: string, target: string): boolean {
+  const normalizedRoot = root.endsWith(sep) ? root : `${root}${sep}`;
+  return target === root || target.startsWith(normalizedRoot);
+}
+
+function dedupe(items: string[]): string[] {
+  return Array.from(new Set(items));
+}

--- a/src/run/project-runner.ts
+++ b/src/run/project-runner.ts
@@ -1,0 +1,870 @@
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, extname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { runCloudCheck, type CloudCheckReport } from "../cloud/check.js";
+import { startAxintSession } from "../project/session.js";
+import { validateSwiftSource } from "../core/swift-validator.js";
+import type { Diagnostic } from "../core/types.js";
+import {
+  renderWorkflowCheckReport,
+  runWorkflowCheck,
+  type WorkflowCheckReport,
+} from "../mcp/workflow-check.js";
+
+export type AxintRunFormat = "markdown" | "json" | "prompt";
+export type AxintRunPlatform = "macOS" | "iOS" | "watchOS" | "visionOS" | "all";
+export type AxintRunStepState = "pass" | "warn" | "fail" | "skipped";
+export type AxintRunKind = "local" | "byo-runner";
+
+export interface AxintRunInput {
+  cwd?: string;
+  kind?: AxintRunKind;
+  projectName?: string;
+  expectedVersion?: string;
+  platform?: AxintRunPlatform;
+  scheme?: string;
+  workspace?: string;
+  project?: string;
+  destination?: string;
+  configuration?: string;
+  derivedDataPath?: string;
+  testPlan?: string;
+  modifiedFiles?: string[];
+  skipBuild?: boolean;
+  skipTests?: boolean;
+  runtime?: boolean;
+  runtimeTimeoutSeconds?: number;
+  timeoutSeconds?: number;
+  expectedBehavior?: string;
+  actualBehavior?: string;
+  runtimeFailure?: string;
+  dryRun?: boolean;
+  writeReport?: boolean;
+}
+
+export interface AxintRunCommandResult {
+  command: string;
+  args: string[];
+  cwd: string;
+  exitCode: number | null;
+  signal: string | null;
+  timedOut: boolean;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  dryRun?: boolean;
+}
+
+export interface AxintRunStep {
+  name: string;
+  state: AxintRunStepState;
+  detail: string;
+  command?: string;
+  durationMs?: number;
+}
+
+export interface AxintRunReport {
+  id: string;
+  kind: AxintRunKind;
+  status: "pass" | "needs_review" | "fail";
+  gate: {
+    decision: "ready_to_ship" | "fix_required" | "evidence_required";
+    reason: string;
+  };
+  cwd: string;
+  projectName: string;
+  platform: AxintRunPlatform;
+  scheme?: string;
+  destination: string;
+  createdAt: string;
+  session: {
+    token: string;
+    path: string;
+  };
+  workflow: WorkflowCheckReport;
+  swiftValidation: {
+    filesChecked: number;
+    diagnostics: Diagnostic[];
+  };
+  cloudChecks: CloudCheckReport[];
+  commands: {
+    build?: AxintRunCommandResult;
+    test?: AxintRunCommandResult;
+    runtime?: AxintRunCommandResult;
+    buildSettings?: AxintRunCommandResult;
+  };
+  steps: AxintRunStep[];
+  artifacts: {
+    json?: string;
+    markdown?: string;
+  };
+  nextSteps: string[];
+  repairPrompt: string;
+}
+
+interface XcodePlan {
+  containerKind: "workspace" | "project";
+  containerPath: string;
+  scheme?: string;
+  destination: string;
+  configuration?: string;
+  derivedDataPath?: string;
+  testPlan?: string;
+}
+
+export async function runAxintProject(
+  input: AxintRunInput = {}
+): Promise<AxintRunReport> {
+  const startedAt = Date.now();
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const platform = input.platform ?? inferPlatform(input.destination);
+  const projectName = input.projectName ?? inferProjectName(cwd);
+  const session = startAxintSession({
+    targetDir: cwd,
+    projectName,
+    expectedVersion: input.expectedVersion ?? "unknown",
+    platform,
+    agent: "all",
+  });
+  const swiftFiles = resolveSwiftFiles(cwd, input.modifiedFiles);
+  const validationDiagnostics: Diagnostic[] = [];
+  const cloudChecks: CloudCheckReport[] = [];
+  const steps: AxintRunStep[] = [
+    {
+      name: "Axint session",
+      state: "pass",
+      detail: `Started session ${session.session.token}.`,
+    },
+  ];
+
+  for (const file of swiftFiles) {
+    const source = readFileSync(file, "utf-8");
+    validationDiagnostics.push(
+      ...validateSwiftSource(source, relativeOrAbsolute(cwd, file)).diagnostics
+    );
+  }
+
+  steps.push({
+    name: "Swift validation",
+    state: validationDiagnostics.some((d) => d.severity === "error")
+      ? "fail"
+      : validationDiagnostics.some((d) => d.severity === "warning")
+        ? "warn"
+        : "pass",
+    detail:
+      swiftFiles.length === 0
+        ? "No Swift files were found to validate."
+        : `Validated ${swiftFiles.length} Swift file${swiftFiles.length === 1 ? "" : "s"}.`,
+  });
+
+  const cloudTargets = swiftFiles.length > 0 ? swiftFiles : [];
+  for (const file of cloudTargets) {
+    cloudChecks.push(
+      runCloudCheck({
+        sourcePath: file,
+        platform,
+        runtimeFailure: input.runtimeFailure,
+        expectedBehavior: input.expectedBehavior,
+        actualBehavior: input.actualBehavior,
+      })
+    );
+  }
+
+  steps.push({
+    name: "Cloud Check",
+    state:
+      cloudChecks.length === 0
+        ? "skipped"
+        : cloudChecks.some((check) => check.status === "fail")
+          ? "fail"
+          : cloudChecks.some((check) => check.status === "needs_review")
+            ? "warn"
+            : "pass",
+    detail:
+      cloudChecks.length === 0
+        ? "No source file was available for Cloud Check."
+        : `Ran ${cloudChecks.length} Cloud Check report${cloudChecks.length === 1 ? "" : "s"}.`,
+  });
+
+  const workflow = runWorkflowCheck({
+    cwd,
+    stage: "pre-build",
+    sessionStarted: true,
+    sessionToken: session.session.token,
+    readAgentInstructions: true,
+    readDocsContext: true,
+    readRehydrationContext: true,
+    ranStatus: true,
+    ranSuggest: true,
+    ranSwiftValidate: swiftFiles.length > 0,
+    ranCloudCheck: cloudChecks.length > 0,
+    modifiedFiles: swiftFiles.map((file) => relativeOrAbsolute(cwd, file)),
+  });
+
+  const commands: AxintRunReport["commands"] = {};
+  let plan: XcodePlan | undefined;
+  try {
+    plan = createXcodePlan(cwd, input, platform);
+  } catch (err) {
+    steps.push({
+      name: "Xcode plan",
+      state: input.skipBuild ? "skipped" : "fail",
+      detail: (err as Error).message,
+    });
+  }
+
+  if (plan && !input.skipBuild) {
+    const buildArgs = buildXcodeArgs(plan, "build");
+    commands.build = runCommand("xcodebuild", buildArgs, {
+      cwd,
+      timeoutSeconds: input.timeoutSeconds ?? 600,
+      dryRun: input.dryRun,
+    });
+    steps.push(stepFromCommand("Xcode build", commands.build));
+  } else if (input.skipBuild) {
+    steps.push({
+      name: "Xcode build",
+      state: "skipped",
+      detail: "Build skipped by input.",
+    });
+  }
+
+  if (plan && !input.skipTests && !input.skipBuild) {
+    const testArgs = buildXcodeArgs(plan, "test");
+    commands.test = runCommand("xcodebuild", testArgs, {
+      cwd,
+      timeoutSeconds: input.timeoutSeconds ?? 900,
+      dryRun: input.dryRun,
+    });
+    steps.push(stepFromCommand("Xcode test", commands.test));
+  } else if (input.skipTests) {
+    steps.push({
+      name: "Xcode test",
+      state: "skipped",
+      detail: "Tests skipped by input.",
+    });
+  }
+
+  if (plan && input.runtime && platform === "macOS" && !input.dryRun) {
+    const runtime = runMacRuntimeProbe(cwd, plan, input);
+    commands.buildSettings = runtime.buildSettings;
+    commands.runtime = runtime.launch;
+    steps.push(
+      runtime.launch
+        ? stepFromCommand("Runtime launch", runtime.launch)
+        : {
+            name: "Runtime launch",
+            state: "warn",
+            detail: runtime.detail,
+          }
+    );
+  } else if (input.runtime && input.dryRun) {
+    steps.push({
+      name: "Runtime launch",
+      state: "skipped",
+      detail: "Runtime launch skipped in dry-run mode.",
+    });
+  } else if (input.runtime && platform !== "macOS") {
+    steps.push({
+      name: "Runtime launch",
+      state: "skipped",
+      detail: "Runtime launch MVP currently supports macOS app targets.",
+    });
+  }
+
+  const status = summarizeStatus(steps, workflow, validationDiagnostics, cloudChecks);
+  const report: AxintRunReport = {
+    id: `axrun_${randomUUID()}`,
+    kind: input.kind ?? "local",
+    status,
+    gate: gateForStatus(status, steps),
+    cwd,
+    projectName,
+    platform,
+    scheme: plan?.scheme,
+    destination: plan?.destination ?? defaultDestination(platform),
+    createdAt: new Date().toISOString(),
+    session: {
+      token: session.session.token,
+      path: session.sessionPath,
+    },
+    workflow,
+    swiftValidation: {
+      filesChecked: swiftFiles.length,
+      diagnostics: validationDiagnostics,
+    },
+    cloudChecks,
+    commands,
+    steps: steps.map((step) =>
+      step.durationMs === undefined && step.name === "Axint session"
+        ? { ...step, durationMs: Date.now() - startedAt }
+        : step
+    ),
+    artifacts: {},
+    nextSteps: buildNextSteps(status, steps, workflow, cloudChecks),
+    repairPrompt: buildRunRepairPrompt({
+      status,
+      workflow,
+      validationDiagnostics,
+      cloudChecks,
+      commands,
+    }),
+  };
+
+  if (input.writeReport !== false) {
+    const artifacts = writeRunArtifacts(report);
+    report.artifacts = artifacts;
+  }
+
+  return report;
+}
+
+export function renderAxintRunReport(
+  report: AxintRunReport,
+  format: AxintRunFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(report, null, 2);
+  if (format === "prompt") return report.repairPrompt;
+
+  const lines = [
+    `# Axint Run: ${report.status}`,
+    "",
+    `- Project: ${report.projectName}`,
+    `- Platform: ${report.platform}`,
+    `- Scheme: ${report.scheme ?? "not detected"}`,
+    `- Destination: ${report.destination}`,
+    `- Gate: ${report.gate.decision}`,
+    `- Reason: ${report.gate.reason}`,
+    `- Session: ${report.session.token}`,
+    "",
+    "## Steps",
+    ...report.steps.map(
+      (step) =>
+        `- ${stateLabel(step.state)} ${step.name}: ${step.detail}${
+          step.command ? `\n  - \`${step.command}\`` : ""
+        }`
+    ),
+    "",
+    "## Workflow Gate",
+    "",
+    renderWorkflowCheckReport(report.workflow),
+    "",
+    "## Swift Diagnostics",
+    ...(report.swiftValidation.diagnostics.length > 0
+      ? report.swiftValidation.diagnostics
+          .slice(0, 20)
+          .map(
+            (diagnostic) =>
+              `- ${diagnostic.severity.toUpperCase()} ${diagnostic.code}: ${diagnostic.message}`
+          )
+      : ["- None."]),
+    "",
+    "## Cloud Checks",
+    ...(report.cloudChecks.length > 0
+      ? report.cloudChecks.map(
+          (check) =>
+            `- ${check.fileName}: ${check.status} · ${check.gate.decision} · ${check.errors} errors, ${check.warnings} warnings`
+        )
+      : ["- None."]),
+    "",
+    "## Next Steps",
+    ...(report.nextSteps.length > 0
+      ? report.nextSteps.map((step) => `- ${step}`)
+      : ["- None."]),
+  ];
+
+  if (report.artifacts.json || report.artifacts.markdown) {
+    lines.push("", "## Artifacts");
+    if (report.artifacts.json) lines.push(`- JSON: ${report.artifacts.json}`);
+    if (report.artifacts.markdown) {
+      lines.push(`- Markdown: ${report.artifacts.markdown}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function createXcodePlan(
+  cwd: string,
+  input: AxintRunInput,
+  platform: AxintRunPlatform
+): XcodePlan {
+  const workspace = input.workspace
+    ? resolve(cwd, input.workspace)
+    : findFirstWithExtension(cwd, ".xcworkspace");
+  const project = input.project
+    ? resolve(cwd, input.project)
+    : findFirstWithExtension(cwd, ".xcodeproj");
+  const containerPath = workspace ?? project;
+  if (!containerPath) {
+    throw new Error(
+      "No .xcworkspace or .xcodeproj found. Pass --workspace or --project."
+    );
+  }
+  const scheme =
+    input.scheme ?? inferScheme(containerPath) ?? stripXcodeExtension(containerPath);
+
+  return {
+    containerKind: workspace ? "workspace" : "project",
+    containerPath,
+    scheme,
+    destination: input.destination ?? defaultDestination(platform),
+    configuration: input.configuration,
+    derivedDataPath: input.derivedDataPath,
+    testPlan: input.testPlan,
+  };
+}
+
+function buildXcodeArgs(plan: XcodePlan, action: "build" | "test"): string[] {
+  const args = [
+    plan.containerKind === "workspace" ? "-workspace" : "-project",
+    plan.containerPath,
+  ];
+  if (plan.scheme) args.push("-scheme", plan.scheme);
+  if (plan.destination) args.push("-destination", plan.destination);
+  if (plan.configuration) args.push("-configuration", plan.configuration);
+  if (plan.derivedDataPath) args.push("-derivedDataPath", plan.derivedDataPath);
+  if (action === "test" && plan.testPlan) args.push("-testPlan", plan.testPlan);
+  args.push(action);
+  return args;
+}
+
+function runCommand(
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    timeoutSeconds: number;
+    dryRun?: boolean;
+  }
+): AxintRunCommandResult {
+  const started = Date.now();
+  if (options.dryRun) {
+    return {
+      command,
+      args,
+      cwd: options.cwd,
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+      durationMs: 0,
+      dryRun: true,
+    };
+  }
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf-8",
+    timeout: options.timeoutSeconds * 1000,
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  return {
+    command,
+    args,
+    cwd: options.cwd,
+    exitCode: result.status,
+    signal: result.signal,
+    timedOut: Boolean(result.error && result.error.message.includes("ETIMEDOUT")),
+    stdout: result.stdout ?? "",
+    stderr:
+      result.stderr ??
+      (result.error ? `${result.error.name}: ${result.error.message}` : ""),
+    durationMs: Date.now() - started,
+  };
+}
+
+function runMacRuntimeProbe(
+  cwd: string,
+  plan: XcodePlan,
+  input: AxintRunInput
+): {
+  buildSettings?: AxintRunCommandResult;
+  launch?: AxintRunCommandResult;
+  detail: string;
+} {
+  const settings = runCommand(
+    "xcodebuild",
+    [...buildXcodeArgs(plan, "build").slice(0, -1), "-showBuildSettings", "-json"],
+    {
+      cwd,
+      timeoutSeconds: 90,
+    }
+  );
+  if (settings.exitCode !== 0) {
+    return {
+      buildSettings: settings,
+      detail: "Could not read Xcode build settings for runtime launch.",
+    };
+  }
+  const appPath = inferMacAppPath(settings.stdout);
+  if (!appPath || !existsSync(appPath)) {
+    return {
+      buildSettings: settings,
+      detail: "Build settings did not resolve to a built .app bundle.",
+    };
+  }
+  const launch = runRuntimeLaunchProbe(cwd, appPath, input.runtimeTimeoutSeconds ?? 8);
+  return {
+    buildSettings: settings,
+    launch,
+    detail: `Launched ${appPath}.`,
+  };
+}
+
+function runRuntimeLaunchProbe(
+  cwd: string,
+  appPath: string,
+  waitSeconds: number
+): AxintRunCommandResult {
+  const started = Date.now();
+  const appName = basename(appPath, ".app");
+  const openResult = runCommand("open", ["-n", appPath], {
+    cwd,
+    timeoutSeconds: 15,
+  });
+  if (openResult.exitCode !== 0) return openResult;
+
+  const boundedWait = String(Math.min(Math.max(Math.round(waitSeconds), 1), 60));
+  spawnSync("sleep", [boundedWait], {
+    cwd,
+    encoding: "utf-8",
+    timeout: (Number(boundedWait) + 2) * 1000,
+  });
+  const processCheck = runCommand("pgrep", ["-x", appName], {
+    cwd,
+    timeoutSeconds: 5,
+  });
+  return {
+    command: "axint-runtime-probe",
+    args: [appPath, "--process", appName, "--wait", boundedWait],
+    cwd,
+    exitCode: processCheck.exitCode,
+    signal: processCheck.signal,
+    timedOut: processCheck.timedOut,
+    stdout: processCheck.stdout,
+    stderr:
+      processCheck.exitCode === 0
+        ? processCheck.stderr
+        : `Launched ${appPath}, but no running process named ${appName} was found after ${boundedWait}s.\n${processCheck.stderr}`,
+    durationMs: Date.now() - started,
+  };
+}
+
+function inferMacAppPath(buildSettingsJson: string): string | undefined {
+  try {
+    const parsed = JSON.parse(buildSettingsJson) as Array<{
+      buildSettings?: Record<string, string>;
+    }>;
+    const settings = parsed[0]?.buildSettings;
+    if (!settings) return undefined;
+    const dir = settings.BUILT_PRODUCTS_DIR;
+    const product = settings.FULL_PRODUCT_NAME;
+    if (!dir || !product || !product.endsWith(".app")) return undefined;
+    return join(dir, product);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveSwiftFiles(cwd: string, files?: string[]): string[] {
+  if (files && files.length > 0) {
+    return unique(
+      files
+        .map((file) => resolve(cwd, file))
+        .filter((file) => extname(file) === ".swift" && existsSync(file))
+    );
+  }
+  return findSwiftFiles(cwd).slice(0, 80);
+}
+
+function findSwiftFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const ignored = new Set([
+    ".git",
+    ".build",
+    ".swiftpm",
+    "DerivedData",
+    "node_modules",
+    "Pods",
+    ".axint",
+  ]);
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (ignored.has(entry)) continue;
+    const path = join(dir, entry);
+    const stat = safeStat(path);
+    if (!stat) continue;
+    if (stat.isDirectory()) {
+      if (entry.endsWith(".xcodeproj") || entry.endsWith(".xcworkspace")) continue;
+      results.push(...findSwiftFiles(path));
+    } else if (entry.endsWith(".swift")) {
+      results.push(path);
+    }
+  }
+  return results;
+}
+
+function findFirstWithExtension(dir: string, suffix: ".xcodeproj" | ".xcworkspace") {
+  if (!existsSync(dir)) return undefined;
+  const entries = readdirSync(dir).sort();
+  for (const entry of entries) {
+    const path = join(dir, entry);
+    const stat = safeStat(path);
+    if (stat?.isDirectory() && entry.endsWith(suffix)) return path;
+  }
+  return undefined;
+}
+
+function inferScheme(containerPath: string): string | undefined {
+  const schemes = findFiles(containerPath, ".xcscheme", 6);
+  if (schemes.length === 0) return undefined;
+  return basename(schemes[0], ".xcscheme");
+}
+
+function findFiles(dir: string, suffix: string, depth: number): string[] {
+  if (depth < 0 || !existsSync(dir)) return [];
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = safeStat(path);
+    if (!stat) continue;
+    if (stat.isDirectory()) results.push(...findFiles(path, suffix, depth - 1));
+    if (stat.isFile() && entry.endsWith(suffix)) results.push(path);
+  }
+  return results.sort();
+}
+
+function safeStat(path: string) {
+  try {
+    return statSync(path);
+  } catch {
+    return undefined;
+  }
+}
+
+function inferProjectName(cwd: string) {
+  return basename(cwd) || "AppleApp";
+}
+
+function inferPlatform(destination?: string): AxintRunPlatform {
+  if (!destination) return "macOS";
+  if (/visionOS/i.test(destination)) return "visionOS";
+  if (/watchOS/i.test(destination)) return "watchOS";
+  if (/iOS/i.test(destination)) return "iOS";
+  if (/macOS/i.test(destination)) return "macOS";
+  return "all";
+}
+
+function defaultDestination(platform: AxintRunPlatform) {
+  if (platform === "iOS") return "platform=iOS Simulator,name=iPhone 16";
+  if (platform === "visionOS") {
+    return "platform=visionOS Simulator,name=Apple Vision Pro";
+  }
+  if (platform === "watchOS") {
+    return "platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)";
+  }
+  return "platform=macOS";
+}
+
+function stripXcodeExtension(path: string) {
+  return basename(path).replace(/\.(xcodeproj|xcworkspace)$/i, "");
+}
+
+function stepFromCommand(name: string, result: AxintRunCommandResult): AxintRunStep {
+  const printable = [result.command, ...result.args].map(shellQuote).join(" ");
+  return {
+    name,
+    state: result.exitCode === 0 && !result.timedOut ? "pass" : "fail",
+    detail: result.dryRun
+      ? "Dry run planned the command without executing it."
+      : result.timedOut
+        ? `Command timed out after ${Math.round(result.durationMs / 1000)}s.`
+        : result.exitCode === 0
+          ? "Command completed successfully."
+          : `Command exited with ${result.exitCode ?? result.signal ?? "unknown"}.`,
+    command: printable,
+    durationMs: result.durationMs,
+  };
+}
+
+function summarizeStatus(
+  steps: AxintRunStep[],
+  workflow: WorkflowCheckReport,
+  diagnostics: Diagnostic[],
+  cloudChecks: CloudCheckReport[]
+): AxintRunReport["status"] {
+  if (
+    steps.some((step) => step.state === "fail") ||
+    workflow.status === "needs_action" ||
+    diagnostics.some((diagnostic) => diagnostic.severity === "error") ||
+    cloudChecks.some((check) => check.status === "fail")
+  ) {
+    return "fail";
+  }
+  if (
+    steps.some((step) => step.state === "warn" || step.state === "skipped") ||
+    diagnostics.some((diagnostic) => diagnostic.severity === "warning") ||
+    cloudChecks.some((check) => check.status === "needs_review")
+  ) {
+    return "needs_review";
+  }
+  return "pass";
+}
+
+function gateForStatus(
+  status: AxintRunReport["status"],
+  steps: AxintRunStep[]
+): AxintRunReport["gate"] {
+  if (status === "pass") {
+    return {
+      decision: "ready_to_ship",
+      reason: "Axint gates, build/test commands, and supplied runtime evidence passed.",
+    };
+  }
+  if (steps.some((step) => step.state === "fail")) {
+    return {
+      decision: "fix_required",
+      reason: "One or more Axint Run steps failed.",
+    };
+  }
+  return {
+    decision: "evidence_required",
+    reason: "Static checks passed, but runtime or test evidence is incomplete.",
+  };
+}
+
+function buildNextSteps(
+  status: AxintRunReport["status"],
+  steps: AxintRunStep[],
+  workflow: WorkflowCheckReport,
+  cloudChecks: CloudCheckReport[]
+): string[] {
+  if (status === "pass") {
+    return ["Commit the generated Axint Run artifacts with the related code change."];
+  }
+  const next = new Set<string>();
+  for (const item of workflow.required) next.add(item);
+  for (const check of cloudChecks) {
+    for (const item of check.nextSteps) next.add(item);
+  }
+  for (const step of steps) {
+    if (step.state === "fail" && step.command) {
+      next.add(`Fix the failing step, then rerun: ${step.command}`);
+    }
+  }
+  if (next.size === 0) {
+    next.add("Add build, test, or runtime evidence and rerun axint run.");
+  }
+  return [...next];
+}
+
+function buildRunRepairPrompt(input: {
+  status: AxintRunReport["status"];
+  workflow: WorkflowCheckReport;
+  validationDiagnostics: Diagnostic[];
+  cloudChecks: CloudCheckReport[];
+  commands: AxintRunReport["commands"];
+}) {
+  const lines = [
+    "You are repairing an Apple-native project under Axint Run.",
+    `Overall status: ${input.status}.`,
+    "",
+    "Do not continue ordinary coding until the Axint Run failures are addressed.",
+    "",
+    "Workflow gate:",
+    ...input.workflow.required.map((item) => `- REQUIRED: ${item}`),
+    ...input.workflow.recommended.map((item) => `- RECOMMENDED: ${item}`),
+    "",
+    "Swift diagnostics:",
+    ...(input.validationDiagnostics.length > 0
+      ? input.validationDiagnostics
+          .slice(0, 12)
+          .map(
+            (diagnostic) =>
+              `- ${diagnostic.severity.toUpperCase()} ${diagnostic.code}: ${diagnostic.message}`
+          )
+      : ["- None."]),
+    "",
+    "Cloud Check findings:",
+    ...(input.cloudChecks.length > 0
+      ? input.cloudChecks
+          .slice(0, 8)
+          .flatMap((check) => [
+            `- ${check.fileName}: ${check.status} (${check.gate.decision})`,
+            ...check.diagnostics
+              .slice(0, 6)
+              .map(
+                (diagnostic) =>
+                  `  - ${diagnostic.severity.toUpperCase()} ${diagnostic.code}: ${diagnostic.message}`
+              ),
+          ])
+      : ["- None."]),
+  ];
+
+  for (const [label, result] of Object.entries(input.commands)) {
+    if (!result || result.exitCode === 0) continue;
+    lines.push(
+      "",
+      `${label} command failed:`,
+      `- Command: ${[result.command, ...result.args].map(shellQuote).join(" ")}`,
+      `- Exit: ${result.exitCode ?? result.signal ?? "unknown"}`,
+      result.stderr ? `- stderr: ${result.stderr.slice(0, 4000)}` : "",
+      result.stdout ? `- stdout: ${result.stdout.slice(-4000)}` : ""
+    );
+  }
+
+  lines.push(
+    "",
+    "After repairing, rerun `axint run` so Axint validates, Cloud Checks, builds, tests, and records the new evidence."
+  );
+  return lines.filter(Boolean).join("\n");
+}
+
+function writeRunArtifacts(report: AxintRunReport) {
+  const dir = join(report.cwd, ".axint", "run");
+  mkdirSync(dir, { recursive: true });
+  const jsonPath = join(dir, "latest.json");
+  const markdownPath = join(dir, "latest.md");
+  const serializable = {
+    ...report,
+    artifacts: {
+      json: jsonPath,
+      markdown: markdownPath,
+    },
+  };
+  writeFileSync(jsonPath, `${JSON.stringify(serializable, null, 2)}\n`, "utf-8");
+  writeFileSync(markdownPath, renderAxintRunReport(serializable), "utf-8");
+  return {
+    json: jsonPath,
+    markdown: markdownPath,
+  };
+}
+
+function relativeOrAbsolute(cwd: string, path: string) {
+  return path.startsWith(cwd) ? path.slice(cwd.length + 1) : path;
+}
+
+function unique(values: string[]) {
+  return [...new Set(values)];
+}
+
+function shellQuote(value: string) {
+  if (/^[A-Za-z0-9_./:=+-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function stateLabel(state: AxintRunStepState) {
+  if (state === "pass") return "PASS";
+  if (state === "warn") return "WARN";
+  if (state === "fail") return "FAIL";
+  return "SKIP";
+}

--- a/tests/cli/xcode.test.ts
+++ b/tests/cli/xcode.test.ts
@@ -167,6 +167,53 @@ describe("xcode CLI smoke coverage", () => {
     expect(config.mcpServers.axint.env?.PATH).toContain(dirname(npxPath));
   });
 
+  it("writes guarded project memory and Xcode guard proof when requested", async () => {
+    const npxPath = join(tempRoot, "bin", "npx");
+    const projectDir = join(tempRoot, "Swarm");
+    mkdirSync(dirname(npxPath), { recursive: true });
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(npxPath, "", "utf-8");
+
+    execSyncMock.mockImplementation((command: string) => {
+      if (command.startsWith("xcodebuild -version")) {
+        return "Xcode 26.3\nBuild version 17E123";
+      }
+      if (command.startsWith("xcrun mcpbridge --help")) {
+        return "";
+      }
+      if (command.startsWith("which axint")) {
+        return "/usr/local/bin/axint\n";
+      }
+      if (command.startsWith("claude mcp add --transport stdio")) {
+        return "";
+      }
+      if (command.startsWith("command -v npx")) {
+        return `${npxPath}\n`;
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await setupXcode({
+      agent: "claude",
+      remote: false,
+      guarded: true,
+      project: projectDir,
+      name: "Swarm",
+    });
+
+    const guardPath = join(projectDir, ".axint", "guard", "latest.json");
+    const guard = JSON.parse(readFileSync(guardPath, "utf-8")) as {
+      status: string;
+      session?: { token: string };
+    };
+
+    expect(readFileSync(join(projectDir, "AGENTS.md"), "utf-8")).toContain(
+      "axint.xcode.guard"
+    );
+    expect(guard.status).toBe("ready");
+    expect(guard.session?.token).toMatch(/^axsess_/);
+  });
+
   it("covers extension status when the app is installed", async () => {
     const appPath = join(
       mockedState.home,

--- a/tests/core/swift-validator.test.ts
+++ b/tests/core/swift-validator.test.ts
@@ -769,4 +769,77 @@ describe("swift validator — AX739 undeclared SwiftUI body references", () => {
       0
     );
   });
+
+  it("accepts tuple closure parameters in ForEach bodies", () => {
+    const source = `
+      import SwiftUI
+
+      struct HomeFeedView: View {
+          let posts = ["Launch", "Build"]
+
+          var body: some View {
+              VStack {
+                  ForEach(Array(posts.enumerated()), id: \\.offset) { index, post in
+                      Text("\\(index): \\(post)")
+                  }
+              }
+          }
+      }
+    `;
+
+    expect(validate(source).diagnostics.filter((d) => d.code === "AX739")).toHaveLength(
+      0
+    );
+  });
+
+  it("accepts modifier closure parameters like onChange values", () => {
+    const source = `
+      import SwiftUI
+
+      struct ProjectImportProgressView: View {
+          @State private var phase = "idle"
+
+          var body: some View {
+              Text(phase)
+                  .onChange(of: phase) { _, newPhase in
+                      if newPhase == "complete" {
+                          print(newPhase)
+                      }
+                  }
+          }
+      }
+    `;
+
+    expect(validate(source).diagnostics.filter((d) => d.code === "AX739")).toHaveLength(
+      0
+    );
+  });
+
+  it("accepts private helper methods declared on the view", () => {
+    const source = `
+      import SwiftUI
+
+      struct OverlayView: View {
+          var body: some View {
+              ZStack {
+                  detailOverlayScrim()
+                  detailCloseButton()
+              }
+          }
+
+          @ViewBuilder
+          private func detailOverlayScrim() -> some View {
+              Color.black.opacity(0.2)
+          }
+
+          private func detailCloseButton() -> some View {
+              Button("Close") {}
+          }
+      }
+    `;
+
+    expect(validate(source).diagnostics.filter((d) => d.code === "AX739")).toHaveLength(
+      0
+    );
+  });
 });

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -11,6 +11,10 @@ import { scaffoldIntent } from "../../src/mcp/scaffold.js";
 import { TEMPLATES, getTemplate } from "../../src/templates/index.js";
 import { validateSwiftSource } from "../../src/core/swift-validator.js";
 import { fixSwiftSource } from "../../src/core/swift-fixer.js";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { writeProjectStartPack } from "../../src/project/start-pack.js";
 
 describe("axint.status tool", () => {
   it("reports the running MCP server version and restart instructions", async () => {
@@ -26,7 +30,7 @@ describe("axint.status tool", () => {
     expect(payload.server).toBe("axint-mcp");
     expect(payload.version).toMatch(/^\d+\.\d+\.\d+/);
     expect(payload.restartRequiredAfterUpdate).toBe(true);
-    expect(payload.xcodeSetupCommand).toBe("axint xcode setup --agent claude");
+    expect(payload.xcodeSetupCommand).toBe("axint xcode setup --agent claude --guarded");
   });
 
   it("returns a human-readable Xcode update path", async () => {
@@ -35,6 +39,104 @@ describe("axint.status tool", () => {
     expect(result.content[0].text).toContain("# Axint MCP Status");
     expect(result.content[0].text).toContain("Call axint.status");
     expect(result.content[0].text).toContain("Restart the Xcode Claude Agent");
+  });
+});
+
+describe("axint.run tool", () => {
+  it("returns a structured Axint Run report for a dry-run Xcode project", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-mcp-run-"));
+    const schemeDir = join(dir, "Demo.xcodeproj", "xcshareddata", "xcschemes");
+    mkdirSync(schemeDir, { recursive: true });
+    writeFileSync(join(schemeDir, "Demo.xcscheme"), "<Scheme></Scheme>\n");
+    writeFileSync(
+      join(dir, "ContentView.swift"),
+      'import SwiftUI\nstruct ContentView: View { var body: some View { Text("Hi") } }\n'
+    );
+
+    const result = await handleToolCall("axint.run", {
+      cwd: dir,
+      dryRun: true,
+      format: "json",
+    });
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      session: { token: string };
+      commands: { build: { dryRun: boolean } };
+      cloudChecks: unknown[];
+    };
+    expect(payload.session.token).toMatch(/^axsess_/);
+    expect(payload.commands.build.dryRun).toBe(true);
+    expect(payload.cloudChecks.length).toBe(1);
+  });
+});
+
+describe("axint.xcode.guard tool", () => {
+  it("starts a guarded Xcode session and writes durable proof artifacts", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-mcp-guard-"));
+    writeProjectStartPack({
+      targetDir: dir,
+      projectName: "GuardedDemo",
+      version: "0.4.9",
+      force: true,
+    });
+
+    const result = await handleToolCall("axint.xcode.guard", {
+      cwd: dir,
+      projectName: "GuardedDemo",
+      stage: "context-recovery",
+      format: "json",
+    });
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      status: string;
+      session: { token: string; autoStarted: boolean };
+      proofFiles: { json: string; markdown: string };
+      latestEvidence: { kind: string };
+    };
+    expect(payload.status).toBe("ready");
+    expect(payload.session.token).toMatch(/^axsess_/);
+    expect(payload.session.autoStarted).toBe(true);
+    expect(payload.latestEvidence.kind).toBe("session");
+    expect(existsSync(payload.proofFiles.json)).toBe(true);
+    expect(existsSync(payload.proofFiles.markdown)).toBe(true);
+  });
+
+  it("writes Swift through the guarded Xcode path", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-mcp-write-"));
+    writeProjectStartPack({
+      targetDir: dir,
+      projectName: "WriteDemo",
+      version: "0.4.9",
+      force: true,
+    });
+
+    const source =
+      'import SwiftUI\nstruct GuardedView: View { var body: some View { Text("Guarded") } }\n';
+    const result = await handleToolCall("axint.xcode.write", {
+      cwd: dir,
+      projectName: "WriteDemo",
+      path: "Sources/GuardedView.swift",
+      content: source,
+      platform: "macOS",
+      format: "json",
+    });
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      status: string;
+      relativePath: string;
+      swiftValidation: { diagnostics: unknown[] };
+      cloudCheck: { status: string };
+      guard: { status: string };
+    };
+    expect(payload.status).toBe("pass");
+    expect(payload.relativePath).toBe("Sources/GuardedView.swift");
+    expect(payload.swiftValidation.diagnostics).toHaveLength(0);
+    expect(payload.cloudCheck.status).toBe("needs_review");
+    expect(payload.guard.status).toBe("ready");
+    expect(readFileSync(join(dir, "Sources", "GuardedView.swift"), "utf-8")).toBe(source);
   });
 });
 

--- a/tests/run/project-runner.test.ts
+++ b/tests/run/project-runner.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { renderAxintRunReport, runAxintProject } from "../../src/run/project-runner.js";
+
+function makeFakeXcodeProject() {
+  const dir = mkdtempSync(join(tmpdir(), "axint-run-"));
+  const schemeDir = join(dir, "Swarm.xcodeproj", "xcshareddata", "xcschemes");
+  mkdirSync(schemeDir, { recursive: true });
+  writeFileSync(join(schemeDir, "Swarm.xcscheme"), "<Scheme></Scheme>\n");
+  writeFileSync(
+    join(dir, "ContentView.swift"),
+    [
+      "import SwiftUI",
+      "",
+      "struct ContentView: View {",
+      "  var body: some View {",
+      '    Text("Hello")',
+      "  }",
+      "}",
+      "",
+    ].join("\n")
+  );
+  return dir;
+}
+
+describe("runAxintProject", () => {
+  it("plans the enforced Axint build loop in dry-run mode", async () => {
+    const dir = makeFakeXcodeProject();
+    const report = await runAxintProject({
+      cwd: dir,
+      expectedVersion: "0.0.0-test",
+      dryRun: true,
+      writeReport: true,
+    });
+
+    expect(report.session.token).toMatch(/^axsess_/);
+    expect(report.workflow.status).toBe("ready");
+    expect(report.swiftValidation.filesChecked).toBe(1);
+    expect(report.cloudChecks).toHaveLength(1);
+    expect(report.commands.build?.dryRun).toBe(true);
+    expect(report.commands.test?.dryRun).toBe(true);
+    expect(report.commands.build?.args).toContain("-project");
+    expect(report.commands.build?.args).toContain("Swarm");
+    expect(report.artifacts.json).toBeDefined();
+    expect(readFileSync(report.artifacts.json!, "utf-8")).toContain('"status"');
+  });
+
+  it("renders a repair prompt for agents", async () => {
+    const dir = makeFakeXcodeProject();
+    const report = await runAxintProject({
+      cwd: dir,
+      dryRun: true,
+      runtime: true,
+      writeReport: false,
+    });
+
+    const prompt = renderAxintRunReport(report, "prompt");
+    expect(prompt).toContain("You are repairing an Apple-native project");
+    expect(prompt).toContain("After repairing, rerun `axint run`");
+  });
+});


### PR DESCRIPTION
## Summary
- add the guarded Xcode Axint loop with `axint.xcode.guard`, `axint.xcode.write`, and `axint run`
- wire guarded setup into Xcode Claude Agent config, project memory, prompts, doctor/status output, and MCP manifest/server
- fix AX739 dogfooding false positives for tuple closure parameters, `onChange` closure values, and view helper methods
- refresh metrics to 23 MCP tools + 5 prompts, 182 diagnostics, and 1107 tests

## Validation
- `npm run typecheck`
- `npm test` after rerun: 70 files / 996 tests passed
- `npm run build`
- `npm run metrics:check`
- `npm run docs:check`
- `npm run boundary:check`
- workspace `npm run truth:sync`
- workspace `npm run truth:check`

## Notes
Direct push to `main` is blocked by repository rules, so this PR carries the pushed branch.
