### PR TITLE
Keep workflow checks inside Axint loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.9 · 23 MCP tools + 5 prompts · 182 diagnostic codes · 1107 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.9 · 23 MCP tools + 5 prompts · 182 diagnostic codes · 1108 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/metrics.json
+++ b/metrics.json
@@ -73,7 +73,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 993,
+    "typescript": 994,
     "python": 114
   },
   "registryPackages": 14,

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -601,7 +601,9 @@ export const TOOL_MANIFEST = [
       "building, or committing to make sure the agent has actually used the " +
       "right Axint tools: suggest for planning, feature for new surfaces, " +
       "swift.validate for modified Swift, cloud.check for coverage-aware " +
-      "repair feedback, and Xcode build/test evidence for runtime proof.",
+      "repair feedback, and Xcode build/test evidence for runtime proof. " +
+      "A ready result is not a completion stamp: the response includes the next " +
+      "Axint action the agent should call before returning to ordinary Xcode work.",
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,

--- a/src/mcp/workflow-check.ts
+++ b/src/mcp/workflow-check.ts
@@ -188,6 +188,10 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
   }
 
   const status = required.length === 0 ? "ready" : "needs_action";
+  const nextTool =
+    status === "needs_action"
+      ? nextToolForRequired(required)
+      : nextToolForSatisfiedStage(stage, surfaces, modifiedFiles);
   const score = Math.max(
     0,
     100 - required.length * 30 - recommended.length * 10 - (checked.length === 0 ? 10 : 0)
@@ -198,12 +202,14 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
     stage,
     summary:
       status === "ready"
-        ? "Axint workflow gate is satisfied for this stage."
+        ? nextTool
+          ? `Axint workflow gate is satisfied for this stage. This is not a completion stamp; continue with ${nextTool} before ordinary Xcode work.`
+          : "Axint workflow gate is satisfied for this stage."
         : "Axint workflow gate needs one or more agent actions before moving on.",
     score,
     required,
     recommended,
-    nextTool: nextToolFor(required),
+    nextTool,
     checked,
   };
 }
@@ -233,7 +239,12 @@ export function renderWorkflowCheckReport(report: WorkflowCheckReport): string {
   ];
 
   if (report.nextTool) {
-    lines.push("", "## Next Tool", `- ${report.nextTool}`);
+    lines.push(
+      "",
+      "## Next Axint Action",
+      `- ${report.nextTool}`,
+      "- Do not treat this workflow check as the only Axint step. Call the next Axint action before continuing with raw Xcode tools or hand-written Swift."
+    );
   }
 
   return lines.join("\n");
@@ -250,7 +261,7 @@ function inferSurfaces(files: string[]): Surface[] {
   return [...surfaces];
 }
 
-function nextToolFor(required: string[]): string | undefined {
+function nextToolForRequired(required: string[]): string | undefined {
   const text = required.join(" ").toLowerCase();
   if (text.includes("axint.session.start")) return "axint.session.start";
   if (
@@ -268,6 +279,33 @@ function nextToolFor(required: string[]): string | undefined {
   if (text.includes("axint.feature")) return "axint.feature";
   if (text.includes("axint.swift.validate")) return "axint.swift.validate";
   if (text.includes("axint.cloud.check")) return "axint.cloud.check";
+  return undefined;
+}
+
+function nextToolForSatisfiedStage(
+  stage: WorkflowStage,
+  surfaces: Surface[],
+  modifiedFiles: string[]
+): string | undefined {
+  if (stage === "session-start" || stage === "context-recovery") {
+    return "axint.suggest";
+  }
+  if (stage === "planning") {
+    return surfaces.some((surface) =>
+      ["view", "component", "intent", "widget", "app", "store"].includes(surface)
+    )
+      ? "axint.feature"
+      : "axint.xcode.guard";
+  }
+  if (stage === "before-write") {
+    return "axint.xcode.write";
+  }
+  if (stage === "pre-build") {
+    return "axint.run";
+  }
+  if (stage === "pre-commit" && modifiedFiles.some((file) => file.endsWith(".swift"))) {
+    return "axint.cloud.check";
+  }
   return undefined;
 }
 

--- a/src/project/docs-context.ts
+++ b/src/project/docs-context.ts
@@ -180,6 +180,8 @@ Use \`axint.workflow.check\` at these stages:
 - \`pre-build\`: requires Swift validation and Cloud Check.
 - \`pre-commit\`: requires validation, Cloud Check, build evidence, and focused tests when relevant.
 
+A \`ready\` workflow check is not the last Axint step. The report includes \`Next Axint Action\`; call that tool before returning to raw Xcode tools or hand-written Swift.
+
 ## Cloud Check Rules
 
 Cloud Check is not a rubber stamp. It should return a ship gate:

--- a/src/project/rehydration.ts
+++ b/src/project/rehydration.ts
@@ -57,6 +57,7 @@ The model's memory is not the source of truth. These project files are. If the a
 - New Swift file: prefer \`axint.xcode.write\` so the write runs validation, Cloud Check, and guard proof immediately.
 - Before build: prefer \`axint.run\` for the full enforced loop. If doing it manually, call \`axint.workflow.check\` with \`stage: "pre-build"\`, \`ranSwiftValidate: true\`, and \`ranCloudCheck: true\`.
 - Before done: \`axint.workflow.check\` with \`stage: "pre-commit"\`, validation, Cloud Check, build evidence, and relevant tests.
+- If \`axint.workflow.check\` returns \`ready\`, it is not permission to stop using Axint. Read the \`Next Axint Action\` line and call that tool before ordinary Xcode work.
 
 ## Drift Triggers
 

--- a/src/project/start-pack.ts
+++ b/src/project/start-pack.ts
@@ -349,11 +349,12 @@ Do not rely on model memory alone. Rehydrate the workflow from the files.
 3. Read the Axint docs listed in the start prompt.
 4. Call \`axint.status\`.
 5. Call \`axint.workflow.check\` with \`sessionToken\` at session start, after context recovery, before planning, before writing, before building, and before committing.
-6. Use \`axint.suggest\` for feature planning.
-7. Use \`axint.feature\`, \`axint.scaffold\`, \`axint.compile\`, or \`axint.schema.compile\` for Apple-native surfaces.
-8. Prefer \`axint.xcode.write\` for new Swift files so Axint validation, Cloud Check, and guard proof happen as part of the write.
-9. Run \`axint.swift.validate\` on modified Swift.
-10. Run \`axint.cloud.check\` with Xcode build, test, runtime, or behavior evidence when available.
+6. If \`axint.workflow.check\` returns \`ready\`, call the report's \`Next Axint Action\` before ordinary Xcode work.
+7. Use \`axint.suggest\` for feature planning.
+8. Use \`axint.feature\`, \`axint.scaffold\`, \`axint.compile\`, or \`axint.schema.compile\` for Apple-native surfaces.
+9. Prefer \`axint.xcode.write\` for new Swift files so Axint validation, Cloud Check, and guard proof happen as part of the write.
+10. Run \`axint.swift.validate\` on modified Swift.
+11. Run \`axint.cloud.check\` with Xcode build, test, runtime, or behavior evidence when available.
 11. Prefer \`axint.run\` when moving toward build/test/runtime proof so Axint owns the loop instead of relying on memory.
 12. Build in Xcode or via \`xcodebuild\`. Static Axint checks are not a replacement for runtime proof.
 

--- a/tests/mcp/workflow-check.test.ts
+++ b/tests/mcp/workflow-check.test.ts
@@ -137,8 +137,27 @@ describe("axint.workflow.check", () => {
 
     expect(report.status).toBe("ready");
     expect(report.required).toEqual([]);
+    expect(report.nextTool).toBe("axint.run");
     expect(renderWorkflowCheckReport(report)).toContain(
       "Axint workflow gate is satisfied"
     );
+  });
+
+  it("returns the next Axint action even when context recovery is satisfied", () => {
+    const report = runWorkflowCheck({
+      ...sessionArgs(),
+      stage: "context-recovery",
+      readRehydrationContext: true,
+      readAgentInstructions: true,
+      readDocsContext: true,
+      ranStatus: true,
+    });
+
+    const rendered = renderWorkflowCheckReport(report);
+    expect(report.status).toBe("ready");
+    expect(report.nextTool).toBe("axint.suggest");
+    expect(report.summary).toContain("not a completion stamp");
+    expect(rendered).toContain("Next Axint Action");
+    expect(rendered).toContain("Do not treat this workflow check as the only Axint step");
   });
 });


### PR DESCRIPTION
## Summary
- make `axint.workflow.check` return a next Axint action even when the gate is ready
- update rendered reports so agents cannot treat workflow check as the only Axint step
- refresh recovery docs/start-pack language around the continuous Axint loop
- add regression coverage for the context-recovery ready path
- refresh metrics/truth to 1108 tests

## Validation
- `npm run typecheck`
- focused `npm test -- tests/mcp/workflow-check.test.ts tests/mcp/server.test.ts tests/mcp/machine.test.ts`
- `npm test` after build completed: 70 files / 997 tests passed
- `npm run build`
- `npm run metrics:check`
- `npm run docs:check`
- `npm run boundary:check`
- workspace `npm run truth:sync`
- workspace `npm run truth:check`
