### PR TITLE
Harden workflow next action transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.9 · 23 MCP tools + 5 prompts · 182 diagnostic codes · 1108 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.9 · 23 MCP tools + 5 prompts · 182 diagnostic codes · 1110 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/metrics.json
+++ b/metrics.json
@@ -73,7 +73,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 994,
+    "typescript": 996,
     "python": 114
   },
   "registryPackages": 14,

--- a/src/mcp/workflow-check.ts
+++ b/src/mcp/workflow-check.ts
@@ -191,7 +191,13 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
   const nextTool =
     status === "needs_action"
       ? nextToolForRequired(required)
-      : nextToolForSatisfiedStage(stage, surfaces, modifiedFiles);
+      : nextToolForSatisfiedStage({
+          stage,
+          surfaces,
+          modifiedFiles,
+          xcodeBuildPassed: Boolean(input.xcodeBuildPassed),
+          xcodeTestsPassed: Boolean(input.xcodeTestsPassed),
+        });
   const score = Math.max(
     0,
     100 - required.length * 30 - recommended.length * 10 - (checked.length === 0 ? 10 : 0)
@@ -282,11 +288,14 @@ function nextToolForRequired(required: string[]): string | undefined {
   return undefined;
 }
 
-function nextToolForSatisfiedStage(
-  stage: WorkflowStage,
-  surfaces: Surface[],
-  modifiedFiles: string[]
-): string | undefined {
+function nextToolForSatisfiedStage(input: {
+  stage: WorkflowStage;
+  surfaces: Surface[];
+  modifiedFiles: string[];
+  xcodeBuildPassed: boolean;
+  xcodeTestsPassed: boolean;
+}): string | undefined {
+  const { stage, surfaces, modifiedFiles, xcodeBuildPassed, xcodeTestsPassed } = input;
   if (stage === "session-start" || stage === "context-recovery") {
     return "axint.suggest";
   }
@@ -301,10 +310,13 @@ function nextToolForSatisfiedStage(
     return "axint.xcode.write";
   }
   if (stage === "pre-build") {
-    return "axint.run";
+    return xcodeBuildPassed ? "axint.workflow.check(stage=pre-commit)" : "axint.run";
   }
-  if (stage === "pre-commit" && modifiedFiles.some((file) => file.endsWith(".swift"))) {
-    return "axint.cloud.check";
+  if (stage === "pre-commit") {
+    if (!xcodeTestsPassed) return "axint.run";
+    if (modifiedFiles.some((file) => file.endsWith(".swift"))) {
+      return "axint.xcode.guard(stage=finish)";
+    }
   }
   return undefined;
 }

--- a/tests/mcp/workflow-check.test.ts
+++ b/tests/mcp/workflow-check.test.ts
@@ -137,10 +137,40 @@ describe("axint.workflow.check", () => {
 
     expect(report.status).toBe("ready");
     expect(report.required).toEqual([]);
-    expect(report.nextTool).toBe("axint.run");
+    expect(report.nextTool).toBe("axint.workflow.check(stage=pre-commit)");
     expect(renderWorkflowCheckReport(report)).toContain(
       "Axint workflow gate is satisfied"
     );
+  });
+
+  it("sends a ready pre-build gate to axint.run when build evidence is still missing", () => {
+    const report = runWorkflowCheck({
+      ...sessionArgs(),
+      stage: "pre-build",
+      modifiedFiles: ["CreateMissionIntent.swift"],
+      ranSwiftValidate: true,
+      ranCloudCheck: true,
+      xcodeBuildPassed: false,
+    });
+
+    expect(report.status).toBe("ready");
+    expect(report.nextTool).toBe("axint.run");
+    expect(report.recommended.join("\n")).toMatch(/Xcode build/);
+  });
+
+  it("sends a ready pre-commit gate to finish guard after tests pass", () => {
+    const report = runWorkflowCheck({
+      ...sessionArgs(),
+      stage: "pre-commit",
+      modifiedFiles: ["HomeFeedView.swift"],
+      ranSwiftValidate: true,
+      ranCloudCheck: true,
+      xcodeBuildPassed: true,
+      xcodeTestsPassed: true,
+    });
+
+    expect(report.status).toBe("ready");
+    expect(report.nextTool).toBe("axint.xcode.guard(stage=finish)");
   });
 
   it("returns the next Axint action even when context recovery is satisfied", () => {


### PR DESCRIPTION
## Summary
- harden ready workflow transitions so the next action advances instead of looping on `axint.run`
- route pre-build gates with build evidence to `axint.workflow.check(stage=pre-commit)`
- route final pre-commit gates with test evidence to `axint.xcode.guard(stage=finish)`
- add regression tests for missing build evidence vs build-present vs final finish proof
- refresh metrics/truth to 1110 tests

## Validation
- `npm run typecheck`
- focused `npm test -- tests/mcp/workflow-check.test.ts tests/run/project-runner.test.ts tests/mcp/server.test.ts`
- `npm test`: 70 files / 999 tests passed
- `npm run build`
- `npm run metrics:check`
- `npm run docs:check`
- `npm run boundary:check`
- workspace `npm run truth:sync`
- workspace `npm run truth:check`
