### PR TITLE
Harden Cloud Check and semantic component generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.10 · 23 MCP tools + 5 prompts · 182 diagnostic codes · 1110 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.10 · 23 MCP tools + 5 prompts · 182 diagnostic codes · 1115 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/metrics.json
+++ b/metrics.json
@@ -73,7 +73,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 996,
+    "typescript": 1001,
     "python": 114
   },
   "registryPackages": 14,

--- a/src/cloud/check.ts
+++ b/src/cloud/check.ts
@@ -566,17 +566,19 @@ function inferEvidenceDiagnostics(input: {
   if (
     input.input.expectedBehavior &&
     input.input.actualBehavior &&
-    normalizeTextForEvidence(input.input.expectedBehavior) !==
-      normalizeTextForEvidence(input.input.actualBehavior)
+    behaviorEvidenceContradictsExpectation(
+      input.input.expectedBehavior,
+      input.input.actualBehavior
+    )
   ) {
     diagnostics.push({
       code: "AXCLOUD-BEHAVIOR-MISMATCH",
       severity: "warning",
       file,
       message:
-        "The supplied expected behavior and actual behavior differ, so the static pass is not enough to call this fixed.",
+        "The supplied actual behavior appears to contradict or miss the expected behavior, so the static pass is not enough to call this fixed.",
       suggestion:
-        "Add or update a focused unit/UI test for the expected behavior, then include the failing test output in the next Cloud Check call.",
+        "Add or update a focused unit/UI test for the expected behavior. If the behavior is implemented, include clean build/test proof rather than only prose evidence.",
     });
   }
 
@@ -703,6 +705,44 @@ function diagnosticsFromBuildLog(buildLog: string, file: string): Diagnostic[] {
       message: "Xcode build evidence reports a missing symbol.",
       suggestion:
         "Add the missing file to the target, import the required framework, or rename the generated reference to match the real project symbol.",
+    });
+  }
+
+  if (/\b(?:type|value)\s+'[^']+'\s+has no member\s+'[^']+'/.test(text)) {
+    diagnostics.push({
+      code: "AXCLOUD-BUILD-MISSING-MEMBER",
+      severity: "error",
+      file,
+      message:
+        "Xcode build evidence reports a member reference that does not exist on the resolved type.",
+      suggestion:
+        "Rename the generated enum case, static token, or type member to match the project symbol. If Axint generated it, feed the declaring type or design-token file as context before regenerating.",
+    });
+  }
+
+  if (
+    /\bincorrect argument label\b|\bextraneous argument label\b|\bmissing argument label\b/.test(
+      text
+    )
+  ) {
+    diagnostics.push({
+      code: "AXCLOUD-BUILD-ARGUMENT-LABEL",
+      severity: "error",
+      file,
+      message: "Xcode build evidence reports an incorrect function argument label.",
+      suggestion:
+        "Update the call site to the callee's real signature. For generated code, include the target method declaration as context before regenerating.",
+    });
+  }
+
+  if (/\bcannot convert value of type\b|\bcannot assign value of type\b/.test(text)) {
+    diagnostics.push({
+      code: "AXCLOUD-BUILD-TYPE-MISMATCH",
+      severity: "error",
+      file,
+      message: "Xcode build evidence reports a Swift type mismatch.",
+      suggestion:
+        "Fix the expression type instead of suppressing the error. Common agent mistakes include mapping a String/Substring into [String], quoting non-string defaults, or returning an array where a scalar is expected.",
     });
   }
 
@@ -1054,6 +1094,78 @@ function dedupeDiagnostics(diagnostics: Diagnostic[]): Diagnostic[] {
 
 function normalizeTextForEvidence(value: string): string {
   return value.toLowerCase().replace(/[’']/g, "'").replace(/\s+/g, " ").trim();
+}
+
+function behaviorEvidenceContradictsExpectation(
+  expectedBehavior: string,
+  actualBehavior: string
+): boolean {
+  const expected = normalizeTextForEvidence(expectedBehavior);
+  const actual = normalizeTextForEvidence(actualBehavior);
+  if (!expected || !actual || expected === actual) return false;
+
+  const negativeEvidence =
+    /\b(fail|fails|failed|failing|missing|misses|missed|never|no longer|wrong|incorrect|broken|regress|regressed|regression|freeze|freezes|frozen|hang|hangs|hung|crash|crashes|unresponsive|timeout|timed out|instead|mismatch|contradict|contradicts)\b/.test(
+      actual
+    ) ||
+    /\b(?:not|doesn't|does not|can't|cannot)\s+(?:work|working|implemented|show|render|match|pass|compile|build|load|open|respond|appear|exist|route|preserve)\b/.test(
+      actual
+    );
+  if (negativeEvidence) return true;
+
+  const implementationEvidence =
+    /\b(implemented|added|wired|built|created|preserved|kept|supports|shows|renders|uses|matches|includes|completed|fixed|passes|passed|clean|succeeds|succeeded)\b/.test(
+      actual
+    );
+  if (implementationEvidence) return false;
+
+  const expectedTokens = evidenceConceptTokens(expected);
+  const actualTokens = evidenceConceptTokens(actual);
+  if (expectedTokens.length === 0 || actualTokens.length === 0) return false;
+
+  const actualSet = new Set(actualTokens);
+  const overlap = expectedTokens.filter((token) => actualSet.has(token)).length;
+  const overlapRatio = overlap / Math.max(1, Math.min(expectedTokens.length, 10));
+  return overlap < 2 && overlapRatio < 0.25;
+}
+
+function evidenceConceptTokens(text: string): string[] {
+  const stopWords = new Set([
+    "about",
+    "actual",
+    "after",
+    "and",
+    "are",
+    "behavior",
+    "but",
+    "can",
+    "code",
+    "expected",
+    "for",
+    "from",
+    "has",
+    "have",
+    "into",
+    "its",
+    "not",
+    "now",
+    "out",
+    "should",
+    "that",
+    "the",
+    "this",
+    "through",
+    "with",
+  ]);
+  return Array.from(
+    new Set(
+      text
+        .replace(/[^a-z0-9\s-]/g, " ")
+        .split(/\s+/)
+        .map((token) => token.trim())
+        .filter((token) => token.length > 3 && !stopWords.has(token))
+    )
+  );
 }
 
 function labelForStatus(status: CloudCheckStatus): string {

--- a/src/mcp/semantic-planner.ts
+++ b/src/mcp/semantic-planner.ts
@@ -261,6 +261,9 @@ function extractComponentNames(description: string): string[] {
   const suffixPattern = COMPONENT_SUFFIXES.join("|");
   const pascalRe = new RegExp(`\\b[A-Z][A-Za-z0-9]*(?:${suffixPattern})\\b`, "g");
   for (const match of description.matchAll(pascalRe)) {
+    if (isContextComponentReference(description, match.index ?? 0, match[0].length)) {
+      continue;
+    }
     names.add(match[0]);
   }
 
@@ -270,6 +273,9 @@ function extractComponentNames(description: string): string[] {
     "gi"
   );
   for (const match of phraseSource.matchAll(phraseRe)) {
+    if (isContextComponentReference(phraseSource, match.index ?? 0, match[0].length)) {
+      continue;
+    }
     const name = phraseToComponentName(match[1] ?? "", match[2] ?? "");
     if (name.length > 4) names.add(name);
   }
@@ -283,6 +289,26 @@ function extractComponentNames(description: string): string[] {
         "NavigationSplitView",
         "HSplitView",
       ].includes(name)
+  );
+}
+
+function isContextComponentReference(
+  description: string,
+  index: number,
+  length: number
+): boolean {
+  const before = description.slice(Math.max(0, index - 90), index).toLowerCase();
+  const after = description.slice(index + length, index + length + 90).toLowerCase();
+  const window = `${before} ${after}`;
+  const explicitlyRequested =
+    /\b(named|called)\b/.test(before.slice(-60)) ||
+    /\b(create|generate|emit|build)\s+(?:a\s+|an\s+|the\s+)?(?:new\s+)?$/.test(
+      before.slice(-80)
+    );
+  if (explicitlyRequested) return false;
+
+  return /\b(existing|current|provided|nearby|already|context|without replacing|do not replace|don't replace|not replace|not replacing|preserve existing|reuse existing|use existing|existing app)\b/.test(
+    window
   );
 }
 
@@ -441,17 +467,26 @@ function phraseToComponentName(lead: string, suffix: string): string {
           "basic",
           "build",
           "create",
+          "and",
+          "context",
           "distinct",
+          "existing",
           "first",
           "generic",
           "make",
           "new",
+          "or",
           "primary",
+          "provided",
           "real",
+          "replacing",
           "reusable",
+          "right",
           "second",
           "swiftui",
           "third",
+          "use",
+          "using",
         ].includes(word)
     );
   if (words.length === 0) return "";

--- a/src/mcp/view-blueprints.ts
+++ b/src/mcp/view-blueprints.ts
@@ -849,6 +849,8 @@ function buildSemanticPillBody(input: ViewBlueprintInput): string {
 }
 
 function buildSemanticPanelBody(input: ViewBlueprintInput): string {
+  if (usesCommandLayerPanel(input)) return buildCommandLayerPanelBody(input);
+
   return `VStack(alignment: .leading, spacing: 14) {
             HStack {
                 Text("${escapeSwiftString(humanizeLocal(input.name))}")
@@ -873,6 +875,87 @@ function buildSemanticPanelBody(input: ViewBlueprintInput): string {
         }
         .padding(16)
         .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.10)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "14")}, style: .continuous))`;
+}
+
+function usesCommandLayerPanel(input: ViewBlueprintInput): boolean {
+  const lower = `${input.name} ${input.description ?? ""}`.toLowerCase();
+  return (
+    /\b(command layer|command center|composer|ambient activity|feed-first|top layer|status pill|status pills|home hierarchy)\b/.test(
+      lower
+    ) ||
+    (lower.includes("command") && lower.includes("feed"))
+  );
+}
+
+function buildCommandLayerPanelBody(input: ViewBlueprintInput): string {
+  return `VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Command layer")
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textPrimary", ".primary")})
+                    Text("Feed stays primary. Agent actions stay one move away.")
+                        .font(.caption)
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+                }
+
+                Spacer()
+
+                Label("Ready", systemImage: "checkmark.seal.fill")
+                    .font(.caption2.weight(.bold))
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 5)
+                    .background(${colorRef(input.tokenNamespace, "successSoft", "Color.green.opacity(0.14)")}, in: Capsule())
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "success", ".green")})
+            }
+
+            HStack(spacing: 8) {
+                ForEach(["Command Summary", "Ambient Activity", "Composer"], id: \\.self) { item in
+                    Text(item)
+                        .font(.caption2.weight(.semibold))
+                        .lineLimit(1)
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 5)
+                        .background(${colorRef(input.tokenNamespace, "surface", "Color.secondary.opacity(0.08)")}, in: Capsule())
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+                }
+            }
+
+            HStack(spacing: 10) {
+                Image(systemName: "sparkles")
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "accent", "Color.accentColor")})
+                TextField("Ask the swarm to route, summarize, or prepare a handoff", text: .constant(""))
+                    .textFieldStyle(.plain)
+                Button { } label: {
+                    Image(systemName: "arrow.up.right")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding(10)
+            .background(${colorRef(input.tokenNamespace, "bg", "Color.black.opacity(0.06)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "row", "12")}, style: .continuous))
+
+            HStack(spacing: 10) {
+                ForEach(["2 handoffs", "5 updates", "1 risk"], id: \\.self) { item in
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(${colorRef(input.tokenNamespace, "accent", "Color.accentColor")})
+                            .frame(width: 6, height: 6)
+                        Text(item)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, maxHeight: 180, alignment: .topLeading)
+        .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.10)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "14")}, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "14")}, style: .continuous)
+                .strokeBorder(${colorRef(input.tokenNamespace, "border", "Color.secondary.opacity(0.16)")}, lineWidth: 1)
+        }`;
 }
 
 function buildSemanticBarBody(input: ViewBlueprintInput): string {

--- a/tests/cloud/check.test.ts
+++ b/tests/cloud/check.test.ts
@@ -214,6 +214,60 @@ struct ContentView: View {
     );
   });
 
+  it("treats expected and actual behavior as semantic evidence instead of string equality", () => {
+    const report = runCloudCheck({
+      fileName: "HomeCommandLayer.swift",
+      platform: "macOS",
+      source: `
+import SwiftUI
+
+struct HomeCommandLayer: View {
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Command layer")
+            TextField("Ask the swarm", text: .constant(""))
+        }
+    }
+}
+`,
+      expectedBehavior:
+        "Compact 15-20 percent top command layer above the feed with command summary, status pills, ambient activity, and composer interactivity.",
+      actualBehavior:
+        "Implemented a compact command layer that does not bury the feed, preserves feed-first browsing, shows command summary, status pills, ambient activity, and a composer row.",
+      xcodeBuildLog: "Build succeeded. 38 tests passed.",
+    });
+
+    expect(report.diagnostics.map((d) => d.code)).not.toContain(
+      "AXCLOUD-BEHAVIOR-MISMATCH"
+    );
+    expect(report.status).toBe("pass");
+    expect(report.gate.decision).toBe("ready_to_ship");
+  });
+
+  it("flags behavior evidence only when the actual text describes a failure", () => {
+    const report = runCloudCheck({
+      fileName: "HomeCommandLayer.swift",
+      platform: "macOS",
+      source: `
+import SwiftUI
+
+struct HomeCommandLayer: View {
+    var body: some View {
+        Text("Home")
+    }
+}
+`,
+      expectedBehavior:
+        "Compact top command layer with command summary, status pills, ambient activity, and composer interactivity.",
+      actualBehavior:
+        "The command layer is missing. The app still shows the old home view instead.",
+    });
+
+    expect(report.status).toBe("needs_review");
+    expect(report.diagnostics.map((d) => d.code)).toContain("AXCLOUD-BEHAVIOR-MISMATCH");
+    expect(report.gate.decision).toBe("fix_required");
+  });
+
   it("classifies Xcode duplicate symbol build logs", () => {
     const report = runCloudCheck({
       fileName: "BrokenIntent.swift",
@@ -233,6 +287,38 @@ struct BrokenIntent: AppIntent {
     expect(report.diagnostics.map((d) => d.code)).toContain(
       "AXCLOUD-BUILD-REDECLARATION"
     );
+    expect(report.learningSignal?.signals).toContain("runtime-evidence-supplied");
+  });
+
+  it("classifies common hallucinated-symbol Xcode build logs", () => {
+    const report = runCloudCheck({
+      fileName: "ProjectImportProgressView.swift",
+      source: `
+import SwiftUI
+
+struct ProjectImportProgressView: View {
+    var body: some View { Text("Importing") }
+}
+`,
+      xcodeBuildLog: [
+        "error: type 'ImportSource.Kind' has no member 'githubRepo'",
+        "error: incorrect argument label in call (have 'threadID:content:', expected 'to:content:')",
+        "error: type 'SwarmFont' has no member 'codeCaption'",
+        "error: cannot convert value of type '[String]' to expected argument type 'String'",
+      ].join("\n"),
+    });
+
+    expect(report.status).toBe("fail");
+    expect(report.diagnostics.map((d) => d.code)).toContain(
+      "AXCLOUD-BUILD-MISSING-MEMBER"
+    );
+    expect(report.diagnostics.map((d) => d.code)).toContain(
+      "AXCLOUD-BUILD-ARGUMENT-LABEL"
+    );
+    expect(report.diagnostics.map((d) => d.code)).toContain(
+      "AXCLOUD-BUILD-TYPE-MISMATCH"
+    );
+    expect(report.repairPrompt).toContain("AXCLOUD-BUILD-MISSING-MEMBER");
     expect(report.learningSignal?.signals).toContain("runtime-evidence-supplied");
   });
 

--- a/tests/core/swift-validator.test.ts
+++ b/tests/core/swift-validator.test.ts
@@ -842,4 +842,41 @@ describe("swift validator — AX739 undeclared SwiftUI body references", () => {
       0
     );
   });
+
+  it("accepts private helper methods invoked with trailing closures", () => {
+    const source = `
+      import SwiftUI
+
+      struct HomeFeedView: View {
+          @State private var selectedPost: String?
+
+          var body: some View {
+              ZStack {
+                  if selectedPost != nil {
+                      detailOverlayScrim {
+                          selectedPost = nil
+                      }
+                      detailCloseButton {
+                          selectedPost = nil
+                      }
+                  }
+              }
+          }
+
+          @ViewBuilder
+          private func detailOverlayScrim(_ dismiss: @escaping () -> Void) -> some View {
+              Color.black.opacity(0.24)
+                  .onTapGesture(perform: dismiss)
+          }
+
+          private func detailCloseButton(_ dismiss: @escaping () -> Void) -> some View {
+              Button("Close", action: dismiss)
+          }
+      }
+    `;
+
+    expect(validate(source).diagnostics.filter((d) => d.code === "AX739")).toHaveLength(
+      0
+    );
+  });
 });

--- a/tests/mcp/feature.test.ts
+++ b/tests/mcp/feature.test.ts
@@ -348,6 +348,42 @@ describe("axint.feature", () => {
     }
   });
 
+  it("keeps existing context components out of new semantic panel output", () => {
+    const result = generateFeature({
+      description:
+        "A scoped Swarm Home premium command-layer component. It should sit as a compact 15-20 percent top layer above the feed, preserve feed-first browsing, show command summary, status pills, ambient activity, composer interactivity, and use existing HomeFeedView, FeedPostCard, BuilderAvatarView, ProjectLogoView, and right rail context without replacing those existing types.",
+      surfaces: ["component"],
+      name: "HomeCommandLayer",
+      componentKind: "semanticPanel",
+      platform: "macOS",
+      tokenNamespace: "SwarmDesignTokens",
+    });
+
+    expect(result.success).toBe(true);
+    const paths = result.files.map((f) => f.path).join("\n");
+    expect(paths).toContain("Sources/Components/HomeCommandLayer.swift");
+    expect(paths).not.toContain("Sources/Components/HomeFeedView.swift");
+    expect(paths).not.toContain("Sources/Components/FeedPostCard.swift");
+    expect(paths).not.toContain("Sources/Components/BuilderAvatarView.swift");
+    expect(paths).not.toContain("Sources/Components/ProjectLogoView.swift");
+    expect(paths).not.toContain("RightRail.swift");
+
+    const component = result.files.find(
+      (f) => f.path === "Sources/Components/HomeCommandLayer.swift"
+    );
+    expect(component).toBeDefined();
+    expect(component!.content).toContain("struct HomeCommandLayer: View");
+    expect(component!.content).toContain("Command layer");
+    expect(component!.content).toContain("TextField");
+    expect(component!.content).toContain("SwarmDesignTokens.");
+    expect(component!.content).toContain("maxHeight: 180");
+    expect(component!.content).not.toContain("Approve");
+    expect(component!.content).not.toContain("Defer");
+    expect(validateSwiftSource(component!.content, component!.path).diagnostics).toEqual(
+      []
+    );
+  });
+
   it("extracts named component kits instead of returning one generic scaffold", () => {
     const result = generateFeature({
       description:


### PR DESCRIPTION
## Summary
- Treat Cloud Check expected/actual behavior as semantic evidence instead of string equality
- Add Cloud diagnostics for hallucinated member references, bad argument labels, and type mismatches from Xcode build logs
- Prevent semantic component generation from creating files for existing context components
- Add a compact command-layer semantic panel blueprint
- Add regression tests for AX739 trailing-closure helpers, behavior evidence, Cloud build-log classification, and component collision avoidance
- Refresh metrics.json test count

## Verification
- npm test -- tests/cloud/check.test.ts tests/mcp/feature.test.ts tests/core/swift-validator.test.ts
- npm run typecheck
- npm test
- npm run lint
- npm run build
- npm run metrics:check
