### PR TITLE
Release Axint 0.4.11 dogfooding hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ axint compile my-app.ts --out ios/App/
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.10 · 23 MCP tools + 5 prompts · 182 diagnostic codes · 1115 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.11 · 24 MCP tools + 5 prompts · 183 diagnostic codes · 1131 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -294,6 +294,7 @@ MCP tools and built-in prompts:
 | `axint.validate` | Dry-run validation with diagnostics |
 | `axint.feature` | Generate an editable feature package: intents, views, widgets, components, app shells, stores, tests, and support fragments |
 | `axint.project.pack` | Generate `.mcp.json`, `AGENTS.md`, `CLAUDE.md`, `.axint` rehydration/memory/docs/project files, and the session-first workflow for first-try agent setup |
+| `axint.project.index` | Scan the local Apple project and write a compact `.axint/context` pack so Cloud Check can reason over changed files and nearby SwiftUI surfaces |
 | `axint.context.memory` | Return the compact Axint operating memory for new chats and context-compaction recovery |
 | `axint.context.docs` | Return the project-local Axint docs context so agents can reload docs after compaction |
 | `axint.suggest` | Suggest app-specific Apple-native features, reusable components, and shared stores from a product description |

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.4.10",
-  "mcpTools": 23,
+  "version": "0.4.11",
+  "mcpTools": 24,
   "mcpToolNames": [
     "axint.status",
     "axint.doctor",
@@ -9,6 +9,7 @@
     "axint.session.start",
     "axint.feature",
     "axint.project.pack",
+    "axint.project.index",
     "axint.context.memory",
     "axint.context.docs",
     "axint.suggest",
@@ -35,7 +36,7 @@
     "axint.create-intent"
   ],
   "bundledTemplates": 26,
-  "diagnostics": 182,
+  "diagnostics": 183,
   "xcodeFixRules": 33,
   "xcodeFixRuleCodes": [
     "AX701",
@@ -73,7 +74,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1001,
+    "typescript": 1017,
     "python": 114
   },
   "registryPackages": 14,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.10"
+__version__ = "0.4.11"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.10"
+version = "0.4.11"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "transport": {
         "type": "stdio"
       }
@@ -28,7 +28,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "transport": {
         "type": "stdio"
       }

--- a/src/cli/cloud.ts
+++ b/src/cli/cloud.ts
@@ -74,6 +74,10 @@ export function registerCloud(program: Command) {
     .option("--expected <text>", "Expected behavior when checking a semantic bug")
     .option("--actual <text>", "Actual behavior when checking a semantic bug")
     .option(
+      "--context <file>",
+      "Read a local .axint/context pack written by `axint project index`"
+    )
+    .option(
       "--write-feedback [dir]",
       "Write the redacted learning signal to .axint/feedback or the provided directory"
     )
@@ -95,6 +99,7 @@ export function registerCloud(program: Command) {
           runtimeFailureFile?: string;
           expected?: string;
           actual?: string;
+          context?: string;
           writeFeedback?: boolean | string;
         }
       ) => {
@@ -121,6 +126,7 @@ export function registerCloud(program: Command) {
             ),
             expectedBehavior: options.expected,
             actualBehavior: options.actual,
+            projectContextPath: options.context,
           });
           if (options.writeFeedback && report.learningSignal) {
             const stored = writeCloudFeedbackSignal(report.learningSignal, {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,7 +6,7 @@
  *   axint init [dir]              Scaffold a new Axint project
  *   axint compile <file>          Compile TS intent → Swift App Intent
  *   axint validate <file>         Validate a compiled intent
- *   axint validate-swift <path>   Validate existing Swift sources against Axint's build-time rules
+ *   axint validate-swift <path...> Validate existing Swift sources against Axint's build-time rules
  *   axint eject <file>            Eject intent to standalone Swift (no vendor lock-in)
  *   axint format <file>           Format a .axint source file in canonical style
  *   axint templates               List bundled intent templates
@@ -23,17 +23,19 @@
  *   axint status                  Show local package/runtime status and Xcode restart steps
  *   axint doctor                  Audit version truth, MCP wiring, and project start files
  *   axint project init            Write Axint project-start files for agent workflows
+ *   axint project index           Index the local Apple project into .axint/context
  *   axint session start           Start an enforced Axint agent session and refresh context
  *   axint run                     Run Axint's enforced Apple build/test/runtime loop
  *   axint runner once             Execute one BYO-Mac runner Axint job
  *   axint mcp                     Start the MCP server (stdio)
  *   axint mcp status              Show local MCP launch command and Xcode restart steps
+ *   axint xcode install           Install the full Axint Xcode workflow in one pass
  *   axint xcode setup             Configure Axint for Xcode agentic coding
  *   axint xcode guard             Check/write the Axint Xcode drift guard
  *   axint xcode verify            Verify the MCP connection is working
  *   axint xcode fix <path>        Auto-fix mechanical Swift validator errors
  *   axint xcode doctor            Audit environment for Apple-platform agentic coding
- *   axint xcode check             Print the latest Xcode Axint Check summary, prompt, or artifact path
+ *   axint xcode check             Check a Swift file directly or print the latest Xcode Axint Check summary
  *   axint xcode packet            Print the latest Xcode Fix Packet or AI prompt
  *   axint xcode extension install Install the notarized Axint Source Editor Extension
  *   axint xcode extension status  Report whether the extension is installed
@@ -210,6 +212,34 @@ const xcode = program
   .description("Xcode integration setup and management");
 
 xcode
+  .command("install")
+  .description(
+    "Install the full Axint Xcode workflow: MCP setup, guarded project files, context index, and verification"
+  )
+  .option("--agent <agent>", "Which agent to configure (claude, codex, all)", "claude")
+  .option("--remote", "Use the hosted remote MCP endpoint instead of local stdio")
+  .option(
+    "--local-build",
+    "Use this checkout's built dist/mcp/register.js instead of the npm package"
+  )
+  .option("--project <dir>", "Project directory for guarded setup", ".")
+  .option("--name <name>", "Project name for guarded setup")
+  .option("--no-verify", "Skip the final MCP verification pass")
+  .action(
+    async (options: {
+      agent: string;
+      remote: boolean;
+      localBuild?: boolean;
+      project?: string;
+      name?: string;
+      verify?: boolean;
+    }) => {
+      const { installXcodeWorkflow } = await import("./xcode-setup.js");
+      await installXcodeWorkflow(options);
+    }
+  );
+
+xcode
   .command("setup")
   .description("Configure Axint as an MCP server for Xcode's agentic coding workflow")
   .option("--agent <agent>", "Which agent to configure (claude, codex, all)", "all")
@@ -268,10 +298,38 @@ xcode
 
 xcode
   .command("check")
-  .description("Read the latest Xcode Axint Check summary emitted by Axint build plugins")
+  .description(
+    "Check a current Swift file directly, or read the latest emitted Xcode Axint Check summary"
+  )
+  .argument(
+    "[file]",
+    "Swift file to check directly. Omit to read the latest emitted Xcode packet summary."
+  )
   .option(
     "--root <dir>",
     "DerivedData root, plugin work directory, or exact latest.json packet path"
+  )
+  .option("--source <file>", "Swift file to check directly")
+  .option("--project <dir>", "Project root for direct file checks")
+  .option(
+    "--platform <platform>",
+    "Target platform for direct file checks (iOS, macOS, watchOS, visionOS, all)"
+  )
+  .option("--build-log <text>", "Inline Xcode build log evidence for direct file checks")
+  .option("--test-failure <text>", "Inline failing test evidence for direct file checks")
+  .option(
+    "--runtime-failure <text>",
+    "Inline runtime or interaction failure evidence for direct file checks"
+  )
+  .option("--expected <text>", "Expected behavior for direct file checks")
+  .option("--actual <text>", "Actual behavior for direct file checks")
+  .option(
+    "--changed <files...>",
+    "Changed files to pin into the refreshed project context"
+  )
+  .option(
+    "--no-refresh-context",
+    "Skip refreshing .axint/context before direct file checks"
   )
   .option(
     "--kind <kind>",
@@ -286,13 +344,40 @@ xcode
     "markdown"
   )
   .action(
-    async (options: {
-      root?: string;
-      kind: XcodePacketKind;
-      format: XcodeCheckOutput;
-    }) => {
+    async (
+      file: string | undefined,
+      options: {
+        root?: string;
+        source?: string;
+        project?: string;
+        platform?: "iOS" | "macOS" | "watchOS" | "visionOS" | "all";
+        buildLog?: string;
+        testFailure?: string;
+        runtimeFailure?: string;
+        expected?: string;
+        actual?: string;
+        changed?: string[];
+        refreshContext?: boolean;
+        kind: XcodePacketKind;
+        format: XcodeCheckOutput;
+      }
+    ) => {
       const { runXcodeCheck } = await import("./xcode-check.js");
-      await runXcodeCheck(options);
+      await runXcodeCheck({
+        root: options.root,
+        sourcePath: options.source ?? file,
+        project: options.project,
+        platform: options.platform,
+        xcodeBuildLog: options.buildLog,
+        testFailure: options.testFailure,
+        runtimeFailure: options.runtimeFailure,
+        expectedBehavior: options.expected,
+        actualBehavior: options.actual,
+        changedFiles: options.changed,
+        refreshContext: options.refreshContext,
+        kind: options.kind,
+        format: options.format,
+      });
     }
   );
 

--- a/src/cli/project.ts
+++ b/src/cli/project.ts
@@ -6,6 +6,11 @@ import {
   type ProjectMcpMode,
   type ProjectStartPackFormat,
 } from "../project/start-pack.js";
+import {
+  renderProjectContextIndex,
+  writeProjectContextIndex,
+  type ProjectContextIndexFormat,
+} from "../project/context-index.js";
 
 export function registerProject(program: Command, version: string) {
   const project = program
@@ -59,6 +64,42 @@ export function registerProject(program: Command, version: string) {
         console.log(renderProjectStartPack(result, options.format));
       }
     );
+
+  project
+    .command("index")
+    .description(
+      "Scan the local Apple project and write a compact .axint/context pack for project-aware checks"
+    )
+    .option("--dir <dir>", "Project directory to scan", ".")
+    .option("--name <name>", "Project name override")
+    .option("--changed <file...>", "Changed files to pin into the context pack")
+    .option("--no-git", "Skip git changed-file discovery")
+    .option("--dry-run", "Print the context pack without writing .axint/context")
+    .option(
+      "--format <format>",
+      "Output format: markdown or json",
+      parseContextIndexFormat,
+      "markdown" as ProjectContextIndexFormat
+    )
+    .action(
+      (options: {
+        dir: string;
+        name?: string;
+        changed?: string[];
+        git?: boolean;
+        dryRun?: boolean;
+        format: ProjectContextIndexFormat;
+      }) => {
+        const result = writeProjectContextIndex({
+          targetDir: options.dir,
+          projectName: options.name,
+          changedFiles: options.changed,
+          includeGit: options.git,
+          dryRun: options.dryRun ?? false,
+        });
+        console.log(renderProjectContextIndex(result.index, options.format));
+      }
+    );
 }
 
 function parseAgent(value: string): ProjectAgent {
@@ -74,4 +115,9 @@ function parseMode(value: string): ProjectMcpMode {
 function parseFormat(value: string): ProjectStartPackFormat {
   if (value === "markdown" || value === "json") return value;
   throw new Error(`invalid format: ${value}`);
+}
+
+function parseContextIndexFormat(value: string): ProjectContextIndexFormat {
+  if (value === "markdown" || value === "json") return value;
+  throw new Error(`invalid context index format: ${value}`);
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -21,6 +21,10 @@ export function registerRun(program: Command, version: string) {
     .option("--derived-data <path>", "xcodebuild -derivedDataPath")
     .option("--test-plan <name>", "xcodebuild -testPlan")
     .option(
+      "--only-testing <selector...>",
+      "Focused xcodebuild -only-testing selector(s), e.g. SwarmUITests/SwarmUITests/testName"
+    )
+    .option(
       "--platform <platform>",
       "Target platform: macOS, iOS, watchOS, visionOS, all",
       parsePlatform
@@ -54,6 +58,7 @@ export function registerRun(program: Command, version: string) {
         configuration?: string;
         derivedData?: string;
         testPlan?: string;
+        onlyTesting?: string[];
         platform?: AxintRunPlatform;
         changed?: string[];
         skipBuild?: boolean;
@@ -82,6 +87,7 @@ export function registerRun(program: Command, version: string) {
           configuration: options.configuration,
           derivedDataPath: options.derivedData,
           testPlan: options.testPlan,
+          onlyTesting: options.onlyTesting,
           modifiedFiles: options.changed,
           skipBuild: options.skipBuild,
           skipTests: options.skipTests,
@@ -112,6 +118,10 @@ export function registerRun(program: Command, version: string) {
     .option("--dir <dir>", "Project directory", ".")
     .option("--scheme <scheme>", "Xcode scheme")
     .option("--destination <destination>", "xcodebuild destination")
+    .option(
+      "--only-testing <selector...>",
+      "Focused xcodebuild -only-testing selector(s)"
+    )
     .option("--skip-tests", "Skip xcodebuild test")
     .option("--runtime", "Launch the built macOS app and capture runtime evidence")
     .option("--dry-run", "Plan commands without executing them")
@@ -126,6 +136,7 @@ export function registerRun(program: Command, version: string) {
         dir: string;
         scheme?: string;
         destination?: string;
+        onlyTesting?: string[];
         skipTests?: boolean;
         runtime?: boolean;
         dryRun?: boolean;
@@ -137,6 +148,7 @@ export function registerRun(program: Command, version: string) {
           expectedVersion: version,
           scheme: options.scheme,
           destination: options.destination,
+          onlyTesting: options.onlyTesting,
           skipTests: options.skipTests,
           runtime: options.runtime,
           dryRun: options.dryRun,

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -32,7 +32,7 @@ export function renderCliStatus(
     cwd: process.cwd(),
     mcpCommand: `${which("npx") ?? "npx"} -y @axint/compiler axint-mcp`,
     updateCommand: `${which("npm") ?? "npm"} install -g @axint/compiler@latest`,
-    xcodeSetupCommand: "axint xcode setup --agent claude --guarded",
+    xcodeSetupCommand: "axint xcode install --project .",
     doctorCommand: "axint doctor",
     projectInitCommand: "axint project init",
     verificationPrompt:
@@ -84,7 +84,7 @@ export function renderCliStatus(
     "For a new project, install the full Axint agent pack:",
     "",
     "```sh",
-    status.projectInitCommand,
+    status.xcodeSetupCommand,
     status.doctorCommand,
     "```",
     "",

--- a/src/cli/validate-swift.ts
+++ b/src/cli/validate-swift.ts
@@ -3,8 +3,9 @@ import { readFileSync, statSync, readdirSync } from "node:fs";
 import { resolve, join, extname } from "node:path";
 import { validateSwiftSource } from "../core/swift-validator.js";
 import type { Diagnostic } from "../core/types.js";
+import { getAxintLoginState } from "../core/credentials.js";
 import {
-  printRepairArtifactLines,
+  renderRepairArtifactLines,
   tryEmitRepairArtifacts,
 } from "../repair/repair-artifacts.js";
 
@@ -14,9 +15,10 @@ export function registerValidateSwift(program: Command) {
     .description(
       "Validate existing Swift sources (App Intents, Widgets, SwiftUI views) against Axint's rules"
     )
-    .argument("<path>", "Swift file or directory to validate")
+    .argument("<paths...>", "Swift file(s) or directories to validate")
     .option("--quiet", "Only print errors, not the success banner")
     .option("--json", "Emit a machine-readable JSON report to stdout")
+    .option("--color", "Force ANSI color output even when stdout/stderr are not TTYs")
     .option(
       "--no-fix-packet",
       "Skip writing the local Fix Packet under .axint/fix/latest.{json,md}"
@@ -28,24 +30,46 @@ export function registerValidateSwift(program: Command) {
     )
     .action(
       async (
-        pathArg: string,
+        pathArgs: string[],
         options: {
           quiet?: boolean;
           json?: boolean;
+          color?: boolean;
           fixPacket?: boolean;
           fixPacketDir: string;
         }
       ) => {
-        const target = resolve(pathArg);
-        const files = collectSwiftFiles(target);
+        const color = shouldUseColor(options.color === true);
+        const targets = pathArgs.map((pathArg) => ({
+          input: pathArg,
+          resolved: resolve(pathArg),
+        }));
+        const files = new Set<string>();
+        const missingTargets: string[] = [];
 
-        if (files.length === 0) {
-          console.error(`\x1b[31merror:\x1b[0m no .swift files found at ${pathArg}`);
+        for (const target of targets) {
+          const targetFiles = collectSwiftFiles(target.resolved);
+          if (targetFiles.length === 0) {
+            missingTargets.push(target.input);
+            continue;
+          }
+          for (const file of targetFiles) files.add(file);
+        }
+
+        if (missingTargets.length > 0) {
+          printLine(
+            "error",
+            `no .swift files found at ${missingTargets.join(", ")}`,
+            color,
+            console.error
+          );
           process.exit(1);
         }
 
         const all: Diagnostic[] = [];
-        for (const file of files) {
+        const filesToScan = [...files].sort();
+
+        for (const file of filesToScan) {
           const source = readFileSync(file, "utf-8");
           const result = validateSwiftSource(source, file);
           all.push(...result.diagnostics);
@@ -62,12 +86,20 @@ export function registerValidateSwift(program: Command) {
               success: errors.length === 0,
               surface: "swift",
               diagnostics: all,
-              source: files.length === 1 ? readFileSync(files[0], "utf-8") : undefined,
+              source:
+                filesToScan.length === 1
+                  ? readFileSync(filesToScan[0], "utf-8")
+                  : undefined,
               fileName:
-                files.length === 1
-                  ? files[0].split(/[\\/]/).pop()
-                  : (target.split(/[\\/]/).pop() ?? "swift-validation"),
-              filePath: files.length === 1 ? files[0] : target,
+                filesToScan.length === 1
+                  ? filesToScan[0].split(/[\\/]/).pop()
+                  : "swift-validation",
+              filePath:
+                filesToScan.length === 1
+                  ? filesToScan[0]
+                  : targets.length === 1
+                    ? targets[0]!.resolved
+                    : process.cwd(),
               language: "swift",
               packetDir: options.fixPacketDir,
               command: "validate_swift",
@@ -77,7 +109,9 @@ export function registerValidateSwift(program: Command) {
           repairArtifacts = repairResult.artifacts;
           if (repairResult.error) {
             console.error(
-              `\x1b[33mwarning:\x1b[0m Fix Packet skipped — ${repairResult.error.message}`
+              color
+                ? `\x1b[33mwarning:\x1b[0m Fix Packet skipped — ${repairResult.error.message}`
+                : `warning: Fix Packet skipped — ${repairResult.error.message}`
             );
           }
         }
@@ -85,7 +119,7 @@ export function registerValidateSwift(program: Command) {
         if (options.json) {
           const payload = {
             ok: errors.length === 0,
-            filesScanned: files.length,
+            filesScanned: filesToScan.length,
             diagnostics: all,
             fixPacketPath: repairArtifacts?.packet.jsonPath ?? null,
             checkSummaryPath: repairArtifacts?.check.jsonPath ?? null,
@@ -95,25 +129,32 @@ export function registerValidateSwift(program: Command) {
         }
 
         for (const d of all) {
-          printDiagnostic(d);
+          printDiagnostic(d, color);
         }
 
         if (errors.length > 0) {
           if (repairArtifacts) {
-            printRepairArtifactLines(repairArtifacts, console.error);
+            printRepairArtifactLinesWithColor(repairArtifacts, color, console.error);
           }
-          console.error(
-            `\n\x1b[31m✗\x1b[0m ${errors.length} error${errors.length === 1 ? "" : "s"} in ${files.length} file${files.length === 1 ? "" : "s"}`
+          printLine(
+            "error",
+            `${errors.length} error${errors.length === 1 ? "" : "s"} in ${filesToScan.length} file${filesToScan.length === 1 ? "" : "s"}`,
+            color,
+            console.error,
+            "\n"
           );
           process.exit(1);
         }
 
         if (!options.quiet) {
           if (repairArtifacts) {
-            printRepairArtifactLines(repairArtifacts, console.log);
+            printRepairArtifactLinesWithColor(repairArtifacts, color, console.log);
           }
-          console.log(
-            `\x1b[32m✓\x1b[0m ${files.length} Swift file${files.length === 1 ? "" : "s"} passed axint validation`
+          printLine(
+            "success",
+            `${filesToScan.length} Swift file${filesToScan.length === 1 ? "" : "s"} passed axint validation`,
+            color,
+            console.log
           );
         }
       }
@@ -152,18 +193,57 @@ function walk(dir: string, out: string[]) {
   }
 }
 
-function printDiagnostic(d: Diagnostic) {
+function printDiagnostic(d: Diagnostic, color: boolean) {
   const loc = d.file ? `${d.file}${d.line ? `:${d.line}` : ""}` : "";
-  const color =
+  const severityColor =
     d.severity === "error"
       ? "\x1b[31m"
       : d.severity === "warning"
         ? "\x1b[33m"
         : "\x1b[36m";
-  console.error(
-    `${loc ? loc + " " : ""}${color}${d.severity}\x1b[0m[${d.code}]: ${d.message}`
-  );
+  const severityLabel = color ? `${severityColor}${d.severity}\x1b[0m` : d.severity;
+  console.error(`${loc ? loc + " " : ""}${severityLabel}[${d.code}]: ${d.message}`);
   if (d.suggestion) {
-    console.error(`  \x1b[2mhelp:\x1b[0m ${d.suggestion}`);
+    console.error(
+      color ? `  \x1b[2mhelp:\x1b[0m ${d.suggestion}` : `  help: ${d.suggestion}`
+    );
   }
+}
+
+function shouldUseColor(forceColor: boolean): boolean {
+  if (forceColor) return true;
+  if ("NO_COLOR" in process.env) return false;
+  return process.stdout.isTTY === true && process.stderr.isTTY === true;
+}
+
+function printRepairArtifactLinesWithColor(
+  artifacts: NonNullable<ReturnType<typeof tryEmitRepairArtifacts>["artifacts"]>,
+  color: boolean,
+  writeLine: (line: string) => void
+) {
+  for (const line of renderRepairArtifactLines(artifacts, {
+    signedIn: getAxintLoginState().signedIn,
+  })) {
+    writeLine(color ? line : stripAnsi(line));
+  }
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g"), "");
+}
+
+function printLine(
+  kind: "error" | "success",
+  message: string,
+  color: boolean,
+  writeLine: (line: string) => void,
+  prefix = ""
+) {
+  const symbol = kind === "error" ? "✗" : "✓";
+  const ansi = kind === "error" ? "\x1b[31m" : "\x1b[32m";
+  writeLine(
+    color
+      ? `${prefix}${ansi}${symbol}\x1b[0m ${message}`
+      : `${prefix}${symbol} ${message}`
+  );
 }

--- a/src/cli/xcode-check.ts
+++ b/src/cli/xcode-check.ts
@@ -1,5 +1,10 @@
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, resolve, relative, join } from "node:path";
+import {
+  renderCloudCheckReport,
+  runCloudCheck,
+  type CloudCheckInput,
+} from "../cloud/check.js";
 import {
   buildCheckSummary,
   renderCheckSummaryMarkdown,
@@ -7,6 +12,10 @@ import {
   type CheckSummary,
 } from "../repair/check-summary.js";
 import type { FixPacket } from "../repair/fix-packet.js";
+import {
+  writeProjectContextIndex,
+  type ProjectContextIndex,
+} from "../project/context-index.js";
 import {
   defaultDerivedDataRoot,
   findLatestXcodePacket,
@@ -17,8 +26,18 @@ export type XcodeCheckOutput = "markdown" | "json" | "prompt" | "path";
 
 interface XcodeCheckOptions {
   root?: string;
+  project?: string;
+  sourcePath?: string;
   kind: XcodePacketKind;
   format: XcodeCheckOutput;
+  platform?: CloudCheckInput["platform"];
+  xcodeBuildLog?: string;
+  testFailure?: string;
+  runtimeFailure?: string;
+  expectedBehavior?: string;
+  actualBehavior?: string;
+  changedFiles?: string[];
+  refreshContext?: boolean;
 }
 
 function readExistingSummary(packetPath: string): CheckSummary | null {
@@ -53,6 +72,11 @@ function renderCheckOutput(
 }
 
 export async function runXcodeCheck(options: XcodeCheckOptions): Promise<void> {
+  if (isDirectFileCheck(options)) {
+    runDirectFileCheck(options);
+    return;
+  }
+
   const root = resolve(options.root ?? defaultDerivedDataRoot());
   const candidate = findLatestXcodePacket(root, options.kind);
 
@@ -69,4 +93,141 @@ export async function runXcodeCheck(options: XcodeCheckOptions): Promise<void> {
   process.stdout.write(
     `${renderCheckOutput(candidate.path, candidate.packet, options.format)}\n`
   );
+}
+
+function runDirectFileCheck(options: XcodeCheckOptions): void {
+  try {
+    if (!options.sourcePath) {
+      console.error(
+        "error: direct Xcode file checks need a Swift file path. Pass `axint xcode check <file>`."
+      );
+      process.exit(1);
+    }
+
+    if (options.format === "path") {
+      console.error(
+        "error: --format path is only available when reading emitted Xcode packet summaries."
+      );
+      process.exit(1);
+    }
+
+    const sourcePath = resolve(options.sourcePath);
+    if (!existsSync(sourcePath)) {
+      console.error(`error: source file not found: ${sourcePath}`);
+      process.exit(1);
+    }
+
+    const projectRoot = options.project
+      ? resolve(options.project)
+      : findProjectRootFromSource(sourcePath);
+    const context =
+      options.refreshContext === false
+        ? undefined
+        : writeProjectContextIndex({
+            targetDir: projectRoot,
+            changedFiles: normalizeChangedFiles(
+              projectRoot,
+              sourcePath,
+              options.changedFiles
+            ),
+          });
+
+    const report = runCloudCheck({
+      sourcePath,
+      platform: options.platform,
+      xcodeBuildLog: options.xcodeBuildLog,
+      testFailure: options.testFailure,
+      runtimeFailure: options.runtimeFailure,
+      expectedBehavior: options.expectedBehavior,
+      actualBehavior: options.actualBehavior,
+      projectContext: context?.index,
+      projectContextPath: context?.jsonPath,
+    });
+
+    process.stdout.write(
+      `${renderCloudCheckReport(report, options.format as "markdown" | "json" | "prompt")}\n`
+    );
+    if (report.status === "fail") {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error(`error: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}
+
+function isDirectFileCheck(options: XcodeCheckOptions): boolean {
+  return Boolean(
+    options.sourcePath ||
+    options.project ||
+    options.platform ||
+    options.xcodeBuildLog ||
+    options.testFailure ||
+    options.runtimeFailure ||
+    options.expectedBehavior ||
+    options.actualBehavior ||
+    options.changedFiles?.length
+  );
+}
+
+function findProjectRootFromSource(sourcePath: string): string {
+  let current = dirname(resolve(sourcePath));
+
+  while (true) {
+    if (hasProjectMarkers(current)) return current;
+    const parent = dirname(current);
+    if (parent === current) return dirname(resolve(sourcePath));
+    current = parent;
+  }
+}
+
+function hasProjectMarkers(dir: string): boolean {
+  if (existsSync(join(dir, ".axint"))) return true;
+
+  try {
+    const entries = readdirSync(dir);
+    return entries.some(
+      (entry) => entry.endsWith(".xcodeproj") || entry.endsWith(".xcworkspace")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function normalizeChangedFiles(
+  projectRoot: string,
+  sourcePath: string,
+  changedFiles?: string[]
+): string[] {
+  if (changedFiles && changedFiles.length > 0) {
+    return changedFiles.map((file) =>
+      normalizeRelative(projectRoot, resolve(projectRoot, file))
+    );
+  }
+  return [normalizeRelative(projectRoot, sourcePath)];
+}
+
+function normalizeRelative(root: string, target: string): string {
+  return relative(root, target).replace(/\\/g, "/");
+}
+
+export function refreshXcodeProjectContext(input: {
+  projectRoot: string;
+  sourcePath?: string;
+  changedFiles?: string[];
+}): { index: ProjectContextIndex; jsonPath: string; markdownPath: string } {
+  const context = writeProjectContextIndex({
+    targetDir: input.projectRoot,
+    changedFiles:
+      input.changedFiles && input.changedFiles.length > 0
+        ? input.changedFiles
+        : input.sourcePath
+          ? [normalizeRelative(input.projectRoot, resolve(input.sourcePath))]
+          : undefined,
+  });
+  return {
+    index: context.index,
+    jsonPath: context.jsonPath,
+    markdownPath: context.markdownPath,
+  };
 }

--- a/src/cli/xcode-doctor.ts
+++ b/src/cli/xcode-doctor.ts
@@ -302,7 +302,7 @@ function agentCheck(name: string, paths: string[], needle: RegExp): Check {
         label: name,
         status: "warn",
         detail: "config found but axint not registered",
-        hint: `axint xcode setup --agent ${name.toLowerCase().split(" ")[0]}`,
+        hint: `axint xcode install --agent ${name.toLowerCase().split(" ")[0]} --project .`,
       };
     } catch {
       // fall through

--- a/src/cli/xcode-setup.ts
+++ b/src/cli/xcode-setup.ts
@@ -10,6 +10,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { writeProjectContextIndex } from "../project/context-index.js";
 import { writeProjectStartPack } from "../project/start-pack.js";
 import { renderXcodeGuardReport, runXcodeGuard } from "../project/xcode-guard.js";
 
@@ -35,11 +36,11 @@ const START_PROMPT = [
   "Then list MCP servers and confirm both xcode-tools and axint are available.",
   "Call axint.xcode.guard with stage=context-recovery so the project writes .axint/guard/latest.* proof before any long task.",
   "Call axint.status and report the running MCP server version before editing code.",
-  "If the version is older than expected, stop and tell me to update Axint, rerun `axint xcode setup --agent claude --guarded`, and restart the Xcode agent chat.",
+  "If the version is older than expected, stop and tell me to update Axint, rerun `axint xcode install --project .`, and restart the Xcode agent chat.",
   "Use Axint before guessing App Intents, widgets, SwiftUI scaffolds, entitlements, Info.plist keys, or repair prompts.",
   "Work in short checkpoints. Do not spend 20+ minutes on a task without running Axint and Xcode validation.",
   "For long build/debug work, prefer axint.run or axint.xcode.guard over raw Xcode actions so Axint proof survives context compaction.",
-  "After each generated Apple surface, run axint.cloud.check or axint cloud check <file> --feedback, then build in Xcode.",
+  "When a specific Swift file or screen is acting up, run `axint xcode check <file>` so Axint refreshes project context before guessing. Then build in Xcode.",
   "Do not claim there is no bug from Axint alone. Cloud Check is static; Xcode build, unit tests, UI tests, accessibility flows, and runtime behavior are separate evidence.",
   "If Axint passes but Xcode/tests/runtime fails, report the exact failure as an Axint validator or runtime-coverage gap before continuing.",
 ].join("\n");
@@ -72,6 +73,7 @@ interface SetupOptions {
   localBuild?: boolean;
   project?: string;
   name?: string;
+  showVerifyHint?: boolean;
 }
 
 export async function setupXcode(options: SetupOptions): Promise<void> {
@@ -149,9 +151,33 @@ export async function setupXcode(options: SetupOptions): Promise<void> {
     `    ${DIM}"Use axint.feature to add a Siri action for logging water intake"${RESET}`
   );
   console.log();
-  console.log(`  Run ${BOLD}axint xcode verify${RESET} to test the connection.`);
-  console.log();
+  if (options.showVerifyHint !== false) {
+    console.log(`  Run ${BOLD}axint xcode verify${RESET} to test the connection.`);
+    console.log();
+  }
   printAgentStartPrompt();
+  console.log();
+}
+
+export async function installXcodeWorkflow(
+  options: Omit<SetupOptions, "guarded"> & { verify?: boolean }
+): Promise<void> {
+  await setupXcode({
+    ...options,
+    guarded: true,
+    showVerifyHint: options.showVerifyHint ?? false,
+  });
+
+  if (options.verify !== false) {
+    await verifyXcode();
+  }
+
+  console.log();
+  console.log(`  ${ORANGE}◆${RESET} ${BOLD}Xcode workflow ready${RESET}`);
+  console.log();
+  console.log(
+    `  Next inside Xcode: ask Axint to ${BOLD}check the current file${RESET} or ${BOLD}run proof${RESET} instead of manually juggling setup, context, and validation steps.`
+  );
   console.log();
 }
 
@@ -180,6 +206,13 @@ function setupGuardedProject(input: {
   console.log(
     `  ${GREEN}✓${RESET} Project guard memory checked (${pack.written.length} written, ${pack.skipped.length} existing)`
   );
+
+  const context = writeProjectContextIndex({
+    targetDir,
+    projectName,
+  });
+  console.log(`  ${GREEN}✓${RESET} Project context indexed`);
+  console.log(`  ${DIM}  ${context.markdownPath}${RESET}`);
 
   const guard = runXcodeGuard({
     cwd: targetDir,
@@ -235,7 +268,7 @@ export async function verifyXcode(): Promise<void> {
     } else if (output.includes("axint.feature")) {
       console.log(`  ${RED}✗${RESET} MCP server is old: axint.status not found`);
       console.log(
-        `  ${DIM}  Update Axint, rerun: axint xcode setup --agent claude --guarded, then restart the Xcode agent chat${RESET}`
+        `  ${DIM}  Update Axint, rerun: axint xcode install --project ., then restart the Xcode agent chat${RESET}`
       );
     } else {
       console.log(`  ${RED}✗${RESET} Server responded but axint.feature not found`);
@@ -382,7 +415,7 @@ function setupXcodeClaudeAgent(options: { localBuild: boolean }): void {
       `  ${DIM}ℹ${RESET} Could not find a durable Axint MCP script. Install globally, then rerun:`
     );
     console.log(`  ${DIM}  npm install -g ${AXINT_NPM_PACKAGE}${RESET}`);
-    console.log(`  ${DIM}  axint xcode setup --agent claude --guarded${RESET}`);
+    console.log(`  ${DIM}  axint xcode install --project .${RESET}`);
     return;
   }
 
@@ -583,7 +616,7 @@ function printManualClaude(remote: boolean): void {
     );
     console.log();
     console.log(
-      `  ${DIM}For Xcode's built-in Claude Agent, run: axint xcode setup --agent claude --guarded${RESET}`
+      `  ${DIM}For the full Xcode workflow, run: axint xcode install --project .${RESET}`
     );
   }
   console.log();

--- a/src/cloud/check.ts
+++ b/src/cloud/check.ts
@@ -4,6 +4,11 @@ import { fileURLToPath } from "node:url";
 import { compileAnySource } from "../core/compiler.js";
 import { validateSwiftSource } from "../core/swift-validator.js";
 import type { CompilerOutput, Diagnostic } from "../core/types.js";
+import {
+  buildProjectContextHint,
+  type ProjectContextIndex,
+  type ProjectContextHint,
+} from "../project/context-index.js";
 
 export type CloudCheckFormat = "markdown" | "json" | "prompt" | "feedback";
 export type CloudCheckLanguage = "swift" | "typescript" | "unknown";
@@ -42,6 +47,8 @@ export interface CloudCheckInput {
   runtimeFailure?: string;
   expectedBehavior?: string;
   actualBehavior?: string;
+  projectContextPath?: string;
+  projectContext?: ProjectContextIndex;
 }
 
 export interface CloudCheckReport {
@@ -85,6 +92,16 @@ export interface CloudCheckReport {
   evidence: {
     provided: string[];
     summary: string[];
+  };
+  projectContext?: {
+    path?: string;
+    summary: string[];
+    relatedFiles: Array<{
+      path: string;
+      reasons: string[];
+    }>;
+    changedFiles: string[];
+    currentFile?: string;
   };
   repairPlan: Array<{
     title: string;
@@ -153,6 +170,7 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
   }
 
   const evidence = collectCloudEvidence(input);
+  const projectContext = resolveCloudProjectContext({ input, fileName, surface });
   diagnostics = [
     ...diagnostics,
     ...inferEvidenceDiagnostics({
@@ -217,6 +235,15 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
           },
         ]
       : []),
+    ...(projectContext
+      ? [
+          {
+            label: "Project context pack",
+            state: "pass" as const,
+            detail: projectContext.summary.join(" "),
+          },
+        ]
+      : []),
   ] satisfies CloudCheckReport["checks"];
   const coverage = buildCloudCoverage({
     language,
@@ -226,6 +253,7 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
     runtimeCoverageRequired,
     evidenceProvided: evidence.provided.length > 0,
     runtimeEvidenceProvided,
+    projectContextLoaded: Boolean(projectContext),
   });
   const confidence = buildCloudConfidence({
     status,
@@ -253,6 +281,7 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
     runtimeCoverageRequired,
     runtimeEvidenceProvided,
     fileName,
+    projectContext,
   });
 
   if (nextSteps.length === 0) {
@@ -302,6 +331,18 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
     checks,
     coverage,
     evidence,
+    projectContext: projectContext
+      ? {
+          path: projectContext.path,
+          summary: projectContext.summary,
+          relatedFiles: projectContext.relatedFiles.map((file) => ({
+            path: file.path,
+            reasons: file.reasons,
+          })),
+          changedFiles: projectContext.changedFiles,
+          currentFile: projectContext.currentFile?.path,
+        }
+      : undefined,
     repairPlan,
     nextSteps,
     repairPrompt: "",
@@ -316,7 +357,7 @@ export function renderCloudCheckReport(
   report: CloudCheckReport,
   format: CloudCheckFormat = "markdown"
 ): string {
-  if (format === "json") return JSON.stringify(report, null, 2);
+  if (format === "json") return JSON.stringify(compactCloudCheckReport(report), null, 2);
   if (format === "prompt") return report.repairPrompt;
   if (format === "feedback") {
     return JSON.stringify(
@@ -353,6 +394,22 @@ export function renderCloudCheckReport(
     ...(report.evidence.provided.length > 0
       ? report.evidence.summary.map((item) => `- ${item}`)
       : ["- No Xcode build, test, runtime, or behavior evidence was supplied."]),
+    ...(report.projectContext
+      ? [
+          "",
+          "## Project Context",
+          ...report.projectContext.summary.map((item) => `- ${item}`),
+          ...(report.projectContext.relatedFiles.length > 0
+            ? [
+                "- Related files:",
+                ...report.projectContext.relatedFiles.map(
+                  (file) =>
+                    `  - ${file.path}${file.reasons.length > 0 ? ` — ${file.reasons.join(", ")}` : ""}`
+                ),
+              ]
+            : []),
+        ]
+      : []),
     "",
     "## Repair Plan",
     ...report.repairPlan.map(
@@ -433,6 +490,37 @@ function readCloudCheckSource(input: CloudCheckInput): {
     source: readFileSync(path, "utf-8"),
     fileName: input.fileName || path,
   };
+}
+
+function resolveCloudProjectContext(input: {
+  input: CloudCheckInput;
+  fileName: string;
+  surface: string;
+}): ProjectContextHint | undefined {
+  const focus = looksLikeInputInteractivityFailure(
+    normalizeTextForEvidence(
+      [
+        input.input.runtimeFailure,
+        input.input.actualBehavior,
+        input.input.testFailure,
+        input.input.expectedBehavior,
+      ]
+        .filter(Boolean)
+        .join("\n")
+    )
+  )
+    ? "interactive-input"
+    : input.surface === "view" || input.surface === "app"
+      ? "runtime"
+      : "generic";
+
+  return buildProjectContextHint({
+    sourcePath: input.input.sourcePath,
+    fileName: input.fileName,
+    contextPath: input.input.projectContextPath,
+    projectContext: input.input.projectContext,
+    focus,
+  });
 }
 
 function inferLanguage(fileName: string, source: string): CloudCheckLanguage {
@@ -531,6 +619,7 @@ function inferEvidenceDiagnostics(input: {
   );
   const sourceText = normalizeTextForEvidence(source);
   const file = input.fileName;
+  const passingXcodeProof = hasPassingXcodeProof(input.input);
 
   if (input.input.platform === "macOS") {
     const iosOnly = findIosOnlySwiftUIUsage(source);
@@ -563,13 +652,24 @@ function inferEvidenceDiagnostics(input: {
     );
   }
 
+  diagnostics.push(
+    ...diagnosticsFromInputInteractivityEvidence(
+      [input.input.runtimeFailure, input.input.actualBehavior, input.input.testFailure]
+        .filter(Boolean)
+        .join("\n"),
+      source,
+      file
+    )
+  );
+
   if (
     input.input.expectedBehavior &&
     input.input.actualBehavior &&
     behaviorEvidenceContradictsExpectation(
       input.input.expectedBehavior,
       input.input.actualBehavior
-    )
+    ) &&
+    !(passingXcodeProof && !hasNegativeBehaviorEvidence(input.input.actualBehavior))
   ) {
     diagnostics.push({
       code: "AXCLOUD-BEHAVIOR-MISMATCH",
@@ -585,6 +685,7 @@ function inferEvidenceDiagnostics(input: {
   if (
     input.evidence.provided.length > 0 &&
     diagnostics.length === 0 &&
+    !passingXcodeProof &&
     /\b(fail|failed|error|crash|exception|not found|no match|timeout)\b/.test(
       evidenceText
     )
@@ -621,11 +722,40 @@ function inferEvidenceDiagnostics(input: {
   return dedupeDiagnostics(diagnostics);
 }
 
+function compactCloudCheckReport(report: CloudCheckReport): Omit<
+  CloudCheckReport,
+  "swiftCode"
+> & {
+  sourceRedaction?: {
+    swiftCode: "omitted_from_rendered_json";
+    reason: string;
+    sourceLines: number;
+    outputLines: number;
+  };
+} {
+  const { swiftCode, ...rest } = report;
+  return {
+    ...rest,
+    ...(swiftCode
+      ? {
+          sourceRedaction: {
+            swiftCode: "omitted_from_rendered_json" as const,
+            reason:
+              "Rendered JSON omits full Swift source by default. Use sourcePath/artifact files for code review and the repair prompt for agent guidance.",
+            sourceLines: report.sourceLines,
+            outputLines: report.outputLines,
+          },
+        }
+      : {}),
+  };
+}
+
 function buildCloudRepairPlan(input: {
   diagnostics: Diagnostic[];
   runtimeCoverageRequired: boolean;
   runtimeEvidenceProvided: boolean;
   fileName: string;
+  projectContext?: ProjectContextHint;
 }): CloudCheckReport["repairPlan"] {
   const actionable = input.diagnostics.filter((d) => d.severity !== "info");
 
@@ -670,6 +800,19 @@ function buildCloudRepairPlan(input: {
           "Open the sample output, find Thread 0, and look for the first frame from your app module. Rerun Cloud Check with that source file and the sample excerpt.",
       }
     );
+  }
+
+  if (input.projectContext?.relatedFiles.length) {
+    steps.push({
+      title: "Inspect related project files",
+      detail: `Project context flagged ${input.projectContext.relatedFiles
+        .slice(0, 5)
+        .map(
+          (file) =>
+            `${file.path}${file.reasons.length > 0 ? ` (${file.reasons.slice(0, 2).join(", ")})` : ""}`
+        )
+        .join(", ")} as nearby context to review before guessing at another fix.`,
+    });
   }
 
   steps.push({
@@ -871,6 +1014,182 @@ function diagnosticsFromRuntimeFailure(
   }
 
   return dedupeDiagnostics(diagnostics);
+}
+
+function diagnosticsFromInputInteractivityEvidence(
+  evidenceText: string,
+  source: string,
+  file: string
+): Diagnostic[] {
+  const text = normalizeTextForEvidence(evidenceText);
+  if (!looksLikeInputInteractivityFailure(text)) {
+    return [];
+  }
+
+  const diagnostics: Diagnostic[] = [];
+  const overlayHazard = findInputOverlayHazard(source);
+  const disabledHazard = findDisabledInputHazard(source);
+  const gestureHazard = findInputGestureHazard(source);
+
+  if (overlayHazard) {
+    diagnostics.push({
+      code: "AXCLOUD-UI-HIT-TEST-BLOCKER",
+      severity: "error",
+      file,
+      line: overlayHazard.line,
+      message: `${overlayHazard.input} is paired with an overlay that can intercept taps and focus.`,
+      suggestion:
+        "If the overlay is decorative or placeholder-only, add `.allowsHitTesting(false)` to it. If it is meant to stay interactive, move it so it does not sit on top of the input field.",
+    });
+  }
+
+  if (disabledHazard) {
+    diagnostics.push({
+      code: "AXCLOUD-UI-DISABLED-STATE",
+      severity: "error",
+      file,
+      line: disabledHazard.line,
+      message: `${disabledHazard.input} sits near .disabled(...), so a new loading, modal, or feature flag may be disabling the compose control.`,
+      suggestion:
+        "Trace the disabled condition and confirm the new feature did not start evaluating it to true. Keep unrelated loading or gating state off the composer subtree.",
+    });
+  }
+
+  if (gestureHazard) {
+    diagnostics.push({
+      code: "AXCLOUD-UI-GESTURE-CAPTURE",
+      severity: "warning",
+      file,
+      line: gestureHazard.line,
+      message: `${gestureHazard.input} sits near ${gestureHazard.pattern}, which can steal taps or prevent the field from becoming first responder.`,
+      suggestion:
+        "Move the gesture to a background container, narrow its hit area, or use a simultaneous gesture strategy that does not sit on top of the text input.",
+    });
+  }
+
+  if (diagnostics.length === 0) {
+    diagnostics.push({
+      code: "AXCLOUD-UI-INPUT-INTERACTION",
+      severity: "error",
+      file,
+      message:
+        "Runtime evidence says a visible input stopped accepting interaction. Common causes are overlay hit-testing, propagated disabled state, or gesture/focus conflicts.",
+      suggestion:
+        "Diff the input subtree for new `.overlay`, `.disabled`, `.gesture`, `.zIndex`, and focus-state changes. After each edit, rerun a focused tap/type smoke test instead of relying on a clean build alone.",
+    });
+  }
+
+  return dedupeDiagnostics(diagnostics);
+}
+
+function looksLikeInputInteractivityFailure(text: string): boolean {
+  if (!text) return false;
+  const subject =
+    /\b(comment box|compose box|composer|composer row|reply box|post box|text field|textfield|text editor|texteditor|input field|input|editor)\b/.test(
+      text
+    ) ||
+    /\b(can't tap|cannot tap|can't type|cannot type|won't focus|can't focus|cannot focus)\b/.test(
+      text
+    );
+  const symptom =
+    /\b(can't|cannot|won't|doesn't|does not|stopped|stop|no longer|never)\s+(?:tap|click|focus|type|edit|write|enter|respond|work)\b/.test(
+      text
+    ) ||
+    /\b(?:stopped|stop|no longer)\s+accept(?:ing|s)?\s+(?:input|focus|typing|taps?)\b/.test(
+      text
+    ) ||
+    /\b(not interactable|not editable|tap ignored|visible but dead|visible but won't focus|visible but can't type)\b/.test(
+      text
+    );
+  return subject && symptom;
+}
+
+type InputHazard = {
+  input: string;
+  line?: number;
+};
+
+function findInputOverlayHazard(source: string): InputHazard | undefined {
+  const lines = source.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const inputMatch = lines[i]?.match(/\b(TextField|TextEditor|SecureField)\s*\(/);
+    if (!inputMatch) continue;
+
+    const windowStart = Math.max(0, i - 4);
+    const windowEnd = Math.min(lines.length, i + 18);
+    const windowText = lines.slice(windowStart, windowEnd).join("\n");
+    if (!/\.overlay\s*(?:\(|\{)/.test(windowText)) continue;
+    if (/\.allowsHitTesting\s*\(\s*false\s*\)/.test(windowText)) continue;
+
+    const overlayLineOffset = lines
+      .slice(windowStart, windowEnd)
+      .findIndex((line) => /\.overlay\s*(?:\(|\{)/.test(line));
+    return {
+      input: inputMatch[1],
+      line: overlayLineOffset >= 0 ? windowStart + overlayLineOffset + 1 : i + 1,
+    };
+  }
+
+  return undefined;
+}
+
+function findDisabledInputHazard(source: string): InputHazard | undefined {
+  const lines = source.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const inputMatch = lines[i]?.match(/\b(TextField|TextEditor|SecureField)\s*\(/);
+    if (!inputMatch) continue;
+
+    const windowStart = Math.max(0, i - 8);
+    const windowEnd = Math.min(lines.length, i + 18);
+    const disabledLineOffset = lines
+      .slice(windowStart, windowEnd)
+      .findIndex(
+        (line) =>
+          /\.disabled\s*\(/.test(line) && !/\.disabled\s*\(\s*false\s*\)/.test(line)
+      );
+    if (disabledLineOffset < 0) continue;
+
+    return {
+      input: inputMatch[1],
+      line: windowStart + disabledLineOffset + 1,
+    };
+  }
+
+  return undefined;
+}
+
+function findInputGestureHazard(
+  source: string
+): (InputHazard & { pattern: string }) | undefined {
+  const lines = source.split("\n");
+  const gesturePatterns: Array<{ regex: RegExp; label: string }> = [
+    { regex: /\.highPriorityGesture\s*\(/, label: ".highPriorityGesture(...)" },
+    { regex: /\.gesture\s*\(/, label: ".gesture(...)" },
+    { regex: /\.onTapGesture\b/, label: ".onTapGesture" },
+  ];
+
+  for (let i = 0; i < lines.length; i++) {
+    const inputMatch = lines[i]?.match(/\b(TextField|TextEditor|SecureField)\s*\(/);
+    if (!inputMatch) continue;
+
+    const windowStart = Math.max(0, i - 8);
+    const windowEnd = Math.min(lines.length, i + 18);
+    const windowLines = lines.slice(windowStart, windowEnd);
+
+    for (const pattern of gesturePatterns) {
+      const gestureLineOffset = windowLines.findIndex((line) => pattern.regex.test(line));
+      if (gestureLineOffset < 0) continue;
+      return {
+        input: inputMatch[1],
+        line: windowStart + gestureLineOffset + 1,
+        pattern: pattern.label,
+      };
+    }
+  }
+
+  return undefined;
 }
 
 function runtimeHazardDiagnostics(source: string, file: string): Diagnostic[] {
@@ -1096,6 +1415,44 @@ function normalizeTextForEvidence(value: string): string {
   return value.toLowerCase().replace(/[’']/g, "'").replace(/\s+/g, " ").trim();
 }
 
+function hasPassingXcodeProof(input: CloudCheckInput): boolean {
+  if (!input.xcodeBuildLog) return false;
+  const text = normalizeTextForEvidence(input.xcodeBuildLog);
+  if (!text) return false;
+  if (hasConcreteXcodeFailure(text)) return false;
+
+  return (
+    /\*\*\s*(?:test|build)\s+succeeded\s*\*\*/.test(text) ||
+    /\b(?:test|tests|test suite|test case|build)\s+(?:passed|succeeded)\b/.test(text) ||
+    /\b\d+\s+tests?\s+passed\b/.test(text) ||
+    /\bexecuted\s+\d+\s+tests?,?\s+with\s+0\s+failures\b/.test(text) ||
+    /\b0\s+failures\b/.test(text)
+  );
+}
+
+function hasConcreteXcodeFailure(normalizedXcodeLog: string): boolean {
+  const text = normalizedXcodeLog
+    .replace(/\b0\s+(?:failures?|failed|errors?)\b/g, " ")
+    .replace(/\bwith\s+0\s+failures\b/g, " ");
+
+  return /\*\*\s*(?:test|build)\s+failed\s*\*\*|\b(?:test|tests|test suite|test case|build)\s+failed\b|\berror:|\bfatal error\b|\bcrash(?:ed|es)?\b|\bexit(?:ed)?\s+(?:with\s+)?(?:code\s+)?[1-9]\d*\b/.test(
+    text
+  );
+}
+
+function hasNegativeBehaviorEvidence(actualBehavior: string): boolean {
+  const actual = normalizeTextForEvidence(actualBehavior);
+  if (!actual) return false;
+  return (
+    /\b(fail|fails|failed|failing|missing|misses|missed|never|no longer|wrong|incorrect|broken|regress|regressed|regression|freeze|freezes|frozen|hang|hangs|hung|crash|crashes|unresponsive|timeout|timed out|instead|mismatch|contradict|contradicts)\b/.test(
+      actual
+    ) ||
+    /\b(?:not|doesn't|does not|can't|cannot)\s+(?:work|working|implemented|show|render|match|pass|compile|build|load|open|respond|appear|exist|route|preserve)\b/.test(
+      actual
+    )
+  );
+}
+
 function behaviorEvidenceContradictsExpectation(
   expectedBehavior: string,
   actualBehavior: string
@@ -1104,14 +1461,7 @@ function behaviorEvidenceContradictsExpectation(
   const actual = normalizeTextForEvidence(actualBehavior);
   if (!expected || !actual || expected === actual) return false;
 
-  const negativeEvidence =
-    /\b(fail|fails|failed|failing|missing|misses|missed|never|no longer|wrong|incorrect|broken|regress|regressed|regression|freeze|freezes|frozen|hang|hangs|hung|crash|crashes|unresponsive|timeout|timed out|instead|mismatch|contradict|contradicts)\b/.test(
-      actual
-    ) ||
-    /\b(?:not|doesn't|does not|can't|cannot)\s+(?:work|working|implemented|show|render|match|pass|compile|build|load|open|respond|appear|exist|route|preserve)\b/.test(
-      actual
-    );
-  if (negativeEvidence) return true;
+  if (hasNegativeBehaviorEvidence(actual)) return true;
 
   const implementationEvidence =
     /\b(implemented|added|wired|built|created|preserved|kept|supports|shows|renders|uses|matches|includes|completed|fixed|passes|passed|clean|succeeds|succeeded)\b/.test(
@@ -1182,6 +1532,7 @@ function buildCloudCoverage(input: {
   runtimeCoverageRequired: boolean;
   evidenceProvided: boolean;
   runtimeEvidenceProvided: boolean;
+  projectContextLoaded: boolean;
 }): CloudCheckReport["coverage"] {
   const coverage: CloudCheckReport["coverage"] = [];
 
@@ -1229,6 +1580,14 @@ function buildCloudCoverage(input: {
       : input.runtimeCoverageRequired
         ? "Not executed by Cloud Check. Run Xcode build/test evidence for SwiftUI route, accessibility, state, and interaction claims."
         : "Not required for this static Apple contract check unless the surrounding project behavior is under investigation.",
+  });
+
+  coverage.push({
+    label: "Project-wide context",
+    state: input.projectContextLoaded ? "checked" : "not_applicable",
+    detail: input.projectContextLoaded
+      ? "Loaded a local .axint/context pack so Cloud Check could consider changed files, nearby SwiftUI surfaces, and interaction-risk files."
+      : "No local .axint/context pack was loaded. Run `axint project index` to give Cloud Check project-level visibility beyond the current file.",
   });
 
   return coverage;
@@ -1359,6 +1718,12 @@ function buildCloudRepairPrompt(report: CloudCheckReport): string {
         `Static confidence: ${report.confidence.level}. ${report.confidence.detail}`,
         `Ship gate: ${report.gate.decision}. ${report.gate.reason}`,
         `Checked: ${checkedCoverageSummary(report)}.`,
+        ...(report.projectContext
+          ? [
+              "Project context:",
+              ...report.projectContext.summary.map((item) => `- ${item}`),
+            ]
+          : []),
         "This is not a runtime pass. Run the Xcode build plus the relevant unit/UI tests before claiming there is no bug.",
         "",
         "Repair plan:",
@@ -1375,6 +1740,12 @@ function buildCloudRepairPrompt(report: CloudCheckReport): string {
       `Static confidence: ${report.confidence.level}. ${report.confidence.detail}`,
       `Ship gate: ${report.gate.decision}. ${report.gate.reason}`,
       `Checked: ${checkedCoverageSummary(report)}.`,
+      ...(report.projectContext
+        ? [
+            "Project context:",
+            ...report.projectContext.summary.map((item) => `- ${item}`),
+          ]
+        : []),
       `Repair plan: ${report.repairPlan.map((step) => step.title).join(" -> ")}.`,
       "Preserve the feature behavior and rerun Cloud Check after the next agent edit.",
     ].join("\n");
@@ -1387,6 +1758,22 @@ function buildCloudRepairPrompt(report: CloudCheckReport): string {
     `Ship gate: ${report.gate.decision}. ${report.gate.reason}`,
     ...(report.evidence.provided.length > 0
       ? ["", "Evidence supplied:", ...report.evidence.summary.map((item) => `- ${item}`)]
+      : []),
+    ...(report.projectContext
+      ? [
+          "",
+          "Project context:",
+          ...report.projectContext.summary.map((item) => `- ${item}`),
+          ...(report.projectContext.relatedFiles.length > 0
+            ? [
+                "- Related files to inspect:",
+                ...report.projectContext.relatedFiles.map(
+                  (file) =>
+                    `  - ${file.path}${file.reasons.length > 0 ? ` (${file.reasons.slice(0, 2).join(", ")})` : ""}`
+                ),
+              ]
+            : []),
+        ]
       : []),
     "",
     "Address these findings:",
@@ -1514,8 +1901,8 @@ function inferLearningSignals(report: CloudCheckReport): string[] {
   ) {
     signals.push("runtime-main-thread-blocker");
   }
-  if (/\bAXCLOUD-UI-TEST|AXCLOUD-UI-ACCESSIBILITY\b/i.test(body)) {
-    signals.push("ui-test-evidence-gap");
+  if (/\bAXCLOUD-UI-[A-Z-]+\b/i.test(body)) {
+    signals.push("ui-interaction-evidence");
   }
 
   if (
@@ -1583,7 +1970,7 @@ function inferLearningOwner(
   if (signals.includes("platform-availability-gap")) return "swift-validator";
   if (signals.includes("runtime-freeze-evidence")) return "cloud";
   if (signals.includes("runtime-evidence-missing")) return "cloud";
-  if (signals.includes("ui-test-evidence-gap")) return "cloud";
+  if (signals.includes("ui-interaction-evidence")) return "cloud";
   if (kind === "validator_gap") return "swift-validator";
   if (signals.includes("generator-validator-contract-drift")) return "compiler";
   if (signals.includes("duplicate-generated-symbol")) return "feature-generator";
@@ -1615,6 +2002,9 @@ function titleForLearningSignal(
   if (diagnosticCodes.includes("AXCLOUD-RUNTIME-FREEZE")) {
     return "Runtime freeze evidence needs Cloud triage";
   }
+  if (diagnosticCodes.some((code) => code.startsWith("AXCLOUD-UI-"))) {
+    return `UI interaction evidence needs Cloud triage (${codeList})`;
+  }
   if (kind === "compiler_gap")
     return `Compiler could not lower source cleanly (${codeList})`;
   if (kind === "swift_api_gap") return `Apple metadata or API contract gap (${codeList})`;
@@ -1630,6 +2020,9 @@ function suggestedActionForLearningSignal(
 ): string {
   if (report.diagnostics.some((d) => d.code === "AXCLOUD-RUNTIME-FREEZE")) {
     return "Capture a freeze sample fixture, classify the first app-owned main-thread frame, and promote repeated freeze signatures into Cloud runtime diagnostics.";
+  }
+  if (report.diagnostics.some((d) => d.code.startsWith("AXCLOUD-UI-"))) {
+    return "Turn repeated tap/focus/input regressions into UI-interaction fixtures so Cloud Check can classify overlay, disabled-state, and gesture-capture bugs immediately.";
   }
   if (kind === "generator_gap") {
     return "Create a regression fixture from the source shape, fix the generator, then require the generated Swift to pass axint.swift.validate.";

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -707,6 +707,12 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticInfo> = {
     message: "TimelineEntry declares duplicate 'let date: Date' properties",
     category: "swift-validator",
   },
+  AX764: {
+    code: "AX764",
+    severity: "warning",
+    message: "Overlay on a SwiftUI text input may block hit testing",
+    category: "swiftui-hit-testing",
+  },
   AX714: {
     code: "AX714",
     severity: "error",

--- a/src/core/swift-validator.ts
+++ b/src/core/swift-validator.ts
@@ -75,6 +75,7 @@ export function validateSwiftSource(source: string, file: string): SwiftValidati
   checkConcurrency(decls, source, file, diagnostics);
   checkLiveActivities(decls, source, file, diagnostics);
   checkContainerAccessibilityIdentifierPropagation(source, stripped, file, diagnostics);
+  checkInteractiveInputOverlayHitTesting(source, stripped, file, diagnostics);
 
   return { file, diagnostics };
 }
@@ -134,6 +135,49 @@ function checkContainerAccessibilityIdentifierPropagation(
         message: `${containerName} has an accessibilityIdentifier while nested controls also define identifiers; UI tests may match the container and hide child identifiers`,
         suggestion:
           "Put the identifier on the specific button/text/row the test needs, or assert on a visible child element instead of tagging the whole container.",
+      })
+    );
+  }
+}
+
+function checkInteractiveInputOverlayHitTesting(
+  source: string,
+  stripped: string,
+  file: string,
+  diagnostics: Diagnostic[]
+) {
+  const lines = source.split("\n");
+  const strippedLines = stripped.split("\n");
+
+  for (let i = 0; i < strippedLines.length; i++) {
+    const inputMatch = strippedLines[i]?.match(
+      /\b(TextField|TextEditor|SecureField)\s*\(/
+    );
+    if (!inputMatch) continue;
+
+    const windowStart = i;
+    const windowEnd = Math.min(strippedLines.length, i + 18);
+    const windowLines = strippedLines.slice(windowStart, windowEnd);
+    const windowText = windowLines.join("\n");
+
+    if (!/\.overlay\s*(?:\(|\{)/.test(windowText)) continue;
+    if (/\.allowsHitTesting\s*\(\s*false\s*\)/.test(windowText)) continue;
+
+    const overlayLineOffset = windowLines.findIndex((line) =>
+      /\.overlay\s*(?:\(|\{)/.test(line)
+    );
+    const overlayLine =
+      overlayLineOffset >= 0 ? windowStart + overlayLineOffset + 1 : i + 1;
+    const inputKind = inputMatch[1];
+    const nearbySource = lines.slice(windowStart, windowEnd).join("\n");
+
+    if (!/\boverlay\b/i.test(nearbySource)) continue;
+
+    diagnostics.push(
+      makeDiagnostic("AX764", file, overlayLine, {
+        message: `${inputKind} has an overlay without .allowsHitTesting(false), which can block taps, focus, or text entry`,
+        suggestion:
+          "If the overlay is decorative or placeholder-only, add `.allowsHitTesting(false)` to the overlay content. Otherwise move the hit target so it does not sit on top of the text input.",
       })
     );
   }

--- a/src/mcp/doctor.ts
+++ b/src/mcp/doctor.ts
@@ -144,7 +144,7 @@ function versionCheck(
     detail: `running ${runningVersion}, expected ${expectedVersion}`,
     fix: matches
       ? undefined
-      : "Install the expected Axint version, rerun axint xcode setup --agent claude --guarded, then restart the Xcode agent chat.",
+      : "Install the expected Axint version, rerun axint xcode install --project ., then restart the Xcode agent chat.",
   };
 }
 
@@ -216,7 +216,7 @@ function mcpConfigCheck(cwd: string): MachineDoctorCheck {
       fix:
         hasAxint && durable
           ? undefined
-          : "Run axint project init --force or axint xcode setup --agent claude --guarded.",
+          : "Run axint project init --force or axint xcode install --project .",
     };
   } catch {
     return {
@@ -243,7 +243,7 @@ function agentConfigCheck(): MachineDoctorCheck {
       label: "Xcode Claude Agent config",
       status: "warn",
       detail: "not found",
-      fix: "Run axint xcode setup --agent claude --guarded after installing Axint.",
+      fix: "Run axint xcode install --project . after installing Axint.",
     };
   }
   const text = readFileSync(configPath, "utf-8");
@@ -252,7 +252,7 @@ function agentConfigCheck(): MachineDoctorCheck {
     label: "Xcode Claude Agent config",
     status: hasAxint ? "ok" : "warn",
     detail: hasAxint ? "axint registered" : "config exists but axint not registered",
-    fix: hasAxint ? undefined : "Run axint xcode setup --agent claude --guarded.",
+    fix: hasAxint ? undefined : "Run axint xcode install --project .",
   };
 }
 

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -444,6 +444,50 @@ export const TOOL_MANIFEST = [
     },
   },
   {
+    name: "axint.project.index",
+    description:
+      "Scan the local Apple project and write a compact .axint/context pack so Axint can reason over changed files, nearby SwiftUI surfaces, and interaction-risk files instead of only one source file at a time.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        targetDir: {
+          type: "string",
+          description:
+            "Project directory to index. Defaults to the current working directory.",
+        },
+        projectName: {
+          type: "string",
+          description: "Optional project name override for the context pack.",
+        },
+        changedFiles: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional changed files to pin into the context pack.",
+        },
+        includeGit: {
+          type: "boolean",
+          description: "Whether to include git changed-file discovery. Defaults to true.",
+        },
+        dryRun: {
+          type: "boolean",
+          description:
+            "When true, returns the index without writing .axint/context files.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json"],
+          description: "Output format. Defaults to markdown.",
+        },
+      },
+    },
+  },
+  {
     name: "axint.context.memory",
     description:
       "Return the compact Axint operating memory that agents should reload " +
@@ -602,6 +646,8 @@ export const TOOL_MANIFEST = [
       "right Axint tools: suggest for planning, feature for new surfaces, " +
       "swift.validate for modified Swift, cloud.check for coverage-aware " +
       "repair feedback, and Xcode build/test evidence for runtime proof. " +
+      "For existing dirty SwiftUI files or Codex-style patch edits, it points " +
+      "agents toward surgical patching plus validation instead of full-file writes. " +
       "A ready result is not a completion stamp: the response includes the next " +
       "Axint action the agent should call before returning to ordinary Xcode work.",
     annotations: {
@@ -690,7 +736,7 @@ export const TOOL_MANIFEST = [
         featureBypassReason: {
           type: "string",
           description:
-            "Concrete reason axint.feature was intentionally bypassed for a new surface. Use only for existing-code edits or when generation is not useful.",
+            "Concrete reason axint.feature was intentionally bypassed. Use for existing-code edits, patch-first repairs, or cases where generation is not useful.",
         },
         ranSwiftValidate: {
           type: "boolean",
@@ -995,6 +1041,11 @@ export const TOOL_MANIFEST = [
           description:
             "Optional observed behavior for behavior-gap checks. Pair with expectedBehavior so Cloud Check can return a repair-oriented mismatch finding.",
         },
+        projectContextPath: {
+          type: "string",
+          description:
+            "Optional path to a local .axint/context/latest.json pack written by axint.project.index. Omit when sourcePath lives inside the same project and Cloud Check can auto-discover the context file.",
+        },
         format: {
           type: "string",
           enum: ["markdown", "json", "prompt", "feedback"],
@@ -1067,6 +1118,12 @@ export const TOOL_MANIFEST = [
         testPlan: {
           type: "string",
           description: "Optional xcodebuild -testPlan for test runs.",
+        },
+        onlyTesting: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional focused xcodebuild -only-testing selectors, e.g. SwarmUITests/SwarmUITests/testProjectCommandCenterPrimaryActionsRouteToCoreTabs.",
         },
         modifiedFiles: {
           type: "array",

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -149,8 +149,8 @@ export function getPromptMessages(
               "3. Call `axint.xcode.guard` with stage `context-recovery` so this chat writes `.axint/guard/latest.*` proof before any long task.\n" +
               "4. Read `.axint/AXINT_REHYDRATE.md`, `.axint/AXINT_MEMORY.md`, `.axint/AXINT_DOCS_CONTEXT.md`, `AGENTS.md`, `CLAUDE.md`, or `.axint/project.json` if present.\n" +
               "5. List the available MCP servers and confirm both xcode-tools and axint are present.\n" +
-              "6. Call `axint.status` and report the running MCP server version before editing code. If the version is older than expected, stop and tell me to update Axint, rerun `axint xcode setup --agent claude --guarded`, and restart the Xcode agent chat.\n" +
-              "7. If axint is missing in Xcode, tell me to run `axint xcode setup --agent claude --guarded`, restart the Xcode agent session, and ask again for available MCP servers.\n" +
+              "6. Call `axint.status` and report the running MCP server version before editing code. If the version is older than expected, stop and tell me to update Axint, rerun `axint xcode install --project .`, and restart the Xcode agent chat.\n" +
+              "7. If axint is missing in Xcode, tell me to run `axint xcode install --project .`, restart the Xcode agent session, and ask again for available MCP servers.\n" +
               "8. Call `axint.workflow.check` with stage `context-recovery`, sessionToken, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.\n" +
               "9. Call `axint.xcode.guard` before long tasks and `axint.workflow.check` with `sessionToken` at planning, before-write, and pre-build checkpoints so you do not skip the Axint loop by accident.\n" +
               "10. Use Axint tools before guessing App Intents, widgets, SwiftUI scaffolds, entitlements, Info.plist keys, or repair prompts.\n" +

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -29,6 +29,7 @@
  *   - axint.templates.get:    Return the source of a specific template
  *   - axint.status:           Report the running MCP server version + restart help
  *   - axint.project.pack:     Generate first-try project-start files
+ *   - axint.project.index:    Index the local Apple project into .axint/context
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -93,6 +94,11 @@ import {
   type ProjectMcpMode,
   type ProjectStartPackFormat,
 } from "../project/start-pack.js";
+import {
+  renderProjectContextIndex,
+  writeProjectContextIndex,
+  type ProjectContextIndexFormat,
+} from "../project/context-index.js";
 import { buildAxintDocsContext } from "../project/docs-context.js";
 import { buildAxintOperatingMemory } from "../project/operating-memory.js";
 import {
@@ -161,6 +167,14 @@ type SessionStartArgs = {
   ttlMinutes?: number;
   format?: AxintSessionFormat;
 };
+type ProjectContextArgs = {
+  targetDir?: string;
+  projectName?: string;
+  changedFiles?: string[];
+  includeGit?: boolean;
+  dryRun?: boolean;
+  format?: ProjectContextIndexFormat;
+};
 
 // Read version from package.json so it stays in sync.
 let pkg: PackageInfo = { version: "0.3.9" };
@@ -207,6 +221,7 @@ type CloudCheckArgs = {
   runtimeFailure?: string;
   expectedBehavior?: string;
   actualBehavior?: string;
+  projectContextPath?: string;
   format?: CloudCheckFormat;
 };
 type AxintRunArgs = {
@@ -221,6 +236,7 @@ type AxintRunArgs = {
   configuration?: string;
   derivedDataPath?: string;
   testPlan?: string;
+  onlyTesting?: string[];
   modifiedFiles?: string[];
   skipBuild?: boolean;
   skipTests?: boolean;
@@ -290,7 +306,7 @@ function renderStatus(format: StatusArgs["format"] = "markdown"): string {
     promptsRegistered: PROMPT_MANIFEST.length,
     restartRequiredAfterUpdate: true,
     updateCommand: "npm install -g @axint/compiler@latest",
-    xcodeSetupCommand: "axint xcode setup --agent claude --guarded",
+    xcodeSetupCommand: "axint xcode install --project .",
     doctorCommand: "axint doctor",
     projectInitCommand: "axint project init",
     xcodeRestartInstruction:
@@ -303,7 +319,7 @@ function renderStatus(format: StatusArgs["format"] = "markdown"): string {
     return [
       `The running Axint MCP server is v${status.version}.`,
       "If this is older than the version the user expects, stop before editing code.",
-      "Tell the user to update Axint, rerun `axint xcode setup --agent claude --guarded`, and restart the Xcode Claude Agent chat.",
+      "Tell the user to update Axint, rerun `axint xcode install --project .`, and restart the Xcode Claude Agent chat.",
     ].join("\n");
   }
 
@@ -341,7 +357,7 @@ function renderStatus(format: StatusArgs["format"] = "markdown"): string {
     "",
     "4. In the new chat, ask: `Call axint.status and tell me the running version.`",
     "",
-    "For a brand-new project, run `axint project init` once, then `axint doctor` to confirm the machine is wired.",
+    "For a brand-new project, run `axint xcode install --project .`, then `axint doctor` to confirm the machine is wired.",
   ].join("\n");
 }
 
@@ -511,7 +527,11 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
         const loop = s.loop ? `\n   Loop: ${s.loop}` : "";
         const nextStep = s.nextStep ? `\n   Next: ${s.nextStep}` : "";
         const generateCommand = `axint.feature({ description: "${s.featurePrompt}", surfaces: ${JSON.stringify(s.surfaces)} })`;
-        return `${i + 1}. ${s.name}\n   ${s.description}${rationale}${impact}${loop}${nextStep}\n   Surfaces: ${surfaces} | Complexity: ${s.complexity}${confidence}${source}\n   Generate: ${generateCommand}\n   Proof loop: write the generated files, run axint.cloud.check with platform/build/test evidence, then build in Xcode.`;
+        const action =
+          s.domain === "repair"
+            ? `Patch path: ${s.featurePrompt}\n   Proof loop: patch existing files, run axint.swift.validate, run axint.cloud.check with platform/build/test evidence, then run axint.run with focused evidence.`
+            : `Generate: ${generateCommand}\n   Proof loop: write the generated files, run axint.cloud.check with platform/build/test evidence, then build in Xcode.`;
+        return `${i + 1}. ${s.name}\n   ${s.description}${rationale}${impact}${loop}${nextStep}\n   Surfaces: ${surfaces} | Complexity: ${s.complexity}${confidence}${source}\n   ${action}`;
       })
       .join("\n\n");
 
@@ -542,6 +562,25 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
       version: pkg.version,
     });
     return diagnosticsText(renderProjectStartPack(pack, a?.format ?? "markdown"));
+  }
+
+  if (name === "axint.project.index") {
+    const payload = (args ?? {}) as ProjectContextArgs;
+    const result = writeProjectContextIndex({
+      targetDir: payload.targetDir,
+      projectName: payload.projectName,
+      changedFiles: payload.changedFiles,
+      includeGit: payload.includeGit,
+      dryRun: payload.dryRun,
+    });
+    return {
+      content: [
+        {
+          type: "text",
+          text: renderProjectContextIndex(result.index, payload.format ?? "markdown"),
+        },
+      ],
+    };
   }
 
   if (name === "axint.context.memory") {
@@ -644,6 +683,7 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
       runtimeFailure: a.runtimeFailure,
       expectedBehavior: a.expectedBehavior,
       actualBehavior: a.actualBehavior,
+      projectContextPath: a.projectContextPath,
     });
     return {
       content: [
@@ -671,6 +711,7 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
       configuration: a.configuration,
       derivedDataPath: a.derivedDataPath,
       testPlan: a.testPlan,
+      onlyTesting: a.onlyTesting,
       modifiedFiles: a.modifiedFiles,
       skipBuild: a.skipBuild,
       skipTests: a.skipTests,

--- a/src/mcp/suggest.ts
+++ b/src/mcp/suggest.ts
@@ -908,6 +908,11 @@ export function suggestFeatures(input: SuggestInput): FeatureSuggestion[] {
   const text = normalizeText(input.appDescription);
   const excludedText = normalizeText((input.exclude ?? []).join(" "));
   const explicitDomain = normalizeDomain(input.domain);
+
+  if (looksLikeExistingProductRepair(input, text)) {
+    return existingProductRepairSuggestions(input, text, limit);
+  }
+
   const strongestDescriptionScore = Math.max(
     ...FEATURE_CATALOG.map((ds) => domainDescriptionScore(text, ds))
   );
@@ -1203,6 +1208,252 @@ function mergeSuggestions(
     if (merged.length >= limit) break;
   }
   return merged;
+}
+
+function looksLikeExistingProductRepair(
+  input: SuggestInput,
+  normalizedAppDescription: string
+): boolean {
+  if (!normalizedAppDescription) return false;
+
+  const goalsText = normalizeText((input.goals ?? []).join(" "));
+  const constraintsText = normalizeText((input.constraints ?? []).join(" "));
+  const combined = [normalizedAppDescription, goalsText, constraintsText]
+    .filter(Boolean)
+    .join(" ");
+
+  const repairIntent = [
+    "bug",
+    "broken",
+    "can't",
+    "cannot",
+    "does not",
+    "doesn't",
+    "fails",
+    "failing",
+    "fix",
+    "improve",
+    "no longer",
+    "polish",
+    "premium",
+    "not working",
+    "regression",
+    "repair",
+    "restore",
+    "stopped",
+    "turning",
+    "upgrade",
+    "won't",
+  ].some((keyword) => hasKeyword(combined, keyword));
+
+  const existingSurface = [
+    "animation",
+    "build",
+    "click",
+    "command center",
+    "composer",
+    "existing",
+    "focus",
+    "gesture",
+    "hittable",
+    "input",
+    "layout",
+    "project room",
+    "route",
+    "screen",
+    "scroll",
+    "swiftui",
+    "tab",
+    "tap",
+    "test",
+    "ui test",
+    "ux",
+    "view",
+    "xcode",
+    "zindex",
+  ].some((keyword) => hasKeyword(combined, keyword));
+
+  if (
+    /\b(create|generate|scaffold|build)\s+(?:a|an|new)\b/.test(combined) &&
+    /\b(bug report|issue tracker|support ticket)\b/.test(combined)
+  ) {
+    return false;
+  }
+
+  return repairIntent && existingSurface;
+}
+
+function existingProductRepairSuggestions(
+  input: SuggestInput,
+  normalizedAppDescription: string,
+  limit: number
+): FeatureSuggestion[] {
+  const focus = repairProblemFocus(normalizedAppDescription);
+  const concept = repairScreenConcept(normalizedAppDescription);
+  const promptCues = repairPromptCues(normalizedAppDescription);
+  const cueSentence =
+    promptCues.length > 0
+      ? ` Keep these prompt-specific cues in scope: ${promptCues.join(", ")}.`
+      : "";
+  const platform = input.platform ? `${input.platform} ` : "";
+  const rationale =
+    "Detected an existing-product repair request, so Axint is returning a proof-first repair loop instead of new feature ideas.";
+
+  const suggestions: FeatureSuggestion[] = [
+    {
+      name: `Repair Existing ${titleCase(concept)} Flow`,
+      description: `Patch the current ${concept} in place, preserve the surrounding product, and avoid replacing working screens with a fresh scaffold.`,
+      surfaces: ["view", "component"],
+      complexity: "medium",
+      featurePrompt: `Repair the existing ${platform}${concept} SwiftUI flow without replacing the surrounding app. Preserve store state, existing tab routing, first-viewport hierarchy, primary buttons, accessibility identifiers, and the user's current product vocabulary.${cueSentence} Identify the touched files, reproduce the behavior, patch the smallest view/state/hit-testing/routing change, and keep existing components intact.`,
+      domain: "repair",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact:
+        "Moves Axint from idea generation into senior-engineer repair mode for an existing Apple product.",
+      loop: "Reproduce -> patch smallest surface -> validate source -> prove in Xcode",
+      nextStep:
+        "Run Cloud Check with expectedBehavior, actualBehavior, and the focused Xcode build or UI-test log.",
+    },
+    {
+      name: `Add Focused ${titleCase(focus)} Proof`,
+      description:
+        "Create or run the smallest unit/UI proof that can fail before the patch and pass after it.",
+      surfaces: ["view"],
+      complexity: "low",
+      featurePrompt: `Add a focused ${platform}Xcode unit or UI test for the existing ${focus} bug. The proof should exercise the exact tap, scroll, focus, layout, route, or state behavior that regressed and should not depend on unrelated screens.${cueSentence}`,
+      domain: "repair",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact: "Turns the repair into durable evidence an agent can trust.",
+      loop: "Failing proof -> targeted patch -> passing proof -> Cloud Check evidence",
+      nextStep:
+        "Paste the passing focused test log into Cloud Check so the gate can reconcile source and runtime evidence.",
+    },
+    {
+      name: `Preserve ${titleCase(concept)} Routing`,
+      description:
+        "Verify the upgraded screen still routes primary actions to the real existing destinations instead of decorative placeholder states.",
+      surfaces: ["view", "store"],
+      complexity: "medium",
+      featurePrompt: `Audit the existing ${platform}${concept} routes and primary actions. Confirm buttons such as capture, run agent, launch check, open vault, decisions, missions, agents, and project context route to real existing tabs or sheets.${cueSentence} Add accessibility identifiers and a focused UI test for each primary command-center action that must be hittable and route correctly.`,
+      domain: "repair",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact:
+        "Keeps premium UX work wired to the actual product instead of becoming a static mockup.",
+      loop: "Action map -> route proof -> focused UI test -> Cloud Check evidence",
+      nextStep:
+        "Run `axint run --only-testing <UITestTarget/Class/testName>` with the changed files so the proof lands in the final gate.",
+    },
+    {
+      name: `Inspect ${titleCase(focus)} Context`,
+      description:
+        "Look beyond the current file for the overlay, disabled state, gesture, z-index, route, or shared state that may be blocking the behavior.",
+      surfaces: ["view", "store"],
+      complexity: "medium",
+      featurePrompt: `Index the project context for the existing ${focus} bug, then inspect related SwiftUI views, stores, modifiers, overlays, disabled states, gestures, accessibility identifiers, route containers, and recently changed files before patching.${cueSentence}`,
+      domain: "repair",
+      rationale,
+      confidence: "medium",
+      source: "local",
+      impact:
+        "Prevents the agent from guessing inside one file when the blocker lives in a parent shell or shared state layer.",
+      loop: "Context index -> related files -> targeted repair -> proof",
+      nextStep:
+        "Run `axint project index` and rerun Cloud Check against the failing file with the generated project context.",
+    },
+  ];
+
+  return suggestions.slice(0, limit);
+}
+
+function repairProblemFocus(normalizedAppDescription: string): string {
+  if (
+    /\b(command center|command-center|hero|first viewport|first-viewport|primary action|primary actions)\b/.test(
+      normalizedAppDescription
+    )
+  ) {
+    return "command center";
+  }
+  if (
+    /\b(comment box|compose box|composer|reply box|post box|text field|textfield|text editor|texteditor|input|focus|type|tap)\b/.test(
+      normalizedAppDescription
+    )
+  ) {
+    return "input interaction";
+  }
+  if (
+    /\b(scroll|tab|sticky|header|list|feed|position|offset)\b/.test(
+      normalizedAppDescription
+    )
+  ) {
+    return "scroll and layout";
+  }
+  if (/\b(route|navigation|sheet|modal|window|screen)\b/.test(normalizedAppDescription)) {
+    return "route";
+  }
+  if (
+    /\b(accessibility|identifier|hittable|button|click)\b/.test(normalizedAppDescription)
+  ) {
+    return "hittable UI";
+  }
+  if (/\b(build|compile|xcode|diagnostic|error)\b/.test(normalizedAppDescription)) {
+    return "Xcode build";
+  }
+  return "SwiftUI repair";
+}
+
+function repairScreenConcept(normalizedAppDescription: string): string {
+  if (/\bproject room\b/.test(normalizedAppDescription)) return "project room";
+  if (/\bcommand center|command-center\b/.test(normalizedAppDescription)) {
+    return "command center";
+  }
+  if (/\bhome(?:page)?|home screen|home feed\b/.test(normalizedAppDescription)) {
+    return "home screen";
+  }
+  if (/\bdiscover\b/.test(normalizedAppDescription)) return "discover screen";
+  if (/\blaunch readiness|launch check|launch center\b/.test(normalizedAppDescription)) {
+    return "launch readiness";
+  }
+  return repairProblemFocus(normalizedAppDescription);
+}
+
+function repairPromptCues(normalizedAppDescription: string): string[] {
+  const cues: [RegExp, string][] = [
+    [/\bproject room\b/, "Project Room"],
+    [/\bmy project\b/, "My Project"],
+    [/\bcommand center|command-center\b/, "command center"],
+    [/\blaunch readiness|launch check|launch center\b/, "launch readiness"],
+    [/\bcapture\b/, "Capture"],
+    [/\bvault\b/, "Vault"],
+    [/\bagents?\b/, "Agents"],
+    [/\bmissions?\b/, "Missions"],
+    [/\bdecisions?\b/, "Decisions"],
+    [/\bproject context\b/, "project context"],
+    [/\bdiscover\b/, "Discover"],
+    [/\blive\b|\bevents?\b/, "Live/Events"],
+    [/\bbuilders?\b/, "Builders"],
+    [/\bmarketplace\b|\bmarket\b/, "Marketplace"],
+    [/\btab(?:s)?\b|\btab routing\b/, "tab routing"],
+    [/\bcard heights?\b|\buniform\b/, "uniform card heights"],
+    [/\bclick targets?\b|\bhittable\b|\bprimary action/, "real click targets"],
+    [/\breduced motion\b|\bmotion\b/, "reduced motion"],
+    [/\bscroll\b|\btop\b/, "scroll-to-top behavior"],
+  ];
+
+  return unique(
+    cues
+      .filter(([pattern]) => pattern.test(normalizedAppDescription))
+      .map(([, label]) => label)
+  );
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
 }
 
 function normalizeText(value: string): string {

--- a/src/mcp/workflow-check.ts
+++ b/src/mcp/workflow-check.ts
@@ -51,6 +51,7 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
   const recommended: string[] = [];
   const checked: string[] = [];
   const requireSession = input.requireSession !== false;
+  const patchFirstRepair = looksLikePatchFirstRepair(input);
 
   if (requireSession) {
     const session = validateAxintSessionToken({
@@ -152,6 +153,12 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
         );
       }
     }
+    if (patchFirstRepair) {
+      checked.push("Existing-code repair is in patch-first mode.");
+      recommended.push(
+        "Use a small patch edit for the existing dirty SwiftUI file, then run axint.swift.validate and axint.cloud.check on the changed files. Avoid full-file axint.xcode.write unless this is a new file or a clean full-file replacement."
+      );
+    }
   }
 
   if (stage === "pre-build" || stage === "pre-commit") {
@@ -197,6 +204,7 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
           modifiedFiles,
           xcodeBuildPassed: Boolean(input.xcodeBuildPassed),
           xcodeTestsPassed: Boolean(input.xcodeTestsPassed),
+          patchFirstRepair,
         });
   const score = Math.max(
     0,
@@ -245,12 +253,13 @@ export function renderWorkflowCheckReport(report: WorkflowCheckReport): string {
   ];
 
   if (report.nextTool) {
-    lines.push(
-      "",
-      "## Next Axint Action",
-      `- ${report.nextTool}`,
-      "- Do not treat this workflow check as the only Axint step. Call the next Axint action before continuing with raw Xcode tools or hand-written Swift."
-    );
+    const actionHeading = report.nextTool.startsWith("axint.")
+      ? "## Next Axint Action"
+      : "## Next Action";
+    const actionReminder = report.nextTool.startsWith("axint.")
+      ? "- Do not treat this workflow check as the only Axint step. Call the next Axint action before continuing with raw Xcode tools or hand-written Swift."
+      : "- Do not treat this workflow check as the only gate. Patch surgically, then return to Axint validation before claiming the repair is done.";
+    lines.push("", actionHeading, `- ${report.nextTool}`, actionReminder);
   }
 
   return lines.join("\n");
@@ -294,8 +303,16 @@ function nextToolForSatisfiedStage(input: {
   modifiedFiles: string[];
   xcodeBuildPassed: boolean;
   xcodeTestsPassed: boolean;
+  patchFirstRepair: boolean;
 }): string | undefined {
-  const { stage, surfaces, modifiedFiles, xcodeBuildPassed, xcodeTestsPassed } = input;
+  const {
+    stage,
+    surfaces,
+    modifiedFiles,
+    xcodeBuildPassed,
+    xcodeTestsPassed,
+    patchFirstRepair,
+  } = input;
   if (stage === "session-start" || stage === "context-recovery") {
     return "axint.suggest";
   }
@@ -307,6 +324,9 @@ function nextToolForSatisfiedStage(input: {
       : "axint.xcode.guard";
   }
   if (stage === "before-write") {
+    if (patchFirstRepair) {
+      return "apply_patch, then axint.swift.validate";
+    }
     return "axint.xcode.write";
   }
   if (stage === "pre-build") {
@@ -326,4 +346,22 @@ function looksLikeContextDrift(notes: string | undefined): boolean {
   return /\b(compacted|compaction|summarized|summary|new chat|restarted|restart|forgot|forget|drift|stale|ordinary xcode|not using axint|axint unavailable|missing axint|mcp missing|long block|long coding|lost context)\b/i.test(
     notes
   );
+}
+
+function looksLikePatchFirstRepair(input: WorkflowCheckInput): boolean {
+  const text = [input.featureBypassReason, input.notes, ...(input.modifiedFiles ?? [])]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  const patchMode =
+    /\b(codex|apply_patch|patch|surgical|small edit|dirty|existing|hand-written|handwritten|repair|bug|ux|swiftui)\b/.test(
+      text
+    );
+  const fullFileRisk = /\b(3000\+?|large|dirty|already changed|full-file|rewrite)\b/.test(
+    text
+  );
+  const existingBypass = Boolean(input.featureBypassReason);
+
+  return patchMode && (existingBypass || fullFileRisk || text.includes(".swift"));
 }

--- a/src/project/context-index.ts
+++ b/src/project/context-index.ts
@@ -1,0 +1,600 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname, join, relative, resolve } from "node:path";
+
+export type ProjectContextIndexFormat = "markdown" | "json";
+export type ProjectContextFocus = "generic" | "interactive-input" | "runtime";
+
+export interface ProjectContextIndexInput {
+  targetDir?: string;
+  projectName?: string;
+  changedFiles?: string[];
+  includeGit?: boolean;
+}
+
+export interface ProjectContextFileSummary {
+  path: string;
+  lines: number;
+  imports: string[];
+  symbols: string[];
+  swiftUI: boolean;
+  appIntent: boolean;
+  hasInputControls: boolean;
+  hasOverlay: boolean;
+  hasDisabledState: boolean;
+  hasGestureCapture: boolean;
+  hasFocusState: boolean;
+  hasModalPresentation: boolean;
+  hasListOrScroll: boolean;
+  riskScore: number;
+  reasons: string[];
+}
+
+export interface ProjectContextIndex {
+  schema: string;
+  createdAt: string;
+  targetDir: string;
+  projectName: string;
+  xcode: {
+    workspace?: string;
+    project?: string;
+    schemes: string[];
+    inferredScheme?: string;
+  };
+  files: {
+    swift: number;
+    swiftUI: number;
+    appIntents: number;
+    inputCapable: number;
+    withInteractionRisk: number;
+    catalog: ProjectContextFileSummary[];
+  };
+  git: {
+    available: boolean;
+    changedFiles: string[];
+  };
+  artifacts: {
+    sessionPath?: string;
+    latestRunReport?: string;
+  };
+  topInteractionRiskFiles: ProjectContextFileSummary[];
+}
+
+export interface WriteProjectContextIndexOptions extends ProjectContextIndexInput {
+  dryRun?: boolean;
+}
+
+export interface WriteProjectContextIndexResult {
+  index: ProjectContextIndex;
+  jsonPath: string;
+  markdownPath: string;
+  written: string[];
+}
+
+export interface ProjectContextHint {
+  path?: string;
+  summary: string[];
+  relatedFiles: ProjectContextFileSummary[];
+  changedFiles: string[];
+  currentFile?: ProjectContextFileSummary;
+}
+
+const EXCLUDED_DIRS = new Set([
+  ".axint",
+  ".build",
+  ".git",
+  ".next",
+  ".turbo",
+  ".vercel",
+  "DerivedData",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "out",
+]);
+
+export function buildProjectContextIndex(
+  input: ProjectContextIndexInput = {}
+): ProjectContextIndex {
+  const targetDir = resolve(input.targetDir ?? process.cwd());
+  const projectName = input.projectName ?? basename(targetDir) ?? "AppleApp";
+  const workspace = findFirstChildWithExtension(targetDir, ".xcworkspace");
+  const project = findFirstChildWithExtension(targetDir, ".xcodeproj");
+  const schemes = uniqueStrings([
+    ...listSchemes(workspace ? join(targetDir, workspace) : undefined),
+    ...listSchemes(project ? join(targetDir, project) : undefined),
+  ]);
+  const catalog = walkFiles(targetDir)
+    .filter((file) => extname(file).toLowerCase() === ".swift")
+    .map((file) => summarizeSwiftFile(targetDir, file))
+    .sort((a, b) => a.path.localeCompare(b.path));
+  const changedFiles = resolveChangedFiles(
+    targetDir,
+    input.changedFiles,
+    input.includeGit
+  );
+  const topInteractionRiskFiles = [...catalog]
+    .filter((file) => file.riskScore > 0)
+    .sort((a, b) => b.riskScore - a.riskScore || a.path.localeCompare(b.path))
+    .slice(0, 12);
+
+  return {
+    schema: "https://axint.ai/schemas/project-context-index.v1.json",
+    createdAt: new Date().toISOString(),
+    targetDir,
+    projectName,
+    xcode: {
+      workspace,
+      project,
+      schemes,
+      inferredScheme:
+        schemes[0] ??
+        stripXcodeExtension(workspace) ??
+        stripXcodeExtension(project) ??
+        undefined,
+    },
+    files: {
+      swift: catalog.length,
+      swiftUI: catalog.filter((file) => file.swiftUI).length,
+      appIntents: catalog.filter((file) => file.appIntent).length,
+      inputCapable: catalog.filter((file) => file.hasInputControls).length,
+      withInteractionRisk: catalog.filter((file) => file.riskScore > 0).length,
+      catalog,
+    },
+    git: {
+      available: existsSync(join(targetDir, ".git")) || isGitWorktree(targetDir),
+      changedFiles,
+    },
+    artifacts: {
+      sessionPath: existsSync(join(targetDir, ".axint/session/current.json"))
+        ? ".axint/session/current.json"
+        : undefined,
+      latestRunReport: existsSync(join(targetDir, ".axint/run/latest.json"))
+        ? ".axint/run/latest.json"
+        : undefined,
+    },
+    topInteractionRiskFiles,
+  };
+}
+
+export function writeProjectContextIndex(
+  input: WriteProjectContextIndexOptions = {}
+): WriteProjectContextIndexResult {
+  const index = buildProjectContextIndex(input);
+  const jsonPath = resolve(index.targetDir, ".axint/context/latest.json");
+  const markdownPath = resolve(index.targetDir, ".axint/context/latest.md");
+  const written: string[] = [];
+
+  if (!input.dryRun) {
+    mkdirSync(dirname(jsonPath), { recursive: true });
+    writeFileSync(jsonPath, `${JSON.stringify(index, null, 2)}\n`, "utf-8");
+    writeFileSync(markdownPath, renderProjectContextIndex(index, "markdown"), "utf-8");
+  }
+
+  written.push(".axint/context/latest.json", ".axint/context/latest.md");
+  return { index, jsonPath, markdownPath, written };
+}
+
+export function renderProjectContextIndex(
+  index: ProjectContextIndex,
+  format: ProjectContextIndexFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(index, null, 2);
+
+  const lines = [
+    "# Axint Project Context",
+    "",
+    `- Project: ${index.projectName}`,
+    `- Root: ${index.targetDir}`,
+    `- Created: ${index.createdAt}`,
+    `- Swift files: ${index.files.swift}`,
+    `- SwiftUI files: ${index.files.swiftUI}`,
+    `- Input-capable files: ${index.files.inputCapable}`,
+    `- Changed files: ${index.git.changedFiles.length}`,
+    "",
+    "## Xcode",
+    `- Workspace: ${index.xcode.workspace ?? "not found"}`,
+    `- Project: ${index.xcode.project ?? "not found"}`,
+    `- Schemes: ${index.xcode.schemes.length > 0 ? index.xcode.schemes.join(", ") : "none detected"}`,
+    `- Inferred scheme: ${index.xcode.inferredScheme ?? "not detected"}`,
+  ];
+
+  if (index.git.changedFiles.length > 0) {
+    lines.push(
+      "",
+      "## Changed Files",
+      ...index.git.changedFiles.map((file) => `- ${file}`)
+    );
+  }
+
+  lines.push("", "## Interaction Risk Files");
+  if (index.topInteractionRiskFiles.length === 0) {
+    lines.push("- None detected.");
+  } else {
+    lines.push(
+      ...index.topInteractionRiskFiles.map(
+        (file) =>
+          `- ${file.path}: score ${file.riskScore}${file.reasons.length > 0 ? ` — ${file.reasons.join(", ")}` : ""}`
+      )
+    );
+  }
+
+  lines.push("", "## File Catalog");
+  if (index.files.catalog.length === 0) {
+    lines.push("- No Swift files found.");
+  } else {
+    lines.push(
+      ...index.files.catalog.map((file) => {
+        const flags = [
+          file.swiftUI ? "SwiftUI" : undefined,
+          file.appIntent ? "AppIntent" : undefined,
+          file.hasInputControls ? "inputs" : undefined,
+          file.hasOverlay ? "overlay" : undefined,
+          file.hasDisabledState ? "disabled" : undefined,
+          file.hasGestureCapture ? "gesture" : undefined,
+          file.hasFocusState ? "focus" : undefined,
+          file.hasModalPresentation ? "modal" : undefined,
+        ].filter(Boolean);
+        return `- ${file.path}: ${file.lines} lines${flags.length > 0 ? ` — ${flags.join(", ")}` : ""}`;
+      })
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function readProjectContextIndex(path: string): ProjectContextIndex | undefined {
+  const fullPath = resolve(path);
+  if (!existsSync(fullPath)) return undefined;
+  try {
+    return JSON.parse(readFileSync(fullPath, "utf-8")) as ProjectContextIndex;
+  } catch {
+    return undefined;
+  }
+}
+
+export function discoverProjectContextPath(startPath: string): string | undefined {
+  let current = resolve(startPath);
+
+  while (true) {
+    const candidate = join(current, ".axint/context/latest.json");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+export function buildProjectContextHint(input: {
+  sourcePath?: string;
+  fileName?: string;
+  contextPath?: string;
+  projectContext?: ProjectContextIndex;
+  focus?: ProjectContextFocus;
+}): ProjectContextHint | undefined {
+  const contextPath =
+    input.contextPath ??
+    (input.sourcePath
+      ? discoverProjectContextPath(dirname(resolve(input.sourcePath)))
+      : undefined);
+  const projectContext =
+    input.projectContext ??
+    (contextPath ? readProjectContextIndex(contextPath) : undefined);
+  if (!projectContext) return undefined;
+
+  const currentFile = matchCurrentFile(projectContext, input.sourcePath, input.fileName);
+  const relatedFiles = rankRelatedFiles(projectContext, currentFile, input.focus);
+  const summary = [
+    `Project context loaded from ${contextPath ? relativeOrAbsolute(projectContext.targetDir, contextPath) : "inline context"}.`,
+    `Indexed ${projectContext.files.swift} Swift files, ${projectContext.files.swiftUI} SwiftUI files, and ${projectContext.files.inputCapable} input-capable files.`,
+  ];
+
+  if (projectContext.git.changedFiles.length > 0) {
+    summary.push(
+      `Changed files: ${projectContext.git.changedFiles.slice(0, 6).join(", ")}${
+        projectContext.git.changedFiles.length > 6
+          ? `, +${projectContext.git.changedFiles.length - 6} more`
+          : ""
+      }.`
+    );
+  }
+
+  if (relatedFiles.length > 0) {
+    summary.push(
+      `Check these related files next: ${relatedFiles
+        .slice(0, 5)
+        .map(
+          (file) =>
+            `${file.path}${file.reasons.length > 0 ? ` (${file.reasons.slice(0, 2).join(", ")})` : ""}`
+        )
+        .join(", ")}.`
+    );
+  }
+
+  return {
+    path: contextPath,
+    summary,
+    relatedFiles,
+    changedFiles: projectContext.git.changedFiles,
+    currentFile,
+  };
+}
+
+function walkFiles(root: string): string[] {
+  const entries = readdirSync(root, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") && entry.name !== ".axint" && entry.name !== ".git") {
+      if (entry.name !== ".xcode.env") {
+        if (entry.isDirectory()) continue;
+      }
+    }
+    if (EXCLUDED_DIRS.has(entry.name)) continue;
+    const fullPath = join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath));
+      continue;
+    }
+    files.push(fullPath);
+  }
+
+  return files;
+}
+
+function summarizeSwiftFile(
+  targetDir: string,
+  fullPath: string
+): ProjectContextFileSummary {
+  const source = readFileSync(fullPath, "utf-8");
+  const lines = source.split("\n");
+  const imports = uniqueStrings(
+    Array.from(source.matchAll(/^\s*import\s+([A-Za-z0-9_]+)/gm)).map((match) => match[1])
+  );
+  const symbols = uniqueStrings(
+    Array.from(
+      source.matchAll(
+        /\b(?:struct|class|enum|actor|protocol)\s+([A-Za-z_][A-Za-z0-9_]*)/g
+      )
+    )
+      .map((match) => match[1])
+      .slice(0, 12)
+  );
+  const swiftUI =
+    imports.includes("SwiftUI") ||
+    /\b:\s*View\b/.test(source) ||
+    /\bWindowGroup\s*\{/.test(source);
+  const appIntent = imports.includes("AppIntents") || /\bAppIntent\b/.test(source);
+  const hasInputControls = /\b(TextField|TextEditor|SecureField)\s*\(/.test(source);
+  const hasOverlay = /\.overlay\s*(?:\(|\{)/.test(source);
+  const hasDisabledState = /\.disabled\s*\(/.test(source);
+  const hasGestureCapture =
+    /\.highPriorityGesture\s*\(/.test(source) ||
+    /\.gesture\s*\(/.test(source) ||
+    /\.onTapGesture\b/.test(source);
+  const hasFocusState = /\b@FocusState\b|\.focused\s*\(/.test(source);
+  const hasModalPresentation =
+    /\.sheet\s*\(/.test(source) ||
+    /\.fullScreenCover\s*\(/.test(source) ||
+    /\.confirmationDialog\s*\(/.test(source) ||
+    /\.popover\s*\(/.test(source);
+  const hasListOrScroll = /\b(List|ScrollView|LazyVStack|LazyHStack)\b/.test(source);
+
+  let riskScore = 0;
+  const reasons: string[] = [];
+
+  if (hasInputControls) {
+    riskScore += 3;
+    reasons.push("input controls");
+  }
+  if (hasOverlay) {
+    riskScore += 2;
+    reasons.push("overlay");
+  }
+  if (hasDisabledState) {
+    riskScore += 2;
+    reasons.push("disabled state");
+  }
+  if (hasGestureCapture) {
+    riskScore += 2;
+    reasons.push("gesture capture");
+  }
+  if (hasFocusState) {
+    riskScore += 2;
+    reasons.push("focus state");
+  }
+  if (hasModalPresentation) {
+    riskScore += 1;
+    reasons.push("modal presentation");
+  }
+  if (hasListOrScroll) {
+    riskScore += 1;
+    reasons.push("list/scroll container");
+  }
+  if (/\b(home|feed|composer|comment|reply|post)\b/i.test(basename(fullPath))) {
+    riskScore += 1;
+    reasons.push("high-risk screen name");
+  }
+
+  return {
+    path: relative(targetDir, fullPath),
+    lines: lines.length,
+    imports,
+    symbols,
+    swiftUI,
+    appIntent,
+    hasInputControls,
+    hasOverlay,
+    hasDisabledState,
+    hasGestureCapture,
+    hasFocusState,
+    hasModalPresentation,
+    hasListOrScroll,
+    riskScore,
+    reasons,
+  };
+}
+
+function findFirstChildWithExtension(
+  root: string,
+  extension: string
+): string | undefined {
+  const entries = readdirSync(root, { withFileTypes: true });
+  const match = entries.find(
+    (entry) => entry.isDirectory() && extname(entry.name) === extension
+  );
+  return match?.name;
+}
+
+function listSchemes(containerPath?: string): string[] {
+  if (!containerPath || !existsSync(containerPath)) return [];
+  const schemeDir = join(containerPath, "xcshareddata", "xcschemes");
+  if (!existsSync(schemeDir)) return [];
+  return readdirSync(schemeDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && extname(entry.name) === ".xcscheme")
+    .map((entry) => entry.name.replace(/\.xcscheme$/i, ""));
+}
+
+function stripXcodeExtension(value?: string): string | undefined {
+  if (!value) return undefined;
+  return value.replace(/\.(xcworkspace|xcodeproj)$/i, "");
+}
+
+function resolveChangedFiles(
+  targetDir: string,
+  changedFiles: string[] | undefined,
+  includeGit: boolean | undefined
+): string[] {
+  if (Array.isArray(changedFiles) && changedFiles.length > 0) {
+    return uniqueStrings(
+      changedFiles.map((file) => normalizeRelativePath(targetDir, file))
+    );
+  }
+  if (includeGit === false) return [];
+  return readGitChangedFiles(targetDir);
+}
+
+function readGitChangedFiles(targetDir: string): string[] {
+  try {
+    const result = spawnSync("git", ["-C", targetDir, "status", "--porcelain=v1"], {
+      encoding: "utf-8",
+    });
+    if (!result || result.status !== 0 || !result.stdout?.trim()) return [];
+
+    return uniqueStrings(
+      result.stdout
+        .split("\n")
+        .map((line) => line.trimEnd())
+        .filter(Boolean)
+        .map((line) => line.slice(3).trim())
+        .map((path) => {
+          const rename = path.split(" -> ");
+          return rename[rename.length - 1] ?? path;
+        })
+        .map((path) => normalizeRelativePath(targetDir, path))
+    );
+  } catch {
+    return [];
+  }
+}
+
+function isGitWorktree(targetDir: string): boolean {
+  try {
+    const result = spawnSync("git", ["-C", targetDir, "rev-parse", "--show-toplevel"], {
+      encoding: "utf-8",
+    });
+    return Boolean(result && result.status === 0);
+  } catch {
+    return false;
+  }
+}
+
+function matchCurrentFile(
+  projectContext: ProjectContextIndex,
+  sourcePath?: string,
+  fileName?: string
+): ProjectContextFileSummary | undefined {
+  const target = sourcePath
+    ? normalizeRelativePath(projectContext.targetDir, sourcePath)
+    : fileName
+      ? normalizeRelativePath(projectContext.targetDir, fileName)
+      : undefined;
+  if (!target) return undefined;
+
+  return (
+    projectContext.files.catalog.find((file) => file.path === target) ??
+    projectContext.files.catalog.find((file) => file.path.endsWith(`/${target}`)) ??
+    projectContext.files.catalog.find((file) => basename(file.path) === basename(target))
+  );
+}
+
+function rankRelatedFiles(
+  projectContext: ProjectContextIndex,
+  currentFile: ProjectContextFileSummary | undefined,
+  focus: ProjectContextFocus = "generic"
+): ProjectContextFileSummary[] {
+  const catalog = projectContext.files.catalog.filter(
+    (file) => file.path !== currentFile?.path
+  );
+  const currentDir = currentFile ? dirname(currentFile.path) : undefined;
+  const changedSet = new Set(projectContext.git.changedFiles);
+
+  return [...catalog]
+    .map((file) => ({
+      file,
+      score: relatedFileScore(file, {
+        currentDir,
+        changed: changedSet.has(file.path),
+        focus,
+      }),
+    }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || a.file.path.localeCompare(b.file.path))
+    .slice(0, 8)
+    .map((entry) => entry.file);
+}
+
+function relatedFileScore(
+  file: ProjectContextFileSummary,
+  input: {
+    currentDir?: string;
+    changed: boolean;
+    focus: ProjectContextFocus;
+  }
+): number {
+  let score = file.riskScore;
+  if (input.currentDir && dirname(file.path) === input.currentDir) score += 3;
+  if (input.changed) score += 4;
+
+  if (input.focus === "interactive-input") {
+    if (file.hasInputControls) score += 5;
+    if (file.hasOverlay) score += 4;
+    if (file.hasDisabledState) score += 4;
+    if (file.hasGestureCapture) score += 3;
+    if (file.hasFocusState) score += 3;
+    if (file.hasModalPresentation) score += 2;
+  }
+
+  if (input.focus === "runtime") {
+    if (file.swiftUI) score += 2;
+    if (file.hasModalPresentation) score += 2;
+    if (file.hasListOrScroll) score += 1;
+  }
+
+  return score;
+}
+
+function normalizeRelativePath(root: string, value: string): string {
+  const absolute = value.startsWith("/") ? value : resolve(root, value);
+  return relative(root, absolute).replace(/\\/g, "/");
+}
+
+function relativeOrAbsolute(root: string, value: string): string {
+  const rel = relative(root, value).replace(/\\/g, "/");
+  return rel && !rel.startsWith("..") ? rel : value;
+}
+
+function uniqueStrings(values: Array<string | undefined>): string[] {
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value))));
+}

--- a/src/project/docs-context.ts
+++ b/src/project/docs-context.ts
@@ -211,7 +211,7 @@ Typical project setup:
 
 \`\`\`bash
 npm install -g @axint/compiler
-axint xcode setup --agent claude --guarded
+axint xcode install --project .
 axint project init --dir /path/to/App --name AppName --agent claude --force
 \`\`\`
 

--- a/src/project/start-pack.ts
+++ b/src/project/start-pack.ts
@@ -288,7 +288,7 @@ function buildStartPrompt(input: { projectName: string; version: string }): stri
     "6. Call axint.status and report the running MCP server version.",
     "7. Call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.",
     `8. Expected Axint package version from this project pack: ${input.version}.`,
-    "9. If the running MCP version is stale, stop and tell me to update Axint, rerun axint xcode setup --agent claude --guarded, and restart this Xcode agent chat.",
+    "9. If the running MCP version is stale, stop and tell me to update Axint, rerun axint xcode install --project ., and restart this Xcode agent chat.",
     "10. Call axint.xcode.guard before long tasks, before broad Swift edits, and after any context recovery.",
     "11. Call axint.workflow.check with sessionToken at planning, before-write, pre-build, and pre-commit checkpoints.",
     "12. Before planning new Apple-native surfaces, call axint.suggest.",

--- a/src/run/project-runner.ts
+++ b/src/run/project-runner.ts
@@ -10,6 +10,7 @@ import {
 import { basename, extname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { runCloudCheck, type CloudCheckReport } from "../cloud/check.js";
+import { writeProjectContextIndex } from "../project/context-index.js";
 import { startAxintSession } from "../project/session.js";
 import { validateSwiftSource } from "../core/swift-validator.js";
 import type { Diagnostic } from "../core/types.js";
@@ -37,6 +38,7 @@ export interface AxintRunInput {
   configuration?: string;
   derivedDataPath?: string;
   testPlan?: string;
+  onlyTesting?: string[];
   modifiedFiles?: string[];
   skipBuild?: boolean;
   skipTests?: boolean;
@@ -105,6 +107,8 @@ export interface AxintRunReport {
   artifacts: {
     json?: string;
     markdown?: string;
+    projectContextJson?: string;
+    projectContextMarkdown?: string;
   };
   nextSteps: string[];
   repairPrompt: string;
@@ -118,6 +122,7 @@ interface XcodePlan {
   configuration?: string;
   derivedDataPath?: string;
   testPlan?: string;
+  onlyTesting: string[];
 }
 
 export async function runAxintProject(
@@ -134,6 +139,11 @@ export async function runAxintProject(
     platform,
     agent: "all",
   });
+  const projectContext = writeProjectContextIndex({
+    targetDir: cwd,
+    projectName,
+    changedFiles: input.modifiedFiles,
+  });
   const swiftFiles = resolveSwiftFiles(cwd, input.modifiedFiles);
   const validationDiagnostics: Diagnostic[] = [];
   const cloudChecks: CloudCheckReport[] = [];
@@ -142,6 +152,11 @@ export async function runAxintProject(
       name: "Axint session",
       state: "pass",
       detail: `Started session ${session.session.token}.`,
+    },
+    {
+      name: "Project context index",
+      state: "pass",
+      detail: `Indexed ${projectContext.index.files.swift} Swift files and wrote ${relativeOrAbsolute(cwd, projectContext.jsonPath)}.`,
     },
   ];
 
@@ -174,6 +189,7 @@ export async function runAxintProject(
         runtimeFailure: input.runtimeFailure,
         expectedBehavior: input.expectedBehavior,
         actualBehavior: input.actualBehavior,
+        projectContext: projectContext.index,
       })
     );
   }
@@ -280,6 +296,29 @@ export async function runAxintProject(
     });
   }
 
+  const xcodeEvidence = buildXcodeEvidence(commands);
+  if (xcodeEvidence && cloudTargets.length > 0) {
+    cloudChecks.splice(
+      0,
+      cloudChecks.length,
+      ...cloudTargets.map((file) =>
+        runCloudCheck({
+          sourcePath: file,
+          platform,
+          xcodeBuildLog: xcodeEvidence,
+          runtimeFailure:
+            input.runtimeFailure ?? runtimeFailureFromCommand(commands.runtime),
+          expectedBehavior: input.expectedBehavior,
+          actualBehavior: input.actualBehavior,
+          projectContext: projectContext.index,
+        })
+      )
+    );
+    updateCloudCheckStep(steps, cloudChecks, {
+      refreshedWithEvidence: true,
+    });
+  }
+
   const status = summarizeStatus(steps, workflow, validationDiagnostics, cloudChecks);
   const report: AxintRunReport = {
     id: `axrun_${randomUUID()}`,
@@ -308,7 +347,10 @@ export async function runAxintProject(
         ? { ...step, durationMs: Date.now() - startedAt }
         : step
     ),
-    artifacts: {},
+    artifacts: {
+      projectContextJson: projectContext.jsonPath,
+      projectContextMarkdown: projectContext.markdownPath,
+    },
     nextSteps: buildNextSteps(status, steps, workflow, cloudChecks),
     repairPrompt: buildRunRepairPrompt({
       status,
@@ -381,11 +423,24 @@ export function renderAxintRunReport(
       : ["- None."]),
   ];
 
-  if (report.artifacts.json || report.artifacts.markdown) {
+  if (
+    report.artifacts.json ||
+    report.artifacts.markdown ||
+    report.artifacts.projectContextJson ||
+    report.artifacts.projectContextMarkdown
+  ) {
     lines.push("", "## Artifacts");
     if (report.artifacts.json) lines.push(`- JSON: ${report.artifacts.json}`);
     if (report.artifacts.markdown) {
       lines.push(`- Markdown: ${report.artifacts.markdown}`);
+    }
+    if (report.artifacts.projectContextJson) {
+      lines.push(`- Project context JSON: ${report.artifacts.projectContextJson}`);
+    }
+    if (report.artifacts.projectContextMarkdown) {
+      lines.push(
+        `- Project context Markdown: ${report.artifacts.projectContextMarkdown}`
+      );
     }
   }
 
@@ -420,6 +475,7 @@ function createXcodePlan(
     configuration: input.configuration,
     derivedDataPath: input.derivedDataPath,
     testPlan: input.testPlan,
+    onlyTesting: normalizeOnlyTesting(input.onlyTesting),
   };
 }
 
@@ -432,9 +488,27 @@ function buildXcodeArgs(plan: XcodePlan, action: "build" | "test"): string[] {
   if (plan.destination) args.push("-destination", plan.destination);
   if (plan.configuration) args.push("-configuration", plan.configuration);
   if (plan.derivedDataPath) args.push("-derivedDataPath", plan.derivedDataPath);
-  if (action === "test" && plan.testPlan) args.push("-testPlan", plan.testPlan);
+  if (action === "test") {
+    if (plan.testPlan) args.push("-testPlan", plan.testPlan);
+    for (const selector of plan.onlyTesting) {
+      args.push(formatOnlyTestingArg(selector));
+    }
+  }
   args.push(action);
   return args;
+}
+
+function normalizeOnlyTesting(selectors?: string[]): string[] {
+  return unique(
+    (selectors ?? [])
+      .flatMap((selector) => selector.split(","))
+      .map((selector) => selector.trim())
+      .filter(Boolean)
+  );
+}
+
+function formatOnlyTestingArg(selector: string): string {
+  return selector.startsWith("-only-testing:") ? selector : `-only-testing:${selector}`;
 }
 
 function runCommand(
@@ -696,6 +770,73 @@ function stepFromCommand(name: string, result: AxintRunCommandResult): AxintRunS
   };
 }
 
+function updateCloudCheckStep(
+  steps: AxintRunStep[],
+  cloudChecks: CloudCheckReport[],
+  options: { refreshedWithEvidence?: boolean } = {}
+) {
+  const step = steps.find((item) => item.name === "Cloud Check");
+  if (!step) return;
+  step.state =
+    cloudChecks.length === 0
+      ? "skipped"
+      : cloudChecks.some((check) => check.status === "fail")
+        ? "fail"
+        : cloudChecks.some((check) => check.status === "needs_review")
+          ? "warn"
+          : "pass";
+  step.detail =
+    cloudChecks.length === 0
+      ? "No source file was available for Cloud Check."
+      : options.refreshedWithEvidence
+        ? `Reconciled ${cloudChecks.length} Cloud Check report${cloudChecks.length === 1 ? "" : "s"} with Xcode build/test/runtime evidence.`
+        : `Ran ${cloudChecks.length} Cloud Check report${cloudChecks.length === 1 ? "" : "s"}.`;
+}
+
+function buildXcodeEvidence(commands: AxintRunReport["commands"]): string | undefined {
+  const chunks = [
+    commandEvidence("Xcode build", commands.build),
+    commandEvidence("Xcode test", commands.test),
+    commandEvidence("Runtime launch", commands.runtime),
+  ].filter(Boolean);
+  return chunks.length > 0 ? chunks.join("\n\n") : undefined;
+}
+
+function commandEvidence(
+  label: string,
+  result?: AxintRunCommandResult
+): string | undefined {
+  if (!result || result.dryRun) return undefined;
+
+  const state = result.exitCode === 0 && !result.timedOut ? "succeeded" : "failed";
+  const header = `${label} ${state}. Exit: ${
+    result.exitCode ?? result.signal ?? "unknown"
+  }.`;
+  const output = trimCommandEvidence([result.stdout, result.stderr].join("\n"));
+  return output ? `${header}\n${output}` : header;
+}
+
+function runtimeFailureFromCommand(result?: AxintRunCommandResult): string | undefined {
+  if (!result || result.dryRun || (result.exitCode === 0 && !result.timedOut)) {
+    return undefined;
+  }
+  return trimCommandEvidence(
+    [
+      `Runtime command failed. Exit: ${result.exitCode ?? result.signal ?? "unknown"}.`,
+      result.stderr,
+      result.stdout,
+    ].join("\n")
+  );
+}
+
+function trimCommandEvidence(value: string, maxChars = 12000): string {
+  const text = value.trim();
+  if (text.length <= maxChars) return text;
+  const head = text.slice(0, 1600).trimEnd();
+  const tail = text.slice(-(maxChars - head.length - 80)).trimStart();
+  return `${head}\n\n[... axint trimmed long command evidence ...]\n\n${tail}`;
+}
+
 function summarizeStatus(
   steps: AxintRunStep[],
   workflow: WorkflowCheckReport,
@@ -839,6 +980,8 @@ function writeRunArtifacts(report: AxintRunReport) {
     artifacts: {
       json: jsonPath,
       markdown: markdownPath,
+      projectContextJson: report.artifacts.projectContextJson,
+      projectContextMarkdown: report.artifacts.projectContextMarkdown,
     },
   };
   writeFileSync(jsonPath, `${JSON.stringify(serializable, null, 2)}\n`, "utf-8");
@@ -846,6 +989,8 @@ function writeRunArtifacts(report: AxintRunReport) {
   return {
     json: jsonPath,
     markdown: markdownPath,
+    projectContextJson: report.artifacts.projectContextJson,
+    projectContextMarkdown: report.artifacts.projectContextMarkdown,
   };
 }
 

--- a/tests/cli/validate-swift.test.ts
+++ b/tests/cli/validate-swift.test.ts
@@ -5,6 +5,7 @@ import { resolve, join } from "node:path";
 import { tmpdir } from "node:os";
 
 const CLI = resolve(__dirname, "../../dist/cli/index.js");
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
 
 const INVALID_SWIFT = `
 import AppIntents
@@ -103,5 +104,69 @@ describe("axint validate-swift", () => {
 
     expect(packet.outcome.verdict).toBe("pass");
     expect(packet.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts multiple Swift file arguments in one run", () => {
+    const firstFile = join(tmpDir, "PlainSwift.swift");
+    const secondFile = join(tmpDir, "Second.swift");
+    const packetDir = join(tmpDir, "fix");
+    writeFileSync(firstFile, VALID_SWIFT, "utf-8");
+    writeFileSync(
+      secondFile,
+      `
+struct SecondSwift {
+    let value: String = "ok"
+}
+`,
+      "utf-8"
+    );
+
+    const result = spawnSync(
+      "node",
+      [CLI, "validate-swift", firstFile, secondFile, "--fix-packet-dir", packetDir],
+      {
+        cwd: tmpDir,
+        encoding: "utf-8",
+      }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("2 Swift files passed axint validation");
+
+    const packetPath = join(packetDir, "latest.json");
+    const packet = JSON.parse(readFileSync(packetPath, "utf-8")) as {
+      outcome: { verdict: string };
+      diagnostics: Array<unknown>;
+    };
+
+    expect(packet.outcome.verdict).toBe("pass");
+    expect(packet.diagnostics).toHaveLength(0);
+  });
+
+  it("disables ANSI color in non-TTY output by default", () => {
+    const swiftFile = join(tmpDir, "PlainSwift.swift");
+    writeFileSync(swiftFile, VALID_SWIFT, "utf-8");
+
+    const result = spawnSync("node", [CLI, "validate-swift", swiftFile], {
+      cwd: tmpDir,
+      encoding: "utf-8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toMatch(ANSI_PATTERN);
+    expect(result.stderr).not.toMatch(ANSI_PATTERN);
+  });
+
+  it("forces ANSI color when --color is set", () => {
+    const swiftFile = join(tmpDir, "PlainSwift.swift");
+    writeFileSync(swiftFile, VALID_SWIFT, "utf-8");
+
+    const result = spawnSync("node", [CLI, "validate-swift", swiftFile, "--color"], {
+      cwd: tmpDir,
+      encoding: "utf-8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(ANSI_PATTERN);
   });
 });

--- a/tests/cli/xcode-check.test.ts
+++ b/tests/cli/xcode-check.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import { mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { buildFixPacket } from "../../src/repair/fix-packet.js";
 import { emitCheckSummaryArtifacts } from "../../src/repair/check-summary.js";
+import { runXcodeCheck } from "../../src/cli/xcode-check.js";
 
 const CLI = resolve(__dirname, "../../dist/cli/index.js");
 
@@ -187,5 +188,61 @@ describe("axint xcode check", () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("no validate Axint Check found");
     expect(result.stderr).toContain("DerivedData");
+  });
+
+  it("can check a live Swift file directly and refresh project context", async () => {
+    const stdout: string[] = [];
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+
+    try {
+      const projectRoot = join(tempRoot, "Swarm");
+      mkdirSync(join(projectRoot, "Swarm.xcodeproj"), { recursive: true });
+      writeFileSync(
+        join(projectRoot, "HomeComposer.swift"),
+        [
+          "import SwiftUI",
+          "",
+          "struct HomeComposer: View {",
+          '    @State private var draft = ""',
+          "    var body: some View {",
+          "        TextEditor(text: $draft)",
+          "    }",
+          "}",
+          "",
+        ].join("\n")
+      );
+      writeFileSync(
+        join(projectRoot, "FeedShell.swift"),
+        [
+          "import SwiftUI",
+          "",
+          "struct FeedShell: View {",
+          "    @State private var isPosting = false",
+          "    var body: some View {",
+          "        HomeComposer()",
+          "            .disabled(isPosting)",
+          "    }",
+          "}",
+          "",
+        ].join("\n")
+      );
+
+      await runXcodeCheck({
+        sourcePath: join(projectRoot, "HomeComposer.swift"),
+        project: projectRoot,
+        changedFiles: ["FeedShell.swift"],
+        kind: "any",
+        format: "markdown",
+      });
+
+      expect(stdout.join("")).toContain("# Axint Cloud Check");
+      expect(stdout.join("")).toContain("## Project Context");
+      expect(stdout.join("")).toContain("FeedShell.swift");
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
 });

--- a/tests/cli/xcode.test.ts
+++ b/tests/cli/xcode.test.ts
@@ -27,7 +27,11 @@ vi.mock("node:os", async () => {
   };
 });
 
-import { setupXcode, verifyXcode } from "../../src/cli/xcode-setup.js";
+import {
+  installXcodeWorkflow,
+  setupXcode,
+  verifyXcode,
+} from "../../src/cli/xcode-setup.js";
 import { xcodeExtensionStatus } from "../../src/cli/xcode-extension.js";
 
 describe("xcode CLI smoke coverage", () => {
@@ -202,6 +206,7 @@ describe("xcode CLI smoke coverage", () => {
     });
 
     const guardPath = join(projectDir, ".axint", "guard", "latest.json");
+    const contextPath = join(projectDir, ".axint", "context", "latest.json");
     const guard = JSON.parse(readFileSync(guardPath, "utf-8")) as {
       status: string;
       session?: { token: string };
@@ -212,6 +217,56 @@ describe("xcode CLI smoke coverage", () => {
     );
     expect(guard.status).toBe("ready");
     expect(guard.session?.token).toMatch(/^axsess_/);
+    expect(readFileSync(contextPath, "utf-8")).toContain('"projectName": "Swarm"');
+  });
+
+  it("installs the full Xcode workflow in one pass", async () => {
+    const projectDir = join(tempRoot, "Swarm");
+    const npxPath = join(tempRoot, "bin", "npx");
+    mkdirSync(dirname(npxPath), { recursive: true });
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(npxPath, "", "utf-8");
+
+    execSyncMock.mockImplementation((command: string) => {
+      if (command.startsWith("xcodebuild -version")) {
+        return "Xcode 26.3\nBuild version 17E123";
+      }
+      if (command.startsWith("xcrun mcpbridge --help")) {
+        return "";
+      }
+      if (command.startsWith("which axint")) {
+        return "/usr/local/bin/axint\n";
+      }
+      if (command.startsWith("claude mcp add --transport stdio")) {
+        return "";
+      }
+      if (command.startsWith("command -v npx")) {
+        return `${npxPath}\n`;
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    spawnSyncMock.mockReturnValue({
+      stdout: JSON.stringify({
+        tools: [
+          { name: "axint.status" },
+          { name: "axint.feature" },
+          { name: "axint.project.index" },
+        ],
+      }),
+      stderr: "",
+    });
+
+    await installXcodeWorkflow({
+      agent: "claude",
+      remote: false,
+      project: projectDir,
+      name: "Swarm",
+    });
+
+    expect(
+      readFileSync(join(projectDir, ".axint", "context", "latest.json"), "utf-8")
+    ).toContain('"projectName": "Swarm"');
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Xcode workflow ready"));
   });
 
   it("covers extension status when the app is installed", async () => {

--- a/tests/cloud/check.test.ts
+++ b/tests/cloud/check.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it } from "vitest";
 import { renderCloudCheckReport, runCloudCheck } from "../../src/cloud/check.js";
 import { writeCloudFeedbackSignal } from "../../src/cloud/feedback-store.js";
 import { handleToolCall } from "../../src/mcp/server.js";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { writeProjectContextIndex } from "../../src/project/context-index.js";
 
 describe("cloud check", () => {
   it("runs a Swift source check and returns an agent repair prompt", () => {
@@ -105,6 +106,8 @@ struct ContentView: View {
     expect(payload.gate.decision).toBe("evidence_required");
     expect(payload.gate.canClaimFixed).toBe(false);
     expect(payload.fileName).toBe("ContentView.swift");
+    expect(payload.swiftCode).toBeUndefined();
+    expect(payload.sourceRedaction.swiftCode).toBe("omitted_from_rendered_json");
     expect(payload.confidence.level).toBe("medium");
     expect(payload.coverage).toContainEqual(
       expect.objectContaining({
@@ -242,6 +245,51 @@ struct HomeCommandLayer: View {
     );
     expect(report.status).toBe("pass");
     expect(report.gate.decision).toBe("ready_to_ship");
+  });
+
+  it("trusts passing focused Xcode proof when behavior prose uses different wording", () => {
+    const report = runCloudCheck({
+      fileName: "DiscoverTabView.swift",
+      platform: "macOS",
+      source: `
+import SwiftUI
+
+struct DiscoverTabView: View {
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, pinnedViews: [.sectionHeaders]) {
+                Section {
+                    Text("Feed")
+                } header: {
+                    Text("Discover")
+                }
+            }
+        }
+    }
+}
+`,
+      expectedBehavior:
+        "Discover tab preserves scroll offset, sticky header position, visible feed cards, and composer tap target after filter changes.",
+      actualBehavior:
+        "Focused UITest transcript attached for the current branch repair proof.",
+      xcodeBuildLog: [
+        "Test Suite 'SwarmUITests' started.",
+        "Test Case '-[SwarmUITests testDiscoverTabScrollAnchors]' passed (1.18 seconds).",
+        "Test Case '-[SwarmUITests testDiscoverComposerRemainsHittable]' passed (0.92 seconds).",
+        "** TEST SUCCEEDED **",
+        "Executed 2 tests, with 0 failures",
+      ].join("\n"),
+    });
+
+    expect(report.diagnostics.map((d) => d.code)).not.toContain(
+      "AXCLOUD-BEHAVIOR-MISMATCH"
+    );
+    expect(report.diagnostics.map((d) => d.code)).not.toContain(
+      "AXCLOUD-EVIDENCE-UNCLASSIFIED"
+    );
+    expect(report.status).toBe("pass");
+    expect(report.gate.decision).toBe("ready_to_ship");
+    expect(report.repairPrompt).not.toContain("This is not a runtime pass");
   });
 
   it("flags behavior evidence only when the actual text describes a failure", () => {
@@ -389,6 +437,126 @@ struct ProfileDataView: View {
     expect(report.diagnostics.map((d) => d.code)).toContain("AXCLOUD-RUNTIME-FREEZE");
     expect(report.diagnostics.map((d) => d.code)).toContain("AXCLOUD-RUNTIME-SYNC-IO");
     expect(report.repairPrompt).toContain("Synchronous I/O");
+  });
+
+  it("classifies overlay hit-testing blockers when a compose box stops accepting input", () => {
+    const report = runCloudCheck({
+      fileName: "HomeComposer.swift",
+      platform: "iOS",
+      source: `
+import SwiftUI
+
+struct HomeComposer: View {
+    @State private var draft = ""
+
+    var body: some View {
+        TextEditor(text: $draft)
+            .frame(minHeight: 120)
+            .overlay(alignment: .topLeading) {
+                if draft.isEmpty {
+                    Text("Write a comment")
+                        .padding(.top, 12)
+                        .padding(.leading, 16)
+                }
+            }
+    }
+}
+`,
+      runtimeFailure:
+        "The home feed still renders, but the comment box is visible and I can't tap into it or type anymore.",
+    });
+
+    expect(report.status).toBe("fail");
+    expect(report.diagnostics.map((d) => d.code)).toContain(
+      "AXCLOUD-UI-HIT-TEST-BLOCKER"
+    );
+    expect(report.repairPrompt).toContain("allowsHitTesting(false)");
+    expect(report.learningSignal?.signals).toContain("ui-interaction-evidence");
+  });
+
+  it("classifies propagated disabled state when a compose box no longer works", () => {
+    const report = runCloudCheck({
+      fileName: "HomeComposer.swift",
+      platform: "iOS",
+      source: `
+import SwiftUI
+
+struct HomeComposer: View {
+    @State private var draft = ""
+    @State private var isPosting = false
+    @State private var isShowingFeatureGate = false
+
+    var body: some View {
+        VStack {
+            TextField("Write a comment", text: $draft)
+                .textFieldStyle(.roundedBorder)
+        }
+        .disabled(isPosting || isShowingFeatureGate)
+    }
+}
+`,
+      actualBehavior:
+        "After adding the new feature, the compose box is visible but no longer accepts input or focus.",
+    });
+
+    expect(report.status).toBe("fail");
+    expect(report.diagnostics.map((d) => d.code)).toContain("AXCLOUD-UI-DISABLED-STATE");
+  });
+
+  it("loads local project context and surfaces related files for a dead composer", () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-cloud-context-"));
+    try {
+      mkdirSync(join(dir, ".axint"), { recursive: true });
+      writeFileSync(
+        join(dir, "HomeComposer.swift"),
+        [
+          "import SwiftUI",
+          "",
+          "struct HomeComposer: View {",
+          '    @State private var draft = ""',
+          "    var body: some View {",
+          "        TextEditor(text: $draft)",
+          "    }",
+          "}",
+          "",
+        ].join("\n")
+      );
+      writeFileSync(
+        join(dir, "FeedShell.swift"),
+        [
+          "import SwiftUI",
+          "",
+          "struct FeedShell: View {",
+          "    @State private var isPosting = false",
+          "    var body: some View {",
+          "        HomeComposer()",
+          "            .disabled(isPosting)",
+          "    }",
+          "}",
+          "",
+        ].join("\n")
+      );
+      writeProjectContextIndex({
+        targetDir: dir,
+        changedFiles: ["FeedShell.swift"],
+      });
+
+      const report = runCloudCheck({
+        sourcePath: join(dir, "HomeComposer.swift"),
+        actualBehavior:
+          "The comment box is visible, but after the new feature landed I can't tap into it or type anymore.",
+      });
+
+      expect(report.projectContext?.summary.join("\n")).toContain(
+        "Project context loaded"
+      );
+      expect(report.projectContext?.relatedFiles.map((file) => file.path)).toContain(
+        "FeedShell.swift"
+      );
+      expect(report.repairPrompt).toContain("Related files to inspect");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("emits a learning signal when static SwiftUI validation needs runtime evidence", () => {

--- a/tests/core/swift-validator.test.ts
+++ b/tests/core/swift-validator.test.ts
@@ -880,3 +880,58 @@ describe("swift validator — AX739 undeclared SwiftUI body references", () => {
     );
   });
 });
+
+describe("swift validator — AX764 input overlay hit testing", () => {
+  it("warns when a text input overlay can block hit testing", () => {
+    const source = `
+      import SwiftUI
+
+      struct ComposerView: View {
+          @State private var draft = ""
+
+          var body: some View {
+              TextEditor(text: $draft)
+                  .frame(minHeight: 120)
+                  .overlay(alignment: .topLeading) {
+                      if draft.isEmpty {
+                          Text("Write a comment")
+                              .padding(.top, 12)
+                              .padding(.leading, 16)
+                      }
+                  }
+          }
+      }
+    `;
+
+    const diagnostic = validate(source).diagnostics.find((d) => d.code === "AX764");
+    expect(diagnostic?.message).toContain("TextEditor");
+    expect(diagnostic?.suggestion).toContain("allowsHitTesting(false)");
+  });
+
+  it("does not warn when the overlay explicitly disables hit testing", () => {
+    const source = `
+      import SwiftUI
+
+      struct ComposerView: View {
+          @State private var draft = ""
+
+          var body: some View {
+              TextEditor(text: $draft)
+                  .frame(minHeight: 120)
+                  .overlay(alignment: .topLeading) {
+                      if draft.isEmpty {
+                          Text("Write a comment")
+                              .padding(.top, 12)
+                              .padding(.leading, 16)
+                              .allowsHitTesting(false)
+                      }
+                  }
+          }
+      }
+    `;
+
+    expect(validate(source).diagnostics.filter((d) => d.code === "AX764")).toHaveLength(
+      0
+    );
+  });
+});

--- a/tests/mcp/feature.test.ts
+++ b/tests/mcp/feature.test.ts
@@ -643,6 +643,47 @@ describe("axint.suggest", () => {
     ).toBe(false);
   });
 
+  it("switches to existing-product repair mode for SwiftUI UX bugs", () => {
+    const suggestions = suggestFeatures({
+      appDescription:
+        "Existing Discover tab scroll UX bug: the header sticks wrong, the tab loses position, and a focused Xcode UI test should prove the repair.",
+      platform: "macOS",
+      limit: 3,
+    });
+
+    expect(suggestions).toHaveLength(3);
+    expect(suggestions[0].domain).toBe("repair");
+    expect(suggestions[0].name).toMatch(/Repair Existing/i);
+    expect(suggestions[0].featurePrompt).toMatch(
+      /existing macOS discover screen SwiftUI flow/i
+    );
+    expect(suggestions[0].featurePrompt).toMatch(/smallest view\/state/i);
+    expect(suggestions[1].featurePrompt).toMatch(/focused macOS Xcode/i);
+    expect(suggestions.map((s) => s.domain)).not.toContain("collaboration");
+  });
+
+  it("preserves product nouns for existing command-center screen repairs", () => {
+    const suggestions = suggestFeatures({
+      appDescription:
+        "Turn the existing macOS SwiftUI Project Room screen for My Project into a premium command center with launch readiness, Capture, Vault, Agents, existing tab routing, and primary actions.",
+      platform: "macOS",
+      limit: 4,
+    });
+
+    const routing = suggestions.find((suggestion) => /routing/i.test(suggestion.name));
+
+    expect(suggestions[0].domain).toBe("repair");
+    expect(suggestions[0].name).toMatch(/Project Room/i);
+    expect(suggestions[0].featurePrompt).toMatch(/Project Room/);
+    expect(suggestions[0].featurePrompt).toMatch(/My Project/);
+    expect(suggestions[0].featurePrompt).toMatch(/command center/);
+    expect(suggestions[0].featurePrompt).toMatch(/launch readiness/);
+    expect(routing).toBeDefined();
+    expect(routing!.featurePrompt).toMatch(/capture|run agent|launch check|open vault/i);
+    expect(routing!.featurePrompt).toMatch(/tab routing|hittable|route/i);
+    expect(routing!.nextStep).toMatch(/--only-testing/);
+  });
+
   it("uses broader app context instead of falling back to collaboration for recipes", () => {
     const suggestions = suggestFeatures({
       appDescription: "A recipe and cooking app for meal plans and groceries",

--- a/tests/mcp/machine.test.ts
+++ b/tests/mcp/machine.test.ts
@@ -194,5 +194,15 @@ describe("Axint project machine", () => {
     expect(
       readFileSync(join(sessionDir, ".axint/session/current.json"), "utf-8")
     ).toContain(session.session.token);
+
+    const contextResult = await handleToolCall("axint.project.index", {
+      targetDir: sessionDir,
+      projectName: "Swarm",
+      dryRun: true,
+      format: "json",
+    });
+    const context = JSON.parse(contextResult.content[0].text);
+    expect(context.schema).toBe("https://axint.ai/schemas/project-context-index.v1.json");
+    expect(context.projectName).toBe("Swarm");
   });
 });

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -30,7 +30,7 @@ describe("axint.status tool", () => {
     expect(payload.server).toBe("axint-mcp");
     expect(payload.version).toMatch(/^\d+\.\d+\.\d+/);
     expect(payload.restartRequiredAfterUpdate).toBe(true);
-    expect(payload.xcodeSetupCommand).toBe("axint xcode setup --agent claude --guarded");
+    expect(payload.xcodeSetupCommand).toBe("axint xcode install --project .");
   });
 
   it("returns a human-readable Xcode update path", async () => {

--- a/tests/mcp/workflow-check.test.ts
+++ b/tests/mcp/workflow-check.test.ts
@@ -121,6 +121,10 @@ describe("axint.workflow.check", () => {
     expect(report.status).toBe("ready");
     expect(report.required).toEqual([]);
     expect(report.checked.join("\n")).toMatch(/intentionally bypassed/);
+    expect(report.checked.join("\n")).toMatch(/patch-first mode/);
+    expect(report.recommended.join("\n")).toMatch(/small patch edit/);
+    expect(report.nextTool).toBe("apply_patch, then axint.swift.validate");
+    expect(renderWorkflowCheckReport(report)).toContain("## Next Action");
   });
 
   it("passes when static checks and build evidence are present", () => {

--- a/tests/project/context-index.test.ts
+++ b/tests/project/context-index.test.ts
@@ -1,0 +1,130 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildProjectContextHint,
+  buildProjectContextIndex,
+  writeProjectContextIndex,
+} from "../../src/project/context-index.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+
+function tempProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "axint-context-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("project context index", () => {
+  it("indexes SwiftUI interaction risk and writes local artifacts", () => {
+    const dir = tempProject();
+    mkdirSync(join(dir, "Swarm.xcodeproj", "xcshareddata", "xcschemes"), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(dir, "Swarm.xcodeproj", "xcshareddata", "xcschemes", "Swarm.xcscheme"),
+      "<Scheme></Scheme>\n"
+    );
+    writeFileSync(
+      join(dir, "HomeView.swift"),
+      [
+        "import SwiftUI",
+        "",
+        "struct HomeView: View {",
+        '    @State private var draft = ""',
+        "    var body: some View {",
+        "        TextEditor(text: $draft)",
+        "            .overlay {",
+        '                Text("Comment")',
+        "            }",
+        "    }",
+        "}",
+        "",
+      ].join("\n")
+    );
+    writeFileSync(
+      join(dir, "FeedOverlay.swift"),
+      [
+        "import SwiftUI",
+        "",
+        "struct FeedOverlay: View {",
+        "    var body: some View {",
+        "        Color.clear",
+        "            .highPriorityGesture(DragGesture())",
+        "    }",
+        "}",
+        "",
+      ].join("\n")
+    );
+
+    const result = writeProjectContextIndex({
+      targetDir: dir,
+      projectName: "Swarm",
+      changedFiles: ["FeedOverlay.swift"],
+    });
+
+    expect(result.index.projectName).toBe("Swarm");
+    expect(result.index.xcode.schemes).toContain("Swarm");
+    expect(result.index.files.swift).toBe(2);
+    expect(result.index.git.changedFiles).toContain("FeedOverlay.swift");
+    expect(result.index.topInteractionRiskFiles.map((file) => file.path)).toContain(
+      "HomeView.swift"
+    );
+    expect(readFileSync(result.jsonPath, "utf-8")).toContain('"projectName": "Swarm"');
+    expect(readFileSync(result.markdownPath, "utf-8")).toContain(
+      "## Interaction Risk Files"
+    );
+  });
+
+  it("builds related-file hints for input interaction failures", () => {
+    const dir = tempProject();
+    writeFileSync(
+      join(dir, "HomeComposer.swift"),
+      [
+        "import SwiftUI",
+        "",
+        "struct HomeComposer: View {",
+        '    @State private var draft = ""',
+        "    var body: some View {",
+        "        TextEditor(text: $draft)",
+        "    }",
+        "}",
+        "",
+      ].join("\n")
+    );
+    writeFileSync(
+      join(dir, "FeedScreen.swift"),
+      [
+        "import SwiftUI",
+        "",
+        "struct FeedScreen: View {",
+        "    @State private var gate = false",
+        "    var body: some View {",
+        "        HomeComposer()",
+        "            .disabled(gate)",
+        "    }",
+        "}",
+        "",
+      ].join("\n")
+    );
+
+    const index = buildProjectContextIndex({
+      targetDir: dir,
+      changedFiles: ["FeedScreen.swift"],
+    });
+    const hint = buildProjectContextHint({
+      sourcePath: join(dir, "HomeComposer.swift"),
+      projectContext: index,
+      focus: "interactive-input",
+    });
+
+    expect(hint?.relatedFiles.map((file) => file.path)).toContain("FeedScreen.swift");
+    expect(hint?.summary.join("\n")).toContain("Changed files: FeedScreen.swift");
+  });
+});

--- a/tests/run/project-runner.test.ts
+++ b/tests/run/project-runner.test.ts
@@ -44,6 +44,10 @@ describe("runAxintProject", () => {
     expect(report.commands.build?.args).toContain("-project");
     expect(report.commands.build?.args).toContain("Swarm");
     expect(report.artifacts.json).toBeDefined();
+    expect(report.artifacts.projectContextJson).toBeDefined();
+    expect(readFileSync(report.artifacts.projectContextJson!, "utf-8")).toContain(
+      '"schema": "https://axint.ai/schemas/project-context-index.v1.json"'
+    );
     expect(readFileSync(report.artifacts.json!, "utf-8")).toContain('"status"');
   });
 
@@ -59,5 +63,28 @@ describe("runAxintProject", () => {
     const prompt = renderAxintRunReport(report, "prompt");
     expect(prompt).toContain("You are repairing an Apple-native project");
     expect(prompt).toContain("After repairing, rerun `axint run`");
+  });
+
+  it("plans focused Xcode UI tests with only-testing selectors", async () => {
+    const dir = makeFakeXcodeProject();
+    const report = await runAxintProject({
+      cwd: dir,
+      dryRun: true,
+      writeReport: false,
+      onlyTesting: [
+        "SwarmUITests/SwarmUITests/testProjectCommandCenterPrimaryActionsRouteToCoreTabs",
+        "SwarmUITests/SwarmUITests/testCaptureButtonIsHittable, -only-testing:SwarmUITests/SwarmUITests/testOpenVaultRoutes",
+      ],
+    });
+
+    expect(report.commands.test?.args).toContain(
+      "-only-testing:SwarmUITests/SwarmUITests/testProjectCommandCenterPrimaryActionsRouteToCoreTabs"
+    );
+    expect(report.commands.test?.args).toContain(
+      "-only-testing:SwarmUITests/SwarmUITests/testCaptureButtonIsHittable"
+    );
+    expect(report.commands.test?.args).toContain(
+      "-only-testing:SwarmUITests/SwarmUITests/testOpenVaultRoutes"
+    );
   });
 });

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.10";
+const VERSION = "0.4.11";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary

Release Axint `0.4.11` with the dogfooding hardening from the latest Swarm feedback loop.

This adds a more senior existing-screen repair path, focused Xcode UI-test selectors for `axint.run`, project context indexing for Cloud Check, and patch-first workflow guidance for Codex-style agents working on dirty SwiftUI files.

## What changed

- Added project context indexing via `axint.project.index` and wired `axint.run` / Cloud Check to use the generated `.axint/context` pack.
- Improved `axint.suggest` existing-product repair mode so targeted SwiftUI prompts preserve nouns like Project Room, command center, launch readiness, Capture, Vault, Agents, routing, hit targets, and focused UI proof.
- Added `--only-testing` / `onlyTesting` support to `axint.run` for focused `xcodebuild test` evidence.
- Made `axint.workflow.check` recognize patch-first existing-code repair mode instead of steering agents toward risky full-file writes.
- Bumped all release surfaces to `0.4.11` and synced public truth to `24 MCP tools + 5 prompts · 183 diagnostic codes · 1131 tests`.

## Validation

- `npm run versions:check`
- `npm run metrics:check`
- `npm run docs:check`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test`
- `python3 -m pytest` in `python/`
- `npm run truth:check` from the Agentic Empire workspace
- `npm pack --dry-run`
