### PR TITLE
Strengthen Axint repair loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ feature definition
   → Axint IR
   → Swift + plist + entitlements
   → local or Cloud Check verdict
+  → project-aware repair plan
   → Fix Packet
   → agent repair
   → rerun
@@ -56,9 +57,10 @@ The compiler is useful on its own. Registry and Cloud extend the same workflow:
 
 - **Compiler** — open-source TypeScript/Python/preview `.axint` to Apple-native Swift.
 - **Fix Packet** — `latest.check.*` for the quick verdict, `latest.*` for the full repair contract.
+- **Repair** — `axint repair` indexes the existing Apple project, ranks likely files, classifies build/UI/runtime evidence, and returns the smallest patch/proof loop.
 - **MCP** — agents call compile, validate, fix, schema compile, templates, and packet tools directly.
 - **Registry** — install reusable Apple capabilities with source, compiler metadata, and package details attached.
-- **Cloud Check** — free hosted validation for quick results; signed-in Pro checks add the AI-ready repair prompt, history, and a shareable report.
+- **Cloud Check + feedback** — free hosted validation for quick results; signed-in Pro checks add the AI-ready repair prompt, history, and a shareable report. Privacy-safe feedback packets help Axint learn repeated Apple failure modes without shipping source code.
 
 [Read the thesis](https://axint.ai/thesis) · [Open proof](https://axint.ai/proof) · [View Fix Packet](https://axint.ai/fix-packet)
 
@@ -210,11 +212,39 @@ axint compile my-widget.ts --out ios/Widgets/
 axint compile my-app.ts --out ios/App/
 ```
 
+### Repair an existing Apple app
+
+When the Swift already exists and something subtle breaks, use the project-aware
+repair loop instead of asking an agent to guess from one file:
+
+```bash
+axint project index --changed Sources/HomeComposer.swift Sources/FeedScreen.swift
+
+axint repair "comment box is visible but cannot be tapped" \
+  --source Sources/HomeComposer.swift \
+  --platform ios \
+  --actual "visible composer no longer accepts focus or typing" \
+  --agent codex
+
+axint feedback latest --format markdown
+```
+
+`axint repair` writes `.axint/repair/latest.*` and a privacy-safe
+`.axint/feedback/latest.json` packet. The feedback packet includes project shape,
+diagnostic codes, issue class, redacted evidence, and likely Axint product owner,
+but not source code.
+
+The same senior repair read is shared by `axint.suggest`, `axint.feature`,
+`axint.cloud.check`, and `axint.repair`. If a prompt describes a broken existing
+SwiftUI flow, Axint routes toward the smallest repair/proof loop instead of
+generating a replacement screen. New-component prompts can still reference
+existing app types as context without being blocked.
+
 ---
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.11 · 24 MCP tools + 5 prompts · 183 diagnostic codes · 1131 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.12 · 29 MCP tools + 5 prompts · 183 diagnostic codes · 1165 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -238,11 +268,18 @@ axint watch my-intent.ts --out ios/Intents/ --format --swift-build
 `axint run` is the local/BYO-Mac build loop for Apple projects. It exists so agents do not have to remember separate Axint steps after a long chat or context compaction.
 
 ```bash
+axint session start --dir /path/to/MyApp --name MyApp --agent codex
+axint workflow check --dir /path/to/MyApp --agent codex --stage context-recovery --session-token <token> --read-rehydration-context --read-agent-instructions --read-docs-context --ran-status
 axint xcode setup --agent claude --guarded --project /path/to/MyApp --name MyApp
 axint xcode setup --agent claude --guarded --local-build --project /path/to/MyApp --name MyApp
 axint xcode guard --dir /path/to/MyApp --stage context-recovery
 axint run --dir /path/to/MyApp --scheme MyApp --destination "platform=macOS"
+axint run --dir /path/to/MyApp --scheme MyApp --only-testing MyAppUITests/MyAppUITests/testComposerStillAcceptsInput
 axint run --dir /path/to/MyApp --scheme MyApp --runtime
+axint run status --dir /path/to/MyApp
+axint run cancel --dir /path/to/MyApp --id axrun_...
+axint run --dir /path/to/MyApp --scheme MyApp --format json
+axint run --dir /path/to/MyApp --scheme MyApp --format json --include-source
 axint runner once --dir /path/to/MyApp --scheme MyApp
 ```
 
@@ -250,13 +287,40 @@ axint runner once --dir /path/to/MyApp --scheme MyApp
 
 Use `--local-build` only while dogfooding this checkout before publishing; it points Xcode at the built local MCP server instead of the npm package.
 
-When an MCP agent is creating a new Swift file, use `axint.xcode.write` instead of a raw file write. The tool writes inside the project root, validates Swift, runs Cloud Check, and updates the guard proof in one call.
+Agent lanes are explicit now. Codex, Claude Code, Cursor, and Cowork should use their native patch/edit tools for existing files, then run `axint workflow check`, `axint validate-swift`, `axint cloud check`, and `axint run`. Xcode-hosted agents can use `axint.xcode.guard` and `axint.xcode.write` because those tools create real Xcode guard proof.
 
-The run starts an Axint session, refreshes the project recovery context, validates changed Swift, runs Cloud Check, executes `xcodebuild build` and `xcodebuild test`, optionally launches a macOS app for runtime proof, and writes `.axint/run/latest.json` plus `.axint/run/latest.md`.
+When an Xcode MCP agent is creating a new Swift file, use `axint.xcode.write` instead of a raw file write. The tool writes inside the project root, validates Swift, runs Cloud Check, and updates the guard proof in one call. Outside Xcode, do not route routine edits through `axint.xcode.write`; patch surgically in the active client and let Axint validate the result.
+
+The run starts an Axint session, refreshes the project recovery context, validates changed Swift, runs Cloud Check, executes `xcodebuild build` and `xcodebuild test`, optionally launches a macOS app for runtime proof, and writes `.axint/run/latest.json` plus `.axint/run/latest.md`. Passing focused `--only-testing` selectors are also fed back into Cloud Check so stale UI/accessibility warnings do not override real focused test proof.
+
+Long runs also write `.axint/run/jobs/<id>.json` and `.axint/run/latest-active.json`. If a client disconnects, an MCP transport times out, or an agent needs to rejoin a build in the same thread, use `axint run status` to see active process IDs and `axint run cancel` to stop the child process group without restarting the whole chat.
+
+Rendered `axint run --format json` is compact by default: it keeps verdict, evidence, diagnostics, artifact paths, and next actions visible while omitting full Swift source and trimming long command output. Use `--include-source` only when the active agent explicitly needs inline Swift/code output in the response.
 
 Use `--dry-run` to prove the harness and planned `xcodebuild` commands before letting a local or BYO Mac runner execute the job.
 
+If an MCP client still lists Axint tools after the transport has closed, use the CLI fallback instead of restarting the whole thread:
+
+```bash
+axint workflow check --dir /path/to/MyApp --agent codex --stage pre-build --session-token <token> --ran-swift-validate --ran-cloud-check --modified Sources/HomeComposer.swift
+```
+
 This open-source repository does not include the proprietary hosted Axint Cloud control plane: job queues, Mac fleet orchestration, billing, signed-in Pro entitlements, stored report history, or learning pipelines live outside the compiler package.
+
+---
+
+## Same-thread upgrades
+
+Agent sessions should not have to restart from scratch just because Axint shipped a new version. Use the upgrade flow inside Codex, Claude, Xcode, or any MCP client to check the latest package, install it when ready, refresh optional Xcode wiring, and write a continuation packet under `.axint/upgrade/latest.*`.
+
+```bash
+axint upgrade
+axint upgrade --apply
+axint upgrade --apply --xcode-install
+axint upgrade --target 0.4.12 --apply
+```
+
+From MCP, call `axint.upgrade`. The tool returns the exact command plan plus a same-thread prompt that tells the agent to keep the current conversation, reload or reconnect only the Axint MCP server/tool process, then call `axint.status` to prove the running version before editing code.
 
 ---
 
@@ -265,26 +329,29 @@ This open-source repository does not include the proprietary hosted Axint Cloud 
 <!-- truth:readme-mcp-support:start -->Axint ships an MCP server for Claude Desktop, Claude Code, Cursor, Codex, VS Code, Windsurf, Xcode, and any MCP client.<!-- truth:readme-mcp-support:end -->
 
 <!-- truth:readme-mcp-json:start -->```json
+
 {
-  "mcpServers": {
-    "axint": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "-p",
-        "@axint/compiler",
-        "axint-mcp"
-      ]
-    }
-  }
+"mcpServers": {
+"axint": {
+"command": "npx",
+"args": [
+"-y",
+"-p",
+"@axint/compiler",
+"axint-mcp"
+]
 }
-```<!-- truth:readme-mcp-json:end -->
+}
+}
+
+````<!-- truth:readme-mcp-json:end -->
 
 MCP tools and built-in prompts:
 
 | Tool | What it does |
 | --- | --- |
-| `axint.status` | Report the running MCP server version, package path, uptime, and Xcode restart/update instructions |
+| `axint.status` | Report the running MCP server version, package path, uptime, and same-thread reload/update instructions |
+| `axint.upgrade` | Check or apply an Axint upgrade, refresh optional Xcode wiring, and return a same-thread continuation prompt |
 | `axint.doctor` | Audit version truth, Node/npm/npx paths, project MCP wiring, and agent start-pack files |
 | `axint.xcode.guard` | Guard Xcode agent sessions against context compaction and Axint drift, then write `.axint/guard/latest.*` proof artifacts |
 | `axint.xcode.write` | Write a project file through Axint, then validate Swift, run Cloud Check, and update guard proof for Swift files |
@@ -299,12 +366,17 @@ MCP tools and built-in prompts:
 | `axint.context.docs` | Return the project-local Axint docs context so agents can reload docs after compaction |
 | `axint.suggest` | Suggest app-specific Apple-native features, reusable components, and shared stores from a product description |
 | `axint.workflow.check` | Check whether an agent rehydrated Axint after compaction, has an active session token, and used suggest, feature, swift.validate, cloud.check, and Xcode proof before moving on |
+| `axint workflow check` | CLI fallback for the same workflow gate when MCP is stale, closed, or unavailable |
 | `axint.scaffold` | Generate a starter TypeScript intent from a description |
 | `axint.swift.validate` | Validate existing Swift against build-time rules |
 | `axint.swift.fix` | Auto-fix mechanical Swift errors (concurrency, Live Activities) |
 | `axint.fix-packet` | Read the latest AI-ready repair packet from a local compile or watch run |
 | `axint.cloud.check` | Run an agent-callable Cloud Check report against Swift or TypeScript source |
+| `axint.repair` | Plan a project-aware Apple repair loop for existing app bugs, with likely files, root causes, host-aware patch guidance, proof commands, and feedback packet |
+| `axint.feedback.create` | Create or read a privacy-safe, source-free feedback packet users can inspect before sending to Axint Cloud |
 | `axint.run` | Run the enforced Apple build loop: session, workflow gate, Swift validation, Cloud Check, xcodebuild build/test, optional runtime launch, and `.axint/run` artifacts |
+| `axint.run.status` | Read the latest or selected Axint run job, including active child process IDs, after client disconnects or long-running builds |
+| `axint.run.cancel` | Cancel the latest or selected active Axint run by stopping child process groups |
 | `axint.tokens.ingest` | Convert design tokens into SwiftUI token enums for generated views |
 | `axint.templates.list` | List bundled reference templates |
 | `axint.templates.get` | Return the source of a specific template |

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,8 +1,9 @@
 {
-  "version": "0.4.11",
-  "mcpTools": 24,
+  "version": "0.4.12",
+  "mcpTools": 29,
   "mcpToolNames": [
     "axint.status",
+    "axint.upgrade",
     "axint.doctor",
     "axint.xcode.guard",
     "axint.xcode.write",
@@ -19,7 +20,11 @@
     "axint.validate",
     "axint.fix-packet",
     "axint.cloud.check",
+    "axint.repair",
+    "axint.feedback.create",
     "axint.run",
+    "axint.run.status",
+    "axint.run.cancel",
     "axint.tokens.ingest",
     "axint.schema.compile",
     "axint.swift.validate",
@@ -74,7 +79,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1017,
+    "typescript": 1051,
     "python": 114
   },
   "registryPackages": 14,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.11"
+__version__ = "0.4.12"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.11"
+version = "0.4.12"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "transport": {
         "type": "stdio"
       }
@@ -28,7 +28,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "transport": {
         "type": "stdio"
       }

--- a/src/cli/feedback.ts
+++ b/src/cli/feedback.ts
@@ -1,0 +1,116 @@
+import type { Command } from "commander";
+import {
+  readLatestRepairFeedback,
+  renderRepairFeedbackPacket,
+  runAxintRepair,
+} from "../repair/project-repair.js";
+import {
+  normalizeAxintAgent,
+  type AxintAgentProfileName,
+} from "../project/agent-profile.js";
+
+export function registerFeedback(program: Command) {
+  const feedback = program
+    .command("feedback")
+    .description(
+      "Create or inspect privacy-safe Axint feedback packets that help improve repair intelligence without sending source code"
+    );
+
+  feedback
+    .command("create")
+    .description("Create a local, inspectable feedback packet from a failed repair/check")
+    .argument("<issue>", "Bug, weak Axint output, or failed repair behavior")
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--source <path>", "Primary Swift file to inspect")
+    .option("--platform <platform>", "Target platform")
+    .option(
+      "--agent <agent>",
+      "Agent host: codex, claude, cursor, cowork, xcode, all",
+      parseAgent
+    )
+    .option("--expected <text>", "Expected behavior")
+    .option("--actual <text>", "Actual behavior")
+    .option("--xcode-log <text>", "Xcode build/test log evidence")
+    .option("--test-failure <text>", "Focused UI/unit test failure text")
+    .option("--runtime-failure <text>", "Runtime, crash, freeze, or hang evidence")
+    .option("--changed <file...>", "Changed files to pin into the context pack")
+    .option("--markdown", "Shortcut for --format markdown")
+    .option("--format <format>", "Output format: json or markdown", parseFormat, "json")
+    .action(
+      (
+        issue: string,
+        options: {
+          dir: string;
+          source?: string;
+          platform?: "iOS" | "macOS" | "watchOS" | "visionOS" | "all";
+          agent?: AxintAgentProfileName;
+          expected?: string;
+          actual?: string;
+          xcodeLog?: string;
+          testFailure?: string;
+          runtimeFailure?: string;
+          changed?: string[];
+          markdown?: boolean;
+          format: "json" | "markdown";
+        }
+      ) => {
+        const report = runAxintRepair({
+          cwd: options.dir,
+          issue,
+          sourcePath: options.source,
+          platform: options.platform,
+          agent: options.agent,
+          expectedBehavior: options.expected,
+          actualBehavior: options.actual,
+          xcodeBuildLog: options.xcodeLog,
+          testFailure: options.testFailure,
+          runtimeFailure: options.runtimeFailure,
+          changedFiles: options.changed,
+          writeReport: false,
+          writeFeedback: true,
+        });
+        console.log(
+          renderRepairFeedbackPacket(
+            report.feedbackPacket,
+            options.markdown ? "markdown" : options.format
+          )
+        );
+      }
+    );
+
+  feedback
+    .command("latest")
+    .description("Read the latest local Axint feedback packet")
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--markdown", "Shortcut for --format markdown")
+    .option("--format <format>", "Output format: json or markdown", parseFormat, "json")
+    .action(
+      (options: { dir: string; markdown?: boolean; format: "json" | "markdown" }) => {
+        const packet = readLatestRepairFeedback({ cwd: options.dir });
+        if (!packet) {
+          console.error(
+            "No Axint feedback packet found. Run `axint repair` or `axint feedback create` first."
+          );
+          process.exitCode = 1;
+          return;
+        }
+        console.log(
+          renderRepairFeedbackPacket(
+            packet,
+            options.markdown ? "markdown" : options.format
+          )
+        );
+      }
+    );
+}
+
+function parseFormat(value: string): "json" | "markdown" {
+  if (value === "json" || value === "markdown") return value;
+  throw new Error(`invalid feedback format: ${value}`);
+}
+
+function parseAgent(value: string): AxintAgentProfileName {
+  const agent = normalizeAxintAgent(value);
+  if (agent === value) return agent;
+  throw new Error(`invalid agent: ${value}`);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,19 +16,25 @@
  *   axint tokens ingest --source  Convert design tokens into SwiftUI token enums
  *   axint schema compile <file>   Compile compact JSON schemas into Swift
  *   axint feature <description>   Generate a multi-file feature package
+ *   axint repair <issue>          Plan a project-aware Apple repair loop
+ *   axint feedback create         Create privacy-safe repair feedback packets
  *   axint publish                 Publish an intent to the Registry
  *   axint add <package>           Install a template from the Registry
  *   axint search [query]          Search the Axint Registry for intent templates
  *   axint watch <file|dir>         Watch intent files and recompile on change
- *   axint status                  Show local package/runtime status and Xcode restart steps
+ *   axint status                  Show local package/runtime status and MCP reload steps
+ *   axint upgrade                 Check/apply Axint upgrades without losing agent context
  *   axint doctor                  Audit version truth, MCP wiring, and project start files
  *   axint project init            Write Axint project-start files for agent workflows
  *   axint project index           Index the local Apple project into .axint/context
  *   axint session start           Start an enforced Axint agent session and refresh context
+ *   axint workflow check          Run workflow gates from CLI when MCP is unavailable
  *   axint run                     Run Axint's enforced Apple build/test/runtime loop
+ *   axint run status              Show the latest or selected run job state
+ *   axint run cancel              Cancel the latest or selected active run job
  *   axint runner once             Execute one BYO-Mac runner Axint job
  *   axint mcp                     Start the MCP server (stdio)
- *   axint mcp status              Show local MCP launch command and Xcode restart steps
+ *   axint mcp status              Show local MCP launch command and reload steps
  *   axint xcode install           Install the full Axint Xcode workflow in one pass
  *   axint xcode setup             Configure Axint for Xcode agentic coding
  *   axint xcode guard             Check/write the Axint Xcode drift guard
@@ -60,14 +66,18 @@ import { registerCloud } from "./cloud.js";
 import { registerTokens } from "./tokens.js";
 import { registerSchema } from "./schema.js";
 import { registerFeature } from "./feature.js";
+import { registerRepair } from "./repair.js";
+import { registerFeedback } from "./feedback.js";
 import { registerPublish } from "./publish.js";
 import { registerAdd } from "./add.js";
 import { registerSearch } from "./search.js";
 import { registerWatch } from "./watch.js";
 import { registerStatus, renderCliStatus } from "./status.js";
+import { registerUpgrade } from "./upgrade.js";
 import { registerDoctor } from "./doctor.js";
 import { registerProject } from "./project.js";
 import { registerSession } from "./session.js";
+import { registerWorkflow } from "./workflow.js";
 import { registerRun } from "./run.js";
 import { registerXcodeGuard } from "./xcode-guard.js";
 
@@ -175,14 +185,18 @@ registerCloud(program);
 registerTokens(program);
 registerSchema(program);
 registerFeature(program);
+registerRepair(program);
+registerFeedback(program);
 registerPublish(program, VERSION);
 registerAdd(program, VERSION);
 registerSearch(program, VERSION);
 registerWatch(program);
 registerStatus(program, VERSION);
+registerUpgrade(program, VERSION);
 registerDoctor(program, VERSION);
 registerProject(program, VERSION);
 registerSession(program, VERSION);
+registerWorkflow(program);
 registerRun(program, VERSION);
 
 // ─── mcp ─────────────────────────────────────────────────────────────
@@ -199,7 +213,7 @@ const mcp = program
 
 mcp
   .command("status")
-  .description("Show local Axint MCP launch details and Xcode restart steps")
+  .description("Show local Axint MCP launch details and reload steps")
   .option("--format <format>", "Output format: markdown, json, or prompt", "markdown")
   .action((options: { format?: "markdown" | "json" | "prompt" }) => {
     console.log(renderCliStatus(VERSION, options.format ?? "markdown"));

--- a/src/cli/project.ts
+++ b/src/cli/project.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { normalizeAxintAgent } from "../project/agent-profile.js";
 import {
   renderProjectStartPack,
   writeProjectStartPack,
@@ -24,7 +25,7 @@ export function registerProject(program: Command, version: string) {
     .option("--name <name>", "Project name")
     .option(
       "--agent <agent>",
-      "Agent target: claude, codex, all",
+      "Agent target: claude, codex, cowork, cursor, xcode, all",
       parseAgent,
       "all" as ProjectAgent
     )
@@ -103,7 +104,8 @@ export function registerProject(program: Command, version: string) {
 }
 
 function parseAgent(value: string): ProjectAgent {
-  if (value === "claude" || value === "codex" || value === "all") return value;
+  const agent = normalizeAxintAgent(value);
+  if (agent === value) return agent;
   throw new Error(`invalid agent: ${value}`);
 }
 

--- a/src/cli/repair.ts
+++ b/src/cli/repair.ts
@@ -1,0 +1,113 @@
+import type { Command } from "commander";
+import {
+  renderAxintRepairReport,
+  runAxintRepair,
+  type AxintRepairFormat,
+} from "../repair/project-repair.js";
+import {
+  normalizeAxintAgent,
+  type AxintAgentProfileName,
+} from "../project/agent-profile.js";
+
+export function registerRepair(program: Command) {
+  program
+    .command("repair")
+    .description(
+      "Plan a project-aware Apple repair: index the app, classify evidence, rank likely files, and produce a proof loop"
+    )
+    .argument("<issue>", "Bug, broken behavior, build failure, or UI/runtime issue")
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--source <path>", "Primary Swift file to inspect")
+    .option(
+      "--file-name <name>",
+      "Display name when --source is omitted and --inline-source is used"
+    )
+    .option(
+      "--inline-source <source>",
+      "Inline Swift source for agents that cannot read files"
+    )
+    .option(
+      "--platform <platform>",
+      "Target platform: iOS, macOS, watchOS, visionOS, all"
+    )
+    .option(
+      "--agent <agent>",
+      "Agent host: codex, claude, cursor, cowork, xcode, all",
+      parseAgent
+    )
+    .option("--expected <text>", "Expected behavior")
+    .option("--actual <text>", "Actual behavior")
+    .option("--xcode-log <text>", "Xcode build/test log evidence")
+    .option("--test-failure <text>", "Focused UI/unit test failure text")
+    .option("--runtime-failure <text>", "Runtime, crash, freeze, or hang evidence")
+    .option("--changed <file...>", "Changed files to pin into the context pack")
+    .option("--context <path>", "Existing .axint/context/latest.json path")
+    .option("--no-write-report", "Do not write .axint/repair/latest artifacts")
+    .option("--no-write-feedback", "Do not write the privacy-safe .axint/feedback packet")
+    .option("--json", "Shortcut for --format json")
+    .option("--prompt", "Shortcut for --format prompt")
+    .option(
+      "--format <format>",
+      "Output format: markdown, json, or prompt",
+      parseRepairFormat,
+      "markdown" as AxintRepairFormat
+    )
+    .action(
+      (
+        issue: string,
+        options: {
+          dir: string;
+          source?: string;
+          fileName?: string;
+          inlineSource?: string;
+          platform?: "iOS" | "macOS" | "watchOS" | "visionOS" | "all";
+          agent?: AxintAgentProfileName;
+          expected?: string;
+          actual?: string;
+          xcodeLog?: string;
+          testFailure?: string;
+          runtimeFailure?: string;
+          changed?: string[];
+          context?: string;
+          writeReport?: boolean;
+          writeFeedback?: boolean;
+          json?: boolean;
+          prompt?: boolean;
+          format: AxintRepairFormat;
+        }
+      ) => {
+        const report = runAxintRepair({
+          cwd: options.dir,
+          issue,
+          sourcePath: options.source,
+          source: options.inlineSource,
+          fileName: options.fileName,
+          platform: options.platform,
+          agent: options.agent,
+          expectedBehavior: options.expected,
+          actualBehavior: options.actual,
+          xcodeBuildLog: options.xcodeLog,
+          testFailure: options.testFailure,
+          runtimeFailure: options.runtimeFailure,
+          changedFiles: options.changed,
+          projectContextPath: options.context,
+          writeReport: options.writeReport,
+          writeFeedback: options.writeFeedback,
+        });
+        const format = options.prompt ? "prompt" : options.json ? "json" : options.format;
+        console.log(renderAxintRepairReport(report, format));
+        if (report.status === "fix_required") process.exitCode = 1;
+      }
+    );
+}
+
+function parseRepairFormat(value: string): AxintRepairFormat {
+  if (value === "markdown" || value === "json" || value === "prompt") return value;
+  throw new Error(`invalid repair format: ${value}`);
+}
+
+function parseAgent(value: string): AxintAgentProfileName {
+  const agent = normalizeAxintAgent(value);
+  if (agent === value) return agent;
+  throw new Error(`invalid agent: ${value}`);
+}

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -5,13 +5,22 @@ import {
   type AxintRunFormat,
   type AxintRunPlatform,
 } from "../run/project-runner.js";
+import {
+  cancelRunJob,
+  getRunJobStatus,
+  renderRunCancelResult,
+  renderRunJobStatus,
+  type AxintRunJobOutputFormat,
+} from "../run/job-store.js";
 
 export function registerRun(program: Command, version: string) {
-  program
+  const run = program
     .command("run")
     .description(
       "Run the enforced Axint Apple build loop: session, workflow gate, validate, Cloud Check, xcodebuild, and optional runtime proof"
-    )
+    );
+
+  run
     .option("--dir <dir>", "Project directory", ".")
     .option("--scheme <scheme>", "Xcode scheme")
     .option("--workspace <path>", "Path to .xcworkspace")
@@ -40,6 +49,10 @@ export function registerRun(program: Command, version: string) {
     .option("--runtime-failure <text>", "Runtime, freeze, crash, or hang evidence")
     .option("--dry-run", "Plan the xcodebuild commands without executing them")
     .option("--no-write-report", "Do not write .axint/run/latest artifacts")
+    .option(
+      "--include-source",
+      "Include full Swift source and command output in JSON output"
+    )
     .option("--json", "Shortcut for --format json")
     .option("--prompt", "Shortcut for --format prompt")
     .option(
@@ -71,6 +84,7 @@ export function registerRun(program: Command, version: string) {
         runtimeFailure?: string;
         dryRun?: boolean;
         writeReport?: boolean;
+        includeSource?: boolean;
         json?: boolean;
         prompt?: boolean;
         format: AxintRunFormat;
@@ -101,8 +115,73 @@ export function registerRun(program: Command, version: string) {
           writeReport: options.writeReport,
         });
         const format = options.prompt ? "prompt" : options.json ? "json" : options.format;
-        console.log(renderAxintRunReport(report, format));
+        console.log(
+          renderAxintRunReport(report, format, {
+            includeSource: options.includeSource,
+          })
+        );
         if (report.status === "fail") process.exit(1);
+      }
+    );
+
+  run
+    .command("status")
+    .description("Show the latest or selected Axint run job, including active child PIDs")
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--id <id>", "Run id. Defaults to latest active run.")
+    .option("--json", "Shortcut for --format json")
+    .option(
+      "--format <format>",
+      "Output format: markdown or json",
+      parseJobFormat,
+      "markdown" as AxintRunJobOutputFormat
+    )
+    .action(
+      (options: {
+        dir: string;
+        id?: string;
+        json?: boolean;
+        format: AxintRunJobOutputFormat;
+      }) => {
+        const jobOptions = resolveRunJobCliOptions(options);
+        const result = getRunJobStatus({
+          cwd: jobOptions.dir,
+          id: jobOptions.id,
+        });
+        console.log(renderRunJobStatus(result, jobOptions.format));
+      }
+    );
+
+  run
+    .command("cancel")
+    .description(
+      "Cancel the latest or selected Axint run by killing active child process groups"
+    )
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--id <id>", "Run id. Defaults to latest active run.")
+    .option("--json", "Shortcut for --format json")
+    .option(
+      "--format <format>",
+      "Output format: markdown or json",
+      parseJobFormat,
+      "markdown" as AxintRunJobOutputFormat
+    )
+    .action(
+      (options: {
+        dir: string;
+        id?: string;
+        json?: boolean;
+        format: AxintRunJobOutputFormat;
+      }) => {
+        const jobOptions = resolveRunJobCliOptions(options);
+        const result = cancelRunJob({
+          cwd: jobOptions.dir,
+          id: jobOptions.id,
+        });
+        console.log(renderRunCancelResult(result, jobOptions.format));
+        if (result.status === "error" || result.status === "not_found") {
+          process.exit(1);
+        }
       }
     );
 
@@ -126,6 +205,10 @@ export function registerRun(program: Command, version: string) {
     .option("--runtime", "Launch the built macOS app and capture runtime evidence")
     .option("--dry-run", "Plan commands without executing them")
     .option(
+      "--include-source",
+      "Include full Swift source and command output in JSON output"
+    )
+    .option(
       "--format <format>",
       "Output format: markdown, json, or prompt",
       parseFormat,
@@ -140,6 +223,7 @@ export function registerRun(program: Command, version: string) {
         skipTests?: boolean;
         runtime?: boolean;
         dryRun?: boolean;
+        includeSource?: boolean;
         format: AxintRunFormat;
       }) => {
         const report = await runAxintProject({
@@ -153,7 +237,11 @@ export function registerRun(program: Command, version: string) {
           runtime: options.runtime,
           dryRun: options.dryRun,
         });
-        console.log(renderAxintRunReport(report, options.format));
+        console.log(
+          renderAxintRunReport(report, options.format, {
+            includeSource: options.includeSource,
+          })
+        );
         if (report.status === "fail") process.exit(1);
       }
     );
@@ -162,6 +250,62 @@ export function registerRun(program: Command, version: string) {
 function parseFormat(value: string): AxintRunFormat {
   if (value === "markdown" || value === "json" || value === "prompt") return value;
   throw new Error(`invalid run format: ${value}`);
+}
+
+function parseJobFormat(value: string): AxintRunJobOutputFormat {
+  if (value === "markdown" || value === "json") return value;
+  throw new Error(`invalid run job format: ${value}`);
+}
+
+function resolveRunJobCliOptions(options: {
+  dir: string;
+  id?: string;
+  json?: boolean;
+  format: AxintRunJobOutputFormat;
+}): {
+  dir: string;
+  id?: string;
+  format: AxintRunJobOutputFormat;
+} {
+  // Commander gives parent `axint run` option defaults precedence when a
+  // subcommand reuses names like --dir, --json, or --format. Read the raw argv
+  // as a narrow fallback so `axint run status --dir /app --json` behaves as
+  // users and agents expect.
+  const rawFormat = readRawOption("format");
+  return {
+    dir: readRawOption("dir") ?? options.dir,
+    id: readRawOption("id") ?? options.id,
+    format:
+      readRawFlag("json") || options.json
+        ? "json"
+        : rawFormat
+          ? parseJobFormat(rawFormat)
+          : options.format,
+  };
+}
+
+function readRawOption(name: string): string | undefined {
+  const option = `--${name}`;
+  const equalsPrefix = `${option}=`;
+  const args = process.argv.slice(2);
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === option) {
+      const next = args[index + 1];
+      return next && !next.startsWith("-") ? next : undefined;
+    }
+    if (arg.startsWith(equalsPrefix)) {
+      return arg.slice(equalsPrefix.length);
+    }
+  }
+
+  return undefined;
+}
+
+function readRawFlag(name: string): boolean {
+  const option = `--${name}`;
+  return process.argv.slice(2).some((arg) => arg === option || arg === `${option}=true`);
 }
 
 function parsePlatform(value: string): AxintRunPlatform {

--- a/src/cli/session.ts
+++ b/src/cli/session.ts
@@ -21,7 +21,7 @@ export function registerSession(program: Command, version: string) {
     .option("--platform <platform>", "Target Apple platform", "the target Apple platform")
     .option(
       "--agent <agent>",
-      "Agent target: claude, codex, cursor, xcode, all",
+      "Agent target: claude, codex, cowork, cursor, xcode, all",
       parseAgent,
       "all" as AxintSessionAgent
     )
@@ -64,6 +64,7 @@ function parseAgent(value: string): AxintSessionAgent {
   if (
     value === "claude" ||
     value === "codex" ||
+    value === "cowork" ||
     value === "cursor" ||
     value === "xcode" ||
     value === "all"

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -9,7 +9,7 @@ type StatusFormat = "markdown" | "json" | "prompt";
 export function registerStatus(program: Command, version: string) {
   program
     .command("status")
-    .description("Show local Axint version, runtime paths, and Xcode MCP restart steps")
+    .description("Show local Axint version, runtime paths, and MCP reload steps")
     .option("--format <format>", "Output format: markdown, json, or prompt", "markdown")
     .action((options: { format?: string }) => {
       console.log(renderCliStatus(version, parseFormat(options.format)));
@@ -32,13 +32,14 @@ export function renderCliStatus(
     cwd: process.cwd(),
     mcpCommand: `${which("npx") ?? "npx"} -y @axint/compiler axint-mcp`,
     updateCommand: `${which("npm") ?? "npm"} install -g @axint/compiler@latest`,
+    upgradeCommand: "axint upgrade --apply",
     xcodeSetupCommand: "axint xcode install --project .",
     doctorCommand: "axint doctor",
     projectInitCommand: "axint project init",
     verificationPrompt:
       "Call axint.status and tell me the running Axint MCP version before editing code.",
     restartInstruction:
-      "Restart the Xcode Claude Agent chat after updating. MCP clients keep the old Node process alive until restarted.",
+      "After updating, reload or reconnect the Axint MCP server/tool process. Keep the current Codex or Claude thread when your client supports MCP reload; if it does not, use the generated same-thread resume prompt instead of starting blind.",
   };
 
   if (format === "json") return JSON.stringify(status, null, 2);
@@ -47,9 +48,9 @@ export function renderCliStatus(
     return [
       "Use Axint before editing Apple-native code.",
       status.verificationPrompt,
-      "Call axint.xcode.guard with stage=context-recovery so this Xcode chat writes durable guard proof.",
+      "Use the active agent lane: Codex/Claude/Cursor/Cowork should patch natively, while Xcode can use axint.xcode.guard for durable guard proof.",
       `Expected local package version: ${status.version}.`,
-      "If axint.status reports an older version, stop and ask me to update/restart the Xcode agent chat.",
+      "If axint.status reports an older version, run axint.upgrade or axint upgrade --apply, then reload only the MCP server/tool process.",
       "After each generated Swift surface, run axint.cloud.check or axint cloud check --source <file> with build/test evidence when available.",
     ].join("\n");
   }
@@ -64,24 +65,24 @@ export function renderCliStatus(
     `- npm: ${status.npmPath ?? "not found on PATH"}`,
     `- npx: ${status.npxPath ?? "not found on PATH"}`,
     "",
-    "## Xcode Agent Setup",
+    "## Agent Setup",
     "",
-    "Use this when starting a new Claude-in-Xcode chat:",
+    "Use this at the start of any Codex, Claude, Cowork, Cursor, or Xcode agent session:",
     "",
     "```text",
     status.verificationPrompt,
-    "Call axint.xcode.guard with stage=context-recovery before any long task.",
-    "If Axint is not available, inspect the project .mcp.json, make sure npx uses a durable full path, then restart this Xcode agent chat.",
+    "Use axint workflow check as the portable guard. In Xcode-hosted sessions, axint.xcode.guard can also write .axint/guard/latest.* proof.",
+    "If MCP tools are visible but calls fail after a reload or transport close, run the CLI fallback: axint workflow check --dir . --stage context-recovery --agent <host> --session-token <token>.",
+    "If Axint is not available, inspect the project .mcp.json or client MCP settings, make sure npx uses a durable full path, then reload the Axint MCP server/tool process.",
     "```",
     "",
-    "If the running MCP version is stale:",
+    "If the running MCP version is stale, use the same-thread upgrade flow:",
     "",
     "```sh",
-    status.updateCommand,
-    status.xcodeSetupCommand,
+    status.upgradeCommand,
     "```",
     "",
-    "For a new project, install the full Axint agent pack:",
+    "For a new Apple project, install the full optional Xcode proof bridge:",
     "",
     "```sh",
     status.xcodeSetupCommand,

--- a/src/cli/upgrade.ts
+++ b/src/cli/upgrade.ts
@@ -1,0 +1,70 @@
+import type { Command } from "commander";
+import {
+  renderAxintUpgradeReport,
+  runAxintUpgrade,
+  type AxintUpgradeFormat,
+} from "../project/upgrade.js";
+
+const FORMATS: AxintUpgradeFormat[] = ["markdown", "json", "prompt"];
+
+export function registerUpgrade(program: Command, version: string): void {
+  program
+    .command("upgrade")
+    .description(
+      "Check or apply an Axint upgrade without losing the current agent thread"
+    )
+    .option(
+      "--target <version>",
+      "Target version. Defaults to latest published npm version."
+    )
+    .option(
+      "--latest-version <version>",
+      "Use a known latest version instead of querying npm"
+    )
+    .option("--dir <dir>", "Project directory for upgrade artifacts", ".")
+    .option("--apply", "Install the target Axint package and write upgrade proof")
+    .option("--xcode-install", "Also refresh optional Xcode MCP wiring")
+    .option(
+      "--write-report",
+      "Write .axint/upgrade/latest.* artifacts in check-only mode"
+    )
+    .option("--no-write-report", "Do not write .axint/upgrade/latest.* artifacts")
+    .option("--format <format>", "Output format: markdown, json, or prompt", "markdown")
+    .action(
+      (options: {
+        target?: string;
+        latestVersion?: string;
+        dir?: string;
+        apply?: boolean;
+        xcodeInstall?: boolean;
+        writeReport?: boolean;
+        format?: string;
+      }) => {
+        const report = runAxintUpgrade({
+          cwd: options.dir,
+          currentVersion: version,
+          targetVersion: options.target,
+          latestVersion: options.latestVersion,
+          apply: options.apply === true,
+          reinstallXcode: options.xcodeInstall === true,
+          writeReport: parseWriteReportFlag(options.writeReport),
+        });
+        console.log(renderAxintUpgradeReport(report, parseFormat(options.format)));
+        if (report.status === "fail") process.exit(1);
+      }
+    );
+}
+
+function parseFormat(value: string | undefined): AxintUpgradeFormat {
+  if (value && FORMATS.includes(value as AxintUpgradeFormat)) {
+    return value as AxintUpgradeFormat;
+  }
+  return "markdown";
+}
+
+function parseWriteReportFlag(value: boolean | undefined): boolean | undefined {
+  const args = process.argv;
+  if (args.includes("--no-write-report")) return false;
+  if (args.includes("--write-report")) return true;
+  return value === false ? false : undefined;
+}

--- a/src/cli/workflow.ts
+++ b/src/cli/workflow.ts
@@ -1,0 +1,181 @@
+import { InvalidArgumentError, type Command } from "commander";
+import {
+  normalizeAxintAgent,
+  type AxintAgentProfileName,
+} from "../project/agent-profile.js";
+import type { Surface } from "../mcp/feature.js";
+import {
+  renderWorkflowCheckReport,
+  runWorkflowCheck,
+  type WorkflowStage,
+} from "../mcp/workflow-check.js";
+
+export type WorkflowCliFormat = "markdown" | "json";
+
+const WORKFLOW_STAGES = [
+  "session-start",
+  "context-recovery",
+  "planning",
+  "before-write",
+  "pre-build",
+  "pre-commit",
+] as const satisfies readonly WorkflowStage[];
+
+const SURFACES = [
+  "intent",
+  "view",
+  "widget",
+  "component",
+  "app",
+  "store",
+] as const satisfies readonly Surface[];
+
+export function registerWorkflow(program: Command) {
+  const workflow = program
+    .command("workflow")
+    .description(
+      "Run Axint workflow gates from the CLI when MCP is stale, closed, or unavailable"
+    );
+
+  workflow
+    .command("check")
+    .description(
+      "Check session/context/planning/write/build gates without relying on an MCP transport"
+    )
+    .option(
+      "--dir <dir>",
+      "Project directory containing .axint/session/current.json",
+      "."
+    )
+    .option(
+      "--agent <agent>",
+      "Agent host/tool lane: codex, claude, cowork, cursor, xcode, or all",
+      parseAgent,
+      "all" as AxintAgentProfileName
+    )
+    .option("--session-token <token>", "Token returned by axint.session.start")
+    .option("--session-started", "Mark that axint.session.start ran in this pass")
+    .option(
+      "--no-session",
+      "Allow a legacy/manual check without requiring .axint/session/current.json"
+    )
+    .option(
+      "--stage <stage>",
+      `Workflow stage: ${WORKFLOW_STAGES.join(", ")}`,
+      parseStage,
+      "pre-build" as WorkflowStage
+    )
+    .option("--surface <surface...>", `Touched surfaces: ${SURFACES.join(", ")}`)
+    .option("--modified <file...>", "Modified files in this pass")
+    .option("--ran-suggest", "Mark that axint.suggest was used")
+    .option("--ran-status", "Mark that axint.status was used")
+    .option("--read-rehydration-context", "Mark that .axint/AXINT_REHYDRATE.md was read")
+    .option(
+      "--read-agent-instructions",
+      "Mark that AGENTS.md/CLAUDE.md/project.json was read"
+    )
+    .option("--read-docs-context", "Mark that .axint/AXINT_DOCS_CONTEXT.md was read")
+    .option("--ran-feature", "Mark that axint.feature was used")
+    .option(
+      "--feature-bypass-reason <reason>",
+      "Why generation was intentionally bypassed"
+    )
+    .option("--ran-swift-validate", "Mark that axint.swift.validate was used")
+    .option("--ran-cloud-check", "Mark that axint.cloud.check was used")
+    .option("--xcode-build-passed", "Mark that Xcode build evidence passed")
+    .option("--xcode-tests-passed", "Mark that focused unit/UI tests passed")
+    .option("--notes <notes>", "Human/agent notes for drift or bypass detection")
+    .option("--json", "Shortcut for --format json")
+    .option(
+      "--format <format>",
+      "Output format: markdown or json",
+      parseFormat,
+      "markdown" as WorkflowCliFormat
+    )
+    .action(
+      (options: {
+        dir: string;
+        agent: AxintAgentProfileName;
+        sessionToken?: string;
+        sessionStarted?: boolean;
+        session?: boolean;
+        stage: WorkflowStage;
+        surface?: string[];
+        modified?: string[];
+        ranSuggest?: boolean;
+        ranStatus?: boolean;
+        readRehydrationContext?: boolean;
+        readAgentInstructions?: boolean;
+        readDocsContext?: boolean;
+        ranFeature?: boolean;
+        featureBypassReason?: string;
+        ranSwiftValidate?: boolean;
+        ranCloudCheck?: boolean;
+        xcodeBuildPassed?: boolean;
+        xcodeTestsPassed?: boolean;
+        notes?: string;
+        json?: boolean;
+        format: WorkflowCliFormat;
+      }) => {
+        const report = runWorkflowCheck({
+          cwd: options.dir,
+          agent: options.agent,
+          sessionStarted: options.sessionStarted,
+          sessionToken: options.sessionToken,
+          requireSession: options.session !== false,
+          stage: options.stage,
+          surfaces: parseSurfaces(options.surface),
+          modifiedFiles: options.modified,
+          ranSuggest: options.ranSuggest,
+          ranStatus: options.ranStatus,
+          readRehydrationContext: options.readRehydrationContext,
+          readAgentInstructions: options.readAgentInstructions,
+          readDocsContext: options.readDocsContext,
+          ranFeature: options.ranFeature,
+          featureBypassReason: options.featureBypassReason,
+          ranSwiftValidate: options.ranSwiftValidate,
+          ranCloudCheck: options.ranCloudCheck,
+          xcodeBuildPassed: options.xcodeBuildPassed,
+          xcodeTestsPassed: options.xcodeTestsPassed,
+          notes: options.notes,
+          format: options.json ? "json" : options.format,
+        });
+
+        console.log(
+          options.json || options.format === "json"
+            ? JSON.stringify(report, null, 2)
+            : renderWorkflowCheckReport(report)
+        );
+      }
+    );
+}
+
+function parseAgent(value: string): AxintAgentProfileName {
+  const agent = normalizeAxintAgent(value);
+  if (agent === value) return agent;
+  throw new InvalidArgumentError(`invalid agent: ${value}`);
+}
+
+function parseStage(value: string): WorkflowStage {
+  if ((WORKFLOW_STAGES as readonly string[]).includes(value)) {
+    return value as WorkflowStage;
+  }
+  throw new InvalidArgumentError(
+    `invalid workflow stage: ${value} (expected one of ${WORKFLOW_STAGES.join(", ")})`
+  );
+}
+
+function parseFormat(value: string): WorkflowCliFormat {
+  if (value === "markdown" || value === "json") return value;
+  throw new InvalidArgumentError(`invalid format: ${value}`);
+}
+
+function parseSurfaces(values: string[] | undefined): Surface[] | undefined {
+  if (!values || values.length === 0) return undefined;
+  return values.map((value) => {
+    if ((SURFACES as readonly string[]).includes(value)) return value as Surface;
+    throw new InvalidArgumentError(
+      `invalid surface: ${value} (expected one of ${SURFACES.join(", ")})`
+    );
+  });
+}

--- a/src/cli/xcode-setup.ts
+++ b/src/cli/xcode-setup.ts
@@ -36,7 +36,7 @@ const START_PROMPT = [
   "Then list MCP servers and confirm both xcode-tools and axint are available.",
   "Call axint.xcode.guard with stage=context-recovery so the project writes .axint/guard/latest.* proof before any long task.",
   "Call axint.status and report the running MCP server version before editing code.",
-  "If the version is older than expected, stop and tell me to update Axint, rerun `axint xcode install --project .`, and restart the Xcode agent chat.",
+  "If the version is older than expected, stop and call `axint.upgrade` or tell me to run `axint upgrade --apply`, then reload only the Axint MCP server/tool process.",
   "Use Axint before guessing App Intents, widgets, SwiftUI scaffolds, entitlements, Info.plist keys, or repair prompts.",
   "Work in short checkpoints. Do not spend 20+ minutes on a task without running Axint and Xcode validation.",
   "For long build/debug work, prefer axint.run or axint.xcode.guard over raw Xcode actions so Axint proof survives context compaction.",
@@ -268,7 +268,7 @@ export async function verifyXcode(): Promise<void> {
     } else if (output.includes("axint.feature")) {
       console.log(`  ${RED}✗${RESET} MCP server is old: axint.status not found`);
       console.log(
-        `  ${DIM}  Update Axint, rerun: axint xcode install --project ., then restart the Xcode agent chat${RESET}`
+        `  ${DIM}  Run: axint upgrade --apply, then reload the Axint MCP server/tool process${RESET}`
       );
     } else {
       console.log(`  ${RED}✗${RESET} Server responded but axint.feature not found`);
@@ -283,9 +283,7 @@ export async function verifyXcode(): Promise<void> {
 }
 
 function printAgentStartPrompt(): void {
-  console.log(
-    `  ${ORANGE}◆${RESET} ${BOLD}Start a new Xcode agent chat with this${RESET}`
-  );
+  console.log(`  ${ORANGE}◆${RESET} ${BOLD}Use this in the Xcode agent chat${RESET}`);
   console.log();
   for (const line of START_PROMPT.split("\n")) {
     console.log(line.length > 0 ? `    ${DIM}${line}${RESET}` : "");

--- a/src/cloud/check.ts
+++ b/src/cloud/check.ts
@@ -9,6 +9,11 @@ import {
   type ProjectContextIndex,
   type ProjectContextHint,
 } from "../project/context-index.js";
+import {
+  analyzeAppleRepairTask,
+  formatAppleRepairRead,
+  type AppleRepairIntelligence,
+} from "../repair/intelligence.js";
 
 export type CloudCheckFormat = "markdown" | "json" | "prompt" | "feedback";
 export type CloudCheckLanguage = "swift" | "typescript" | "unknown";
@@ -103,6 +108,7 @@ export interface CloudCheckReport {
     changedFiles: string[];
     currentFile?: string;
   };
+  repairIntelligence?: AppleRepairIntelligence;
   repairPlan: Array<{
     title: string;
     detail: string;
@@ -171,6 +177,20 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
 
   const evidence = collectCloudEvidence(input);
   const projectContext = resolveCloudProjectContext({ input, fileName, surface });
+  const repairIntelligence = analyzeAppleRepairTask({
+    text: [
+      input.xcodeBuildLog,
+      input.testFailure,
+      input.runtimeFailure,
+      input.expectedBehavior,
+      input.actualBehavior,
+    ]
+      .filter(Boolean)
+      .join("\n"),
+    source: swiftCode ?? source,
+    fileName,
+    platform: input.platform,
+  });
   diagnostics = [
     ...diagnostics,
     ...inferEvidenceDiagnostics({
@@ -282,6 +302,11 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
     runtimeEvidenceProvided,
     fileName,
     projectContext,
+    repairIntelligence:
+      repairIntelligence.isExistingProductRepair ||
+      diagnostics.some((d) => d.severity !== "info")
+        ? repairIntelligence
+        : undefined,
   });
 
   if (nextSteps.length === 0) {
@@ -343,6 +368,11 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
           currentFile: projectContext.currentFile?.path,
         }
       : undefined,
+    repairIntelligence:
+      repairIntelligence.isExistingProductRepair ||
+      diagnostics.some((d) => d.severity !== "info")
+        ? repairIntelligence
+        : undefined,
     repairPlan,
     nextSteps,
     repairPrompt: "",
@@ -408,6 +438,19 @@ export function renderCloudCheckReport(
                 ),
               ]
             : []),
+        ]
+      : []),
+    ...(report.repairIntelligence
+      ? [
+          "",
+          "## Senior Repair Read",
+          ...formatAppleRepairRead(report.repairIntelligence).map((item) => `- ${item}`),
+          "- Inspect:",
+          ...report.repairIntelligence.inspectionChecklist
+            .slice(0, 5)
+            .map((item) => `  - ${item}`),
+          "- Avoid:",
+          ...report.repairIntelligence.avoid.slice(0, 3).map((item) => `  - ${item}`),
         ]
       : []),
     "",
@@ -578,7 +621,7 @@ function collectCloudEvidence(input: CloudCheckInput): CloudCheckReport["evidenc
   const summary = provided.map((label) => {
     if (label === "platform") return `Platform hint: ${input.platform}`;
     const value = String((input as Record<string, unknown>)[label] ?? "");
-    return `${label}: ${normalizeDiagnosticText(value)}`;
+    return `${label}: ${summarizeEvidenceValue(label, value)}`;
   });
 
   return { provided, summary };
@@ -620,6 +663,13 @@ function inferEvidenceDiagnostics(input: {
   const sourceText = normalizeTextForEvidence(source);
   const file = input.fileName;
   const passingXcodeProof = hasPassingXcodeProof(input.input);
+  const intentionalAbsenceProof =
+    passingXcodeProof &&
+    hasIntentionalAbsenceProof(
+      input.input.expectedBehavior,
+      input.input.actualBehavior,
+      input.input.xcodeBuildLog
+    );
 
   if (input.input.platform === "macOS") {
     const iosOnly = findIosOnlySwiftUIUsage(source);
@@ -669,7 +719,11 @@ function inferEvidenceDiagnostics(input: {
       input.input.expectedBehavior,
       input.input.actualBehavior
     ) &&
-    !(passingXcodeProof && !hasNegativeBehaviorEvidence(input.input.actualBehavior))
+    !(
+      passingXcodeProof &&
+      (!hasNegativeBehaviorEvidence(input.input.actualBehavior) ||
+        intentionalAbsenceProof)
+    )
   ) {
     diagnostics.push({
       code: "AXCLOUD-BEHAVIOR-MISMATCH",
@@ -705,6 +759,7 @@ function inferEvidenceDiagnostics(input: {
     input.surface === "view" &&
     evidenceText.includes("accessibility") &&
     sourceText.includes("accessibilityidentifier") &&
+    hasNegativeAccessibilityEvidence(evidenceText) &&
     diagnostics.every((d) => d.code !== "AXCLOUD-UI-ACCESSIBILITY-ID")
   ) {
     diagnostics.push({
@@ -756,11 +811,29 @@ function buildCloudRepairPlan(input: {
   runtimeEvidenceProvided: boolean;
   fileName: string;
   projectContext?: ProjectContextHint;
+  repairIntelligence?: AppleRepairIntelligence;
 }): CloudCheckReport["repairPlan"] {
   const actionable = input.diagnostics.filter((d) => d.severity !== "info");
+  const intelligenceSteps: CloudCheckReport["repairPlan"] = input.repairIntelligence
+    ? [
+        {
+          title: "Senior Apple repair read",
+          detail: input.repairIntelligence.summary,
+        },
+        ...(input.repairIntelligence.rootCauses[0]
+          ? [
+              {
+                title: input.repairIntelligence.rootCauses[0].title,
+                detail: input.repairIntelligence.rootCauses[0].suggestedPatch,
+              },
+            ]
+          : []),
+      ]
+    : [];
 
   if (actionable.length === 0) {
     return [
+      ...intelligenceSteps,
       {
         title: "Keep source behavior stable",
         detail:
@@ -785,6 +858,7 @@ function buildCloudRepairPlan(input: {
       title: `${diagnostic.code} (${diagnostic.severity})`,
       detail: diagnostic.suggestion || diagnostic.message,
     }));
+  steps.unshift(...intelligenceSteps);
 
   if (input.diagnostics.some((d) => d.code === "AXCLOUD-RUNTIME-FREEZE")) {
     steps.unshift(
@@ -954,6 +1028,22 @@ function diagnosticsFromTestFailure(
         "UI-test evidence points to an accessibility identifier issue, often caused by putting one identifier on a broad SwiftUI container.",
       suggestion:
         "Remove container-level identifiers that mask children, attach identifiers to the exact queried controls, and rerun the UI smoke test.",
+    });
+  }
+
+  if (
+    /\b(should be hittable after scrolling|not hittable|not tappable|not foreground|does not allow background interaction|background interaction|failed to synthesize event|hit point|scroll.*hittable)\b/.test(
+      text
+    )
+  ) {
+    diagnostics.push({
+      code: "AXCLOUD-UI-HIT-TEST-BLOCKER",
+      severity: "error",
+      file,
+      message:
+        "UI-test evidence says a visible control is not actually hittable or in the foreground after scrolling.",
+      suggestion:
+        "Treat this as a SwiftUI hit-testing and focus-order bug. Check overlays, sheets, popovers, disabled ancestors, container identifiers, scroll anchors, zIndex, and app activation before claiming the UI is fixed.",
     });
   }
 
@@ -1419,9 +1509,16 @@ function hasPassingXcodeProof(input: CloudCheckInput): boolean {
   if (!input.xcodeBuildLog) return false;
   const text = normalizeTextForEvidence(input.xcodeBuildLog);
   if (!text) return false;
-  if (hasConcreteXcodeFailure(text)) return false;
+  const focusedProofPass =
+    /\bfocused xcode test proof passed\b/.test(text) &&
+    /\*\*\s*test\s+succeeded\s*\*\*/.test(text);
+  if (/\*\*\s*build\s+failed\s*\*\*|\bfatal error\b|\berror:/.test(text)) {
+    return false;
+  }
+  if (hasConcreteXcodeFailure(text) && !focusedProofPass) return false;
 
   return (
+    focusedProofPass ||
     /\*\*\s*(?:test|build)\s+succeeded\s*\*\*/.test(text) ||
     /\b(?:test|tests|test suite|test case|build)\s+(?:passed|succeeded)\b/.test(text) ||
     /\b\d+\s+tests?\s+passed\b/.test(text) ||
@@ -1450,6 +1547,50 @@ function hasNegativeBehaviorEvidence(actualBehavior: string): boolean {
     /\b(?:not|doesn't|does not|can't|cannot)\s+(?:work|working|implemented|show|render|match|pass|compile|build|load|open|respond|appear|exist|route|preserve)\b/.test(
       actual
     )
+  );
+}
+
+function hasIntentionalAbsenceProof(
+  expectedBehavior: string | undefined,
+  actualBehavior: string | undefined,
+  xcodeBuildLog: string | undefined
+): boolean {
+  const expected = normalizeTextForEvidence(expectedBehavior ?? "");
+  const actual = normalizeTextForEvidence(actualBehavior ?? "");
+  const xcode = normalizeTextForEvidence(xcodeBuildLog ?? "");
+  if (!expected || !actual) return false;
+
+  const expectedAbsence =
+    /\b(do not|does not|should not|must not|hide|hides|hidden|absent|absence|not show|not display|not render|not present|does not exist)\b/.test(
+      expected
+    );
+  const actualVerifiedAbsence =
+    /\b(asserted|assert|verified|confirmed|passed|proves|proof|expected)\b/.test(
+      actual
+    ) &&
+    /\b(did not exist|does not exist|not exist|not present|not visible|not shown|not rendered|absent|absence|hidden|do not show|not show|not display)\b/.test(
+      actual
+    );
+  const passingProof =
+    /\*\*\s*test\s+succeeded\s*\*\*/.test(xcode) ||
+    /\btest case\b.*\bpassed\b/.test(xcode) ||
+    /\b0\s+failures\b/.test(xcode);
+
+  return expectedAbsence && actualVerifiedAbsence && passingProof;
+}
+
+function hasNegativeAccessibilityEvidence(evidence: string): boolean {
+  const text = normalizeTextForEvidence(evidence);
+  if (!text) return false;
+
+  const mentionsAccessibility =
+    /\b(accessibility|accessibilityidentifier|accessibility identifier|identifier|hittable|tap target|button|textfield|text field|element)\b/.test(
+      text
+    );
+  if (!mentionsAccessibility) return false;
+
+  return /\b(fail|fails|failed|failing|failure|not found|no match|no matching|not hittable|does not exist|not exist|never appears|timed out|timeout|masked|masking|overwrote|blocked|can't tap|cannot tap|not tappable)\b/.test(
+    text
   );
 }
 
@@ -1724,6 +1865,9 @@ function buildCloudRepairPrompt(report: CloudCheckReport): string {
               ...report.projectContext.summary.map((item) => `- ${item}`),
             ]
           : []),
+        ...(report.repairIntelligence
+          ? ["", ...formatAppleRepairRead(report.repairIntelligence)]
+          : []),
         "This is not a runtime pass. Run the Xcode build plus the relevant unit/UI tests before claiming there is no bug.",
         "",
         "Repair plan:",
@@ -1745,6 +1889,9 @@ function buildCloudRepairPrompt(report: CloudCheckReport): string {
             "Project context:",
             ...report.projectContext.summary.map((item) => `- ${item}`),
           ]
+        : []),
+      ...(report.repairIntelligence
+        ? ["", ...formatAppleRepairRead(report.repairIntelligence)]
         : []),
       `Repair plan: ${report.repairPlan.map((step) => step.title).join(" -> ")}.`,
       "Preserve the feature behavior and rerun Cloud Check after the next agent edit.",
@@ -1774,6 +1921,9 @@ function buildCloudRepairPrompt(report: CloudCheckReport): string {
               ]
             : []),
         ]
+      : []),
+    ...(report.repairIntelligence
+      ? ["", ...formatAppleRepairRead(report.repairIntelligence)]
       : []),
     "",
     "Address these findings:",
@@ -2054,6 +2204,28 @@ function hasRuntimeCoverageWarning(report: CloudCheckReport): boolean {
 
 function normalizeDiagnosticText(value: string): string {
   return value.replace(/\s+/g, " ").trim().slice(0, 180);
+}
+
+function summarizeEvidenceValue(label: string, value: string): string {
+  if (label !== "xcodeBuildLog") return normalizeDiagnosticText(value);
+
+  const lines = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const highSignal = unique([
+    ...lines.filter((line) => /\bfocused xcode test proof\b/i.test(line)),
+    ...lines.filter((line) => /\bselectors?:\b/i.test(line)),
+    ...lines.filter((line) => /\*\*\s*test\s+(?:succeeded|failed)\s*\*\*/i.test(line)),
+    ...lines.filter((line) => /\bexecuted\s+\d+\s+tests?\b/i.test(line)),
+    ...lines.filter((line) => /\btest case\b/i.test(line)),
+  ]);
+  return (highSignal.length > 0 ? highSignal : lines)
+    .slice(0, 12)
+    .join(" | ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 1500);
 }
 
 function unique<T>(values: T[]): T[] {

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -959,7 +959,7 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticInfo> = {
   },
   AX853: {
     code: "AX853",
-    severity: "warning",
+    severity: "error",
     message: "Generated UI has low semantic coverage of the prompt",
     category: "generation-quality",
   },

--- a/src/mcp/doctor.ts
+++ b/src/mcp/doctor.ts
@@ -144,7 +144,7 @@ function versionCheck(
     detail: `running ${runningVersion}, expected ${expectedVersion}`,
     fix: matches
       ? undefined
-      : "Install the expected Axint version, rerun axint xcode install --project ., then restart the Xcode agent chat.",
+      : "Run axint upgrade --apply, then reload or reconnect the Axint MCP server/tool process.",
   };
 }
 
@@ -260,7 +260,7 @@ function nextStepsFor(checks: MachineDoctorCheck[]): string[] {
   const fixes = checks.filter((check) => check.fix).map((check) => check.fix!);
   if (fixes.length > 0) return [...new Set(fixes)].slice(0, 5);
   return [
-    "Start the Xcode agent chat and ask it to call axint.status.",
+    "Start the agent session and ask it to call axint.status.",
     "Run axint.workflow.check before planning, before writing, before building, and before committing.",
   ];
 }

--- a/src/mcp/feature.ts
+++ b/src/mcp/feature.ts
@@ -40,8 +40,10 @@ import {
   buildSmartViewBody,
   reservedViewPropertyName,
   usesSettingsBlueprint,
+  usesOperatingModelSettings,
   usesProfileCardBlueprint,
   usesInboxBlueprint,
+  usesTrustPostureBlueprint,
 } from "./view-blueprints.js";
 import {
   auditGeneratedFeature,
@@ -49,6 +51,7 @@ import {
   inferSemanticComponentKind,
   usesSemanticLayout,
 } from "./semantic-planner.js";
+import { analyzeAppleRepairTask, formatAppleRepairRead } from "../repair/intelligence.js";
 
 export type Surface = "intent" | "view" | "widget" | "component" | "app" | "store";
 
@@ -106,6 +109,34 @@ export function generateFeature(input: FeatureInput): FeatureResult {
   const shouldEmitArtifacts = shouldEmitDomainArtifacts(domain, planningDescription);
   const diagnostics: string[] = [];
   const files: FeatureFile[] = [];
+
+  const repairRead = analyzeAppleRepairTask({
+    text: input.description,
+    source: input.context,
+    fileName: input.name,
+    platform: input.platform,
+  });
+  if (
+    repairRead.isExistingProductRepair &&
+    surfaces.some((surface) => ["view", "component", "store", "app"].includes(surface))
+  ) {
+    return {
+      success: false,
+      name,
+      files: [],
+      summary: [
+        `Generation quality gate stopped output for "${name}"`,
+        "Reason: Axint detected an existing-product Apple repair request, not a new scaffold request.",
+        ...formatAppleRepairRead(repairRead),
+        "Next: run `axint repair` with the failing source/evidence, or ask `axint.suggest` for a proof-first repair loop.",
+        "Files:",
+        "  none emitted because replacing an existing product screen would be unsafe",
+      ].join("\n"),
+      diagnostics: [
+        `[AX854] error: Existing-product repair prompt should use axint.repair instead of axint.feature\n  help: ${repairRead.summary}`,
+      ],
+    };
+  }
 
   // --- Intent surface ---
   if (surfaces.includes("intent")) {
@@ -194,7 +225,7 @@ export function generateFeature(input: FeatureInput): FeatureResult {
   if (surfaces.includes("component")) {
     const componentName = withoutSuffix(withoutSuffix(name, "View"), "Component");
     const archetypes = inferComponentArchetypes(
-      planningDescription,
+      input.description,
       componentName,
       input.componentKind
     );
@@ -226,7 +257,7 @@ export function generateFeature(input: FeatureInput): FeatureResult {
     } else {
       const componentKind =
         input.componentKind ??
-        inferComponentKindForFeature(planningDescription, componentName);
+        inferComponentKindForFeature(input.description, componentName);
       const componentResult = buildView(
         componentName,
         planningDescription,
@@ -320,26 +351,34 @@ export function generateFeature(input: FeatureInput): FeatureResult {
   diagnostics.push(...auditGeneratedFeature(input, files));
 
   const success = !diagnostics.some((d) => /^\[AX[^\]]+\]\s+error\b/.test(d));
+  const qualityGateBlocked = diagnostics.some((d) => /^\[AX85[023]\]\s+error\b/.test(d));
+  const emittedFiles = qualityGateBlocked ? [] : files;
   const surfaceList = surfaces.join(", ");
-  const fileCount = files.filter((f) => f.type === "swift").length;
-  const testCount = files.filter((f) => f.type === "test").length;
+  const fileCount = emittedFiles.filter((f) => f.type === "swift").length;
+  const testCount = emittedFiles.filter((f) => f.type === "test").length;
 
   const summary = [
-    `Generated scaffold: ${fileCount} Swift file${fileCount !== 1 ? "s" : ""} + ${testCount} test${testCount !== 1 ? "s" : ""} for "${name}"`,
+    qualityGateBlocked
+      ? `Generation quality gate stopped output for "${name}"`
+      : `Generated scaffold: ${fileCount} Swift file${fileCount !== 1 ? "s" : ""} + ${testCount} test${testCount !== 1 ? "s" : ""} for "${name}"`,
     `Surfaces: ${surfaceList}`,
     input.platform ? `Platform: ${input.platform}` : null,
     domain ? `Domain: ${domain}` : null,
-    `Note: generated files are editable first drafts; connect real persistence, app state, and product behavior before shipping.`,
+    qualityGateBlocked
+      ? `Note: Axint refused to emit generic Swift because the generated UI did not preserve enough of the prompt. Use the diagnostics below as the repair brief, add context or a more specific component kind, then rerun axint.feature.`
+      : `Note: generated files are editable first drafts; connect real persistence, app state, and product behavior before shipping.`,
     input.context
       ? `Context: nearby project/design context was used as a weak structural hint.`
       : null,
     `Files:`,
-    ...files.map((f) => `  ${f.path} (${f.type})`),
+    ...(emittedFiles.length > 0
+      ? emittedFiles.map((f) => `  ${f.path} (${f.type})`)
+      : ["  none emitted because the generation quality gate failed"]),
   ]
     .filter(Boolean)
     .join("\n");
 
-  return { success, name, files, summary, diagnostics };
+  return { success, name, files: emittedFiles, summary, diagnostics };
 }
 
 function withContext(description: string, context?: string): string {
@@ -539,6 +578,27 @@ function buildView(
     ensureState(state, "appearanceMode", "string", "System");
     ensureState(state, "accentColor", "string", "Blue");
     ensureState(state, "transcriptionEngine", "string", "Apple Speech");
+    ensureState(state, "reduceMotion", "boolean", false);
+    if (usesOperatingModelSettings(description)) {
+      ensureState(state, "visibility", "string", "Invite only");
+      ensureState(state, "invitePolicy", "string", "Owner approval");
+      ensureState(state, "inviteLimit", "int", 25);
+      ensureState(state, "publicModulesEnabled", "boolean", true);
+      ensureState(state, "membersCanInvite", "boolean", false);
+      ensureState(state, "agentsCanPublish", "boolean", false);
+      ensureState(state, "requireReview", "boolean", true);
+      ensureState(state, "privacyPosture", "string", "Strict");
+      ensureState(state, "integrationReadiness", "string", "Ready");
+    }
+  }
+
+  if (usesTrustPostureBlueprint(`${name} ${description}`)) {
+    ensureState(state, "visibility", "string", "Invite only");
+    ensureState(state, "invitePolicy", "string", "Owner approval");
+    ensureState(state, "publicModulesEnabled", "boolean", true);
+    ensureState(state, "membersCanInvite", "boolean", false);
+    ensureState(state, "agentsCanPublish", "boolean", false);
+    ensureState(state, "privacyPosture", "string", "Strict");
     ensureState(state, "reduceMotion", "boolean", false);
   }
 
@@ -801,6 +861,24 @@ function ensureBlueprintState(
     ensureState(state, "name", "string", "Research Agent");
     ensureState(state, "role", "string", "Tracks the frontier");
     ensureState(state, "status", "string", "awake");
+  }
+
+  if (matchesKind("settingsview", "settings", "preferences")) {
+    ensureState(state, "appearanceMode", "string", "System");
+    ensureState(state, "accentColor", "string", "Blue");
+    ensureState(state, "transcriptionEngine", "string", "Apple Speech");
+    ensureState(state, "reduceMotion", "boolean", false);
+    if (usesOperatingModelSettings(description)) {
+      ensureState(state, "visibility", "string", "Invite only");
+      ensureState(state, "invitePolicy", "string", "Owner approval");
+      ensureState(state, "inviteLimit", "int", 25);
+      ensureState(state, "publicModulesEnabled", "boolean", true);
+      ensureState(state, "membersCanInvite", "boolean", false);
+      ensureState(state, "agentsCanPublish", "boolean", false);
+      ensureState(state, "requireReview", "boolean", true);
+      ensureState(state, "privacyPosture", "string", "Strict");
+      ensureState(state, "integrationReadiness", "string", "Ready");
+    }
   }
 }
 
@@ -1280,6 +1358,12 @@ function inferComponentKindForFeature(
   if (semanticKind) return semanticKind;
 
   const lower = `${name} ${description}`.toLowerCase();
+  if (
+    /\b(settings|preferences|visibility|invite policy|invite limit|permissions|privacy posture|integration readiness|operating model)\b/.test(
+      lower
+    )
+  )
+    return "settingsView";
   if (
     /\b(feed post|feedpost|post card|author avatar|reaction|comment|action row)\b/.test(
       lower

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -10,8 +10,8 @@ export const TOOL_MANIFEST = [
     name: "axint.status",
     description:
       "Report the exact running Axint MCP server version, package path, uptime, " +
-      "registered tool count, and Xcode restart/update instructions. Use this " +
-      "as the first tool in a new Xcode agent chat to prove which Axint process " +
+      "registered tool count, and same-thread MCP reload/update instructions. Use this " +
+      "as the first tool in a new Codex, Claude, or Xcode agent chat to prove which Axint process " +
       "the agent is actually connected to. This answers the running MCP server, " +
       "not a guessed npm, PyPI, or docs version.",
     annotations: {
@@ -29,6 +29,62 @@ export const TOOL_MANIFEST = [
           description:
             "Output format. markdown is human-readable, json is structured, " +
             "and prompt is a short instruction an agent can repeat back before editing.",
+        },
+      },
+    },
+  },
+  {
+    name: "axint.upgrade",
+    description:
+      "Check the latest Axint package and optionally apply the upgrade while preserving " +
+      "the current agent thread. Returns exact install commands, optional Xcode MCP " +
+      "wiring refresh, .axint/upgrade/latest.* artifacts, and a same-thread resume " +
+      "prompt so Codex, Claude, or Xcode can reload the MCP process without starting " +
+      "from scratch.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cwd: {
+          type: "string",
+          description:
+            "Project directory where .axint/upgrade/latest.* should be written. Defaults to the MCP process cwd.",
+        },
+        targetVersion: {
+          type: "string",
+          description:
+            "Specific Axint version to install. Defaults to the latest published npm version.",
+        },
+        latestVersion: {
+          type: "string",
+          description:
+            "Known latest version to compare against. Useful for deterministic agent tests or offline planning.",
+        },
+        apply: {
+          type: "boolean",
+          description:
+            "Whether to install the target package. Defaults to false, which only returns the plan.",
+        },
+        reinstallXcode: {
+          type: "boolean",
+          description:
+            "Whether apply mode should also refresh optional Xcode MCP wiring. Defaults to false.",
+        },
+        writeReport: {
+          type: "boolean",
+          description:
+            "Whether to write .axint/upgrade/latest.json and latest.md. Defaults to true when apply is true.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json", "prompt"],
+          description:
+            "Output format. markdown is human-readable, json is structured, and prompt is the continuation block.",
         },
       },
     },
@@ -237,10 +293,10 @@ export const TOOL_MANIFEST = [
     name: "axint.session.start",
     description:
       "Start an enforced Axint agent session. Writes " +
-      ".axint/session/current.json, refreshes .axint/AXINT_REHYDRATE.md, " +
+      ".axint/session/current.json plus token-scoped session history, refreshes .axint/AXINT_REHYDRATE.md, " +
       "returns compact operating memory, docs context, a session token, and " +
       "the exact axint.workflow.check args. Use " +
-      "this as the first Axint tool in Xcode after a new chat, MCP restart, or " +
+      "this as the first Axint tool in Codex, Claude, or Xcode after a new chat, MCP reload, or " +
       "context compaction so the agent cannot silently drift away from Axint.",
     annotations: {
       readOnlyHint: false,
@@ -254,7 +310,7 @@ export const TOOL_MANIFEST = [
         targetDir: {
           type: "string",
           description:
-            "Project directory where .axint/session/current.json should be written. Defaults to the MCP process cwd.",
+            "Project directory where .axint/session/current.json and token-scoped session history should be written. Defaults to the MCP process cwd.",
         },
         projectName: {
           type: "string",
@@ -271,7 +327,7 @@ export const TOOL_MANIFEST = [
         },
         agent: {
           type: "string",
-          enum: ["claude", "codex", "cursor", "xcode", "all"],
+          enum: ["all", "claude", "codex", "cowork", "cursor", "xcode"],
           description: "Agent target for the session. Defaults to all.",
         },
         ttlMinutes: {
@@ -427,7 +483,7 @@ export const TOOL_MANIFEST = [
         },
         agent: {
           type: "string",
-          enum: ["claude", "codex", "all"],
+          enum: ["all", "claude", "codex", "cowork", "cursor", "xcode"],
           description: "Agent target. Defaults to all.",
         },
         mode: {
@@ -649,7 +705,7 @@ export const TOOL_MANIFEST = [
       "For existing dirty SwiftUI files or Codex-style patch edits, it points " +
       "agents toward surgical patching plus validation instead of full-file writes. " +
       "A ready result is not a completion stamp: the response includes the next " +
-      "Axint action the agent should call before returning to ordinary Xcode work.",
+      "Axint action the agent should call before returning to broad Apple-native work.",
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
@@ -668,6 +724,12 @@ export const TOOL_MANIFEST = [
           type: "boolean",
           description:
             "Whether axint.session.start was called in this chat/recovery pass.",
+        },
+        agent: {
+          type: "string",
+          enum: ["all", "claude", "codex", "cowork", "cursor", "xcode"],
+          description:
+            "Agent host/tool lane for this gate. Codex/Claude/Cowork/Cursor use patch-first lanes; Xcode may use Xcode guard/write.",
         },
         sessionToken: {
           type: "string",
@@ -1056,6 +1118,195 @@ export const TOOL_MANIFEST = [
     },
   },
   {
+    name: "axint.repair",
+    description:
+      "Plan a project-aware Apple repair for existing apps. Indexes the local project, " +
+      "classifies build/UI/runtime evidence, runs Cloud Check when source is provided, " +
+      "ranks likely SwiftUI/App files, returns a host-aware patch/proof plan, and writes " +
+      ".axint/repair plus a privacy-safe .axint/feedback packet. Use this when the user " +
+      "reports a real app bug such as a visible composer that cannot be tapped, a failed " +
+      "macOS UI test, a runtime freeze, or a Swift build error.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cwd: {
+          type: "string",
+          description: "Project directory. Defaults to the MCP process cwd.",
+        },
+        issue: {
+          type: "string",
+          description:
+            "The broken behavior or repair goal, e.g. 'comment box is visible but cannot be tapped'.",
+        },
+        source: {
+          type: "string",
+          description:
+            "Optional inline Swift source for the suspected file. Source is not included in the feedback packet.",
+        },
+        sourcePath: {
+          type: "string",
+          description:
+            "Optional suspected Swift file path. Axint reads it locally for Cloud Check and project anchoring.",
+        },
+        fileName: {
+          type: "string",
+          description: "Display file name when passing inline source.",
+        },
+        platform: {
+          type: "string",
+          enum: ["iOS", "macOS", "watchOS", "visionOS", "all"],
+          description: "Target Apple platform hint.",
+        },
+        agent: {
+          type: "string",
+          enum: ["all", "claude", "codex", "cowork", "cursor", "xcode"],
+          description:
+            "Active host/tool lane. Axint adapts the repair plan so Codex/Claude/Cursor avoid Xcode-only write tools.",
+        },
+        expectedBehavior: {
+          type: "string",
+          description: "Optional expected behavior for the failing feature.",
+        },
+        actualBehavior: {
+          type: "string",
+          description: "Optional observed behavior from the failing run.",
+        },
+        xcodeBuildLog: {
+          type: "string",
+          description: "Optional Xcode build/test log evidence.",
+        },
+        testFailure: {
+          type: "string",
+          description: "Optional focused unit/UI-test failure text.",
+        },
+        runtimeFailure: {
+          type: "string",
+          description: "Optional crash, freeze, hang, or runtime failure text.",
+        },
+        changedFiles: {
+          type: "array",
+          items: { type: "string" },
+          description: "Changed files to pin into the project context pack.",
+        },
+        projectContextPath: {
+          type: "string",
+          description: "Optional .axint/context/latest.json path.",
+        },
+        writeReport: {
+          type: "boolean",
+          description:
+            "Whether to write .axint/repair/latest.json and latest.md. Defaults to true.",
+        },
+        writeFeedback: {
+          type: "boolean",
+          description:
+            "Whether to write a privacy-safe .axint/feedback packet. Defaults to true.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json", "prompt"],
+          description:
+            "Output format. markdown returns the report, json returns structured data, and prompt returns the agent repair prompt.",
+        },
+      },
+      required: ["issue"],
+    },
+  },
+  {
+    name: "axint.feedback.create",
+    description:
+      "Create or read a privacy-safe learning packet for Axint repair intelligence. " +
+      "Packets include project shape, diagnostic codes, issue class, redacted evidence, " +
+      "and likely product owner, but never include source code. Users can inspect the JSON " +
+      "before sending it to Axint Cloud.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cwd: {
+          type: "string",
+          description: "Project directory. Defaults to the MCP process cwd.",
+        },
+        latest: {
+          type: "boolean",
+          description:
+            "When true, return the latest local feedback packet instead of creating a new one.",
+        },
+        issue: {
+          type: "string",
+          description: "Bug, weak Axint output, or failed repair behavior.",
+        },
+        source: {
+          type: "string",
+          description: "Optional inline Swift source used locally only.",
+        },
+        sourcePath: {
+          type: "string",
+          description: "Optional suspected Swift file path used locally only.",
+        },
+        fileName: {
+          type: "string",
+          description: "Display file name when passing inline source.",
+        },
+        platform: {
+          type: "string",
+          enum: ["iOS", "macOS", "watchOS", "visionOS", "all"],
+          description: "Target Apple platform hint.",
+        },
+        agent: {
+          type: "string",
+          enum: ["all", "claude", "codex", "cowork", "cursor", "xcode"],
+          description: "Active host/tool lane.",
+        },
+        expectedBehavior: {
+          type: "string",
+          description: "Optional expected behavior.",
+        },
+        actualBehavior: {
+          type: "string",
+          description: "Optional actual behavior.",
+        },
+        xcodeBuildLog: {
+          type: "string",
+          description: "Optional Xcode build/test log evidence.",
+        },
+        testFailure: {
+          type: "string",
+          description: "Optional focused unit/UI-test failure text.",
+        },
+        runtimeFailure: {
+          type: "string",
+          description: "Optional crash, freeze, hang, or runtime failure text.",
+        },
+        changedFiles: {
+          type: "array",
+          items: { type: "string" },
+          description: "Changed files to pin into the context pack.",
+        },
+        projectContextPath: {
+          type: "string",
+          description: "Optional .axint/context/latest.json path.",
+        },
+        format: {
+          type: "string",
+          enum: ["json", "markdown"],
+          description: "Output format. Defaults to json.",
+        },
+      },
+    },
+  },
+  {
     name: "axint.run",
     description:
       "Run the enforced Axint Apple build loop outside the Xcode UI. Starts or refreshes " +
@@ -1173,11 +1424,81 @@ export const TOOL_MANIFEST = [
           description:
             "Whether to write .axint/run/latest.json and latest.md. Defaults to true.",
         },
+        background: {
+          type: "boolean",
+          description:
+            "Start the run and immediately return a resumable job id instead of waiting for long Xcode build, test, or runtime proof. Use this from MCP clients when xcodebuild might outlive the tool transport timeout.",
+        },
+        includeSource: {
+          type: "boolean",
+          description:
+            "Include full Swift source and full command output in json output. Defaults to false so long agent threads receive compact verdict/evidence JSON.",
+        },
         format: {
           type: "string",
           enum: ["markdown", "json", "prompt"],
           description:
             "Output format. markdown returns the run report, json returns structured data, prompt returns only the repair prompt.",
+        },
+      },
+    },
+  },
+  {
+    name: "axint.run.status",
+    description:
+      "Read the latest or selected Axint run job record, including active child process IDs. " +
+      "Use this when a long xcodebuild run may still be active after an MCP timeout or client disconnect.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cwd: {
+          type: "string",
+          description: "Project directory. Defaults to the MCP process cwd.",
+        },
+        id: {
+          type: "string",
+          description: "Optional Axint run id. Defaults to latest active run.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json"],
+          description: "Output format. Defaults to markdown.",
+        },
+      },
+    },
+  },
+  {
+    name: "axint.run.cancel",
+    description:
+      "Cancel the latest or selected Axint run by killing active child process groups. " +
+      "Use this when xcodebuild or a UI-test runner survived an MCP timeout or transport close.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cwd: {
+          type: "string",
+          description: "Project directory. Defaults to the MCP process cwd.",
+        },
+        id: {
+          type: "string",
+          description: "Optional Axint run id. Defaults to latest active run.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json"],
+          description: "Output format. Defaults to markdown.",
         },
       },
     },

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -6,6 +6,11 @@
  * messages array by GetPromptRequestSchema (template expansion).
  */
 
+import {
+  buildAgentToolProfile,
+  renderAgentToolProfile,
+} from "../project/agent-profile.js";
+
 export const PROMPT_MANIFEST = [
   {
     name: "axint.quick-start",
@@ -30,6 +35,11 @@ export const PROMPT_MANIFEST = [
         description: "Target platform: iOS, macOS, visionOS, or all",
         required: false,
       },
+      {
+        name: "agent",
+        description: "Agent host: codex, claude, cowork, cursor, xcode, or all",
+        required: false,
+      },
     ],
   },
   {
@@ -47,6 +57,11 @@ export const PROMPT_MANIFEST = [
       {
         name: "lastTask",
         description: "Optional last task or file area the agent was working on",
+        required: false,
+      },
+      {
+        name: "agent",
+        description: "Agent host: codex, claude, cowork, cursor, xcode, or all",
         required: false,
       },
     ],
@@ -130,6 +145,16 @@ export function getPromptMessages(
   if (name === "axint.project-start") {
     const projectName = args?.projectName || "this project";
     const platform = args?.platform || "the target Apple platform";
+    const profile = buildAgentToolProfile(args?.agent);
+    const xcodeStep = profile.xcodeToolsAllowed
+      ? "3. Call `axint.xcode.guard` with stage `context-recovery` so this chat writes `.axint/guard/latest.*` proof before any long task.\n"
+      : "3. Stay in this host's tool lane. Do not call `axint.xcode.guard` or `axint.xcode.write` unless this chat is actually running inside Xcode.\n";
+    const serverStep = profile.xcodeToolsAllowed
+      ? "5. List the available MCP servers and confirm both xcode-tools and axint are present.\n"
+      : "5. List available MCP servers/tools when the client supports it and confirm axint is present. If MCP is stale or closed, use the CLI fallback instead of continuing by hand.\n";
+    const writeStep = profile.xcodeToolsAllowed
+      ? "11. Prefer `axint.xcode.write` when writing new Swift files so validation, Cloud Check, and guard proof happen with the write.\n"
+      : `11. Write through this host lane: ${profile.defaultWriteAction}. Do not route normal edits through \`axint.xcode.write\` outside Xcode.\n`;
     return {
       messages: [
         {
@@ -137,7 +162,11 @@ export function getPromptMessages(
           content: {
             type: "text" as const,
             text:
-              `Start ${projectName} with Axint for ${platform}. Before generating or editing Apple-native code, do this setup pass:\n\n` +
+              `Start ${projectName} with Axint for ${platform}. Before generating or editing Apple-native code, do this setup pass with the ${profile.label} lane:\n\n` +
+              "Agent tool profile:\n" +
+              "```text\n" +
+              renderAgentToolProfile(profile) +
+              "\n```\n\n" +
               "1. Read the current Axint docs in this order:\n" +
               "   - https://docs.axint.ai/guides/live-now/\n" +
               "   - https://docs.axint.ai/mcp/xcode/\n" +
@@ -146,15 +175,15 @@ export function getPromptMessages(
               "   - https://docs.axint.ai/guides/fix-packets/\n" +
               "   - https://docs.axint.ai/reference/cli/\n" +
               "2. Call `axint.session.start` and keep the returned `sessionToken` visible.\n" +
-              "3. Call `axint.xcode.guard` with stage `context-recovery` so this chat writes `.axint/guard/latest.*` proof before any long task.\n" +
+              xcodeStep +
               "4. Read `.axint/AXINT_REHYDRATE.md`, `.axint/AXINT_MEMORY.md`, `.axint/AXINT_DOCS_CONTEXT.md`, `AGENTS.md`, `CLAUDE.md`, or `.axint/project.json` if present.\n" +
-              "5. List the available MCP servers and confirm both xcode-tools and axint are present.\n" +
-              "6. Call `axint.status` and report the running MCP server version before editing code. If the version is older than expected, stop and tell me to update Axint, rerun `axint xcode install --project .`, and restart the Xcode agent chat.\n" +
-              "7. If axint is missing in Xcode, tell me to run `axint xcode install --project .`, restart the Xcode agent session, and ask again for available MCP servers.\n" +
-              "8. Call `axint.workflow.check` with stage `context-recovery`, sessionToken, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.\n" +
-              "9. Call `axint.xcode.guard` before long tasks and `axint.workflow.check` with `sessionToken` at planning, before-write, and pre-build checkpoints so you do not skip the Axint loop by accident.\n" +
+              serverStep +
+              "6. Call `axint.status` and report the running MCP server version before editing code. If the version is older than expected, call `axint.upgrade` or tell me to run `axint upgrade --apply`, then reload only the Axint MCP server/tool process.\n" +
+              "7. If axint is missing in Xcode, tell me to run `axint xcode install --project .`, reload the Xcode MCP server/tool process, and ask again for available MCP servers.\n" +
+              `8. Call \`axint.workflow.check\` with agent=\`${profile.agent}\`, stage \`context-recovery\`, sessionToken, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.\n` +
+              "9. Call `axint.workflow.check` with `sessionToken` at planning, before-write, and pre-build checkpoints so you do not skip the Axint loop by accident.\n" +
               "10. Use Axint tools before guessing App Intents, widgets, SwiftUI scaffolds, entitlements, Info.plist keys, or repair prompts.\n" +
-              "11. Prefer `axint.xcode.write` when writing new Swift files so validation, Cloud Check, and guard proof happen with the write.\n" +
+              writeStep +
               "12. Work in short checkpoints. Do not spend 20+ minutes on a task without running Axint and Xcode validation.\n" +
               "13. After each generated Apple surface, run `axint.cloud.check` or `axint cloud check <file> --feedback` and then build in Xcode.\n" +
               "14. Do not claim there is no bug from Axint alone. Cloud Check is static; Xcode build, unit tests, UI tests, accessibility flows, and runtime behavior are separate evidence.\n" +
@@ -170,6 +199,10 @@ export function getPromptMessages(
   if (name === "axint.context-recovery") {
     const projectName = args?.projectName || "this project";
     const lastTask = args?.lastTask ? ` The last known task was: ${args.lastTask}.` : "";
+    const profile = buildAgentToolProfile(args?.agent);
+    const xcodeStep = profile.xcodeToolsAllowed
+      ? "2. Call axint.xcode.guard with stage `context-recovery` so this chat writes `.axint/guard/latest.*` proof.\n"
+      : "2. Stay in the host-native patch/edit lane. Do not call Xcode-only guard/write tools unless this chat is actually inside Xcode.\n";
     return {
       messages: [
         {
@@ -178,14 +211,18 @@ export function getPromptMessages(
             type: "text" as const,
             text:
               `Recover the Axint workflow for ${projectName}.${lastTask}\n\n` +
+              "Agent tool profile:\n" +
+              "```text\n" +
+              renderAgentToolProfile(profile) +
+              "\n```\n\n" +
               "Assume this chat may have lost context. Before editing code or continuing the prior task:\n\n" +
               "1. Call axint.session.start and keep the returned sessionToken.\n" +
-              "2. Call axint.xcode.guard with stage `context-recovery` so this chat writes `.axint/guard/latest.*` proof.\n" +
+              xcodeStep +
               "3. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json if they exist.\n" +
               "4. If those files are missing, call axint.context.memory and axint.context.docs, then use them as the compact Axint operating memory and docs context.\n" +
               "5. List the available MCP servers/tools and confirm axint is present.\n" +
               "6. Call axint.status and report the running Axint MCP version.\n" +
-              "7. Call axint.workflow.check with stage `context-recovery`, sessionToken, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.\n" +
+              `7. Call axint.workflow.check with agent=\`${profile.agent}\`, stage \`context-recovery\`, sessionToken, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.\n` +
               "8. If Axint is missing or stale, stop and give the exact setup/restart command instead of continuing by hand.\n" +
               "9. Name the next Axint tool you will use before editing code.\n" +
               "10. Do not claim a bug is fixed until Axint validation, Cloud Check, Xcode build, and relevant tests/runtime evidence support it.\n\n" +

--- a/src/mcp/semantic-planner.ts
+++ b/src/mcp/semantic-planner.ts
@@ -40,9 +40,13 @@ const STOP_WORDS = new Set([
   "cards",
   "component",
   "components",
+  "compact",
   "create",
+  "current",
   "design",
   "distinct",
+  "existing",
+  "focused",
   "for",
   "from",
   "has",
@@ -54,12 +58,17 @@ const STOP_WORDS = new Set([
   "kind",
   "make",
   "native",
+  "new",
   "of",
   "on",
   "one",
+  "only",
   "or",
+  "page",
+  "preserve",
   "surface",
   "surfaces",
+  "screen",
   "swift",
   "swiftui",
   "that",
@@ -191,16 +200,18 @@ export function auditGeneratedFeature(
   files: FeatureFile[]
 ): string[] {
   const diagnostics: string[] = [];
-  const description = `${input.description} ${input.context ?? ""}`;
+  const description = input.description;
   const surfaces = input.surfaces ?? (["intent"] as Surface[]);
   const swiftFiles = files.filter((file) => file.type === "swift");
   const swiftText = swiftFiles.map((file) => file.content).join("\n\n");
-  const normalizedSwift = normalizeForCoverage(swiftText);
+  const normalizedSwift = normalizeForCoverage(visibleSwiftBodyText(swiftText));
   const tokens = meaningfulTokens(description).filter(
     (token) => token.length > 3 && !UI_SIGNAL_WORDS.includes(token)
   );
   const uniqueTokens = unique(tokens).slice(0, 18);
-  const covered = uniqueTokens.filter((token) => normalizedSwift.includes(token));
+  const covered = uniqueTokens.filter((token) =>
+    semanticTokenCovered(normalizedSwift, token)
+  );
   const coverage = uniqueTokens.length === 0 ? 1 : covered.length / uniqueTokens.length;
 
   const requestedComponents = inferSemanticComponentArchetypes(
@@ -245,9 +256,9 @@ export function auditGeneratedFeature(
   ) {
     const missing = uniqueTokens.filter((token) => !covered.includes(token)).slice(0, 6);
     diagnostics.push(
-      `[AX853] warning: Generated UI has low semantic coverage of the prompt (${Math.round(
+      `[AX853] error: Generated UI has low semantic coverage of the prompt (${Math.round(
         coverage * 100
-      )}%)\n  help: Incorporate the requested concepts into the generated names, labels, or component structure: ${missing.join(
+      )}%)\n  help: Do not emit a generic scaffold. Incorporate the requested concepts into visible labels, controls, or component structure before returning Swift: ${missing.join(
         ", "
       )}.`
     );
@@ -366,6 +377,12 @@ function inferKindFromText(text: string): string | undefined {
   const normalized = text.replace(/([a-z0-9])([A-Z])/g, "$1 $2");
   const compact = normalized.replace(/[\s_-]+/g, "").toLowerCase();
   const lower = normalized.toLowerCase();
+  if (
+    /\b(settings|preferences|visibility|invite policy|invite limit|permissions|privacy posture|integration readiness|operating model)\b/.test(
+      lower
+    )
+  )
+    return "settingsView";
   if (/\bfeed|post|reaction|comment|share\b/.test(lower)) return "feedCard";
   if (/\bmedia|image|photo|asset|cover|gallery|preview|nsimage\b/.test(lower))
     return "mediaCard";
@@ -405,6 +422,9 @@ function normalizeSemanticKind(kind: string | undefined): string | undefined {
     semantictoolbar: "semanticBar",
     semanticlist: "semanticList",
     semanticgrid: "semanticList",
+    settingsview: "settingsView",
+    settings: "settingsView",
+    preferences: "settingsView",
   };
   return map[compact];
 }
@@ -426,11 +446,50 @@ function normalizeForCoverage(text: string): string {
     .replace(/[^a-z0-9\s-]/g, " ");
 }
 
+function visibleSwiftBodyText(swiftText: string): string {
+  return swiftText
+    .split(/\r?\n/)
+    .filter((line) => {
+      const trimmed = line.trim();
+      return (
+        trimmed.length > 0 &&
+        !trimmed.startsWith("//") &&
+        !trimmed.startsWith("import ") &&
+        !trimmed.startsWith("struct ") &&
+        !trimmed.startsWith("class ") &&
+        !trimmed.startsWith("enum ") &&
+        !trimmed.startsWith("@State") &&
+        !trimmed.startsWith("@Binding") &&
+        !/^(private\s+)?(?:let|var)\s+[A-Za-z_][A-Za-z0-9_]*\b/.test(trimmed)
+      );
+    })
+    .join("\n");
+}
+
+function semanticTokenCovered(normalizedText: string, token: string): boolean {
+  const forms = new Set<string>([
+    token,
+    token.replace(/[-_]+/g, " "),
+    token.replace(/[-_]+/g, ""),
+  ]);
+  if (token.endsWith("s") && token.length > 4) {
+    const singular = token.slice(0, -1);
+    forms.add(singular);
+    forms.add(singular.replace(/[-_]+/g, " "));
+    forms.add(singular.replace(/[-_]+/g, ""));
+  }
+  return Array.from(forms).some((form) => {
+    const normalized = normalizeForCoverage(form).trim();
+    return normalized.length > 0 && normalizedText.includes(normalized);
+  });
+}
+
 function hasGenericPlaceholder(swiftText: string): boolean {
   return [
     /Text\("Hello"\)/,
     /Text\("Input:\s*\\\(input\)"\)/,
     /VStack\s*\{\s*Text\("[^"]+"\)\s*\}/s,
+    /Generated from the requested product vocabulary, not a generic starter\./,
   ].some((pattern) => pattern.test(swiftText));
 }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,6 +19,8 @@
  *   - axint.compile:          Compile TypeScript intent → Swift App Intent
  *   - axint.fix-packet: Read the latest emitted Fix Packet / AI repair prompt
  *   - axint.cloud.check:     Run an agent-callable Cloud Check report
+ *   - axint.repair:          Plan a project-aware Apple repair loop
+ *   - axint.feedback.create: Create source-free learning packets for repair gaps
  *   - axint.run:             Run enforced build/test/runtime loop outside Xcode UI
  *   - axint.tokens.ingest:    Convert design tokens into SwiftUI token enums
  *   - axint.validate:         Validate an intent definition without codegen
@@ -28,6 +30,7 @@
  *   - axint.templates.list:   List bundled reference templates
  *   - axint.templates.get:    Return the source of a specific template
  *   - axint.status:           Report the running MCP server version + restart help
+ *   - axint.upgrade:          Check/apply Axint upgrades with same-thread recovery
  *   - axint.project.pack:     Generate first-try project-start files
  *   - axint.project.index:    Index the local Apple project into .axint/context
  */
@@ -40,6 +43,7 @@ import {
   ListPromptsRequestSchema,
   GetPromptRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -80,6 +84,11 @@ import {
   type DoctorFormat,
 } from "./doctor.js";
 import {
+  renderAxintUpgradeReport,
+  runAxintUpgrade,
+  type AxintUpgradeFormat,
+} from "../project/upgrade.js";
+import {
   renderXcodeGuardReport,
   renderXcodeWriteReport,
   runXcodeGuard,
@@ -113,6 +122,20 @@ import {
   type AxintRunFormat,
   type AxintRunPlatform,
 } from "../run/project-runner.js";
+import {
+  readLatestRepairFeedback,
+  renderAxintRepairReport,
+  renderRepairFeedbackPacket,
+  runAxintRepair,
+  type AxintRepairFormat,
+} from "../repair/project-repair.js";
+import {
+  cancelRunJob,
+  getRunJobStatus,
+  renderRunCancelResult,
+  renderRunJobStatus,
+  type AxintRunJobOutputFormat,
+} from "../run/job-store.js";
 
 type PackageInfo = {
   name?: string;
@@ -122,6 +145,15 @@ type PackageInfo = {
 
 type StatusArgs = {
   format?: "markdown" | "json" | "prompt";
+};
+type UpgradeArgs = {
+  cwd?: string;
+  targetVersion?: string;
+  latestVersion?: string;
+  apply?: boolean;
+  reinstallXcode?: boolean;
+  writeReport?: boolean;
+  format?: AxintUpgradeFormat;
 };
 type DoctorArgs = {
   cwd?: string;
@@ -224,6 +256,29 @@ type CloudCheckArgs = {
   projectContextPath?: string;
   format?: CloudCheckFormat;
 };
+type RepairArgs = {
+  cwd?: string;
+  issue: string;
+  source?: string;
+  sourcePath?: string;
+  fileName?: string;
+  platform?: "iOS" | "macOS" | "watchOS" | "visionOS" | "all";
+  agent?: AxintSessionAgent;
+  expectedBehavior?: string;
+  actualBehavior?: string;
+  xcodeBuildLog?: string;
+  testFailure?: string;
+  runtimeFailure?: string;
+  changedFiles?: string[];
+  projectContextPath?: string;
+  writeReport?: boolean;
+  writeFeedback?: boolean;
+  format?: AxintRepairFormat;
+};
+type FeedbackArgs = Omit<RepairArgs, "format"> & {
+  format?: "json" | "markdown";
+  latest?: boolean;
+};
 type AxintRunArgs = {
   cwd?: string;
   projectName?: string;
@@ -248,7 +303,14 @@ type AxintRunArgs = {
   runtimeFailure?: string;
   dryRun?: boolean;
   writeReport?: boolean;
+  background?: boolean;
+  includeSource?: boolean;
   format?: AxintRunFormat;
+};
+type AxintRunJobArgs = {
+  cwd?: string;
+  id?: string;
+  format?: AxintRunJobOutputFormat;
 };
 type TokensIngestArgs = TokenIngestArgs & {
   format?: TokenOutputFormat;
@@ -286,6 +348,50 @@ function errorText(text: string): ToolResult {
   };
 }
 
+function renderAxintRunBackgroundStart(input: {
+  id: string;
+  cwd: string;
+  format: AxintRunFormat;
+}): string {
+  const payload = {
+    id: input.id,
+    status: "running",
+    cwd: input.cwd,
+    jobPath: resolve(input.cwd, ".axint/run/jobs", `${input.id}.json`),
+    latestActivePath: resolve(input.cwd, ".axint/run/latest-active.json"),
+    statusCommand: `axint run status --dir ${quoteForShell(input.cwd)} --id ${input.id}`,
+    cancelCommand: `axint run cancel --dir ${quoteForShell(input.cwd)} --id ${input.id}`,
+    note: "Axint Run is continuing in the background so long Xcode proof does not time out the MCP transport.",
+  };
+
+  if (input.format === "json") return JSON.stringify(payload, null, 2);
+  if (input.format === "prompt") {
+    return [
+      `Axint Run ${input.id} is running in the background.`,
+      `Check it with: ${payload.statusCommand}`,
+      `Cancel it with: ${payload.cancelCommand}`,
+    ].join("\n");
+  }
+
+  return [
+    "# Axint Run: running",
+    "",
+    `- Job: ${payload.id}`,
+    `- Cwd: ${payload.cwd}`,
+    `- Job record: ${payload.jobPath}`,
+    `- Latest active: ${payload.latestActivePath}`,
+    `- Status command: \`${payload.statusCommand}\``,
+    `- Cancel command: \`${payload.cancelCommand}\``,
+    "",
+    payload.note,
+  ].join("\n");
+}
+
+function quoteForShell(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 function renderStatus(format: StatusArgs["format"] = "markdown"): string {
   const uptimeSeconds = Math.max(
     0,
@@ -306,11 +412,12 @@ function renderStatus(format: StatusArgs["format"] = "markdown"): string {
     promptsRegistered: PROMPT_MANIFEST.length,
     restartRequiredAfterUpdate: true,
     updateCommand: "npm install -g @axint/compiler@latest",
+    upgradeCommand: "axint upgrade --apply",
     xcodeSetupCommand: "axint xcode install --project .",
     doctorCommand: "axint doctor",
     projectInitCommand: "axint project init",
     xcodeRestartInstruction:
-      "Restart the Xcode Claude Agent chat or MCP server after updating. MCP clients keep the old Node process alive until it is restarted.",
+      "Reload or reconnect the Axint MCP server/tool process after updating. Keep the current Codex or Claude thread when your client supports MCP reload; if not, use the same-thread resume prompt from axint.upgrade.",
   };
 
   if (format === "json") return JSON.stringify(status, null, 2);
@@ -319,7 +426,7 @@ function renderStatus(format: StatusArgs["format"] = "markdown"): string {
     return [
       `The running Axint MCP server is v${status.version}.`,
       "If this is older than the version the user expects, stop before editing code.",
-      "Tell the user to update Axint, rerun `axint xcode install --project .`, and restart the Xcode Claude Agent chat.",
+      "Call axint.upgrade first. If apply is needed, update Axint, reload only the MCP server/tool process, then call axint.status again in the same thread.",
     ].join("\n");
   }
 
@@ -337,27 +444,27 @@ function renderStatus(format: StatusArgs["format"] = "markdown"): string {
     `- Tools registered: ${status.toolsRegistered}`,
     `- Prompts registered: ${status.promptsRegistered}`,
     "",
-    "## Updating Axint for Xcode",
+    "## Updating Axint Without Losing The Thread",
     "",
-    "MCP servers are long-running processes. Installing a newer package does not update the already-running server inside Xcode.",
+    "MCP servers are long-running processes. Installing a newer package does not update the already-running server until the client reloads or reconnects that tool process.",
     "",
-    "1. Update Axint:",
-    "",
-    "```sh",
-    status.updateCommand,
-    "```",
-    "",
-    "2. Rewrite the Xcode Claude Agent MCP config with durable paths and guarded project proof:",
+    "1. Ask Axint for the upgrade plan:",
     "",
     "```sh",
-    status.xcodeSetupCommand,
+    "axint upgrade",
     "```",
     "",
-    "3. Restart the Xcode Claude Agent chat or MCP server.",
+    "2. Apply it when ready:",
     "",
-    "4. In the new chat, ask: `Call axint.status and tell me the running version.`",
+    "```sh",
+    status.upgradeCommand,
+    "```",
     "",
-    "For a brand-new project, run `axint xcode install --project .`, then `axint doctor` to confirm the machine is wired.",
+    "3. Reload or reconnect the Axint MCP server/tool process. Keep the same Codex or Claude thread when the client supports MCP reload.",
+    "",
+    "4. Ask: `Call axint.status and tell me the running version.`",
+    "",
+    "For Xcode, `axint upgrade --apply` can also refresh the optional Xcode MCP wiring. For a brand-new Apple project, run `axint xcode install --project .`, then `axint doctor` to confirm the machine is wired.",
   ].join("\n");
 }
 
@@ -374,6 +481,28 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
   if (name === "axint.status") {
     const a = args as StatusArgs | undefined;
     return diagnosticsText(renderStatus(a?.format ?? "markdown"));
+  }
+
+  if (name === "axint.upgrade") {
+    const a = args as UpgradeArgs | undefined;
+    const report = runAxintUpgrade({
+      cwd: a?.cwd,
+      currentVersion: pkg.version,
+      targetVersion: a?.targetVersion,
+      latestVersion: a?.latestVersion,
+      apply: a?.apply,
+      reinstallXcode: a?.reinstallXcode,
+      writeReport: a?.writeReport,
+    });
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: renderAxintUpgradeReport(report, a?.format ?? "markdown"),
+        },
+      ],
+      isError: report.status === "fail",
+    };
   }
 
   if (name === "axint.doctor") {
@@ -696,9 +825,80 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
     };
   }
 
+  if (name === "axint.repair") {
+    const a = args as RepairArgs;
+    if (!a.issue?.trim()) {
+      return errorText("Error: 'issue' is required for axint.repair");
+    }
+    const report = runAxintRepair({
+      cwd: a.cwd,
+      issue: a.issue,
+      source: a.source,
+      sourcePath: a.sourcePath,
+      fileName: a.fileName,
+      platform: a.platform,
+      agent: a.agent,
+      expectedBehavior: a.expectedBehavior,
+      actualBehavior: a.actualBehavior,
+      xcodeBuildLog: a.xcodeBuildLog,
+      testFailure: a.testFailure,
+      runtimeFailure: a.runtimeFailure,
+      changedFiles: a.changedFiles,
+      projectContextPath: a.projectContextPath,
+      writeReport: a.writeReport,
+      writeFeedback: a.writeFeedback,
+    });
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: renderAxintRepairReport(report, a.format ?? "markdown"),
+        },
+      ],
+      isError: report.status === "fix_required",
+    };
+  }
+
+  if (name === "axint.feedback.create") {
+    const a = args as FeedbackArgs;
+    if (a.latest) {
+      const packet = readLatestRepairFeedback({ cwd: a.cwd });
+      if (!packet) {
+        return errorText(
+          "No Axint feedback packet found. Run axint.repair or axint.feedback.create with an issue first."
+        );
+      }
+      return diagnosticsText(renderRepairFeedbackPacket(packet, a.format ?? "json"));
+    }
+    if (!a.issue?.trim()) {
+      return errorText("Error: 'issue' is required for axint.feedback.create");
+    }
+    const report = runAxintRepair({
+      cwd: a.cwd,
+      issue: a.issue,
+      source: a.source,
+      sourcePath: a.sourcePath,
+      fileName: a.fileName,
+      platform: a.platform,
+      agent: a.agent,
+      expectedBehavior: a.expectedBehavior,
+      actualBehavior: a.actualBehavior,
+      xcodeBuildLog: a.xcodeBuildLog,
+      testFailure: a.testFailure,
+      runtimeFailure: a.runtimeFailure,
+      changedFiles: a.changedFiles,
+      projectContextPath: a.projectContextPath,
+      writeReport: false,
+      writeFeedback: true,
+    });
+    return diagnosticsText(
+      renderRepairFeedbackPacket(report.feedbackPacket, a.format ?? "json")
+    );
+  }
+
   if (name === "axint.run") {
     const a = args as AxintRunArgs;
-    const report = await runAxintProject({
+    const runInput = {
       cwd: a.cwd,
       kind: "local",
       projectName: a.projectName,
@@ -723,15 +923,65 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
       runtimeFailure: a.runtimeFailure,
       dryRun: a.dryRun,
       writeReport: a.writeReport,
+    } as const;
+
+    if (a.background) {
+      const cwd = resolve(a.cwd ?? process.cwd());
+      const id = `axrun_${randomUUID()}`;
+      void runAxintProject({
+        ...runInput,
+        id,
+        cwd,
+      }).catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[axint.run] background run ${id} failed: ${message}`);
+      });
+      return diagnosticsText(
+        renderAxintRunBackgroundStart({
+          id,
+          cwd,
+          format: a.format ?? "markdown",
+        })
+      );
+    }
+
+    const report = await runAxintProject(runInput);
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: renderAxintRunReport(report, a.format ?? "markdown", {
+            includeSource: a.includeSource,
+          }),
+        },
+      ],
+      isError: report.status === "fail",
+    };
+  }
+
+  if (name === "axint.run.status") {
+    const a = args as AxintRunJobArgs | undefined;
+    const result = getRunJobStatus({
+      cwd: a?.cwd,
+      id: a?.id,
+    });
+    return diagnosticsText(renderRunJobStatus(result, a?.format ?? "markdown"));
+  }
+
+  if (name === "axint.run.cancel") {
+    const a = args as AxintRunJobArgs | undefined;
+    const result = cancelRunJob({
+      cwd: a?.cwd,
+      id: a?.id,
     });
     return {
       content: [
         {
           type: "text" as const,
-          text: renderAxintRunReport(report, a.format ?? "markdown"),
+          text: renderRunCancelResult(result, a?.format ?? "markdown"),
         },
       ],
-      isError: report.status === "fail",
+      isError: result.status === "error" || result.status === "not_found",
     };
   }
 

--- a/src/mcp/suggest.ts
+++ b/src/mcp/suggest.ts
@@ -9,6 +9,7 @@
 
 import { requestProSuggestions } from "./pro-intelligence.js";
 import { semanticLabels } from "./semantic-planner.js";
+import { analyzeAppleRepairTask } from "../repair/intelligence.js";
 
 export interface SuggestInput {
   appDescription: string;
@@ -1288,24 +1289,37 @@ function existingProductRepairSuggestions(
   normalizedAppDescription: string,
   limit: number
 ): FeatureSuggestion[] {
+  const repairRead = analyzeAppleRepairTask({
+    text: [
+      input.appDescription,
+      ...(input.goals ?? []),
+      ...(input.constraints ?? []),
+    ].join("\n"),
+    platform: input.platform,
+  });
   const focus = repairProblemFocus(normalizedAppDescription);
   const concept = repairScreenConcept(normalizedAppDescription);
+  const interactionFocus = focus.includes("interaction")
+    ? titleCase(focus)
+    : `${titleCase(focus)} Interaction`;
   const promptCues = repairPromptCues(normalizedAppDescription);
+  const needsInteractionMap = repairNeedsInteractionMap(normalizedAppDescription);
+  const leadCause = repairRead.rootCauses[0];
+  const checklist = repairRead.inspectionChecklist.slice(0, 3).join(" ");
   const cueSentence =
     promptCues.length > 0
       ? ` Keep these prompt-specific cues in scope: ${promptCues.join(", ")}.`
       : "";
   const platform = input.platform ? `${input.platform} ` : "";
-  const rationale =
-    "Detected an existing-product repair request, so Axint is returning a proof-first repair loop instead of new feature ideas.";
+  const rationale = `Detected an existing-product repair request (${repairRead.issueClass}), so Axint is returning a proof-first repair loop instead of new feature ideas. ${repairRead.summary}`;
 
   const suggestions: FeatureSuggestion[] = [
     {
       name: `Repair Existing ${titleCase(concept)} Flow`,
-      description: `Patch the current ${concept} in place, preserve the surrounding product, and avoid replacing working screens with a fresh scaffold.`,
+      description: `Patch the current ${concept} in place, preserve the surrounding product, and avoid replacing working screens with a fresh scaffold. ${leadCause ? `Likely first read: ${leadCause.title}.` : ""}`,
       surfaces: ["view", "component"],
       complexity: "medium",
-      featurePrompt: `Repair the existing ${platform}${concept} SwiftUI flow without replacing the surrounding app. Preserve store state, existing tab routing, first-viewport hierarchy, primary buttons, accessibility identifiers, and the user's current product vocabulary.${cueSentence} Identify the touched files, reproduce the behavior, patch the smallest view/state/hit-testing/routing change, and keep existing components intact.`,
+      featurePrompt: `Repair the existing ${platform}${concept} SwiftUI flow without replacing the surrounding app. ${repairRead.summary} Preserve store state, existing tab routing, first-viewport hierarchy, primary buttons, accessibility identifiers, and the user's current product vocabulary.${cueSentence} Inspect first: ${checklist || "related SwiftUI parent shell, shared stores, and focused proof evidence."} Identify the touched files, reproduce the behavior, patch the smallest view/state/hit-testing/routing change, and keep existing components intact.`,
       domain: "repair",
       rationale,
       confidence: "high",
@@ -1316,6 +1330,32 @@ function existingProductRepairSuggestions(
       nextStep:
         "Run Cloud Check with expectedBehavior, actualBehavior, and the focused Xcode build or UI-test log.",
     },
+    ...(needsInteractionMap
+      ? [
+          {
+            name: `Trace ${interactionFocus} Blockers`,
+            description:
+              "Map the parent wrappers, overlays, disabled state, gestures, focus bindings, and hit-testing layers that can make visible controls stop accepting input.",
+            surfaces: ["view", "store"],
+            complexity: "medium",
+            featurePrompt: `Build an interaction map for the existing ${platform}${concept} before patching. ${repairRead.rootCauses
+              .slice(0, 3)
+              .map((cause) => `${cause.title}: ${cause.inspect.join(", ")}`)
+              .join(
+                " "
+              )}${cueSentence} Patch the smallest parent or child modifier that restores interaction, then prove it with a focused UI test.`,
+            domain: "repair",
+            rationale,
+            confidence: "high",
+            source: "local",
+            impact:
+              "Targets the class of bugs where a visible SwiftUI control stops accepting taps or typing because a parent layer or state gate is blocking it.",
+            loop: "Interaction map -> blocker patch -> focused input proof -> Cloud Check evidence",
+            nextStep:
+              "Run `axint project index --changed <files>` and inspect the highest interaction-risk related files before editing.",
+          } satisfies FeatureSuggestion,
+        ]
+      : []),
     {
       name: `Add Focused ${titleCase(focus)} Proof`,
       description:
@@ -1355,7 +1395,7 @@ function existingProductRepairSuggestions(
         "Look beyond the current file for the overlay, disabled state, gesture, z-index, route, or shared state that may be blocking the behavior.",
       surfaces: ["view", "store"],
       complexity: "medium",
-      featurePrompt: `Index the project context for the existing ${focus} bug, then inspect related SwiftUI views, stores, modifiers, overlays, disabled states, gestures, accessibility identifiers, route containers, and recently changed files before patching.${cueSentence}`,
+      featurePrompt: `Index the project context for the existing ${focus} bug, then inspect related SwiftUI views, stores, modifiers, overlays, disabled states, gestures, accessibility identifiers, route containers, and recently changed files before patching.${cueSentence} Axint senior read: ${repairRead.summary}`,
       domain: "repair",
       rationale,
       confidence: "medium",
@@ -1369,6 +1409,12 @@ function existingProductRepairSuggestions(
   ];
 
   return suggestions.slice(0, limit);
+}
+
+function repairNeedsInteractionMap(normalizedAppDescription: string): boolean {
+  return /\b(input|composer|comment|reply|textfield|text field|texteditor|text editor|tap|click|hittable|focus|keyboard|overlay|zindex|z-index|disabled|allowshittesting|hit testing|gesture)\b/.test(
+    normalizedAppDescription
+  );
 }
 
 function repairProblemFocus(normalizedAppDescription: string): string {

--- a/src/mcp/view-blueprints.ts
+++ b/src/mcp/view-blueprints.ts
@@ -33,10 +33,10 @@ export function usesThreePaneBlueprint(description: string): boolean {
 export function usesSettingsBlueprint(description: string): boolean {
   const lower = description.toLowerCase();
   return (
-    /\b(settings|preferences|app settings|appearance|accent color|reduce motion|keyboard shortcut|transcription engine)\b/.test(
+    /\b(settings|preferences|app settings|appearance|accent color|reduce motion|keyboard shortcut|transcription engine|visibility|invite policy|invite limit|public modules?|member permissions?|agent permissions?|privacy posture|integration readiness|operating model)\b/.test(
       lower
     ) &&
-    /\b(toggle|picker|swatch|mode|preference|setting|appearance|keyboard|transcription|motion)\b/.test(
+    /\b(toggle|picker|swatch|mode|preference|setting|appearance|keyboard|transcription|motion|visibility|invite|permission|privacy|integration|module|public)\b/.test(
       lower
     )
   );
@@ -54,9 +54,39 @@ export function usesInboxBlueprint(description: string): boolean {
   );
 }
 
+export function usesTrustPostureBlueprint(description: string): boolean {
+  const lower = description.toLowerCase();
+  const compact = lower.replace(/[\s_-]+/g, "");
+  return (
+    (/\b(trust posture|command trust|security posture)\b/.test(lower) ||
+      compact.includes("trustposture") ||
+      compact.includes("commandtrust")) &&
+    /\b(trust|posture|visibility|invite|permissions?|privacy|public|agent|member|settings|reduced motion)\b/.test(
+      lower
+    )
+  );
+}
+
+export function usesEmptyStateBlueprint(description: string): boolean {
+  const lower = description.toLowerCase();
+  return (
+    /\b(empty[-\s]?state|sparse state|blank state|zero state|no results|nothing here|purpose-aware sparse|sparse)\b/.test(
+      lower
+    ) &&
+    /\b(purpose|state|surface|screen|view|command|project|action|cta|pattern)\b/.test(
+      lower
+    )
+  );
+}
+
 export function buildSmartViewBody(input: ViewBlueprintInput): string | null {
   const description = input.description ?? "";
+  const semanticHaystack = `${input.name} ${description}`;
   const explicitKind = normalizeKind(input.componentKind);
+  if (explicitKind === "settingsView") return buildComponentBody(explicitKind, input);
+  if (usesTrustPostureBlueprint(semanticHaystack)) return buildTrustPostureBody(input);
+  if (usesEmptyStateBlueprint(semanticHaystack))
+    return buildPurposeAwareSparseStateBody(input);
   if (explicitKind) return buildComponentBody(explicitKind, input);
   if (usesThreePaneBlueprint(description)) return buildThreePaneBody(input);
   if (usesSettingsBlueprint(description)) return buildSettingsBody(input);
@@ -111,13 +141,21 @@ function inferComponentKind(name: string, description: string): string | undefin
     return "approvalCard";
   if (haystack.includes("agent row") || haystack.includes("agentrow")) return "agentRow";
   if (haystack.includes("role card") || haystack.includes("rolecard")) return "roleCard";
+  if (usesTrustPostureBlueprint(haystack)) return "trustPosture";
+  if (usesEmptyStateBlueprint(haystack)) return "purposeAwareSparseState";
   if (haystack.includes("signal card") || haystack.includes("signalcard"))
     return "signalCard";
   if (haystack.includes("channel row") || haystack.includes("channelrow"))
     return "channelRow";
   if (haystack.includes("sidebar rail") || haystack.includes("sidebarrail"))
     return "sidebarRail";
-  if (haystack.includes("settings") || haystack.includes("preferences"))
+  if (
+    haystack.includes("settings") ||
+    haystack.includes("preferences") ||
+    /\b(visibility|invite policy|invite limit|permissions|privacy posture|integration readiness|operating model)\b/.test(
+      haystack
+    )
+  )
     return "settingsView";
   if (haystack.includes("profile card") || haystack.includes("profilecard"))
     return "profileCard";
@@ -143,6 +181,14 @@ function normalizeKind(kind: string | undefined): string | undefined {
   if (lower === "approvalcard" || lower === "approval") return "approvalCard";
   if (lower === "agentrow") return "agentRow";
   if (lower === "rolecard") return "roleCard";
+  if (lower === "trustposture" || lower === "commandtrustposture") return "trustPosture";
+  if (
+    lower === "purposeawaresparsestate" ||
+    lower === "sparsestate" ||
+    lower === "emptystate" ||
+    lower === "zerostate"
+  )
+    return "purposeAwareSparseState";
   if (lower === "signalcard") return "signalCard";
   if (lower === "channelrow") return "channelRow";
   if (lower === "sidebarrail") return "sidebarRail";
@@ -614,6 +660,12 @@ function buildComponentBody(kind: string, input: ViewBlueprintInput): string {
         .padding(14)
         .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.12)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "12")}, style: .continuous))`;
 
+    case "trustPosture":
+      return buildTrustPostureBody(input);
+
+    case "purposeAwareSparseState":
+      return buildPurposeAwareSparseStateBody(input);
+
     case "signalCard":
       return `VStack(alignment: .leading, spacing: 12) {
             Text(${textExpr(input, "sourceTitle", "Apple expands App Intents at WWDC")})
@@ -712,15 +764,166 @@ function buildSemanticSurfaceBody(input: ViewBlueprintInput): string {
   return buildSemanticDashboardBody(input);
 }
 
+function buildTrustPostureBody(input: ViewBlueprintInput): string {
+  return `VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Trust posture")
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textPrimary", ".primary")})
+                    Text("Visibility, permissions, privacy, and agent behavior stay visible before a command runs.")
+                        .font(.caption)
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+                }
+
+                Spacer()
+
+                Label("Governed", systemImage: "checkmark.shield.fill")
+                    .font(.caption2.weight(.bold))
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 5)
+                    .background(${colorRef(input.tokenNamespace, "successSoft", "Color.green.opacity(0.14)")}, in: Capsule())
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "success", ".green")})
+            }
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 10)], spacing: 10) {
+                VStack(alignment: .leading, spacing: 5) {
+                    Label("Visibility", systemImage: "eye")
+                        .font(.caption.weight(.semibold))
+                    Text(visibility)
+                        .font(.headline.weight(.semibold))
+                }
+                .padding(10)
+                .background(${colorRef(input.tokenNamespace, "surface", "Color.secondary.opacity(0.08)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "row", "12")}, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Label("Invite policy", systemImage: "person.badge.plus")
+                        .font(.caption.weight(.semibold))
+                    Text(invitePolicy)
+                        .font(.headline.weight(.semibold))
+                }
+                .padding(10)
+                .background(${colorRef(input.tokenNamespace, "surface", "Color.secondary.opacity(0.08)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "row", "12")}, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Label("Privacy posture", systemImage: "lock.shield")
+                        .font(.caption.weight(.semibold))
+                    Text(privacyPosture)
+                        .font(.headline.weight(.semibold))
+                }
+                .padding(10)
+                .background(${colorRef(input.tokenNamespace, "surface", "Color.secondary.opacity(0.08)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "row", "12")}, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Label("Reduced motion", systemImage: "figure.walk.motion")
+                        .font(.caption.weight(.semibold))
+                    Text(reduceMotion ? "On" : "Off")
+                        .font(.headline.weight(.semibold))
+                }
+                .padding(10)
+                .background(${colorRef(input.tokenNamespace, "surface", "Color.secondary.opacity(0.08)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "row", "12")}, style: .continuous))
+            }
+
+            VStack(spacing: 8) {
+                Label(publicModulesEnabled ? "Public modules enabled" : "Public modules private", systemImage: "square.grid.2x2")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Label(membersCanInvite ? "Members can invite" : "Member invites need owner approval", systemImage: "person.2")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Label(agentsCanPublish ? "Agents can publish drafts" : "Agent output requires review", systemImage: "cpu")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .font(.caption.weight(.medium))
+            .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+
+            HStack(spacing: 8) {
+                Button("Project Settings") { }
+                    .buttonStyle(.borderedProminent)
+                Button("Review policy") { }
+                    .buttonStyle(.bordered)
+                Spacer()
+            }
+            .controlSize(.small)
+        }
+        .padding(16)
+        .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.10)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "14")}, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "14")}, style: .continuous)
+                .strokeBorder(${colorRef(input.tokenNamespace, "border", "Color.secondary.opacity(0.16)")}, lineWidth: 1)
+        }`;
+}
+
+function buildPurposeAwareSparseStateBody(input: ViewBlueprintInput): string {
+  const labels = swiftStringArray(semanticLabels(input.description ?? input.name, 4));
+  return `VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Purpose-aware sparse state")
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textPrimary", ".primary")})
+                    Text("Empty command surfaces still explain purpose, next action, and why the space is quiet.")
+                        .font(.caption)
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+                }
+
+                Spacer()
+
+                Label("Sparse", systemImage: "circle.dotted")
+                    .font(.caption2.weight(.bold))
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 5)
+                    .background(${colorRef(input.tokenNamespace, "accentSoft", "Color.accentColor.opacity(0.16)")}, in: Capsule())
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "accent", "Color.accentColor")})
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(${labels}, id: \\.self) { purpose in
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "sparkle.magnifyingglass")
+                            .frame(width: 28, height: 28)
+                            .background(${colorRef(input.tokenNamespace, "surface", "Color.secondary.opacity(0.08)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "row", "9")}, style: .continuous))
+                            .foregroundStyle(${colorRef(input.tokenNamespace, "accent", "Color.accentColor")})
+
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(purpose)
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(${colorRef(input.tokenNamespace, "textPrimary", ".primary")})
+                            Text("No content yet. Start with a command, connect project context, or keep the state intentionally quiet.")
+                                .font(.caption)
+                                .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+                        }
+                    }
+                    .padding(10)
+                    .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.10)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "row", "12")}, style: .continuous))
+                }
+            }
+
+            HStack(spacing: 8) {
+                Button("Create command") { }
+                    .buttonStyle(.borderedProminent)
+                Button("Attach context") { }
+                    .buttonStyle(.bordered)
+                Spacer()
+            }
+            .controlSize(.small)
+        }
+        .padding(16)
+        .background(${colorRef(input.tokenNamespace, "surface", "Color.secondary.opacity(0.08)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "16")}, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "16")}, style: .continuous)
+                .strokeBorder(${colorRef(input.tokenNamespace, "border", "Color.secondary.opacity(0.16)")}, lineWidth: 1)
+        }`;
+}
+
 function buildSemanticDashboardBody(input: ViewBlueprintInput): string {
   const labels = swiftStringArray(semanticLabels(input.description ?? input.name, 4));
+  const subtitle = semanticLabels(input.description ?? input.name, 3).join(", ");
   return `VStack(alignment: .leading, spacing: 18) {
             HStack(alignment: .firstTextBaseline) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("${escapeSwiftString(humanizeLocal(input.name))}")
                         .font(.title2.weight(.bold))
                         .foregroundStyle(${colorRef(input.tokenNamespace, "textPrimary", ".primary")})
-                    Text("Generated from the requested product vocabulary, not a generic starter.")
+                    Text("${escapeSwiftString(subtitle || "Focused surface with clear status and next action.")}")
                         .font(.caption)
                         .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
                 }
@@ -888,13 +1091,26 @@ function usesCommandLayerPanel(input: ViewBlueprintInput): boolean {
 }
 
 function buildCommandLayerPanelBody(input: ViewBlueprintInput): string {
+  const haystack = `${input.name} ${input.description ?? ""}`.toLowerCase();
+  const title = /\bcommand[-\s]?layer\b/.test(haystack)
+    ? "Command layer"
+    : humanizeLocal(input.name);
+  const terms = semanticLabels(`${input.name} ${input.description ?? ""}`, 5);
+  const summary =
+    terms.length > 0
+      ? `${terms.slice(0, 4).join(", ")} stay visible before action.`
+      : "The current surface stays intact while the next action stays visible.";
+  const chips = swiftStringArray(
+    Array.from(new Set(["Command Summary", ...terms])).slice(0, 4)
+  );
+
   return `VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .firstTextBaseline, spacing: 10) {
                 VStack(alignment: .leading, spacing: 3) {
-                    Text("Command layer")
+                    Text("${escapeSwiftString(title)}")
                         .font(.headline.weight(.semibold))
                         .foregroundStyle(${colorRef(input.tokenNamespace, "textPrimary", ".primary")})
-                    Text("Feed stays primary. Agent actions stay one move away.")
+                    Text("${escapeSwiftString(summary)}")
                         .font(.caption)
                         .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
                 }
@@ -910,7 +1126,7 @@ function buildCommandLayerPanelBody(input: ViewBlueprintInput): string {
             }
 
             HStack(spacing: 8) {
-                ForEach(["Command Summary", "Ambient Activity", "Composer"], id: \\.self) { item in
+                ForEach(${chips}, id: \\.self) { item in
                     Text(item)
                         .font(.caption2.weight(.semibold))
                         .lineLimit(1)
@@ -1031,7 +1247,9 @@ function buildSemanticGridBody(input: ViewBlueprintInput): string {
 }
 
 function buildSemanticListRows(input: ViewBlueprintInput): string {
-  const labels = swiftStringArray(semanticLabels(input.description ?? input.name, 4));
+  const labels = swiftStringArray(
+    semanticLabels(`${input.name} ${input.description ?? ""}`, 4)
+  );
   return `VStack(spacing: 8) {
                 ForEach(${labels}, id: \\.self) { item in
                     HStack(spacing: 10) {
@@ -1062,6 +1280,10 @@ function buildSemanticListRows(input: ViewBlueprintInput): string {
 }
 
 function buildSettingsBody(input: ViewBlueprintInput): string {
+  if (usesOperatingModelSettings(input.description ?? input.name)) {
+    return buildOperatingModelSettingsBody(input);
+  }
+
   return `VStack(alignment: .leading, spacing: 20) {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Settings")
@@ -1145,6 +1367,90 @@ function buildSettingsBody(input: ViewBlueprintInput): string {
         }
         .padding(20)
         .frame(maxWidth: 560, maxHeight: .infinity, alignment: .topLeading)`;
+}
+
+export function usesOperatingModelSettings(description: string): boolean {
+  const lower = description.toLowerCase();
+  return /\b(visibility|invite policy|invite limit|public modules?|member permissions?|agent permissions?|privacy posture|integration readiness|operating model)\b/.test(
+    lower
+  );
+}
+
+function buildOperatingModelSettingsBody(input: ViewBlueprintInput): string {
+  return `VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Operating model")
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "textPrimary", ".primary")})
+                Text("Control who can see, join, automate, and publish from this workspace.")
+                    .font(.caption)
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "textSecondary", ".secondary")})
+            }
+
+            VStack(alignment: .leading, spacing: 14) {
+                Text("Access")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "textMuted", ".secondary")})
+                    .textCase(.uppercase)
+
+                Picker("Visibility", selection: $visibility) {
+                    Text("Private").tag("Private")
+                    Text("Invite only").tag("Invite only")
+                    Text("Public profile").tag("Public profile")
+                }
+
+                Picker("Invite policy", selection: $invitePolicy) {
+                    Text("Owner approval").tag("Owner approval")
+                    Text("Trusted members").tag("Trusted members")
+                    Text("Open request").tag("Open request")
+                }
+
+                Stepper("Invite limit: \\(inviteLimit)", value: $inviteLimit, in: 1...250)
+            }
+            .padding(16)
+            .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.10)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "14")}, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 14) {
+                Text("Permissions")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "textMuted", ".secondary")})
+                    .textCase(.uppercase)
+
+                Toggle("Public modules enabled", isOn: $publicModulesEnabled)
+                Toggle("Members can invite", isOn: $membersCanInvite)
+                Toggle("Agents can publish drafts", isOn: $agentsCanPublish)
+                Toggle("Require human review", isOn: $requireReview)
+            }
+            .padding(16)
+            .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.10)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "14")}, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 14) {
+                Text("Trust")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(${colorRef(input.tokenNamespace, "textMuted", ".secondary")})
+                    .textCase(.uppercase)
+
+                Picker("Privacy posture", selection: $privacyPosture) {
+                    Text("Strict").tag("Strict")
+                    Text("Balanced").tag("Balanced")
+                    Text("Open").tag("Open")
+                }
+
+                HStack {
+                    Text("Integration readiness")
+                    Spacer()
+                    Text(integrationReadiness)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(${colorRef(input.tokenNamespace, "success", ".green")})
+                }
+            }
+            .padding(16)
+            .background(${colorRef(input.tokenNamespace, "surfaceRaised", "Color.secondary.opacity(0.10)")}, in: RoundedRectangle(cornerRadius: ${radiusRef(input.tokenNamespace, "card", "14")}, style: .continuous))
+
+            Spacer()
+        }
+        .padding(20)
+        .frame(maxWidth: 620, maxHeight: .infinity, alignment: .topLeading)`;
 }
 
 function buildThreePaneBody(input: ViewBlueprintInput): string {

--- a/src/mcp/workflow-check.ts
+++ b/src/mcp/workflow-check.ts
@@ -1,4 +1,9 @@
 import type { Surface } from "./feature.js";
+import {
+  buildAgentToolProfile,
+  normalizeAxintAgent,
+  type AxintAgentProfileName,
+} from "../project/agent-profile.js";
 import { validateAxintSessionToken } from "../project/session.js";
 
 export type WorkflowStage =
@@ -11,6 +16,7 @@ export type WorkflowStage =
 
 export interface WorkflowCheckInput {
   cwd?: string;
+  agent?: AxintAgentProfileName;
   sessionStarted?: boolean;
   sessionToken?: string;
   requireSession?: boolean;
@@ -51,7 +57,13 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
   const recommended: string[] = [];
   const checked: string[] = [];
   const requireSession = input.requireSession !== false;
+  const agent = normalizeAxintAgent(input.agent);
+  const profile = buildAgentToolProfile(agent);
   const patchFirstRepair = looksLikePatchFirstRepair(input);
+
+  checked.push(
+    `Agent tool profile: ${profile.label} (${profile.editingMode}). Default write action: ${profile.defaultWriteAction}.`
+  );
 
   if (requireSession) {
     const session = validateAxintSessionToken({
@@ -158,6 +170,10 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
       recommended.push(
         "Use a small patch edit for the existing dirty SwiftUI file, then run axint.swift.validate and axint.cloud.check on the changed files. Avoid full-file axint.xcode.write unless this is a new file or a clean full-file replacement."
       );
+    } else if (profile.editingMode === "patch-first") {
+      recommended.push(
+        `This is ${profile.label}; use its native patch/edit tool for existing files, then run axint.swift.validate and axint.cloud.check. Do not route normal Codex/Claude/Cowork edits through axint.xcode.write.`
+      );
     }
   }
 
@@ -204,6 +220,7 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
           modifiedFiles,
           xcodeBuildPassed: Boolean(input.xcodeBuildPassed),
           xcodeTestsPassed: Boolean(input.xcodeTestsPassed),
+          agent,
           patchFirstRepair,
         });
   const score = Math.max(
@@ -217,7 +234,7 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
     summary:
       status === "ready"
         ? nextTool
-          ? `Axint workflow gate is satisfied for this stage. This is not a completion stamp; continue with ${nextTool} before ordinary Xcode work.`
+          ? `Axint workflow gate is satisfied for this stage. This is not a completion stamp; continue with ${nextTool} before broad Apple-native work.`
           : "Axint workflow gate is satisfied for this stage."
         : "Axint workflow gate needs one or more agent actions before moving on.",
     score,
@@ -303,6 +320,7 @@ function nextToolForSatisfiedStage(input: {
   modifiedFiles: string[];
   xcodeBuildPassed: boolean;
   xcodeTestsPassed: boolean;
+  agent: AxintAgentProfileName;
   patchFirstRepair: boolean;
 }): string | undefined {
   const {
@@ -311,8 +329,10 @@ function nextToolForSatisfiedStage(input: {
     modifiedFiles,
     xcodeBuildPassed,
     xcodeTestsPassed,
+    agent,
     patchFirstRepair,
   } = input;
+  const profile = buildAgentToolProfile(agent);
   if (stage === "session-start" || stage === "context-recovery") {
     return "axint.suggest";
   }
@@ -321,13 +341,15 @@ function nextToolForSatisfiedStage(input: {
       ["view", "component", "intent", "widget", "app", "store"].includes(surface)
     )
       ? "axint.feature"
-      : "axint.xcode.guard";
+      : profile.xcodeToolsAllowed
+        ? "axint.xcode.guard"
+        : "axint.workflow.check(stage=before-write)";
   }
   if (stage === "before-write") {
-    if (patchFirstRepair) {
-      return "apply_patch, then axint.swift.validate";
+    if (patchFirstRepair || profile.editingMode === "patch-first") {
+      return profile.defaultWriteAction;
     }
-    return "axint.xcode.write";
+    return profile.xcodeToolsAllowed ? "axint.xcode.write" : profile.defaultWriteAction;
   }
   if (stage === "pre-build") {
     return xcodeBuildPassed ? "axint.workflow.check(stage=pre-commit)" : "axint.run";
@@ -335,7 +357,9 @@ function nextToolForSatisfiedStage(input: {
   if (stage === "pre-commit") {
     if (!xcodeTestsPassed) return "axint.run";
     if (modifiedFiles.some((file) => file.endsWith(".swift"))) {
-      return "axint.xcode.guard(stage=finish)";
+      return profile.xcodeToolsAllowed
+        ? "axint.xcode.guard(stage=finish)"
+        : profile.finishAction;
     }
   }
   return undefined;

--- a/src/project/agent-profile.ts
+++ b/src/project/agent-profile.ts
@@ -1,0 +1,143 @@
+export type AxintAgentProfileName =
+  | "all"
+  | "claude"
+  | "codex"
+  | "cowork"
+  | "cursor"
+  | "xcode";
+
+export const AXINT_AGENT_PROFILE_NAMES = [
+  "all",
+  "claude",
+  "codex",
+  "cowork",
+  "cursor",
+  "xcode",
+] as const satisfies readonly AxintAgentProfileName[];
+
+export interface AxintAgentToolProfile {
+  agent: AxintAgentProfileName;
+  label: string;
+  editingMode: "patch-first" | "xcode-guarded" | "detect-host";
+  xcodeToolsAllowed: boolean;
+  defaultWriteAction: string;
+  finishAction: string;
+  contextRecoveryAction: string;
+  proofAction: string;
+  avoid: string[];
+}
+
+export function normalizeAxintAgent(value: string | undefined): AxintAgentProfileName {
+  if (value && (AXINT_AGENT_PROFILE_NAMES as readonly string[]).includes(value)) {
+    return value as AxintAgentProfileName;
+  }
+  return "all";
+}
+
+export function buildAgentToolProfile(
+  agent: string | undefined = "all"
+): AxintAgentToolProfile {
+  const normalized = normalizeAxintAgent(agent);
+
+  if (normalized === "xcode") {
+    return {
+      agent: "xcode",
+      label: "Xcode agent",
+      editingMode: "xcode-guarded",
+      xcodeToolsAllowed: true,
+      defaultWriteAction: "axint.xcode.write",
+      finishAction: "axint.xcode.guard(stage=finish)",
+      contextRecoveryAction:
+        "Call axint.xcode.guard with stage=context-recovery, then axint.session.start and axint.workflow.check.",
+      proofAction:
+        "Use axint.run or Xcode build/test evidence, then write .axint/guard/latest.* proof before claiming done.",
+      avoid: [
+        "Do not skip axint.xcode.guard during long Xcode sessions.",
+        "Do not claim SwiftUI behavior is fixed from static checks alone.",
+      ],
+    };
+  }
+
+  if (normalized === "codex") {
+    return patchFirstProfile({
+      agent: "codex",
+      label: "Codex",
+      writeAction: "apply_patch, then axint.swift.validate",
+    });
+  }
+
+  if (normalized === "cowork") {
+    return patchFirstProfile({
+      agent: "cowork",
+      label: "Cowork",
+      writeAction:
+        "use the workspace patch/edit primitive or CLI edits, then axint validate-swift",
+    });
+  }
+
+  if (normalized === "claude" || normalized === "cursor") {
+    return patchFirstProfile({
+      agent: normalized,
+      label: normalized === "claude" ? "Claude Code" : "Cursor",
+      writeAction:
+        "use the client-native patch/file edit tool, then axint.swift.validate",
+    });
+  }
+
+  return {
+    agent: "all",
+    label: "Auto-detect agent host",
+    editingMode: "detect-host",
+    xcodeToolsAllowed: false,
+    defaultWriteAction:
+      "Use the current client's native patch/edit tool; only use axint.xcode.write inside a real Xcode agent session.",
+    finishAction:
+      "Summarize validation, Cloud Check, build/test proof, and do not call Xcode-only guard tools unless the active host is Xcode.",
+    contextRecoveryAction:
+      "Call axint.session.start, read local Axint context files, call axint.status, then axint.workflow.check.",
+    proofAction:
+      "Use axint.swift.validate, axint.cloud.check, and axint.run or shell build/test evidence that the active agent can actually run.",
+    avoid: [
+      "Do not assume Xcode MCP tools exist in Codex, Claude Code, Cursor, or Cowork.",
+      "Do not use full-file axint.xcode.write for dirty existing files in patch-first agents.",
+    ],
+  };
+}
+
+export function renderAgentToolProfile(profile: AxintAgentToolProfile): string {
+  return [
+    `Agent host: ${profile.label}`,
+    `Editing lane: ${profile.editingMode}`,
+    `Default write action: ${profile.defaultWriteAction}`,
+    `Proof action: ${profile.proofAction}`,
+    `Context recovery: ${profile.contextRecoveryAction}`,
+    `Xcode-only tools allowed by default: ${profile.xcodeToolsAllowed ? "yes" : "no"}`,
+    "Avoid:",
+    ...profile.avoid.map((item) => `- ${item}`),
+  ].join("\n");
+}
+
+function patchFirstProfile(input: {
+  agent: AxintAgentProfileName;
+  label: string;
+  writeAction: string;
+}): AxintAgentToolProfile {
+  return {
+    agent: input.agent,
+    label: input.label,
+    editingMode: "patch-first",
+    xcodeToolsAllowed: false,
+    defaultWriteAction: input.writeAction,
+    finishAction:
+      "Summarize Axint validation, Cloud Check, and build/test proof. Do not call axint.xcode.guard unless this chat is actually running inside Xcode.",
+    contextRecoveryAction:
+      "Call axint.session.start, read .axint context files, call axint.status, then axint.workflow.check.",
+    proofAction:
+      "Use axint.swift.validate, axint.cloud.check, and axint.run or shell xcodebuild evidence when available.",
+    avoid: [
+      "Do not call axint.xcode.write for dirty existing files; patch surgically instead.",
+      "Do not call axint.xcode.guard as a routine finish gate outside Xcode.",
+      "Do not rely on Xcode packet readers unless Xcode emitted those packets.",
+    ],
+  };
+}

--- a/src/project/context-index.ts
+++ b/src/project/context-index.ts
@@ -17,10 +17,20 @@ export interface ProjectContextFileSummary {
   lines: number;
   imports: string[];
   symbols: string[];
+  testCases: string[];
+  accessibilityIdentifiers: string[];
   swiftUI: boolean;
   appIntent: boolean;
+  xctest: boolean;
   hasInputControls: boolean;
+  hasActionControls: boolean;
+  hasNavigationControls: boolean;
+  hasAccessibilityQueries: boolean;
   hasOverlay: boolean;
+  hasHitTestingOverride: boolean;
+  hasContentShape: boolean;
+  hasZIndex: boolean;
+  hasLayeringStack: boolean;
   hasDisabledState: boolean;
   hasGestureCapture: boolean;
   hasFocusState: boolean;
@@ -229,14 +239,30 @@ export function renderProjectContextIndex(
         const flags = [
           file.swiftUI ? "SwiftUI" : undefined,
           file.appIntent ? "AppIntent" : undefined,
+          file.xctest ? "XCTest" : undefined,
           file.hasInputControls ? "inputs" : undefined,
+          file.hasActionControls ? "actions" : undefined,
+          file.hasNavigationControls ? "navigation" : undefined,
+          file.hasAccessibilityQueries ? "UI-test queries" : undefined,
           file.hasOverlay ? "overlay" : undefined,
+          file.hasHitTestingOverride ? "hit-testing" : undefined,
+          file.hasContentShape ? "contentShape" : undefined,
+          file.hasZIndex ? "zIndex" : undefined,
+          file.hasLayeringStack ? "layering" : undefined,
           file.hasDisabledState ? "disabled" : undefined,
           file.hasGestureCapture ? "gesture" : undefined,
           file.hasFocusState ? "focus" : undefined,
           file.hasModalPresentation ? "modal" : undefined,
         ].filter(Boolean);
-        return `- ${file.path}: ${file.lines} lines${flags.length > 0 ? ` — ${flags.join(", ")}` : ""}`;
+        const ids =
+          file.accessibilityIdentifiers.length > 0
+            ? ` IDs: ${file.accessibilityIdentifiers.slice(0, 5).join(", ")}`
+            : "";
+        const tests =
+          file.testCases.length > 0
+            ? ` Tests: ${file.testCases.slice(0, 4).join(", ")}`
+            : "";
+        return `- ${file.path}: ${file.lines} lines${flags.length > 0 ? ` — ${flags.join(", ")}` : ""}${ids}${tests}`;
       })
     );
   }
@@ -312,6 +338,21 @@ export function buildProjectContextHint(input: {
     );
   }
 
+  if (
+    input.focus === "interactive-input" &&
+    projectContext.topInteractionRiskFiles.length > 0
+  ) {
+    summary.push(
+      `Interaction map: ${projectContext.topInteractionRiskFiles
+        .slice(0, 5)
+        .map(
+          (file) =>
+            `${file.path}${file.reasons.length > 0 ? ` (${file.reasons.slice(0, 3).join(", ")})` : ""}`
+        )
+        .join(", ")}.`
+    );
+  }
+
   return {
     path: contextPath,
     summary,
@@ -361,13 +402,38 @@ function summarizeSwiftFile(
       .map((match) => match[1])
       .slice(0, 12)
   );
+  const testCases = uniqueStrings(
+    Array.from(source.matchAll(/\bfunc\s+(test[A-Za-z0-9_]*)\s*\(/g)).map(
+      (match) => match[1]
+    )
+  ).slice(0, 12);
+  const accessibilityIdentifiers = uniqueStrings(
+    Array.from(
+      source.matchAll(
+        /\.accessibilityIdentifier\s*\(\s*"([^"]+)"\s*\)|app\.(?:buttons|staticTexts|textFields|textViews|otherElements|scrollViews|tables|collectionViews)\s*\[\s*"([^"]+)"\s*\]/g
+      )
+    ).map((match) => match[1] ?? match[2])
+  ).slice(0, 20);
   const swiftUI =
     imports.includes("SwiftUI") ||
     /\b:\s*View\b/.test(source) ||
     /\bWindowGroup\s*\{/.test(source);
   const appIntent = imports.includes("AppIntents") || /\bAppIntent\b/.test(source);
+  const xctest = imports.includes("XCTest") || /\bXCTestCase\b/.test(source);
   const hasInputControls = /\b(TextField|TextEditor|SecureField)\s*\(/.test(source);
+  const hasActionControls =
+    /\b(Button|Toggle|Picker|Stepper|Slider|Menu|NavigationLink)\s*\(/.test(source);
+  const hasNavigationControls =
+    /\b(NavigationStack|NavigationSplitView|NavigationLink|TabView)\b/.test(source);
+  const hasAccessibilityQueries =
+    /\bXCUIApplication\b|app\.(?:buttons|staticTexts|textFields|textViews|otherElements|scrollViews|tables|collectionViews)/.test(
+      source
+    );
   const hasOverlay = /\.overlay\s*(?:\(|\{)/.test(source);
+  const hasHitTestingOverride = /\.allowsHitTesting\s*\(/.test(source);
+  const hasContentShape = /\.contentShape\s*\(/.test(source);
+  const hasZIndex = /\.zIndex\s*\(/.test(source);
+  const hasLayeringStack = /\bZStack\s*(?:\(|\{)/.test(source);
   const hasDisabledState = /\.disabled\s*\(/.test(source);
   const hasGestureCapture =
     /\.highPriorityGesture\s*\(/.test(source) ||
@@ -388,9 +454,37 @@ function summarizeSwiftFile(
     riskScore += 3;
     reasons.push("input controls");
   }
+  if (hasActionControls) {
+    riskScore += 1;
+    reasons.push("action controls");
+  }
+  if (hasNavigationControls) {
+    riskScore += 1;
+    reasons.push("navigation controls");
+  }
+  if (hasAccessibilityQueries) {
+    riskScore += 2;
+    reasons.push("UI-test accessibility queries");
+  }
   if (hasOverlay) {
     riskScore += 2;
     reasons.push("overlay");
+  }
+  if (hasHitTestingOverride) {
+    riskScore += 3;
+    reasons.push("hit-testing override");
+  }
+  if (hasContentShape) {
+    riskScore += 1;
+    reasons.push("content shape");
+  }
+  if (hasZIndex) {
+    riskScore += 2;
+    reasons.push("z-index layering");
+  }
+  if (hasLayeringStack) {
+    riskScore += 1;
+    reasons.push("layering stack");
   }
   if (hasDisabledState) {
     riskScore += 2;
@@ -422,10 +516,20 @@ function summarizeSwiftFile(
     lines: lines.length,
     imports,
     symbols,
+    testCases,
+    accessibilityIdentifiers,
     swiftUI,
     appIntent,
+    xctest,
     hasInputControls,
+    hasActionControls,
+    hasNavigationControls,
+    hasAccessibilityQueries,
     hasOverlay,
+    hasHitTestingOverride,
+    hasContentShape,
+    hasZIndex,
+    hasLayeringStack,
     hasDisabledState,
     hasGestureCapture,
     hasFocusState,
@@ -570,10 +674,15 @@ function relatedFileScore(
   if (input.focus === "interactive-input") {
     if (file.hasInputControls) score += 5;
     if (file.hasOverlay) score += 4;
+    if (file.hasHitTestingOverride) score += 4;
+    if (file.hasZIndex) score += 3;
+    if (file.hasLayeringStack) score += 2;
+    if (file.hasContentShape) score += 1;
     if (file.hasDisabledState) score += 4;
     if (file.hasGestureCapture) score += 3;
     if (file.hasFocusState) score += 3;
     if (file.hasModalPresentation) score += 2;
+    if (file.hasAccessibilityQueries) score += 3;
   }
 
   if (input.focus === "runtime") {

--- a/src/project/docs-context.ts
+++ b/src/project/docs-context.ts
@@ -1,21 +1,45 @@
+import {
+  buildAgentToolProfile,
+  renderAgentToolProfile,
+  type AxintAgentProfileName,
+} from "./agent-profile.js";
+
 export interface AxintDocsContextInput {
   projectName?: string;
   expectedVersion?: string;
   platform?: string;
+  agent?: AxintAgentProfileName;
 }
 
 export function buildAxintDocsContext(input: AxintDocsContextInput = {}): string {
   const projectName = input.projectName ?? "this Apple project";
   const expectedVersion = input.expectedVersion ?? "the project-pinned version";
   const platform = input.platform ?? "the target Apple platform";
+  const profile = buildAgentToolProfile(input.agent);
+  const xcodeGuardStep = profile.xcodeToolsAllowed
+    ? "`axint.xcode.guard`: writes `.axint/guard/latest.*` so the user can audit whether Axint was used after a long Xcode task."
+    : "`axint.workflow.check`: use the active agent profile as the guard. Patch-first clients should not call Xcode-only guard/write tools unless they are actually inside Xcode.";
+  const guardLoopStep = profile.xcodeToolsAllowed
+    ? "`axint.xcode.guard` proves the Xcode agent is still inside the Axint loop."
+    : "`axint.workflow.check` keeps patch-first agents inside the Axint loop without pretending Xcode-only guard proof exists.";
+  const writeStep = profile.xcodeToolsAllowed
+    ? "`axint.xcode.write` writes Swift files through the guard path and runs validation/Cloud Check immediately."
+    : `${profile.defaultWriteAction}; then validate with \`axint.swift.validate\` and \`axint.cloud.check\`.`;
 
   return `# Axint Docs Context
 
 Project: ${projectName}
 Platform: ${platform}
 Expected Axint version: ${expectedVersion}
+Agent profile: ${profile.label}
 
 This is the project-local docs memory. It exists because agents forget web docs after context compaction. Reload this file at the start of a new chat, after compaction, and before any long Apple-native coding pass.
+
+## Agent Tool Lane
+
+\`\`\`text
+${renderAgentToolProfile(profile)}
+\`\`\`
 
 ## Read Order After Context Loss
 
@@ -27,9 +51,10 @@ When a chat is new, compacted, summarized, or confused, reload context in this o
 4. \`.axint/project.json\`: machine-readable gates and pinned version.
 5. \`AGENTS.md\` and \`CLAUDE.md\`: local instructions for the active agent.
 6. \`axint.session.start\`: writes \`.axint/session/current.json\` and returns the session token.
-7. \`axint.xcode.guard\`: writes \`.axint/guard/latest.*\` so the user can audit whether Axint was used after a long Xcode task.
-8. \`axint.status\`: current MCP version and restart/setup guidance.
-9. \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
+7. ${xcodeGuardStep}
+8. \`axint.status\`: current MCP version and same-thread reload/setup guidance.
+9. \`axint.upgrade\`: use this if the running MCP version is stale so the agent can keep the current thread and reload only the MCP process.
+10. \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
 
 If any local context file is missing, call \`axint.context.memory\` and \`axint.context.docs\`, then continue from those returned documents.
 
@@ -49,7 +74,7 @@ Examples:
 
 If the agent cannot name the current checkpoint, it must stop and run \`axint.workflow.check\`.
 
-For Xcode work, prefer \`axint.xcode.guard\` as the checkpoint because it creates durable proof under \`.axint/guard/latest.*\`.
+${profile.xcodeToolsAllowed ? "For Xcode work, prefer `axint.xcode.guard` as the checkpoint because it creates durable proof under `.axint/guard/latest.*`." : "For patch-first work, the durable proof is the workflow-check report, validator/Cloud Check output, build/test evidence, and the host-native diff. Do not manufacture Xcode guard proof outside Xcode."}
 
 ## What Axint Is
 
@@ -71,23 +96,24 @@ Use Axint for:
 Use this loop before ordinary hand-written Swift:
 
 1. \`axint.status\` confirms the running MCP version.
-2. \`axint.session.start\` creates a durable token for the current agent pass.
-3. \`axint.xcode.guard\` proves the Xcode agent is still inside the Axint loop.
-4. \`axint.context.memory\` reloads compact operating memory when local files are missing.
-5. \`axint.context.docs\` reloads this docs context when local files are missing.
-6. \`axint.workflow.check\` verifies the agent is at the right gate and has the active token.
-7. \`axint.suggest\` proposes relevant Apple-native surfaces from the app description.
-8. \`axint.feature\` generates a package of surfaces: intent, view, widget, component, app, store, tests, plist, and entitlements.
-9. \`axint.xcode.write\` writes Swift files through the guard path and runs validation/Cloud Check immediately.
-10. \`axint.scaffold\` creates TypeScript \`defineIntent(...)\` source for an App Intent.
-11. \`axint.compile\` compiles TypeScript intent source to Swift + Info.plist + entitlements.
-12. \`axint.schema.compile\` compiles low-token JSON directly to Swift.
-13. \`axint.tokens.ingest\` converts design tokens into SwiftUI token enums.
-14. \`axint.swift.validate\` checks changed Swift before Xcode build.
-15. \`axint.swift.fix\` applies mechanical Swift repairs when safe.
-16. \`axint.cloud.check\` runs coverage-aware Cloud Check with source plus build/test/runtime evidence.
-17. \`axint.fix-packet\` reads the latest AI-ready repair packet.
-18. Xcode build and tests provide runtime proof.
+2. \`axint.upgrade\` checks for a newer package when the running MCP version is stale and returns same-thread reload instructions.
+3. \`axint.session.start\` creates a durable token for the current agent pass.
+4. ${guardLoopStep}
+5. \`axint.context.memory\` reloads compact operating memory when local files are missing.
+6. \`axint.context.docs\` reloads this docs context when local files are missing.
+7. \`axint.workflow.check\` verifies the agent is at the right gate and has the active token.
+8. \`axint.suggest\` proposes relevant Apple-native surfaces from the app description.
+9. \`axint.feature\` generates a package of surfaces: intent, view, widget, component, app, store, tests, plist, and entitlements.
+10. ${writeStep}
+11. \`axint.scaffold\` creates TypeScript \`defineIntent(...)\` source for an App Intent.
+12. \`axint.compile\` compiles TypeScript intent source to Swift + Info.plist + entitlements.
+13. \`axint.schema.compile\` compiles low-token JSON directly to Swift.
+14. \`axint.tokens.ingest\` converts design tokens into SwiftUI token enums.
+15. \`axint.swift.validate\` checks changed Swift before Xcode build.
+16. \`axint.swift.fix\` applies mechanical Swift repairs when safe.
+17. \`axint.cloud.check\` runs coverage-aware Cloud Check with source plus build/test/runtime evidence.
+18. \`axint.fix-packet\` reads the latest AI-ready repair packet.
+19. Xcode build and tests provide runtime proof.
 
 ## Axint Language And Input Surfaces
 
@@ -147,11 +173,12 @@ axint.tokens.ingest -> axint.suggest -> axint.feature with context -> axint.swif
 
 ## MCP Tool Map
 
-- \`axint.status\`: running version, uptime, package path, restart/update help.
+- \`axint.status\`: running version, uptime, package path, same-thread reload/update help.
+- \`axint.upgrade\`: checks or applies a package upgrade, writes \`.axint/upgrade/latest.*\`, and returns a same-thread continuation prompt.
 - \`axint.doctor\`: checks version truth, Node/npm/npx paths, MCP config, Xcode Claude config, and project memory files.
 - \`axint.session.start\`: starts the enforced session, writes \`.axint/session/current.json\`, and returns the token required by workflow gates.
-- \`axint.xcode.guard\`: checks for Xcode drift, enforces fresh Axint evidence, and writes \`.axint/guard/latest.json\` plus \`.axint/guard/latest.md\`.
-- \`axint.xcode.write\`: writes files inside the project through Axint, then runs Swift validation, Cloud Check, and guard proof for Swift files.
+- \`axint.xcode.guard\`: Xcode-only drift guard that enforces fresh Axint evidence and writes \`.axint/guard/latest.json\` plus \`.axint/guard/latest.md\`.
+- \`axint.xcode.write\`: Xcode-only guarded write lane for files inside the project; Codex/Claude/Cursor/Cowork should use their native patch/edit lane unless they are actually running inside Xcode.
 - \`axint.project.pack\`: returns first-try project setup files without writing.
 - \`axint.context.memory\`: returns compact operating memory for context recovery.
 - \`axint.context.docs\`: returns this docs context for context recovery.
@@ -180,7 +207,7 @@ Use \`axint.workflow.check\` at these stages:
 - \`pre-build\`: requires Swift validation and Cloud Check.
 - \`pre-commit\`: requires validation, Cloud Check, build evidence, and focused tests when relevant.
 
-A \`ready\` workflow check is not the last Axint step. The report includes \`Next Axint Action\`; call that tool before returning to raw Xcode tools or hand-written Swift.
+A \`ready\` workflow check is not the last Axint step. The report includes \`Next Axint Action\`; call that action before returning to broad Apple-native edits.
 
 ## Cloud Check Rules
 
@@ -200,9 +227,9 @@ When the app freezes, hangs, beachballs, launch-tests time out, or UI is unrespo
 Inside Xcode Claude or another Xcode agent:
 
 1. Confirm both \`xcode-tools\` and \`axint\` MCP servers are available.
-2. If Axint is missing, run the setup command in a normal terminal, then restart the Xcode agent chat.
+2. If Axint is missing, run the setup command in a normal terminal, then reload or reconnect the Axint MCP server/tool process.
 3. If npm/npx is missing in Xcode's restricted PATH, use the durable Homebrew path in \`.mcp.json\`.
-4. Always call \`axint.status\` after restart to verify the active version.
+4. Always call \`axint.status\` after reload to verify the active version.
 5. Xcode build/test failures are Axint feedback if Axint passed the same code.
 
 ## Setup Commands

--- a/src/project/operating-memory.ts
+++ b/src/project/operating-memory.ts
@@ -1,21 +1,45 @@
+import {
+  buildAgentToolProfile,
+  renderAgentToolProfile,
+  type AxintAgentProfileName,
+} from "./agent-profile.js";
+
 export interface AxintOperatingMemoryInput {
   projectName?: string;
   expectedVersion?: string;
   platform?: string;
+  agent?: AxintAgentProfileName;
 }
 
 export function buildAxintOperatingMemory(input: AxintOperatingMemoryInput = {}): string {
   const projectName = input.projectName ?? "this Apple project";
   const expectedVersion = input.expectedVersion ?? "the project-pinned version";
   const platform = input.platform ?? "the target Apple platform";
+  const profile = buildAgentToolProfile(input.agent);
+  const xcodeCheckpoint = profile.xcodeToolsAllowed
+    ? "In Xcode, call `axint.xcode.guard` before long tasks, after context recovery, and whenever the agent might drift. It writes `.axint/guard/latest.*` so the user can audit whether Axint was actually used."
+    : "Outside Xcode, do not use `axint.xcode.guard` or `axint.xcode.write` as the routine lane. Use the active client's patch/edit primitive, then prove the work with `axint.workflow.check`, `axint.swift.validate`, `axint.cloud.check`, and `axint.run` or shell build/test evidence.";
+  const writeLane = profile.xcodeToolsAllowed
+    ? "Prefer `axint.xcode.write` for new Swift files so the write itself runs Swift validation, Cloud Check, and guard proof."
+    : `Use this host's write lane: ${profile.defaultWriteAction}. Only use \`axint.xcode.write\` when the active session is actually inside Xcode.`;
+  const recoveryGuard = profile.xcodeToolsAllowed
+    ? 'Call `axint.xcode.guard` with `stage: "context-recovery"` so this chat writes durable guard proof.'
+    : "Use `axint.workflow.check` with the active `agent` value as the recovery gate; do not invent Xcode guard proof in a patch-first client.";
 
   return `# Axint Operating Memory
 
 Project: ${projectName}
 Platform: ${platform}
 Expected Axint version: ${expectedVersion}
+Agent profile: ${profile.label}
 
 This file is the compact Axint memory for agents. Read it with \`.axint/AXINT_REHYDRATE.md\` and \`.axint/AXINT_DOCS_CONTEXT.md\` at the start of every new chat, after context compaction, and before any long Apple-native implementation pass.
+
+## Agent Tool Lane
+
+\`\`\`text
+${renderAgentToolProfile(profile)}
+\`\`\`
 
 ## Default Posture
 
@@ -28,8 +52,8 @@ Work in Axint first:
 3. Plan with \`axint.suggest\`.
 4. Generate or scaffold with \`axint.feature\`, \`axint.scaffold\`, \`axint.compile\`, or \`axint.schema.compile\`.
 5. Prefer \`axint.run\` when you need the whole loop in one call. It starts/refreshes the session, validates, Cloud Checks, builds/tests with \`xcodebuild\`, and writes \`.axint/run/latest.*\`.
-6. In Xcode, call \`axint.xcode.guard\` before long tasks, after context recovery, and whenever the agent might drift. It writes \`.axint/guard/latest.*\` so the user can audit whether Axint was actually used.
-7. Prefer \`axint.xcode.write\` for new Swift files so the write itself runs Swift validation, Cloud Check, and guard proof.
+6. ${xcodeCheckpoint}
+7. ${writeLane}
 8. If running tools manually, validate changed Swift with \`axint.swift.validate\`.
 9. Run \`axint.cloud.check\` with source and any Xcode/test/runtime evidence.
 10. Build and test with Xcode or \`axint run\`.
@@ -40,7 +64,7 @@ Work in Axint first:
 Models lose memory when chats compact. The project does not. When context is missing, compacted, or uncertain:
 
 1. Call \`axint.session.start\` and keep the returned \`sessionToken\`.
-2. Call \`axint.xcode.guard\` with \`stage: "context-recovery"\` so this chat writes durable guard proof.
+2. ${recoveryGuard}
 3. Read \`.axint/AXINT_REHYDRATE.md\`, this file, \`.axint/AXINT_DOCS_CONTEXT.md\`, \`AGENTS.md\`, \`CLAUDE.md\`, and \`.axint/project.json\`.
 4. If the docs context file is missing, call \`axint.context.docs\`.
 5. List MCP servers/tools and confirm \`axint\` is present.
@@ -48,13 +72,14 @@ Models lose memory when chats compact. The project does not. When context is mis
 7. Call \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
 8. Name the next Axint tool before editing code.
 
-If Axint is missing or stale, stop. Do not continue by hand. Tell the user to reinstall/update Axint, rerun the Xcode setup, and restart the Xcode agent chat.
+If Axint is missing or stale, stop. Do not continue by hand. Run \`axint.upgrade\` or tell the user to run \`axint upgrade --apply\`, then reload or reconnect only the Axint MCP server/tool process. Keep the current Codex or Claude thread when the client supports MCP reload.
 
 ## Drift Guard
 
 Do not spend more than 10 minutes or make broad multi-file Swift changes without an Axint checkpoint. A checkpoint means one of:
 
 - \`axint.workflow.check\`
+- \`axint.upgrade\`
 - \`axint.xcode.guard\`
 - \`axint.xcode.write\`
 - \`axint.session.start\`
@@ -73,7 +98,7 @@ Axint checkpoint: <stage> · <last Axint tool> · <result> · next <proof step>
 
 If the agent cannot fill this out, it must run \`axint.workflow.check\` before continuing.
 
-For Xcode work, prefer \`axint.xcode.guard\` as the checkpoint because it writes durable proof under \`.axint/guard/latest.*\`.
+${profile.xcodeToolsAllowed ? "For Xcode work, prefer `axint.xcode.guard` as the checkpoint because it writes durable proof under `.axint/guard/latest.*`." : "For Codex, Claude Code, Cursor, and Cowork, the checkpoint is the Axint workflow/report evidence plus the host-native patch diff; do not fake an Xcode guard packet."}
 
 ## Proof Rules
 
@@ -96,7 +121,7 @@ For Xcode work, prefer \`axint.xcode.guard\` as the checkpoint because it writes
 ## Recovery Prompt
 
 \`\`\`text
-Call axint.xcode.guard with stage=context-recovery, then call axint.session.start if the guard asks for it and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If docs context is missing, call axint.context.docs. Then list MCP servers, call axint.status, call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true. For build/test/runtime proof, use axint.run instead of manually remembering every Axint gate.
+Call axint.session.start for this project and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If docs context is missing, call axint.context.docs. Then list MCP servers, call axint.status, call axint.workflow.check with agent="${profile.agent}", stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true. Use this write lane: ${profile.defaultWriteAction}. For build/test/runtime proof, use axint.run instead of manually remembering every Axint gate.
 \`\`\`
 `;
 }

--- a/src/project/rehydration.ts
+++ b/src/project/rehydration.ts
@@ -1,26 +1,50 @@
+import {
+  buildAgentToolProfile,
+  renderAgentToolProfile,
+  type AxintAgentProfileName,
+} from "./agent-profile.js";
+
 export interface AxintRehydrationInput {
   projectName?: string;
   expectedVersion?: string;
   platform?: string;
   sessionToken?: string;
+  agent?: AxintAgentProfileName;
 }
 
 export function buildAxintRehydrationGuide(input: AxintRehydrationInput = {}): string {
   const projectName = input.projectName ?? "this Apple project";
   const expectedVersion = input.expectedVersion ?? "the project-pinned version";
   const platform = input.platform ?? "the target Apple platform";
+  const profile = buildAgentToolProfile(input.agent);
   const tokenLine = input.sessionToken
     ? `Active session token: ${input.sessionToken}`
     : "Active session token: call axint.session.start to create one";
+  const contextGuard = profile.xcodeToolsAllowed
+    ? 'Call `axint.xcode.guard` with `stage: "context-recovery"` so this chat writes `.axint/guard/latest.*` proof.'
+    : "Use `axint.workflow.check` with this agent profile for context recovery. Do not call Xcode-only guard/write tools unless the active host is Xcode.";
+  const longTaskGuard = profile.xcodeToolsAllowed
+    ? "`axint.xcode.guard` with the current `stage` before starting and again before claiming done."
+    : "`axint.workflow.check` plus validator, Cloud Check, and build/test evidence before broad edits and before claiming done.";
+  const writeLane = profile.xcodeToolsAllowed
+    ? "New Swift file: prefer `axint.xcode.write` so the write runs validation, Cloud Check, and guard proof immediately."
+    : `Write lane: ${profile.defaultWriteAction}. Only use \`axint.xcode.write\` inside Xcode.`;
 
   return `# Axint Rehydration Contract
 
 Project: ${projectName}
 Platform: ${platform}
 Expected Axint version: ${expectedVersion}
+Agent profile: ${profile.label}
 ${tokenLine}
 
-This file is the shortest durable recovery contract for an AI agent working on this project. Read it after every new chat, context compaction, MCP restart, long coding drift, or failed build/test where Axint was not clearly involved.
+This file is the shortest durable recovery contract for an AI agent working on this project. Read it after every new chat, context compaction, MCP reload, long coding drift, or failed build/test where Axint was not clearly involved.
+
+## Agent Tool Lane
+
+\`\`\`text
+${renderAgentToolProfile(profile)}
+\`\`\`
 
 ## Non-Negotiable Rule
 
@@ -29,15 +53,16 @@ The model's memory is not the source of truth. These project files are. If the a
 ## Rehydrate In This Exact Order
 
 1. Call \`axint.session.start\` for this project and keep the returned \`sessionToken\`.
-2. Call \`axint.xcode.guard\` with \`stage: "context-recovery"\` so this chat writes \`.axint/guard/latest.*\` proof.
+2. ${contextGuard}
 3. Read \`.axint/AXINT_REHYDRATE.md\`, \`.axint/AXINT_MEMORY.md\`, and \`.axint/AXINT_DOCS_CONTEXT.md\`.
 4. Read \`AGENTS.md\`, \`CLAUDE.md\`, or \`.axint/project.json\` if present.
-5. Call \`axint.status\` and report the running MCP version.
+5. Call \`axint.status\` and report the running MCP version. If it is stale, call \`axint.upgrade\` or ask the user to run \`axint upgrade --apply\`, then reload only the Axint MCP server/tool process.
 6. Call \`axint.workflow.check\` with:
 
 \`\`\`json
 {
   "stage": "context-recovery",
+  "agent": "${profile.agent}",
   "sessionStarted": true,
   "sessionToken": "<token>",
   "readRehydrationContext": true,
@@ -53,11 +78,11 @@ The model's memory is not the source of truth. These project files are. If the a
 
 - Planning: \`axint.workflow.check\` with \`stage: "planning"\` and \`ranSuggest: true\`.
 - New surface: \`axint.workflow.check\` with \`stage: "before-write"\`, \`ranSuggest: true\`, and either \`ranFeature: true\` or a real \`featureBypassReason\`.
-- Long Xcode task: \`axint.xcode.guard\` with the current \`stage\` before starting and again before claiming done.
-- New Swift file: prefer \`axint.xcode.write\` so the write runs validation, Cloud Check, and guard proof immediately.
+- Long task: ${longTaskGuard}
+- ${writeLane}
 - Before build: prefer \`axint.run\` for the full enforced loop. If doing it manually, call \`axint.workflow.check\` with \`stage: "pre-build"\`, \`ranSwiftValidate: true\`, and \`ranCloudCheck: true\`.
 - Before done: \`axint.workflow.check\` with \`stage: "pre-commit"\`, validation, Cloud Check, build evidence, and relevant tests.
-- If \`axint.workflow.check\` returns \`ready\`, it is not permission to stop using Axint. Read the \`Next Axint Action\` line and call that tool before ordinary Xcode work.
+- If \`axint.workflow.check\` returns \`ready\`, it is not permission to stop using Axint. Read the \`Next Axint Action\` line and call that action before broad Apple-native work.
 
 ## Drift Triggers
 
@@ -77,6 +102,6 @@ Every long response should keep this visible:
 Axint checkpoint: <stage> · <last Axint tool> · <result> · next <proof step>
 \`\`\`
 
-If the agent cannot fill that line honestly, it must run \`axint.xcode.guard\` or \`axint.workflow.check\` before continuing.
+If the agent cannot fill that line honestly, it must run \`axint.workflow.check\` before continuing. Xcode-hosted sessions may also run \`axint.xcode.guard\` for durable Xcode guard proof.
 `;
 }

--- a/src/project/session.ts
+++ b/src/project/session.ts
@@ -1,11 +1,18 @@
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
+import {
+  buildAgentToolProfile,
+  normalizeAxintAgent,
+  renderAgentToolProfile,
+  type AxintAgentProfileName,
+  type AxintAgentToolProfile,
+} from "./agent-profile.js";
 import { buildAxintDocsContext } from "./docs-context.js";
 import { buildAxintOperatingMemory } from "./operating-memory.js";
 import { buildAxintRehydrationGuide } from "./rehydration.js";
 
-export type AxintSessionAgent = "claude" | "codex" | "cursor" | "xcode" | "all";
+export type AxintSessionAgent = AxintAgentProfileName;
 export type AxintSessionFormat = "markdown" | "json";
 
 export interface AxintSessionStartInput {
@@ -33,6 +40,7 @@ export interface AxintSessionRecord {
   expectedVersion: string;
   platform: string;
   agent: AxintSessionAgent;
+  toolProfile: AxintAgentToolProfile;
   startedAt: string;
   expiresAt: string;
   memoryHash: string;
@@ -63,7 +71,8 @@ export function startAxintSession(
   const projectName = input.projectName ?? basename(targetDir) ?? "AppleApp";
   const expectedVersion = input.expectedVersion ?? "unknown";
   const platform = input.platform ?? "the target Apple platform";
-  const agent = input.agent ?? "all";
+  const agent = normalizeAxintAgent(input.agent);
+  const toolProfile = buildAgentToolProfile(agent);
   const ttlMinutes = input.ttlMinutes ?? 720;
   const startedAt = new Date();
   const expiresAt = new Date(startedAt.getTime() + ttlMinutes * 60_000);
@@ -71,11 +80,13 @@ export function startAxintSession(
     projectName,
     expectedVersion,
     platform,
+    agent,
   });
   const docsContext = buildAxintDocsContext({
     projectName,
     expectedVersion,
     platform,
+    agent,
   });
   const token = `axsess_${randomUUID()}`;
   const rehydrationContext = buildAxintRehydrationGuide({
@@ -83,6 +94,7 @@ export function startAxintSession(
     expectedVersion,
     platform,
     sessionToken: token,
+    agent,
   });
   const session: AxintSessionRecord = {
     schema: "https://axint.ai/schemas/session.v1.json",
@@ -92,6 +104,7 @@ export function startAxintSession(
     expectedVersion,
     platform,
     agent,
+    toolProfile,
     startedAt: startedAt.toISOString(),
     expiresAt: expiresAt.toISOString(),
     memoryHash: hashText(memory),
@@ -132,8 +145,11 @@ export function startAxintSession(
     ],
   };
   const sessionPath = sessionFilePath(targetDir);
+  const tokenSessionPath = sessionTokenFilePath(targetDir, token);
   mkdirSync(dirname(sessionPath), { recursive: true });
   writeFileSync(sessionPath, `${JSON.stringify(session, null, 2)}\n`, "utf-8");
+  mkdirSync(dirname(tokenSessionPath), { recursive: true });
+  writeFileSync(tokenSessionPath, `${JSON.stringify(session, null, 2)}\n`, "utf-8");
   const contextFiles =
     input.writeContextFiles === false
       ? []
@@ -155,6 +171,7 @@ export function startAxintSession(
     workflowCheckArgs: {
       cwd: targetDir,
       stage: "context-recovery",
+      agent,
       sessionStarted: true,
       sessionToken: token,
       readRehydrationContext: true,
@@ -169,6 +186,28 @@ export function readCurrentAxintSession(
   targetDir: string = process.cwd()
 ): AxintSessionRecord | undefined {
   const path = sessionFilePath(resolve(targetDir));
+  return readAxintSessionFile(path);
+}
+
+export function readAxintSessionByToken(
+  targetDir: string = process.cwd(),
+  token?: string
+): AxintSessionRecord | undefined {
+  if (!token) return undefined;
+  const path = sessionTokenFilePath(resolve(targetDir), token);
+  const session = readAxintSessionFile(path);
+  return session?.token === token ? session : undefined;
+}
+
+export function axintSessionPath(
+  targetDir: string = process.cwd(),
+  token?: string
+): string {
+  const dir = resolve(targetDir);
+  return token ? sessionTokenFilePath(dir, token) : sessionFilePath(dir);
+}
+
+function readAxintSessionFile(path: string): AxintSessionRecord | undefined {
   if (!existsSync(path)) return undefined;
   try {
     const parsed = JSON.parse(readFileSync(path, "utf-8")) as AxintSessionRecord;
@@ -190,7 +229,13 @@ export function validateAxintSessionToken(
     sessionStarted?: boolean;
   } = {}
 ): { ok: boolean; detail: string; session?: AxintSessionRecord } {
-  const session = readCurrentAxintSession(input.cwd);
+  const targetDir = resolve(input.cwd ?? process.cwd());
+  const currentSession = readCurrentAxintSession(targetDir);
+  const tokenSession =
+    input.sessionToken && currentSession?.token !== input.sessionToken
+      ? readAxintSessionByToken(targetDir, input.sessionToken)
+      : undefined;
+  const session = tokenSession ?? currentSession;
   if (!session) {
     return {
       ok: false,
@@ -216,11 +261,18 @@ export function validateAxintSessionToken(
   if (input.sessionToken && input.sessionToken !== session.token) {
     return {
       ok: false,
-      detail: "supplied sessionToken does not match .axint/session/current.json.",
+      detail:
+        "supplied sessionToken does not match any active Axint session for this project.",
       session,
     };
   }
-  return { ok: true, detail: "Axint session token is valid.", session };
+  return {
+    ok: true,
+    detail: tokenSession
+      ? "Axint session token is valid from token-scoped session history."
+      : "Axint session token is valid.",
+    session,
+  };
 }
 
 export function renderAxintSessionStart(
@@ -235,6 +287,7 @@ export function renderAxintSessionStart(
     `- Project: ${result.session.projectName}`,
     `- Target: ${result.session.targetDir}`,
     `- Agent: ${result.session.agent}`,
+    `- Tool lane: ${result.session.toolProfile.label} (${result.session.toolProfile.editingMode})`,
     `- Platform: ${result.session.platform}`,
     `- Expected Axint: ${result.session.expectedVersion}`,
     `- Token: ${result.session.token}`,
@@ -252,6 +305,12 @@ export function renderAxintSessionStart(
     "",
     "```json",
     JSON.stringify(result.workflowCheckArgs, null, 2),
+    "```",
+    "",
+    "## Agent Tool Profile",
+    "",
+    "```text",
+    renderAgentToolProfile(result.session.toolProfile),
     "```",
     "",
     "## Recovery Prompt",
@@ -276,6 +335,11 @@ export function renderAxintSessionStart(
 
 function sessionFilePath(targetDir: string): string {
   return resolve(targetDir, ".axint/session/current.json");
+}
+
+function sessionTokenFilePath(targetDir: string, token: string): string {
+  const safeToken = token.replace(/[^A-Za-z0-9_-]/g, "_");
+  return resolve(targetDir, ".axint/session/sessions", `${safeToken}.json`);
 }
 
 function hashText(value: string): string {
@@ -312,6 +376,7 @@ function writeSessionContextFiles(
           projectName: input.session.projectName,
           axintVersion: input.session.expectedVersion,
           platform: input.session.platform,
+          agentProfile: input.session.toolProfile,
           session: {
             required: true,
             file: ".axint/session/current.json",
@@ -325,6 +390,7 @@ function writeSessionContextFiles(
           contextRecovery: {
             requiredWorkflowCheckArgs: {
               stage: "context-recovery",
+              agent: input.session.agent,
               sessionStarted: true,
               sessionToken: "<token>",
               readRehydrationContext: true,
@@ -361,10 +427,14 @@ function buildSessionRecoveryPrompt(session: AxintSessionRecord): string {
   return [
     `Axint session is active for ${session.projectName}.`,
     `Session token: ${session.token}`,
+    `Agent lane: ${session.toolProfile.label}.`,
+    "",
+    "Agent tool profile:",
+    renderAgentToolProfile(session.toolProfile),
     "",
     "Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json.",
     "If either Axint context file is missing, call axint.context.memory and axint.context.docs.",
-    "Then call axint.status and axint.workflow.check with stage context-recovery, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, ranStatus=true, and this sessionToken.",
+    `Then call axint.status and axint.workflow.check with agent=${session.agent}, stage context-recovery, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, ranStatus=true, and this sessionToken.`,
     "Do not edit Apple-native code until that workflow check is ready.",
   ].join("\n");
 }

--- a/src/project/start-pack.ts
+++ b/src/project/start-pack.ts
@@ -1,11 +1,18 @@
 import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
+import {
+  buildAgentToolProfile,
+  normalizeAxintAgent,
+  renderAgentToolProfile,
+  type AxintAgentProfileName,
+  type AxintAgentToolProfile,
+} from "./agent-profile.js";
 import { buildAxintDocsContext } from "./docs-context.js";
 import { buildAxintOperatingMemory } from "./operating-memory.js";
 import { buildAxintRehydrationGuide } from "./rehydration.js";
 
-export type ProjectAgent = "claude" | "codex" | "all";
+export type ProjectAgent = AxintAgentProfileName;
 export type ProjectMcpMode = "local" | "remote";
 export type ProjectStartPackFormat = "markdown" | "json";
 
@@ -62,9 +69,10 @@ export function buildProjectStartPack(
   const projectName = input.projectName ?? basename(targetDir) ?? "AppleApp";
   const version = input.version ?? "unknown";
   const mode = input.mode ?? "local";
-  const agent = input.agent ?? "all";
+  const agent = normalizeAxintAgent(input.agent);
+  const profile = buildAgentToolProfile(agent);
   const mcpConfig = buildMcpConfig(mode);
-  const startPrompt = buildStartPrompt({ projectName, version });
+  const startPrompt = buildStartPrompt({ projectName, version, profile });
   const files: ProjectStartPackFile[] = [
     {
       path: ".mcp.json",
@@ -89,6 +97,7 @@ export function buildProjectStartPack(
       content: buildAxintOperatingMemory({
         projectName,
         expectedVersion: version,
+        agent,
       }),
     },
     {
@@ -98,6 +107,7 @@ export function buildProjectStartPack(
       content: buildAxintRehydrationGuide({
         projectName,
         expectedVersion: version,
+        agent,
       }),
     },
     {
@@ -107,6 +117,7 @@ export function buildProjectStartPack(
       content: buildAxintDocsContext({
         projectName,
         expectedVersion: version,
+        agent,
       }),
     },
     {
@@ -118,20 +129,9 @@ export function buildProjectStartPack(
           projectName,
           axintVersion: version,
           mode,
+          agentProfile: profile,
           docs: DOCS,
-          requiredLoop: [
-            "axint.session.start",
-            "axint.xcode.guard",
-            "axint.status",
-            "axint.workflow.check",
-            "axint.suggest",
-            "axint.feature or axint.scaffold",
-            "axint.xcode.write for guarded file writes when available",
-            "axint.swift.validate",
-            "axint.cloud.check",
-            "axint.run",
-            "Xcode build/test evidence",
-          ],
+          requiredLoop: buildRequiredLoop(profile),
           session: {
             required: true,
             file: ".axint/session/current.json",
@@ -148,13 +148,15 @@ export function buildProjectStartPack(
             ],
             requiredActions: [
               "call axint.session.start",
-              "call axint.xcode.guard with stage=context-recovery",
+              profile.xcodeToolsAllowed
+                ? "call axint.xcode.guard with stage=context-recovery"
+                : "call axint.workflow.check with the active agent profile instead of Xcode-only guard tools",
               "read .axint/AXINT_REHYDRATE.md",
               "read .axint/AXINT_MEMORY.md",
               "read .axint/AXINT_DOCS_CONTEXT.md or call axint.context.docs",
               "read AGENTS.md, CLAUDE.md, or .axint/project.json",
               "call axint.status",
-              "call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readDocsContext=true, readAgentInstructions=true, and ranStatus=true",
+              `call axint.workflow.check with agent=${profile.agent}, stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readDocsContext=true, readAgentInstructions=true, and ranStatus=true`,
               "state the next Axint tool that will be used, or call axint.run for the full validation/build loop",
             ],
           },
@@ -165,7 +167,8 @@ export function buildProjectStartPack(
             preferAxintRunForBuildTestRuntimeProof: true,
             recoverAxintAfterContextCompaction: true,
             doNotWorkLongerThanTenMinutesWithoutAxintCheckpoint: true,
-            preferXcodeGuardBeforeLongTasks: true,
+            preferXcodeGuardBeforeLongTasks: profile.xcodeToolsAllowed,
+            preferHostNativePatchLane: !profile.xcodeToolsAllowed,
           },
         },
         null,
@@ -175,7 +178,7 @@ export function buildProjectStartPack(
     {
       path: ".axint/README.md",
       purpose: "Human-readable local Axint operating manual for this project.",
-      content: buildLocalAxintReadme({ projectName, version, startPrompt }),
+      content: buildLocalAxintReadme({ projectName, version, startPrompt, profile }),
     },
   ];
 
@@ -272,29 +275,47 @@ function buildMcpConfig(mode: ProjectMcpMode): unknown {
   };
 }
 
-function buildStartPrompt(input: { projectName: string; version: string }): string {
+function buildStartPrompt(input: {
+  projectName: string;
+  version: string;
+  profile: AxintAgentToolProfile;
+}): string {
+  const profile = input.profile;
+  const xcodeRecoveryStep = profile.xcodeToolsAllowed
+    ? "2. Call axint.xcode.guard with stage=context-recovery so this chat writes .axint/guard/latest.* proof before any long task."
+    : "2. Stay in this host's tool lane. Do not call axint.xcode.guard or axint.xcode.write unless this chat is actually running inside Xcode.";
+  const mcpServerStep = profile.xcodeToolsAllowed
+    ? "5. List MCP servers/tools and confirm xcode-tools and axint are available."
+    : "5. List MCP servers/tools when the client supports it, and confirm axint is available. If MCP is stale or closed, use the CLI fallback commands instead of pretending the tool call worked.";
+  const writeStep = profile.xcodeToolsAllowed
+    ? "15. When writing new Swift files from MCP, prefer axint.xcode.write so validation, Cloud Check, and guard proof happen with the write."
+    : `15. Write through this host's native lane: ${profile.defaultWriteAction}. Do not route normal Codex/Claude/Cowork/Cursor edits through axint.xcode.write.`;
+
   return [
     `We are working on ${input.projectName}. Use Axint before editing Apple-native code.`,
+    `Active agent lane: ${profile.label} (${profile.editingMode}).`,
     "",
     "First, read the current Axint docs in full enough to follow the workflow:",
     ...DOCS.map((url, index) => `${index + 1}. ${url}`),
     "",
     "Then do this exact startup sequence:",
     "1. Call axint.session.start for this project. Keep the returned sessionToken visible.",
-    "2. Call axint.xcode.guard with stage=context-recovery so this chat writes .axint/guard/latest.* proof before any long task.",
+    xcodeRecoveryStep,
     "3. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, or .axint/project.json if present.",
     "4. If those files are missing, call axint.context.memory and axint.context.docs, then use those as the compact Axint operating memory and docs context.",
-    "5. List MCP servers/tools and confirm axint is available.",
+    mcpServerStep,
     "6. Call axint.status and report the running MCP server version.",
-    "7. Call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.",
+    `7. Call axint.workflow.check with agent=${profile.agent}, stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.`,
     `8. Expected Axint package version from this project pack: ${input.version}.`,
-    "9. If the running MCP version is stale, stop and tell me to update Axint, rerun axint xcode install --project ., and restart this Xcode agent chat.",
-    "10. Call axint.xcode.guard before long tasks, before broad Swift edits, and after any context recovery.",
+    "9. If the running MCP version is stale, stop and call axint.upgrade or tell me to run axint upgrade --apply, then reload only the Axint MCP server/tool process.",
+    profile.xcodeToolsAllowed
+      ? "10. Call axint.xcode.guard before long tasks, before broad Swift edits, and after any context recovery."
+      : "10. Use axint.workflow.check as the long-task guard, plus validate/Cloud Check/build evidence. Do not fake Xcode guard packets outside Xcode.",
     "11. Call axint.workflow.check with sessionToken at planning, before-write, pre-build, and pre-commit checkpoints.",
     "12. Before planning new Apple-native surfaces, call axint.suggest.",
     "13. For generated surfaces, use axint.feature, axint.scaffold, axint.compile, or axint.schema.compile before hand-writing from scratch.",
     "14. Prefer axint.run before each build so the session, workflow gate, Swift validation, Cloud Check, xcodebuild, tests, and runtime evidence stay tied together.",
-    "15. When writing new Swift files from MCP, prefer axint.xcode.write so validation, Cloud Check, and guard proof happen with the write.",
+    writeStep,
     "16. If you cannot use axint.run, manually run axint.swift.validate on changed Swift and axint.cloud.check with source plus Xcode/test/runtime evidence when available.",
     "17. Never claim there is no bug from Axint alone. Cloud Check is static unless build, UI test, or runtime evidence is supplied.",
     "18. If Axint passes but Xcode/tests/runtime fails, report the failure as an Axint feedback signal before continuing.",
@@ -304,15 +325,45 @@ function buildStartPrompt(input: { projectName: string; version: string }): stri
   ].join("\n");
 }
 
+function buildRequiredLoop(profile: AxintAgentToolProfile): string[] {
+  return [
+    "axint.session.start",
+    profile.xcodeToolsAllowed
+      ? "axint.xcode.guard for Xcode-hosted drift proof"
+      : "host-native patch/edit lane; do not call Xcode-only guard/write tools outside Xcode",
+    "axint.status",
+    `axint.workflow.check with agent=${profile.agent}`,
+    "axint.suggest",
+    "axint.feature or axint.scaffold",
+    profile.xcodeToolsAllowed
+      ? "axint.xcode.write for guarded Xcode file writes"
+      : profile.defaultWriteAction,
+    "axint.swift.validate",
+    "axint.cloud.check",
+    "axint.run",
+    "Xcode build/test evidence when available",
+  ];
+}
+
 function buildAgentInstructions(input: {
   projectName: string;
   version: string;
   agent: ProjectAgent;
 }): string {
+  const profile = buildAgentToolProfile(input.agent);
   const agentLine =
     input.agent === "all"
       ? "These rules apply to Claude, Codex, Cursor, and any MCP agent."
       : `These rules apply to ${input.agent}.`;
+  const contextGuardLine = profile.xcodeToolsAllowed
+    ? 'Call `axint.xcode.guard` with `stage: "context-recovery"` so the project records `.axint/guard/latest.*` proof for this chat.'
+    : "Stay in the host-native patch/edit lane; do not call `axint.xcode.guard` or `axint.xcode.write` unless this chat is actually running inside Xcode.";
+  const longTaskGuardLine = profile.xcodeToolsAllowed
+    ? "Call `axint.xcode.guard` after session start, before long tasks, and after context recovery."
+    : "Use `axint.workflow.check` as the long-task guard, and preserve proof with validation, Cloud Check, build/test output, and the host-native diff.";
+  const writeLine = profile.xcodeToolsAllowed
+    ? "Prefer `axint.xcode.write` for new Swift files so Axint validation, Cloud Check, and guard proof happen as part of the write."
+    : `Use this write lane: ${profile.defaultWriteAction}. Do not route normal edits through \`axint.xcode.write\` outside Xcode.`;
   return `# Axint Agent Workflow
 
 Project: ${input.projectName}
@@ -320,12 +371,22 @@ Expected Axint version: ${input.version}
 
 ${agentLine}
 
+## Agent Tool Lane
+
+\`\`\`text
+${renderAgentToolProfile(profile)}
+\`\`\`
+
 ## Start Every New Chat
 
 Paste or follow this prompt:
 
 \`\`\`text
-${buildStartPrompt({ projectName: input.projectName, version: input.version })}
+${buildStartPrompt({
+  projectName: input.projectName,
+  version: input.version,
+  profile: buildAgentToolProfile(input.agent),
+})}
 \`\`\`
 
 ## Context Recovery
@@ -333,7 +394,7 @@ ${buildStartPrompt({ projectName: input.projectName, version: input.version })}
 If the chat was restarted, compacted, summarized, or has drifted into ordinary Xcode coding, run this before continuing:
 
 1. Call \`axint.session.start\` and keep the returned \`sessionToken\`.
-2. Call \`axint.xcode.guard\` with \`stage: "context-recovery"\` so the project records \`.axint/guard/latest.*\` proof for this chat.
+2. ${contextGuardLine}
 3. Read \`.axint/AXINT_REHYDRATE.md\`, \`.axint/AXINT_MEMORY.md\`, \`.axint/AXINT_DOCS_CONTEXT.md\`, \`AGENTS.md\`, \`CLAUDE.md\`, or \`.axint/project.json\`.
 4. If either Axint context file is missing, call \`axint.context.memory\` and \`axint.context.docs\`.
 5. Call \`axint.status\` and compare it with the expected version above.
@@ -345,14 +406,14 @@ Do not rely on model memory alone. Rehydrate the workflow from the files.
 ## Required Loop
 
 1. Call \`axint.session.start\` and persist the returned token in the workflow check calls.
-2. Call \`axint.xcode.guard\` after session start, before long tasks, and after context recovery.
+2. ${longTaskGuardLine}
 3. Read the Axint docs listed in the start prompt.
 4. Call \`axint.status\`.
 5. Call \`axint.workflow.check\` with \`sessionToken\` at session start, after context recovery, before planning, before writing, before building, and before committing.
-6. If \`axint.workflow.check\` returns \`ready\`, call the report's \`Next Axint Action\` before ordinary Xcode work.
+6. If \`axint.workflow.check\` returns \`ready\`, call the report's \`Next Axint Action\` before broad Apple-native work.
 7. Use \`axint.suggest\` for feature planning.
 8. Use \`axint.feature\`, \`axint.scaffold\`, \`axint.compile\`, or \`axint.schema.compile\` for Apple-native surfaces.
-9. Prefer \`axint.xcode.write\` for new Swift files so Axint validation, Cloud Check, and guard proof happen as part of the write.
+9. ${writeLine}
 10. Run \`axint.swift.validate\` on modified Swift.
 11. Run \`axint.cloud.check\` with Xcode build, test, runtime, or behavior evidence when available.
 11. Prefer \`axint.run\` when moving toward build/test/runtime proof so Axint owns the loop instead of relying on memory.
@@ -366,7 +427,7 @@ Do not tell the user a bug is gone because static validation passed. Say what Ax
 
 If you are about to spend a long uninterrupted block on implementation, first name the Axint checkpoint you just ran or the one you will run next. If no Axint checkpoint has run in the last task, stop and run one.
 
-In Xcode, the safest checkpoint is \`axint.xcode.guard\`. It writes \`.axint/guard/latest.json\` and \`.axint/guard/latest.md\`, which lets the user audit whether Axint was actually used during a long task.
+${profile.xcodeToolsAllowed ? "In Xcode, the safest checkpoint is `axint.xcode.guard`. It writes `.axint/guard/latest.json` and `.axint/guard/latest.md`, which lets the user audit whether Axint was actually used during a long task." : "In Codex, Claude Code, Cursor, and Cowork, the safest checkpoint is the workflow gate plus a surgical diff and validation evidence. Do not pretend Xcode guard packets exist when the host is not Xcode."}
 `;
 }
 
@@ -374,12 +435,14 @@ function buildLocalAxintReadme(input: {
   projectName: string;
   version: string;
   startPrompt: string;
+  profile: AxintAgentToolProfile;
 }): string {
   return `# .axint
 
 This folder stores Axint project metadata for ${input.projectName}.
 
 - Expected Axint version: ${input.version}
+- Agent lane: ${input.profile.label}
 - Rehydration contract: \`.axint/AXINT_REHYDRATE.md\`
 - Compact agent memory: \`.axint/AXINT_MEMORY.md\`
 - Project-local docs context: \`.axint/AXINT_DOCS_CONTEXT.md\`
@@ -390,7 +453,13 @@ This folder stores Axint project metadata for ${input.projectName}.
 - MCP config: \`.mcp.json\`
 - Agent instructions: \`AGENTS.md\` and \`CLAUDE.md\`
 
-## New Xcode Agent Chat
+## Agent Tool Lane
+
+\`\`\`text
+${renderAgentToolProfile(input.profile)}
+\`\`\`
+
+## New Agent Chat
 
 \`\`\`text
 ${input.startPrompt}
@@ -401,8 +470,7 @@ ${input.startPrompt}
 Ask it to run the Axint context recovery loop:
 
 \`\`\`text
-Call axint.session.start for this project and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If either Axint context file is missing, call axint.context.memory and axint.context.docs. Then call axint.status, call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, ranStatus=true. For build/test/runtime proof, call axint.run so Axint owns the full loop.
-Call axint.xcode.guard with stage=context-recovery first, then call axint.session.start if the guard asks for it. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. Then call axint.status and axint.workflow.check. For build/test/runtime proof, call axint.run so Axint owns the full loop.
+Call axint.session.start for this project and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If either Axint context file is missing, call axint.context.memory and axint.context.docs. Then call axint.status and axint.workflow.check with agent=${input.profile.agent}, stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, ranStatus=true. Use this write lane: ${input.profile.defaultWriteAction}. For build/test/runtime proof, call axint.run so Axint owns the full loop.
 \`\`\`
 
 ## CLI Session Start

--- a/src/project/upgrade.ts
+++ b/src/project/upgrade.ts
@@ -1,0 +1,504 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const AXINT_PACKAGE = "@axint/compiler";
+
+export type AxintUpgradeFormat = "markdown" | "json" | "prompt";
+export type AxintUpgradeStatus = "current" | "ready" | "upgraded" | "fail";
+export type AxintUpgradeCommandStatus = "pending" | "pass" | "fail" | "skipped";
+
+export interface AxintUpgradeInput {
+  cwd?: string;
+  currentVersion: string;
+  targetVersion?: string;
+  latestVersion?: string;
+  apply?: boolean;
+  reinstallXcode?: boolean;
+  writeReport?: boolean;
+}
+
+export interface AxintUpgradeCommandResult {
+  status: number | null;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+}
+
+export interface AxintUpgradeRuntime {
+  lookupLatestVersion?: () => string;
+  runCommand?: (
+    command: string,
+    args: string[],
+    options: { cwd: string }
+  ) => AxintUpgradeCommandResult;
+  now?: () => Date;
+}
+
+export interface AxintUpgradeCommand {
+  label: string;
+  command: string;
+  args: string[];
+  display: string;
+  status: AxintUpgradeCommandStatus;
+  exitCode?: number | null;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+}
+
+export interface AxintUpgradeArtifacts {
+  json: string;
+  markdown: string;
+}
+
+export interface AxintUpgradeReport {
+  packageName: string;
+  generatedAt: string;
+  cwd: string;
+  currentVersion: string;
+  latestVersion: string;
+  targetVersion: string;
+  updateAvailable: boolean;
+  apply: boolean;
+  reinstallXcode: boolean;
+  status: AxintUpgradeStatus;
+  restartRequired: boolean;
+  restartRequiredAfterApply: boolean;
+  commands: AxintUpgradeCommand[];
+  sameThreadPrompt: string;
+  artifacts?: AxintUpgradeArtifacts;
+  notes: string[];
+  error?: string;
+}
+
+export function runAxintUpgrade(
+  input: AxintUpgradeInput,
+  runtime: AxintUpgradeRuntime = {}
+): AxintUpgradeReport {
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const now = runtime.now?.() ?? new Date();
+  const apply = input.apply === true;
+  const reinstallXcode = input.reinstallXcode === true;
+  const notes: string[] = [];
+  const commands: AxintUpgradeCommand[] = [];
+  const currentVersion = normalizeVersion(input.currentVersion);
+
+  let latestVersion: string;
+  let targetVersion: string;
+
+  try {
+    targetVersion = resolveTargetVersion(input, runtime);
+    latestVersion = normalizeVersion(input.latestVersion ?? targetVersion);
+  } catch (error) {
+    const report = buildReport({
+      cwd,
+      generatedAt: now.toISOString(),
+      currentVersion,
+      latestVersion: "",
+      targetVersion: "",
+      updateAvailable: false,
+      apply,
+      reinstallXcode,
+      status: "fail",
+      commands,
+      notes,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    maybeWriteReport(report, input.writeReport);
+    return report;
+  }
+
+  const compare = compareVersions(currentVersion, targetVersion);
+  const updateAvailable = compare < 0;
+
+  if (compare > 0) {
+    notes.push(
+      `Target v${targetVersion} is older than the running Axint v${currentVersion}; downgrade was not applied.`
+    );
+  }
+
+  if (!updateAvailable) {
+    const report = buildReport({
+      cwd,
+      generatedAt: now.toISOString(),
+      currentVersion,
+      latestVersion,
+      targetVersion,
+      updateAvailable,
+      apply,
+      reinstallXcode,
+      status: "current",
+      commands,
+      notes,
+    });
+    maybeWriteReport(report, input.writeReport);
+    return report;
+  }
+
+  commands.push(
+    buildCommand(
+      "Install newest Axint package",
+      "npm",
+      ["install", "-g", `${AXINT_PACKAGE}@${targetVersion}`],
+      "pending"
+    )
+  );
+
+  if (reinstallXcode) {
+    commands.push(
+      buildCommand(
+        "Refresh optional Xcode MCP wiring",
+        "axint",
+        ["xcode", "install", "--project", cwd],
+        "pending"
+      )
+    );
+  }
+
+  if (!apply) {
+    const report = buildReport({
+      cwd,
+      generatedAt: now.toISOString(),
+      currentVersion,
+      latestVersion,
+      targetVersion,
+      updateAvailable,
+      apply,
+      reinstallXcode,
+      status: "ready",
+      commands,
+      notes,
+    });
+    maybeWriteReport(report, input.writeReport);
+    return report;
+  }
+
+  const executed = executeCommands(commands, cwd, runtime);
+  const failed = executed.find((command) => command.status === "fail");
+  const report = buildReport({
+    cwd,
+    generatedAt: now.toISOString(),
+    currentVersion,
+    latestVersion,
+    targetVersion,
+    updateAvailable,
+    apply,
+    reinstallXcode,
+    status: failed ? "fail" : "upgraded",
+    commands: executed,
+    notes,
+    error: failed?.error ?? failed?.stderr,
+  });
+  maybeWriteReport(report, input.writeReport ?? true);
+  return report;
+}
+
+export function renderAxintUpgradeReport(
+  report: AxintUpgradeReport,
+  format: AxintUpgradeFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(report, null, 2);
+  if (format === "prompt") return report.sameThreadPrompt;
+
+  const statusLine =
+    report.status === "upgraded"
+      ? `Upgraded to v${report.targetVersion}. Reload the MCP server, not your whole working context.`
+      : report.status === "ready"
+        ? `v${report.targetVersion} is available. Run with --apply when you are ready.`
+        : report.status === "current"
+          ? `Already on the newest requested version: v${report.currentVersion}.`
+          : `Upgrade check failed: ${report.error ?? "unknown error"}.`;
+
+  const commandLines =
+    report.commands.length === 0
+      ? ["No install commands are needed."]
+      : report.commands.map((command) => {
+          const badge =
+            command.status === "pass"
+              ? "pass"
+              : command.status === "fail"
+                ? "fail"
+                : command.status === "skipped"
+                  ? "skipped"
+                  : "pending";
+          return `- ${badge}: ${command.display}`;
+        });
+
+  const artifacts = report.artifacts
+    ? [
+        "",
+        "## Artifacts",
+        "",
+        `- JSON: ${report.artifacts.json}`,
+        `- Markdown: ${report.artifacts.markdown}`,
+      ]
+    : [];
+
+  const notes =
+    report.notes.length > 0
+      ? ["", "## Notes", "", ...report.notes.map((note) => `- ${note}`)]
+      : [];
+
+  return [
+    "# Axint Same-Thread Upgrade",
+    "",
+    statusLine,
+    "",
+    `- Current: v${report.currentVersion}`,
+    `- Latest checked: ${report.latestVersion ? `v${report.latestVersion}` : "unknown"}`,
+    `- Target: ${report.targetVersion ? `v${report.targetVersion}` : "unknown"}`,
+    `- Project: ${report.cwd}`,
+    `- Apply mode: ${report.apply ? "on" : "off"}`,
+    "",
+    "## Commands",
+    "",
+    ...commandLines,
+    "",
+    "## Same-Thread Continuation",
+    "",
+    "```text",
+    report.sameThreadPrompt,
+    "```",
+    ...artifacts,
+    ...notes,
+  ].join("\n");
+}
+
+function resolveTargetVersion(
+  input: AxintUpgradeInput,
+  runtime: AxintUpgradeRuntime
+): string {
+  const explicit = input.targetVersion?.trim();
+  if (explicit && explicit !== "latest") return normalizeVersion(explicit);
+  if (input.latestVersion) return normalizeVersion(input.latestVersion);
+  return normalizeVersion((runtime.lookupLatestVersion ?? lookupLatestVersion)());
+}
+
+function lookupLatestVersion(): string {
+  const result = spawnSync("npm", ["view", AXINT_PACKAGE, "version", "--json"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr?.trim() || `npm view ${AXINT_PACKAGE} version failed`);
+  }
+
+  const raw = result.stdout.trim();
+  if (!raw) throw new Error(`npm did not return a latest ${AXINT_PACKAGE} version`);
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed === "string") return parsed;
+  } catch {
+    // npm can return a bare version if registry output is customized.
+  }
+
+  return raw.replace(/^"|"$/g, "");
+}
+
+function executeCommands(
+  commands: AxintUpgradeCommand[],
+  cwd: string,
+  runtime: AxintUpgradeRuntime
+): AxintUpgradeCommand[] {
+  const runner = runtime.runCommand ?? runLocalCommand;
+  const executed: AxintUpgradeCommand[] = [];
+
+  for (const command of commands) {
+    const result = runner(command.command, command.args, { cwd });
+    const status = result.status === 0 ? "pass" : "fail";
+    executed.push({
+      ...command,
+      status,
+      exitCode: result.status,
+      stdout: trimOutput(result.stdout),
+      stderr: trimOutput(result.stderr),
+      error: result.error,
+    });
+
+    if (status === "fail") {
+      for (const remaining of commands.slice(executed.length)) {
+        executed.push({ ...remaining, status: "skipped" });
+      }
+      break;
+    }
+  }
+
+  return executed;
+}
+
+function runLocalCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string }
+): AxintUpgradeCommandResult {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    error: result.error?.message,
+  };
+}
+
+function buildReport(input: {
+  cwd: string;
+  generatedAt: string;
+  currentVersion: string;
+  latestVersion: string;
+  targetVersion: string;
+  updateAvailable: boolean;
+  apply: boolean;
+  reinstallXcode: boolean;
+  status: AxintUpgradeStatus;
+  commands: AxintUpgradeCommand[];
+  notes: string[];
+  error?: string;
+}): AxintUpgradeReport {
+  return {
+    packageName: AXINT_PACKAGE,
+    generatedAt: input.generatedAt,
+    cwd: input.cwd,
+    currentVersion: input.currentVersion,
+    latestVersion: input.latestVersion,
+    targetVersion: input.targetVersion,
+    updateAvailable: input.updateAvailable,
+    apply: input.apply,
+    reinstallXcode: input.reinstallXcode,
+    status: input.status,
+    restartRequired:
+      input.status === "ready" || input.status === "upgraded" || input.status === "fail",
+    restartRequiredAfterApply: input.updateAvailable,
+    commands: input.commands,
+    sameThreadPrompt: buildSameThreadPrompt(input),
+    notes: input.notes,
+    error: input.error,
+  };
+}
+
+function buildSameThreadPrompt(input: {
+  cwd: string;
+  currentVersion: string;
+  targetVersion: string;
+  status: AxintUpgradeStatus;
+  updateAvailable: boolean;
+  apply: boolean;
+  reinstallXcode: boolean;
+}): string {
+  const target = input.targetVersion ? `v${input.targetVersion}` : "the latest version";
+  const action =
+    input.status === "upgraded"
+      ? `Axint was upgraded from v${input.currentVersion} to ${target}.`
+      : input.status === "ready"
+        ? `${target} is available for Axint.`
+        : input.status === "current"
+          ? `Axint is already current at v${input.currentVersion}.`
+          : `The Axint upgrade check did not complete.`;
+
+  const reloadLine =
+    input.status === "current"
+      ? "No package upgrade is needed. If the client is still connected to a stale or confused MCP process, reload or reconnect only the Axint MCP server/tool process and call axint.status again."
+      : "Reload or reconnect only the Axint MCP server/tool process so this same conversation can see the new package.";
+  const xcodeLine =
+    input.status === "current"
+      ? "No Xcode wiring refresh is required unless axint.doctor reports a setup issue."
+      : input.reinstallXcode
+        ? "If you are using Xcode, the upgrade flow also refreshes the optional Xcode MCP wiring."
+        : "Xcode MCP wiring was intentionally skipped for this upgrade flow.";
+  const statusLine =
+    input.status === "current"
+      ? "Before editing code, call axint.status if you need to prove the currently connected MCP version."
+      : "After the MCP process reconnects, call axint.status and confirm the running version before editing code.";
+
+  return [
+    action,
+    "Keep this chat/thread. Do not restart from scratch.",
+    reloadLine,
+    statusLine,
+    "Then call axint.session.start or axint.context.memory if the agent needs compact context recovery.",
+    xcodeLine,
+    `Project cwd: ${input.cwd}`,
+    "If your client cannot reload MCP in place, paste this block into the next tool-enabled message so the work resumes with context instead of starting blind.",
+  ].join("\n");
+}
+
+function buildCommand(
+  label: string,
+  command: string,
+  args: string[],
+  status: AxintUpgradeCommandStatus
+): AxintUpgradeCommand {
+  return {
+    label,
+    command,
+    args,
+    display: [command, ...args.map(quoteShellArg)].join(" "),
+    status,
+  };
+}
+
+function maybeWriteReport(
+  report: AxintUpgradeReport,
+  writeReport: boolean | undefined
+): void {
+  if (!writeReport) return;
+  const dir = join(report.cwd, ".axint", "upgrade");
+  mkdirSync(dir, { recursive: true });
+  const json = join(dir, "latest.json");
+  const markdown = join(dir, "latest.md");
+  const withArtifacts = {
+    ...report,
+    artifacts: { json, markdown },
+  };
+  writeFileSync(json, JSON.stringify(withArtifacts, null, 2) + "\n");
+  writeFileSync(markdown, renderAxintUpgradeReport(withArtifacts), "utf8");
+  report.artifacts = { json, markdown };
+}
+
+function normalizeVersion(version: string): string {
+  return version.trim().replace(/^v/, "");
+}
+
+function compareVersions(a: string, b: string): number {
+  const left = parseVersion(a);
+  const right = parseVersion(b);
+  for (let i = 0; i < 3; i += 1) {
+    if (left.numbers[i] !== right.numbers[i]) return left.numbers[i] - right.numbers[i];
+  }
+  if (left.prerelease === right.prerelease) return 0;
+  if (!left.prerelease) return 1;
+  if (!right.prerelease) return -1;
+  return left.prerelease.localeCompare(right.prerelease);
+}
+
+function parseVersion(version: string): {
+  numbers: [number, number, number];
+  prerelease: string;
+} {
+  const [core, prerelease = ""] = normalizeVersion(version).split("-", 2);
+  const parts = core.split(".").map((part) => Number.parseInt(part, 10));
+  return {
+    numbers: [
+      Number.isFinite(parts[0]) ? parts[0] : 0,
+      Number.isFinite(parts[1]) ? parts[1] : 0,
+      Number.isFinite(parts[2]) ? parts[2] : 0,
+    ],
+    prerelease,
+  };
+}
+
+function quoteShellArg(value: string): string {
+  if (/^[A-Za-z0-9_./:@=+-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function trimOutput(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(0, 4000) : undefined;
+}

--- a/src/project/xcode-guard.ts
+++ b/src/project/xcode-guard.ts
@@ -6,6 +6,8 @@ import {
   type SwiftValidationResult,
 } from "../core/swift-validator.js";
 import {
+  axintSessionPath,
+  readAxintSessionByToken,
   readCurrentAxintSession,
   startAxintSession,
   type AxintSessionRecord,
@@ -122,6 +124,14 @@ interface PreviousRunReport {
   };
 }
 
+interface LatestRunProof {
+  path: string;
+  createdAt: string;
+  status: string;
+  decision: string;
+  ageMinutes: number;
+}
+
 const REQUIRED_PROJECT_FILES = [
   ".axint/AXINT_REHYDRATE.md",
   ".axint/AXINT_MEMORY.md",
@@ -140,7 +150,12 @@ export function runXcodeGuard(input: XcodeGuardInput = {}): XcodeGuardReport {
   const required: string[] = [];
   const recommended: string[] = [];
   const checked: string[] = [];
-  let session = readCurrentAxintSession(cwd);
+  const currentSession = readCurrentAxintSession(cwd);
+  const tokenScopedSession =
+    input.sessionToken && currentSession?.token !== input.sessionToken
+      ? readAxintSessionByToken(cwd, input.sessionToken)
+      : undefined;
+  let session = tokenScopedSession ?? currentSession;
   let autoStarted = false;
 
   if (!session && input.autoStartSession !== false) {
@@ -162,10 +177,14 @@ export function runXcodeGuard(input: XcodeGuardInput = {}): XcodeGuardReport {
     );
   } else if (input.sessionToken && input.sessionToken !== session.token) {
     required.push(
-      "The supplied sessionToken does not match .axint/session/current.json. Re-run axint.session.start and use the current token."
+      "The supplied sessionToken does not match any active Axint session for this project. Re-run axint.session.start if the token expired."
     );
   } else {
-    checked.push("Active Axint session is present for this Xcode project.");
+    checked.push(
+      tokenScopedSession
+        ? "Active Axint session is present in token-scoped session history for this Xcode project."
+        : "Active Axint session is present for this Xcode project."
+    );
   }
 
   const missingFiles = REQUIRED_PROJECT_FILES.filter(
@@ -191,6 +210,23 @@ export function runXcodeGuard(input: XcodeGuardInput = {}): XcodeGuardReport {
         ageMinutes: minutesBetween(new Date(latestEvidence.at), createdAt),
       }
     : undefined;
+  const hasFreshEvidence = Boolean(
+    latestEvidenceWithAge && latestEvidenceWithAge.ageMinutes <= maxMinutesSinceAxint
+  );
+  const latestRunProof = readLatestRunProof(cwd, createdAt);
+  const hasFreshReadyRunProof = Boolean(
+    latestRunProof &&
+    latestRunProof.ageMinutes <= maxMinutesSinceAxint &&
+    latestRunProof.status === "pass" &&
+    latestRunProof.decision === "ready_to_ship"
+  );
+  const hasRecoveredContextState = Boolean(
+    session && missingFiles.length === 0 && hasFreshEvidence
+  );
+  const hasPrecommitWorkflowProof = hasPassingWorkflowPrecommitProof(
+    input.lastAxintTool,
+    input.lastAxintResult
+  );
 
   if (!latestEvidenceWithAge) {
     required.push(
@@ -207,9 +243,15 @@ export function runXcodeGuard(input: XcodeGuardInput = {}): XcodeGuardReport {
   }
 
   if (looksLikeDrift(input.notes)) {
-    required.push(
-      "The notes mention drift, compaction, or Axint being forgotten. Run context recovery before continuing."
-    );
+    if (hasRecoveredContextState) {
+      checked.push(
+        "Notes mention drift or compaction, but active session, project memory, and fresh Axint evidence are present."
+      );
+    } else {
+      required.push(
+        "The notes mention drift, compaction, or Axint being forgotten. Run context recovery before continuing."
+      );
+    }
   }
 
   const modifiedSwift = (input.modifiedFiles ?? []).filter((file) =>
@@ -247,7 +289,29 @@ export function runXcodeGuard(input: XcodeGuardInput = {}): XcodeGuardReport {
   }
 
   if (stage === "pre-build" || stage === "runtime" || stage === "finish") {
-    if (latestEvidenceWithAge?.kind !== "run") {
+    if (hasFreshReadyRunProof && latestRunProof) {
+      checked.push(
+        `Build/test/runtime stage accepted fresh ready_to_ship axint.run proof from ${latestRunProof.path}.`
+      );
+    } else if (latestRunProof && latestRunProof.ageMinutes <= maxMinutesSinceAxint) {
+      const detail = `${latestRunProof.status} · ${latestRunProof.decision}`;
+      if (
+        latestRunProof.status === "fail" ||
+        latestRunProof.decision === "fix_required"
+      ) {
+        required.push(
+          `Latest axint.run proof is ${detail}. Repair the failing gate and rerun axint.run before finishing.`
+        );
+      } else {
+        required.push(
+          `Latest axint.run proof is ${detail}. Add the missing build/test/runtime evidence or rerun axint.run before finishing.`
+        );
+      }
+    } else if (stage === "finish" && hasFreshEvidence && hasPrecommitWorkflowProof) {
+      checked.push(
+        "Finish stage accepted fresh axint.workflow.check pre-commit proof with Swift validation, Cloud Check, Xcode build, and Xcode test evidence."
+      );
+    } else {
       required.push(
         "This stage needs build/test/runtime proof. Call axint.run instead of relying on a remembered checklist."
       );
@@ -267,7 +331,7 @@ export function runXcodeGuard(input: XcodeGuardInput = {}): XcodeGuardReport {
     session: session
       ? {
           token: session.token,
-          path: resolve(cwd, ".axint/session/current.json"),
+          path: axintSessionPath(cwd, tokenScopedSession ? session.token : undefined),
           startedAt: session.startedAt,
           autoStarted,
         }
@@ -324,7 +388,7 @@ export function renderXcodeGuardReport(
       : ["- No Axint guard evidence was supplied."]),
     "",
     "## Next Tool",
-    `- ${report.nextTool}`,
+    `- ${formatNextTool(report.nextTool)}`,
   ];
 
   if (report.proofFiles.json || report.proofFiles.markdown) {
@@ -579,6 +643,21 @@ function latestAxintEvidence(input: {
     .sort((a, b) => new Date(b.at).getTime() - new Date(a.at).getTime())[0];
 }
 
+function readLatestRunProof(cwd: string, now: Date): LatestRunProof | undefined {
+  const path = resolve(cwd, ".axint/run/latest.json");
+  const run = readJson<PreviousRunReport>(path);
+  if (!run?.createdAt) return undefined;
+  const createdAt = new Date(run.createdAt);
+  if (Number.isNaN(createdAt.getTime())) return undefined;
+  return {
+    path,
+    createdAt: run.createdAt,
+    status: run.status ?? "unknown",
+    decision: run.gate?.decision ?? "unknown_gate",
+    ageMinutes: minutesBetween(createdAt, now),
+  };
+}
+
 function writeGuardReport(cwd: string, report: XcodeGuardReport): void {
   const dir = resolve(cwd, ".axint/guard");
   mkdirSync(dir, { recursive: true });
@@ -614,6 +693,20 @@ function chooseNextTool(stage: XcodeGuardStage, required: string[]): string {
   return "axint.workflow.check";
 }
 
+function formatNextTool(nextTool: string): string {
+  const cliFallbacks: Record<string, string> = {
+    "axint.workflow.check": "axint workflow check",
+    "axint.session.start": "axint session start",
+    "axint.run": "axint run",
+    "axint.suggest": "axint.suggest (MCP) or axint feature with a concrete bypass reason",
+    "axint.feature": "axint feature",
+  };
+  const cli = cliFallbacks[nextTool];
+  if (!cli) return nextTool;
+  if (cli === nextTool) return nextTool;
+  return `${nextTool} · CLI fallback: ${cli}`;
+}
+
 function buildWriteRepairPrompt(input: {
   path: string;
   status: XcodeWriteReport["status"];
@@ -647,6 +740,31 @@ function looksLikeDrift(notes: string | undefined): boolean {
   if (!notes) return false;
   return /\b(compact|compaction|summarized|new chat|forgot|forget|drift|stale|not using axint|axint unavailable|long task|long block|default xcode|ordinary xcode)\b/i.test(
     notes
+  );
+}
+
+function hasPassingWorkflowPrecommitProof(
+  lastAxintTool: string | undefined,
+  lastAxintResult: string | undefined
+): boolean {
+  if (lastAxintTool !== "axint.workflow.check" || !lastAxintResult) return false;
+  const lower = lastAxintResult.toLowerCase();
+  const stagePassed =
+    lower.includes("stage: pre-commit") ||
+    lower.includes('"stage": "pre-commit"') ||
+    lower.includes("stage=pre-commit") ||
+    lower.includes("stage pre-commit");
+  const statusReady =
+    lower.includes("workflow check: ready") ||
+    lower.includes('"status": "ready"') ||
+    lower.includes("status: ready");
+  return (
+    stagePassed &&
+    statusReady &&
+    lower.includes("axint.swift.validate was run") &&
+    lower.includes("axint.cloud.check was run") &&
+    lower.includes("xcode build evidence passed") &&
+    lower.includes("xcode test evidence passed")
   );
 }
 

--- a/src/repair/intelligence.ts
+++ b/src/repair/intelligence.ts
@@ -1,0 +1,720 @@
+export type AppleRepairIssueClass =
+  | "swiftui-input-interaction"
+  | "swiftui-hit-testing"
+  | "swiftui-routing-state"
+  | "swiftui-layout-regression"
+  | "ui-test-accessibility"
+  | "runtime-freeze"
+  | "xcode-build-repair"
+  | "apple-project-repair";
+
+export interface AppleRepairRootCause {
+  title: string;
+  confidence: "high" | "medium" | "low";
+  detail: string;
+  inspect: string[];
+  suggestedPatch: string;
+}
+
+export interface AppleRepairIntelligence {
+  isExistingProductRepair: boolean;
+  issueClass: AppleRepairIssueClass;
+  confidence: "high" | "medium" | "low";
+  summary: string;
+  signals: string[];
+  rootCauses: AppleRepairRootCause[];
+  inspectionChecklist: string[];
+  proofPlan: string[];
+  avoid: string[];
+}
+
+export interface AppleRepairIntelligenceInput {
+  text?: string;
+  source?: string;
+  fileName?: string;
+  platform?: string;
+}
+
+export function analyzeAppleRepairTask(
+  input: AppleRepairIntelligenceInput
+): AppleRepairIntelligence {
+  const text = normalizeEvidence(input.text ?? "");
+  const source = input.source ?? "";
+  const sourceText = normalizeEvidence(source);
+  const issueClass = classifyAppleRepairIssue(text, sourceText);
+  const signals = inferRepairSignals(text, sourceText);
+  const isExistingProductRepair = looksLikeExistingAppleRepair(text, signals);
+  const rootCauses = buildRootCauses({ issueClass, text, source, sourceText });
+  const confidence = inferRepairConfidence({
+    isExistingProductRepair,
+    issueClass,
+    rootCauses,
+    source,
+    text,
+  });
+
+  return {
+    isExistingProductRepair,
+    issueClass,
+    confidence,
+    summary: buildRepairSummary({
+      issueClass,
+      isExistingProductRepair,
+      confidence,
+      rootCauses,
+      platform: input.platform,
+    }),
+    signals,
+    rootCauses,
+    inspectionChecklist: buildInspectionChecklist(issueClass, signals),
+    proofPlan: buildProofPlan(issueClass, input.fileName),
+    avoid: [
+      "Do not replace the whole screen when the bug is in an existing product flow.",
+      "Do not claim fixed from static source checks alone when the failure is runtime, route, focus, or hit-testing behavior.",
+      "Do not patch only the visible child before checking parent wrappers, overlays, disabled state, gestures, and shared stores.",
+    ],
+  };
+}
+
+export function looksLikeExistingAppleRepairText(text: string): boolean {
+  const normalized = normalizeEvidence(text);
+  return looksLikeExistingAppleRepair(normalized, inferRepairSignals(normalized, ""));
+}
+
+export function formatAppleRepairRead(analysis: AppleRepairIntelligence): string[] {
+  return [
+    `Senior Apple repair read: ${analysis.summary}`,
+    `Issue class: ${analysis.issueClass}`,
+    `Confidence: ${analysis.confidence}`,
+    ...(analysis.signals.length > 0
+      ? [`Signals: ${analysis.signals.slice(0, 6).join(", ")}`]
+      : []),
+    ...(analysis.rootCauses.length > 0
+      ? [
+          "Likely root causes:",
+          ...analysis.rootCauses
+            .slice(0, 3)
+            .map(
+              (cause) => `- ${cause.title} (${cause.confidence}): ${cause.suggestedPatch}`
+            ),
+        ]
+      : []),
+  ];
+}
+
+function classifyAppleRepairIssue(
+  text: string,
+  sourceText: string
+): AppleRepairIssueClass {
+  if (
+    hasAny(text, [
+      "comment box",
+      "compose box",
+      "composer",
+      "reply box",
+      "post box",
+      "text field",
+      "textfield",
+      "text editor",
+      "texteditor",
+      "input field",
+      "input",
+      "keyboard",
+      "focus",
+    ]) &&
+    hasAny(text, [
+      "can't tap",
+      "cannot tap",
+      "can't be tapped",
+      "cannot be tapped",
+      "can't type",
+      "cannot type",
+      "can't be typed",
+      "cannot be typed",
+      "won't focus",
+      "cannot focus",
+      "cannot be focused",
+      "no longer accepts",
+      "stopped accepting",
+      "visible but dead",
+      "not editable",
+      "not interactable",
+      "tap ignored",
+    ])
+  ) {
+    return "swiftui-input-interaction";
+  }
+
+  if (
+    hasAny(text, [
+      "should be hittable",
+      "not hittable",
+      "not tappable",
+      "not foreground",
+      "background interaction",
+      "failed to synthesize event",
+      "hit point",
+      "scroll",
+    ])
+  ) {
+    return "swiftui-hit-testing";
+  }
+
+  if (
+    hasAny(text, [
+      "wrong tab",
+      "does not route",
+      "doesn't route",
+      "navigation",
+      "route",
+      "destination",
+      "sheet",
+      "popover",
+      "opens wrong",
+      "selected tab",
+      "state doesn't update",
+      "state does not update",
+    ])
+  ) {
+    return "swiftui-routing-state";
+  }
+
+  if (
+    hasAny(text, [
+      "layout",
+      "above the fold",
+      "first viewport",
+      "spacing",
+      "overlap",
+      "clipped",
+      "blank",
+      "responsive",
+      "alignment",
+    ])
+  ) {
+    return "swiftui-layout-regression";
+  }
+
+  if (
+    hasAny(text, [
+      "freeze",
+      "freezes",
+      "frozen",
+      "hang",
+      "hung",
+      "beachball",
+      "unresponsive",
+      "launch timeout",
+      "not responding",
+    ]) ||
+    hasAny(sourceText, [
+      "dispatchqueue.main.sync",
+      "dispatchsemaphore",
+      "thread.sleep",
+      "data(contentsof:",
+    ])
+  ) {
+    return "runtime-freeze";
+  }
+
+  if (
+    hasAny(text, [
+      "cannot find",
+      "no member",
+      "incorrect argument label",
+      "type mismatch",
+      "does not conform",
+      "build failed",
+      "error:",
+    ])
+  ) {
+    return "xcode-build-repair";
+  }
+
+  if (
+    hasAny(text, [
+      "accessibility",
+      "identifier",
+      "no matches",
+      "not found",
+      "does not exist",
+      "wait timed out",
+    ])
+  ) {
+    return "ui-test-accessibility";
+  }
+
+  return "apple-project-repair";
+}
+
+function inferRepairSignals(text: string, sourceText: string): string[] {
+  const signals: string[] = [];
+  const add = (condition: boolean, signal: string) => {
+    if (condition && !signals.includes(signal)) signals.push(signal);
+  };
+
+  add(
+    hasAny(text, ["existing", "current", "regression", "no longer", "stopped"]),
+    "existing-product"
+  );
+  add(
+    hasAny(text, ["fix", "repair", "broken", "bug", "not working", "fails", "failing"]),
+    "repair-intent"
+  );
+  add(
+    hasAny(text, ["tap", "click", "hittable", "foreground", "background interaction"]),
+    "hit-testing"
+  );
+  add(
+    hasAny(text, [
+      "type",
+      "focus",
+      "keyboard",
+      "composer",
+      "comment box",
+      "text field",
+      "input",
+    ]),
+    "input-focus"
+  );
+  add(
+    hasAny(text, ["route", "tab", "navigation", "sheet", "popover", "destination"]),
+    "routing-state"
+  );
+  add(
+    hasAny(text, [
+      "ui test",
+      "xctest",
+      "xcuielement",
+      "only-testing",
+      "test succeeded",
+      "test failed",
+    ]),
+    "xcode-ui-proof"
+  );
+  add(hasAny(text, ["build", "xcodebuild", "compiler", "error:"]), "xcode-build-proof");
+  add(
+    hasAny(text, ["freeze", "hang", "unresponsive", "beachball", "launch timeout"]),
+    "runtime-proof"
+  );
+  add(
+    hasAny(sourceText, [".overlay", "zstack", ".zindex", ".allowshittesting"]),
+    "overlay-hit-area"
+  );
+  add(hasAny(sourceText, [".disabled("]), "disabled-state");
+  add(
+    hasAny(sourceText, [".gesture", ".ontapgesture", ".highprioritygesture"]),
+    "gesture-capture"
+  );
+  add(hasAny(sourceText, ["@focusstate", "focused("]), "focus-state");
+  add(hasAny(sourceText, [".accessibilityidentifier", "xcui"]), "accessibility-tree");
+  add(hasAny(sourceText, ["scrollview", "list {", "lazyvstack"]), "scroll-container");
+
+  return signals;
+}
+
+function looksLikeExistingAppleRepair(text: string, signals: string[]): boolean {
+  const failureIntent = hasAny(text, [
+    "can't",
+    "cannot",
+    "won't",
+    "does not",
+    "doesn't",
+    "no longer",
+    "stopped",
+    "visible but",
+    "should be",
+    "not foreground",
+    "not hittable",
+    "not tappable",
+    "not working",
+    "fails",
+    "failing",
+    "broken",
+    "bug",
+  ]);
+  const repairIntent =
+    signals.includes("repair-intent") ||
+    failureIntent ||
+    (signals.includes("existing-product") &&
+      hasAny(text, ["fix", "repair", "regression"]));
+  const appleSurface =
+    hasAny(text, [
+      "swiftui",
+      "xcode",
+      "view",
+      "screen",
+      "tab",
+      "button",
+      "composer",
+      "comment box",
+      "text field",
+      "widget",
+      "app intent",
+      "macos",
+      "ios",
+    ]) ||
+    signals.some((signal) =>
+      [
+        "hit-testing",
+        "input-focus",
+        "routing-state",
+        "xcode-ui-proof",
+        "xcode-build-proof",
+        "runtime-proof",
+      ].includes(signal)
+    );
+
+  if (/\b(create|generate|scaffold|build)\s+(?:a|an|new)\b/.test(text) && !repairIntent) {
+    return false;
+  }
+
+  return repairIntent && appleSurface;
+}
+
+function buildRootCauses(input: {
+  issueClass: AppleRepairIssueClass;
+  text: string;
+  source: string;
+  sourceText: string;
+}): AppleRepairRootCause[] {
+  const causes: AppleRepairRootCause[] = [];
+  const hasSource = input.source.trim().length > 0;
+
+  if (input.issueClass === "swiftui-hit-testing") {
+    causes.push({
+      title: "UI test is hitting an element hidden by foreground or hit-test state",
+      confidence: "high",
+      detail:
+        "macOS UI tests can find a node in the accessibility tree while a sheet, inactive window, broad parent identifier, scroll state, or overlay owns the actual hit point.",
+      inspect: [
+        "foreground window",
+        "blocking sheet/popover",
+        "scroll position",
+        "actionable Button/Text child",
+        "parent accessibility container",
+      ],
+      suggestedPatch:
+        "Activate the app/window, dismiss blockers, scroll to the exact element, and attach identifiers to the actionable child before asserting hittability.",
+    });
+  }
+
+  if (
+    input.issueClass === "swiftui-input-interaction" ||
+    input.issueClass === "swiftui-hit-testing"
+  ) {
+    causes.push({
+      title: "Parent layer or overlay is stealing the hit test",
+      confidence: hasAny(input.sourceText, [
+        ".overlay",
+        "zstack",
+        ".zindex",
+        ".allowshittesting",
+      ])
+        ? "high"
+        : "medium",
+      detail:
+        "SwiftUI controls can stay visible while a placeholder, transparent overlay, ZStack sibling, sheet, or zIndex layer intercepts taps before the TextField/TextEditor/Button receives focus.",
+      inspect: [
+        ".overlay",
+        "ZStack siblings",
+        ".allowsHitTesting",
+        ".zIndex",
+        "sheets/popovers",
+      ],
+      suggestedPatch:
+        "Add `.allowsHitTesting(false)` to decorative overlays, move interactive overlays outside the input hit area, or lower/remove the competing zIndex layer.",
+    });
+    causes.push({
+      title: "Disabled or loading state is propagating too broadly",
+      confidence: hasAny(input.sourceText, [".disabled("]) ? "high" : "medium",
+      detail:
+        "A new feature gate, posting/loading flag, permission branch, or modal state can disable an entire composer or command subtree.",
+      inspect: [
+        ".disabled(...)",
+        "loading state",
+        "permission gates",
+        "feature flags",
+        "modal state",
+      ],
+      suggestedPatch:
+        "Move `.disabled(...)` to the exact button/action that should be blocked and keep the composer/input subtree outside the gated parent.",
+    });
+    causes.push({
+      title: "Gesture or focus routing is swallowing first responder",
+      confidence: hasAny(input.sourceText, [
+        ".gesture",
+        ".ontapgesture",
+        ".highprioritygesture",
+        "@focusstate",
+      ])
+        ? "high"
+        : "low",
+      detail:
+        "Broad gestures, high-priority taps, scroll containers, or conflicting FocusState bindings can prevent the control from becoming first responder.",
+      inspect: [
+        ".gesture",
+        ".highPriorityGesture",
+        ".onTapGesture",
+        "@FocusState",
+        "ScrollView/List parent",
+      ],
+      suggestedPatch:
+        "Narrow the gesture region, avoid high-priority capture over inputs, and assert the expected FocusState after tapping in a focused UI test.",
+    });
+  }
+
+  if (input.issueClass === "swiftui-routing-state") {
+    causes.push({
+      title: "Action is wired to local demo state instead of the real route/store",
+      confidence: "medium",
+      detail:
+        "Premium UI repairs often make buttons look correct but leave them connected to placeholder state, stale selected-tab values, or a sheet that is not the real destination.",
+      inspect: [
+        "Button action closures",
+        "selected tab state",
+        "navigation path",
+        "sheet/popover booleans",
+        "shared store mutation",
+      ],
+      suggestedPatch:
+        "Trace the button to the app's real router/store, patch the smallest action binding, then prove it with a focused UI test that asserts the destination.",
+    });
+  }
+
+  if (input.issueClass === "swiftui-layout-regression") {
+    causes.push({
+      title: "Responsive layout changed without first-viewport proof",
+      confidence: "medium",
+      detail:
+        "A visual polish change can push the main action below the fold, hide content behind fixed chrome, or leave a lazy area blank until scrolled.",
+      inspect: [
+        "GeometryReader",
+        "fixed heights",
+        "safe area insets",
+        "lazy containers",
+        "min/max frame modifiers",
+      ],
+      suggestedPatch:
+        "Patch layout constraints around the first viewport and prove desktop/mobile or compact/expanded states with a focused screenshot/UI assertion.",
+    });
+  }
+
+  if (input.issueClass === "runtime-freeze") {
+    causes.push({
+      title: "Main-thread or launch-path blocker",
+      confidence: hasSource ? "medium" : "low",
+      detail:
+        "Blocking work in View.body, init, onAppear, .task, App startup, or shared stores can freeze SwiftUI before the UI becomes interactive.",
+      inspect: [
+        "View.body",
+        "init",
+        "onAppear",
+        ".task",
+        "App startup",
+        "synchronous IO/network waits",
+      ],
+      suggestedPatch:
+        "Move blocking work into cancellable async model methods, add timeouts, and capture a short sample if the freeze still reproduces.",
+    });
+  }
+
+  if (input.issueClass === "xcode-build-repair") {
+    causes.push({
+      title: "Generated code drifted from real project symbols",
+      confidence: "high",
+      detail:
+        "Build errors usually mean the agent referenced a member, enum case, initializer, label, or type that does not exist in the local project.",
+      inspect: [
+        "missing symbol declaration",
+        "call site signature",
+        "target membership",
+        "imports",
+        "generated enum/token names",
+      ],
+      suggestedPatch:
+        "Patch the call site to the real signature or add the missing file to the target; do not invent a second API beside the existing one.",
+    });
+  }
+
+  if (input.issueClass === "ui-test-accessibility") {
+    causes.push({
+      title: "Accessibility query does not match the rendered element tree",
+      confidence: "medium",
+      detail:
+        "SwiftUI identifiers can be attached too high, masked by parent containers, or asserted as the wrong XCUI element type.",
+      inspect: [
+        ".accessibilityIdentifier",
+        "Button/Text child identifiers",
+        "parent container identifiers",
+        "XCUI element type",
+        "label/value assertions",
+      ],
+      suggestedPatch:
+        "Attach identifiers to the exact queried Button/Text/TextField and assert label or value when macOS StaticText exposes text through value.",
+    });
+  }
+
+  if (causes.length === 0) {
+    causes.push({
+      title: "Existing Apple project needs source plus proof evidence",
+      confidence: "low",
+      detail:
+        "Axint can guide the repair loop, but needs source, project index, build log, UI-test failure, or runtime evidence to name the likely root cause.",
+      inspect: [
+        "recently changed Swift files",
+        "parent SwiftUI shell",
+        "shared stores",
+        "failing build/test log",
+      ],
+      suggestedPatch:
+        "Run `axint project index`, pass the suspicious source file, and include the shortest failing Xcode/UI/runtime evidence.",
+    });
+  }
+
+  return causes.slice(0, 4);
+}
+
+function inferRepairConfidence(input: {
+  isExistingProductRepair: boolean;
+  issueClass: AppleRepairIssueClass;
+  rootCauses: AppleRepairRootCause[];
+  source: string;
+  text: string;
+}): "high" | "medium" | "low" {
+  if (
+    input.isExistingProductRepair &&
+    input.source.trim() &&
+    input.rootCauses.some((cause) => cause.confidence === "high")
+  ) {
+    return "high";
+  }
+  if (
+    input.isExistingProductRepair ||
+    input.issueClass !== "apple-project-repair" ||
+    input.source.trim() ||
+    input.text.trim()
+  ) {
+    return "medium";
+  }
+  return "low";
+}
+
+function buildRepairSummary(input: {
+  issueClass: AppleRepairIssueClass;
+  isExistingProductRepair: boolean;
+  confidence: "high" | "medium" | "low";
+  rootCauses: AppleRepairRootCause[];
+  platform?: string;
+}): string {
+  const platform = input.platform ? `${input.platform} ` : "";
+  if (input.isExistingProductRepair) {
+    const lead = input.rootCauses[0]?.title.toLowerCase() ?? "project context";
+    return `Treat this as an existing ${platform}Apple repair, not a new scaffold. Start with ${lead}, patch the smallest surface, then prove it with focused Xcode evidence.`;
+  }
+  if (input.issueClass !== "apple-project-repair") {
+    return `Apple evidence points toward ${input.issueClass}; collect source and focused proof before making broad changes.`;
+  }
+  return "No specific Apple repair class is proven yet; collect project context, source, and the shortest failing evidence first.";
+}
+
+function buildInspectionChecklist(
+  issueClass: AppleRepairIssueClass,
+  signals: string[]
+): string[] {
+  const checklist = new Set<string>();
+  const add = (item: string) => checklist.add(item);
+
+  if (issueClass === "swiftui-input-interaction" || signals.includes("input-focus")) {
+    add(
+      "Input child: TextField/TextEditor/SecureField label, binding, focus state, and identifier."
+    );
+    add(
+      "Parent wrappers: ZStack, overlay, background, zIndex, allowsHitTesting, disabled state."
+    );
+    add(
+      "Gesture/focus: broad tap handlers, highPriorityGesture, scroll containers, and FocusState conflicts."
+    );
+  }
+  if (issueClass === "swiftui-hit-testing" || signals.includes("hit-testing")) {
+    add(
+      "Hit-test tree: visible element, actionable child, parent container identifier, and foreground window."
+    );
+    add(
+      "Scroll proof: scroll anchor, lazy container state, hittable assertion, and blocking modal/sheet."
+    );
+  }
+  if (issueClass === "swiftui-routing-state" || signals.includes("routing-state")) {
+    add(
+      "Routing action: selected tab/navigation path/sheet boolean and shared store mutation."
+    );
+    add(
+      "Destination proof: assert the real screen/sheet appears, not only that the button exists."
+    );
+  }
+  if (issueClass === "runtime-freeze" || signals.includes("runtime-proof")) {
+    add("Runtime sample: Thread 0 first app-owned frame while frozen.");
+    add(
+      "Lifecycle code: View.body/init/onAppear/.task/App startup/shared stores for blocking work."
+    );
+  }
+  if (issueClass === "xcode-build-repair" || signals.includes("xcode-build-proof")) {
+    add(
+      "Build line: missing member/symbol/label/type and the real declaration or target membership."
+    );
+  }
+  if (issueClass === "ui-test-accessibility" || signals.includes("accessibility-tree")) {
+    add(
+      "Accessibility query: exact element type, identifier placement, label/value behavior, and parent masking."
+    );
+  }
+
+  if (checklist.size === 0) {
+    add(
+      "Project context: recently changed Swift files, related parent shells, shared stores, and failing evidence."
+    );
+  }
+
+  return Array.from(checklist).slice(0, 8);
+}
+
+function buildProofPlan(issueClass: AppleRepairIssueClass, fileName?: string): string[] {
+  const source = fileName ?? "<changed Swift files>";
+  const steps = [
+    `Patch the smallest existing surface around ${source}.`,
+    `Run \`axint validate-swift ${source}\`.`,
+    `Run \`axint cloud check --source ${source}\` with expected/actual evidence.`,
+  ];
+
+  if (
+    issueClass === "swiftui-input-interaction" ||
+    issueClass === "swiftui-hit-testing" ||
+    issueClass === "swiftui-routing-state" ||
+    issueClass === "ui-test-accessibility"
+  ) {
+    steps.push(
+      "Run one focused UI test that taps, types, scrolls, routes, or asserts the exact failing behavior."
+    );
+  }
+  if (issueClass === "runtime-freeze") {
+    steps.push(
+      "Run launch/runtime proof and attach a short sample if the app still freezes."
+    );
+  }
+  if (issueClass === "xcode-build-repair") {
+    steps.push("Run the focused Xcode build that produced the original compiler error.");
+  }
+
+  steps.push(
+    "Only claim fixed after the focused proof passes and Axint run records the evidence."
+  );
+  return steps;
+}
+
+function normalizeEvidence(value: string): string {
+  return value.toLowerCase().replace(/[’']/g, "'").replace(/\s+/g, " ").trim();
+}
+
+function hasAny(value: string, needles: string[]): boolean {
+  return needles.some((needle) => value.includes(needle));
+}

--- a/src/repair/project-repair.ts
+++ b/src/repair/project-repair.ts
@@ -1,0 +1,1126 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import {
+  runCloudCheck,
+  type CloudCheckInput,
+  type CloudCheckReport,
+} from "../cloud/check.js";
+import {
+  buildAgentToolProfile,
+  renderAgentToolProfile,
+  type AxintAgentProfileName,
+  type AxintAgentToolProfile,
+} from "../project/agent-profile.js";
+import {
+  analyzeAppleRepairTask,
+  formatAppleRepairRead,
+  type AppleRepairIntelligence,
+} from "./intelligence.js";
+import {
+  readProjectContextIndex,
+  writeProjectContextIndex,
+  type ProjectContextFileSummary,
+  type ProjectContextIndex,
+} from "../project/context-index.js";
+
+export type AxintRepairFormat = "markdown" | "json" | "prompt";
+export type AxintRepairStatus = "fix_required" | "needs_context" | "ready_to_prove";
+export type AxintRepairPriority = "p0" | "p1" | "p2" | "p3";
+
+export interface AxintRepairInput {
+  cwd?: string;
+  issue: string;
+  source?: string;
+  sourcePath?: string;
+  fileName?: string;
+  platform?: "iOS" | "macOS" | "watchOS" | "visionOS" | "all";
+  agent?: AxintAgentProfileName;
+  expectedBehavior?: string;
+  actualBehavior?: string;
+  xcodeBuildLog?: string;
+  testFailure?: string;
+  runtimeFailure?: string;
+  changedFiles?: string[];
+  projectName?: string;
+  projectContextPath?: string;
+  writeReport?: boolean;
+  writeFeedback?: boolean;
+}
+
+export interface AxintRepairHypothesis {
+  title: string;
+  confidence: "high" | "medium" | "low";
+  detail: string;
+  evidence: string[];
+  inspect: string[];
+  suggestedPatch: string;
+}
+
+export interface AxintRepairFileTarget {
+  path: string;
+  riskScore: number;
+  reasons: string[];
+  why: string;
+}
+
+export interface AxintRepairFeedbackPacket {
+  schema: "https://axint.ai/schemas/repair-feedback.v1.json";
+  id: string;
+  createdAt: string;
+  compilerVersion: string;
+  privacy: {
+    redaction: "source_not_included";
+    localPaths: "project_relative_only";
+    evidence: "summarized_and_truncated";
+    userCanInspectBeforeSending: true;
+  };
+  classification: {
+    issueClass: string;
+    priority: AxintRepairPriority;
+    status: AxintRepairStatus;
+    confidence: "high" | "medium" | "low";
+  };
+  projectShape: {
+    swiftFiles: number;
+    swiftUIFiles: number;
+    appIntentFiles: number;
+    inputCapableFiles: number;
+    interactionRiskFiles: number;
+    platform?: string;
+  };
+  signals: string[];
+  diagnostics: Array<{
+    code: string;
+    severity: string;
+    message: string;
+  }>;
+  hypotheses: Array<{
+    title: string;
+    confidence: string;
+  }>;
+  files: Array<{
+    path: string;
+    reasons: string[];
+  }>;
+  redactedEvidence: string[];
+  suggestedAxintOwner: string;
+  suggestedProductAction: string;
+}
+
+export interface AxintRepairReport {
+  id: string;
+  status: AxintRepairStatus;
+  priority: AxintRepairPriority;
+  compilerVersion: string;
+  createdAt: string;
+  cwd: string;
+  issue: string;
+  issueClass: string;
+  agent: AxintAgentToolProfile;
+  confidence: {
+    level: "high" | "medium" | "low";
+    detail: string;
+  };
+  repairIntelligence: AppleRepairIntelligence;
+  projectContext: {
+    path?: string;
+    swiftFiles: number;
+    swiftUIFiles: number;
+    appIntentFiles: number;
+    inputCapableFiles: number;
+    interactionRiskFiles: number;
+    topRiskFiles: AxintRepairFileTarget[];
+  };
+  cloudCheck?: CloudCheckReport;
+  hypotheses: AxintRepairHypothesis[];
+  filesToInspect: AxintRepairFileTarget[];
+  evidenceToCollect: string[];
+  proofPlan: string[];
+  commands: string[];
+  artifacts: {
+    json?: string;
+    markdown?: string;
+    feedback?: string;
+  };
+  feedbackPacket: AxintRepairFeedbackPacket;
+  repairPrompt: string;
+}
+
+export function runAxintRepair(input: AxintRepairInput): AxintRepairReport {
+  if (!input.issue?.trim()) {
+    throw new Error("axint repair requires an issue description.");
+  }
+
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const createdAt = new Date().toISOString();
+  const projectContext = loadOrCreateProjectContext({
+    cwd,
+    projectName: input.projectName,
+    changedFiles: input.changedFiles,
+    projectContextPath: input.projectContextPath,
+  });
+  const sourcePayload = readRepairSource(input, cwd);
+  const issueText = [
+    input.issue,
+    input.expectedBehavior,
+    input.actualBehavior,
+    input.xcodeBuildLog,
+    input.testFailure,
+    input.runtimeFailure,
+  ]
+    .filter(Boolean)
+    .join("\n");
+  const repairIntelligence = analyzeAppleRepairTask({
+    text: issueText,
+    source: sourcePayload?.source,
+    fileName: sourcePayload?.fileName ?? input.fileName,
+    platform: input.platform,
+  });
+  const issueClass = repairIntelligence.issueClass;
+  const agent = buildAgentToolProfile(input.agent);
+  const cloudCheck = sourcePayload
+    ? runCloudCheck({
+        source: sourcePayload.source,
+        sourcePath: sourcePayload.sourcePath,
+        fileName: sourcePayload.fileName,
+        language: "swift",
+        platform: input.platform,
+        xcodeBuildLog: input.xcodeBuildLog,
+        testFailure: input.testFailure,
+        runtimeFailure: input.runtimeFailure,
+        expectedBehavior: input.expectedBehavior ?? input.issue,
+        actualBehavior: input.actualBehavior,
+        projectContext,
+      } satisfies CloudCheckInput)
+    : undefined;
+  const hypotheses = buildRepairHypotheses({
+    issueClass,
+    issueText,
+    projectContext,
+    cloudCheck,
+    repairIntelligence,
+  });
+  const filesToInspect = rankRepairFiles({
+    issueClass,
+    projectContext,
+    cloudCheck,
+    sourcePath: sourcePayload?.sourcePath,
+    fileName: sourcePayload?.fileName,
+  });
+  const evidenceToCollect = buildEvidencePlan({
+    issueClass,
+    sourcePayload,
+    cloudCheck,
+    input,
+    repairIntelligence,
+  });
+  const proofPlan = buildProofPlan({
+    input,
+    sourcePayload,
+    issueClass,
+    repairIntelligence,
+  });
+  const commands = buildRepairCommands({ input, cwd, sourcePayload, projectContext });
+  const status = resolveRepairStatus({
+    sourcePayload,
+    cloudCheck,
+    hypotheses,
+    filesToInspect,
+  });
+  const confidence = buildRepairConfidence({
+    sourcePayload,
+    cloudCheck,
+    hypotheses,
+    projectContext,
+  });
+  const priority = inferPriority(issueClass, cloudCheck, issueText);
+
+  const reportBase = [
+    cwd,
+    input.issue,
+    issueClass,
+    cloudCheck?.id ?? "no-cloud",
+    filesToInspect.map((file) => file.path).join("|"),
+  ].join(":");
+  const id = `repair-${hashString(reportBase)}`;
+  const feedbackPacket = buildRepairFeedbackPacket({
+    id,
+    createdAt,
+    input,
+    cwd,
+    issueClass,
+    priority,
+    status,
+    confidence: confidence.level,
+    projectContext,
+    cloudCheck,
+    hypotheses,
+    filesToInspect,
+  });
+
+  const report: AxintRepairReport = {
+    id,
+    status,
+    priority,
+    compilerVersion: packageVersion(),
+    createdAt,
+    cwd,
+    issue: input.issue,
+    issueClass,
+    agent,
+    confidence,
+    repairIntelligence,
+    projectContext: {
+      path: projectContextPath(cwd),
+      swiftFiles: projectContext.files.swift,
+      swiftUIFiles: projectContext.files.swiftUI,
+      appIntentFiles: projectContext.files.appIntents,
+      inputCapableFiles: projectContext.files.inputCapable,
+      interactionRiskFiles: projectContext.files.withInteractionRisk,
+      topRiskFiles: projectContext.topInteractionRiskFiles
+        .slice(0, 8)
+        .map((file) => repairFileTarget(file, "High interaction-risk file.")),
+    },
+    cloudCheck,
+    hypotheses,
+    filesToInspect,
+    evidenceToCollect,
+    proofPlan,
+    commands,
+    artifacts: {},
+    feedbackPacket,
+    repairPrompt: "",
+  };
+
+  report.repairPrompt = buildRepairPrompt(report);
+
+  if (input.writeReport !== false) {
+    writeRepairArtifacts(report);
+  }
+  if (input.writeFeedback !== false) {
+    writeRepairFeedback(report);
+  }
+
+  return report;
+}
+
+export function renderAxintRepairReport(
+  report: AxintRepairReport,
+  format: AxintRepairFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(compactRepairReport(report), null, 2);
+  if (format === "prompt") return report.repairPrompt;
+
+  const lines = [
+    `# Axint Repair: ${report.status}`,
+    "",
+    `- Issue: ${report.issue}`,
+    `- Class: ${report.issueClass}`,
+    `- Priority: ${report.priority}`,
+    `- Confidence: ${report.confidence.level} — ${report.confidence.detail}`,
+    `- Agent lane: ${report.agent.label} (${report.agent.editingMode})`,
+    `- Project: ${report.projectContext.swiftFiles} Swift files, ${report.projectContext.swiftUIFiles} SwiftUI files, ${report.projectContext.inputCapableFiles} input-capable files`,
+    "",
+    "## Senior Repair Read",
+    ...formatAppleRepairRead(report.repairIntelligence).map((item) => `- ${item}`),
+    "- Inspect:",
+    ...report.repairIntelligence.inspectionChecklist
+      .slice(0, 6)
+      .map((item) => `  - ${item}`),
+    "- Avoid:",
+    ...report.repairIntelligence.avoid.slice(0, 3).map((item) => `  - ${item}`),
+    "",
+    "## Likely Root Causes",
+    ...(report.hypotheses.length > 0
+      ? report.hypotheses.map(
+          (hypothesis) =>
+            `- ${hypothesis.title}: ${hypothesis.detail} Confidence: ${hypothesis.confidence}. Patch: ${hypothesis.suggestedPatch}`
+        )
+      : ["- Axint needs more evidence before naming a concrete root cause."]),
+    "",
+    "## Files To Inspect",
+    ...(report.filesToInspect.length > 0
+      ? report.filesToInspect.map(
+          (file) =>
+            `- ${file.path}: score ${file.riskScore} — ${file.why}${file.reasons.length > 0 ? ` (${file.reasons.join(", ")})` : ""}`
+        )
+      : [
+          "- No high-confidence file targets yet. Run `axint project index` with changed files or pass --source.",
+        ]),
+    "",
+    "## Evidence To Collect",
+    ...report.evidenceToCollect.map((item) => `- ${item}`),
+    "",
+    "## Proof Plan",
+    ...report.proofPlan.map((item) => `- ${item}`),
+    "",
+    "## Commands",
+    ...report.commands.map((command) => `- \`${command}\``),
+    "",
+    "## Privacy-Safe Feedback Packet",
+    `- Redaction: ${report.feedbackPacket.privacy.redaction}`,
+    `- Local paths: ${report.feedbackPacket.privacy.localPaths}`,
+    `- User can inspect before sending: ${report.feedbackPacket.privacy.userCanInspectBeforeSending ? "yes" : "no"}`,
+  ];
+
+  if (report.cloudCheck) {
+    lines.push(
+      "",
+      "## Cloud Check",
+      `- Status: ${report.cloudCheck.status}`,
+      `- Gate: ${report.cloudCheck.gate.decision}`,
+      `- Diagnostics: ${report.cloudCheck.errors} errors, ${report.cloudCheck.warnings} warnings`,
+      ...report.cloudCheck.diagnostics
+        .slice(0, 6)
+        .map(
+          (diagnostic) =>
+            `- ${diagnostic.code}: ${diagnostic.message}${diagnostic.suggestion ? ` Suggestion: ${diagnostic.suggestion}` : ""}`
+        )
+    );
+  }
+
+  if (report.artifacts.json || report.artifacts.markdown || report.artifacts.feedback) {
+    lines.push("", "## Artifacts");
+    if (report.artifacts.json) lines.push(`- JSON: ${report.artifacts.json}`);
+    if (report.artifacts.markdown) lines.push(`- Markdown: ${report.artifacts.markdown}`);
+    if (report.artifacts.feedback) {
+      lines.push(`- Feedback packet: ${report.artifacts.feedback}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function renderRepairFeedbackPacket(
+  packet: AxintRepairFeedbackPacket,
+  format: "markdown" | "json" = "json"
+): string {
+  if (format === "json") return JSON.stringify(packet, null, 2);
+  return [
+    "# Axint Feedback Packet",
+    "",
+    `- ID: ${packet.id}`,
+    `- Status: ${packet.classification.status}`,
+    `- Issue class: ${packet.classification.issueClass}`,
+    `- Priority: ${packet.classification.priority}`,
+    `- Privacy: ${packet.privacy.redaction}; ${packet.privacy.localPaths}; ${packet.privacy.evidence}`,
+    "",
+    "## Signals",
+    ...(packet.signals.length > 0
+      ? packet.signals.map((item) => `- ${item}`)
+      : ["- None."]),
+    "",
+    "## Diagnostics",
+    ...(packet.diagnostics.length > 0
+      ? packet.diagnostics.map((item) => `- ${item.code}: ${item.message}`)
+      : ["- None."]),
+    "",
+    "## Suggested Product Action",
+    packet.suggestedProductAction,
+    "",
+  ].join("\n");
+}
+
+export function readLatestRepairFeedback(
+  input: {
+    cwd?: string;
+  } = {}
+): AxintRepairFeedbackPacket | undefined {
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const path = join(cwd, ".axint/feedback/latest.json");
+  if (!existsSync(path)) return undefined;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as AxintRepairFeedbackPacket;
+  } catch {
+    return undefined;
+  }
+}
+
+function loadOrCreateProjectContext(input: {
+  cwd: string;
+  projectName?: string;
+  changedFiles?: string[];
+  projectContextPath?: string;
+}): ProjectContextIndex {
+  if (input.projectContextPath) {
+    const context = readProjectContextIndex(input.projectContextPath);
+    if (context) return context;
+  }
+
+  const latest = projectContextPath(input.cwd);
+  if (existsSync(latest)) {
+    const context = readProjectContextIndex(latest);
+    if (context) return context;
+  }
+
+  return writeProjectContextIndex({
+    targetDir: input.cwd,
+    projectName: input.projectName,
+    changedFiles: input.changedFiles,
+  }).index;
+}
+
+function readRepairSource(
+  input: AxintRepairInput,
+  cwd: string
+):
+  | {
+      source: string;
+      sourcePath?: string;
+      fileName: string;
+    }
+  | undefined {
+  if (input.source) {
+    return {
+      source: input.source,
+      fileName: input.fileName ?? input.sourcePath ?? "<repair.swift>",
+      sourcePath: input.sourcePath,
+    };
+  }
+
+  if (!input.sourcePath) return undefined;
+  const fullPath = input.sourcePath.startsWith("/")
+    ? input.sourcePath
+    : resolve(cwd, input.sourcePath);
+  if (!existsSync(fullPath)) return undefined;
+
+  return {
+    source: readFileSync(fullPath, "utf-8"),
+    sourcePath: fullPath,
+    fileName: relativeOrAbsolute(cwd, fullPath),
+  };
+}
+
+function buildRepairHypotheses(input: {
+  issueClass: string;
+  issueText: string;
+  projectContext: ProjectContextIndex;
+  cloudCheck?: CloudCheckReport;
+  repairIntelligence: AppleRepairIntelligence;
+}): AxintRepairHypothesis[] {
+  const hypotheses: AxintRepairHypothesis[] = [];
+  const cloudCodes = new Set(input.cloudCheck?.diagnostics.map((d) => d.code) ?? []);
+  const riskFiles = input.projectContext.topInteractionRiskFiles;
+
+  for (const cause of input.repairIntelligence.rootCauses) {
+    hypotheses.push({
+      title: cause.title,
+      confidence: cause.confidence,
+      detail: cause.detail,
+      evidence: input.repairIntelligence.signals.map((signal) => `Signal: ${signal}`),
+      inspect: cause.inspect,
+      suggestedPatch: cause.suggestedPatch,
+    });
+  }
+
+  if (
+    input.issueClass === "swiftui-input-interaction" ||
+    cloudCodes.has("AXCLOUD-UI-HIT-TEST-BLOCKER")
+  ) {
+    const overlayFiles = riskFiles.filter((file) => file.hasOverlay || file.hasZIndex);
+    const disabledFiles = riskFiles.filter((file) => file.hasDisabledState);
+    const gestureFiles = riskFiles.filter((file) => file.hasGestureCapture);
+
+    hypotheses.push({
+      title: "Overlay or z-index layer is intercepting the control",
+      confidence: overlayFiles.length > 0 ? "high" : "medium",
+      detail:
+        "SwiftUI inputs often appear visible while an overlay, placeholder, sheet, popover, zIndex layer, or transparent hit area steals the click/focus event.",
+      evidence: [
+        "Issue describes visible UI that cannot be tapped, typed into, or made foreground.",
+        ...overlayFiles
+          .slice(0, 3)
+          .map((file) => `${file.path} has ${file.reasons.join(", ")}`),
+      ],
+      inspect: overlayFiles.slice(0, 5).map((file) => file.path),
+      suggestedPatch:
+        "Move decorative overlays out of the input hit area, add `.allowsHitTesting(false)` to placeholders, or lower/remove the competing zIndex layer.",
+    });
+
+    hypotheses.push({
+      title: "Parent disabled/loading state is propagating into the input subtree",
+      confidence: disabledFiles.length > 0 ? "high" : "low",
+      detail:
+        "A new feature flag, loading gate, modal state, or permission branch can accidentally disable a composer or button container.",
+      evidence: disabledFiles
+        .slice(0, 3)
+        .map((file) => `${file.path} contains disabled-state risk.`),
+      inspect: disabledFiles.slice(0, 5).map((file) => file.path),
+      suggestedPatch:
+        "Narrow `.disabled(...)` to the exact action that should be blocked and keep unrelated composer/focus controls outside that gated subtree.",
+    });
+
+    hypotheses.push({
+      title: "Gesture or focus routing is stealing first responder",
+      confidence: gestureFiles.length > 0 ? "medium" : "low",
+      detail:
+        "High-priority gestures, broad tap handlers, FocusState conflicts, or scroll containers can prevent an input from becoming first responder.",
+      evidence: gestureFiles
+        .slice(0, 3)
+        .map((file) => `${file.path} contains gesture/focus risk.`),
+      inspect: gestureFiles.slice(0, 5).map((file) => file.path),
+      suggestedPatch:
+        "Move gestures to smaller regions, use simultaneous gestures carefully, and assert the intended FocusState after tapping the control.",
+    });
+  }
+
+  if (input.issueClass === "swiftui-hit-testing") {
+    hypotheses.push({
+      title: "UI test is hitting a child hidden by foreground/modal/accessibility state",
+      confidence: "high",
+      detail:
+        "macOS UI tests can find an element in the tree while the actual hit point is covered by a sheet, inactive window, scroll state, broad parent identifier, or another foreground element.",
+      evidence: [
+        "Evidence contains hittable/foreground/background interaction failure language.",
+        ...(input.cloudCheck?.diagnostics
+          .filter((d) => d.code === "AXCLOUD-UI-HIT-TEST-BLOCKER")
+          .map((d) => d.message) ?? []),
+      ],
+      inspect: input.projectContext.topInteractionRiskFiles
+        .slice(0, 6)
+        .map((file) => file.path),
+      suggestedPatch:
+        "Dismiss blocking presentations, activate the app/window before assertions, attach identifiers to actionable children, and scroll/assert the exact Button/Text node.",
+    });
+  }
+
+  if (input.issueClass === "xcode-build-repair" && input.cloudCheck) {
+    for (const diagnostic of input.cloudCheck.diagnostics.slice(0, 4)) {
+      hypotheses.push({
+        title: `${diagnostic.code}: ${diagnostic.message}`,
+        confidence: diagnostic.severity === "error" ? "high" : "medium",
+        detail:
+          diagnostic.suggestion ?? "Repair the reported Swift/Xcode build mismatch.",
+        evidence: [diagnostic.message],
+        inspect: diagnostic.file ? [diagnostic.file] : [],
+        suggestedPatch:
+          diagnostic.suggestion ??
+          "Patch the referenced symbol/call site, then rerun Swift validation and the focused Xcode build.",
+      });
+    }
+  }
+
+  if (input.issueClass === "runtime-freeze") {
+    hypotheses.push({
+      title: "Main-thread or launch-path blocker",
+      confidence: "medium",
+      detail:
+        "Runtime freezes usually come from blocking work in View.body/init/onAppear/.task, App startup, shared stores, or synchronous IO/network waits.",
+      evidence: [
+        "Issue/evidence describes a freeze, hang, launch timeout, or unresponsive UI.",
+      ],
+      inspect: input.projectContext.topInteractionRiskFiles
+        .filter((file) => file.swiftUI)
+        .slice(0, 6)
+        .map((file) => file.path),
+      suggestedPatch:
+        "Move blocking work off the main actor, add cancellation/timeouts, and rerun launch/UI proof.",
+    });
+  }
+
+  if (hypotheses.length === 0) {
+    hypotheses.push({
+      title: "Project-aware Apple repair needed",
+      confidence: input.projectContext.files.swift > 0 ? "medium" : "low",
+      detail:
+        "Axint indexed the project and can guide the proof loop, but it needs source, build log, UI-test failure, or runtime evidence to identify a sharper root cause.",
+      evidence: [
+        `Indexed ${input.projectContext.files.swift} Swift files and ${input.projectContext.files.swiftUI} SwiftUI files.`,
+      ],
+      inspect: input.projectContext.topInteractionRiskFiles
+        .slice(0, 6)
+        .map((file) => file.path),
+      suggestedPatch:
+        "Attach the failing file or the shortest Xcode/UI/runtime failure, then rerun `axint repair`.",
+    });
+  }
+
+  const seen = new Set<string>();
+  return hypotheses
+    .filter((hypothesis) => {
+      const key = hypothesis.title.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(0, 6);
+}
+
+function rankRepairFiles(input: {
+  issueClass: string;
+  projectContext: ProjectContextIndex;
+  cloudCheck?: CloudCheckReport;
+  sourcePath?: string;
+  fileName?: string;
+}): AxintRepairFileTarget[] {
+  const targets: AxintRepairFileTarget[] = [];
+  const add = (file: ProjectContextFileSummary | undefined, why: string) => {
+    if (!file || targets.some((target) => target.path === file.path)) return;
+    targets.push(repairFileTarget(file, why));
+  };
+  const sourceMatch = findContextFile(
+    input.projectContext,
+    input.sourcePath ?? input.fileName
+  );
+  add(sourceMatch, "The file supplied to `axint repair` is the first local anchor.");
+
+  for (const diagnostic of input.cloudCheck?.diagnostics ?? []) {
+    add(
+      findContextFile(input.projectContext, diagnostic.file),
+      `Cloud Check emitted ${diagnostic.code}.`
+    );
+  }
+
+  const sorted = [...input.projectContext.files.catalog].sort((a, b) => {
+    const focusBoost =
+      focusScoreForIssue(input.issueClass, b) - focusScoreForIssue(input.issueClass, a);
+    return focusBoost || b.riskScore - a.riskScore || a.path.localeCompare(b.path);
+  });
+  for (const file of sorted.slice(0, 10)) {
+    add(file, "Project context ranks this file as relevant to the reported failure.");
+  }
+
+  return targets.slice(0, 10);
+}
+
+function buildEvidencePlan(input: {
+  issueClass: string;
+  sourcePayload?: { sourcePath?: string; fileName: string };
+  cloudCheck?: CloudCheckReport;
+  input: AxintRepairInput;
+  repairIntelligence: AppleRepairIntelligence;
+}): string[] {
+  const evidence: string[] = [];
+  for (const item of input.repairIntelligence.inspectionChecklist.slice(0, 3)) {
+    evidence.push(`Inspect: ${item}`);
+  }
+  if (!input.sourcePayload) {
+    evidence.push(
+      "Pass `--source <Swift file>` for the most suspicious view/store so Axint can run Cloud Check against real code."
+    );
+  }
+  if (!input.input.xcodeBuildLog) {
+    evidence.push(
+      "Attach the shortest Xcode build/test log or run `axint run` so repair can reconcile static source with proof."
+    );
+  }
+  if (
+    input.issueClass.includes("ui") ||
+    input.issueClass.includes("swiftui") ||
+    input.issueClass === "runtime-freeze"
+  ) {
+    evidence.push(
+      "Run one focused UI test or manual smoke proof for the exact failing interaction."
+    );
+  }
+  if (!input.input.expectedBehavior) {
+    evidence.push(
+      "State the expected behavior in one sentence so Axint can tell contradiction from intentional absence."
+    );
+  }
+  if (
+    !input.input.actualBehavior &&
+    !input.input.testFailure &&
+    !input.input.runtimeFailure
+  ) {
+    evidence.push(
+      "Add actual behavior, UI-test failure, or runtime failure text from the failing run."
+    );
+  }
+  for (const item of input.cloudCheck?.gate.requiredEvidence ?? []) {
+    if (!evidence.includes(item)) evidence.push(item);
+  }
+  return uniqueStrings(evidence).slice(0, 8);
+}
+
+function buildProofPlan(input: {
+  input: AxintRepairInput;
+  sourcePayload?: { sourcePath?: string; fileName: string };
+  issueClass: string;
+  repairIntelligence: AppleRepairIntelligence;
+}): string[] {
+  const source = input.sourcePayload?.fileName ?? "<changed Swift files>";
+  const steps = [
+    ...input.repairIntelligence.proofPlan.slice(0, 3),
+    `Patch the smallest surface around ${source}; do not regenerate unrelated screens.`,
+    `Run \`axint validate-swift ${source}\` after the patch.`,
+    `Run \`axint cloud check --source ${source}\` with the same expected/actual/test evidence.`,
+  ];
+  if (input.issueClass.includes("ui") || input.issueClass.includes("swiftui")) {
+    steps.push(
+      "Run a focused UI test that taps/types/asserts the exact element or proves the intentional absence."
+    );
+  }
+  steps.push(
+    "Run `axint run --changed <files> --only-testing <focused selector>` before claiming fixed."
+  );
+  return steps;
+}
+
+function buildRepairCommands(input: {
+  input: AxintRepairInput;
+  cwd: string;
+  sourcePayload?: { sourcePath?: string; fileName: string };
+  projectContext: ProjectContextIndex;
+}): string[] {
+  const dir = quote(input.cwd);
+  const source = input.sourcePayload?.fileName;
+  const commands = [`axint project index --dir ${dir}`];
+  if (source) {
+    commands.push(`axint validate-swift ${quote(source)}`);
+    commands.push(
+      `axint cloud check --source ${quote(source)}${
+        input.input.platform ? ` --platform ${input.input.platform}` : ""
+      }`
+    );
+  }
+  const container = input.projectContext.xcode.workspace
+    ? `--workspace ${quote(input.projectContext.xcode.workspace)}`
+    : input.projectContext.xcode.project
+      ? `--project ${quote(input.projectContext.xcode.project)}`
+      : "";
+  const scheme = input.projectContext.xcode.inferredScheme
+    ? `--scheme ${quote(input.projectContext.xcode.inferredScheme)}`
+    : "";
+  commands.push(
+    `axint run --dir ${dir} ${container} ${scheme} --changed <files> --only-testing <focused-selector>`.replace(
+      /\s+/g,
+      " "
+    )
+  );
+  return commands;
+}
+
+function buildRepairFeedbackPacket(input: {
+  id: string;
+  createdAt: string;
+  input: AxintRepairInput;
+  cwd: string;
+  issueClass: string;
+  priority: AxintRepairPriority;
+  status: AxintRepairStatus;
+  confidence: "high" | "medium" | "low";
+  projectContext: ProjectContextIndex;
+  cloudCheck?: CloudCheckReport;
+  hypotheses: AxintRepairHypothesis[];
+  filesToInspect: AxintRepairFileTarget[];
+}): AxintRepairFeedbackPacket {
+  const signals = uniqueStrings([
+    input.issueClass,
+    ...(input.cloudCheck?.learningSignal?.signals ?? []),
+    ...(input.cloudCheck?.diagnostics.map((diagnostic) => diagnostic.code) ?? []),
+    ...input.hypotheses.map((hypothesis) => hypothesis.title),
+  ]);
+  const redactedEvidence = [
+    input.input.issue,
+    input.input.expectedBehavior,
+    input.input.actualBehavior,
+    input.input.xcodeBuildLog,
+    input.input.testFailure,
+    input.input.runtimeFailure,
+  ]
+    .filter(Boolean)
+    .map((value) => redactEvidence(String(value), input.cwd))
+    .slice(0, 8);
+
+  return {
+    schema: "https://axint.ai/schemas/repair-feedback.v1.json",
+    id: `${input.id}-feedback`,
+    createdAt: input.createdAt,
+    compilerVersion: packageVersion(),
+    privacy: {
+      redaction: "source_not_included",
+      localPaths: "project_relative_only",
+      evidence: "summarized_and_truncated",
+      userCanInspectBeforeSending: true,
+    },
+    classification: {
+      issueClass: input.issueClass,
+      priority: input.priority,
+      status: input.status,
+      confidence: input.confidence,
+    },
+    projectShape: {
+      swiftFiles: input.projectContext.files.swift,
+      swiftUIFiles: input.projectContext.files.swiftUI,
+      appIntentFiles: input.projectContext.files.appIntents,
+      inputCapableFiles: input.projectContext.files.inputCapable,
+      interactionRiskFiles: input.projectContext.files.withInteractionRisk,
+      platform: input.input.platform,
+    },
+    signals,
+    diagnostics:
+      input.cloudCheck?.diagnostics.slice(0, 10).map((diagnostic) => ({
+        code: diagnostic.code,
+        severity: diagnostic.severity,
+        message: diagnostic.message,
+      })) ?? [],
+    hypotheses: input.hypotheses.map((hypothesis) => ({
+      title: hypothesis.title,
+      confidence: hypothesis.confidence,
+    })),
+    files: input.filesToInspect.map((file) => ({
+      path: file.path,
+      reasons: file.reasons,
+    })),
+    redactedEvidence,
+    suggestedAxintOwner: suggestOwner(input.issueClass, input.cloudCheck),
+    suggestedProductAction: suggestProductAction(input.issueClass, input.cloudCheck),
+  };
+}
+
+function buildRepairPrompt(report: AxintRepairReport): string {
+  return [
+    "You are repairing an Apple-native project with Axint.",
+    `Issue: ${report.issue}`,
+    `Issue class: ${report.issueClass}`,
+    "",
+    "Host/tool lane:",
+    renderAgentToolProfile(report.agent),
+    "",
+    ...formatAppleRepairRead(report.repairIntelligence),
+    "",
+    "Likely root causes:",
+    ...report.hypotheses.map(
+      (hypothesis) =>
+        `- ${hypothesis.title} (${hypothesis.confidence}): ${hypothesis.suggestedPatch}`
+    ),
+    "",
+    "Inspect these files first:",
+    ...report.filesToInspect.slice(0, 8).map((file) => `- ${file.path}: ${file.why}`),
+    "",
+    "Proof plan:",
+    ...report.proofPlan.map((step) => `- ${step}`),
+    "",
+    "Do not claim the bug is fixed until focused build/UI/runtime proof passes.",
+  ].join("\n");
+}
+
+function writeRepairArtifacts(report: AxintRepairReport): void {
+  const dir = resolve(report.cwd, ".axint/repair");
+  mkdirSync(dir, { recursive: true });
+  const jsonPath = join(dir, "latest.json");
+  const markdownPath = join(dir, "latest.md");
+  report.artifacts.json = jsonPath;
+  report.artifacts.markdown = markdownPath;
+  writeFileSync(
+    jsonPath,
+    `${JSON.stringify(compactRepairReport(report), null, 2)}\n`,
+    "utf-8"
+  );
+  writeFileSync(markdownPath, renderAxintRepairReport(report, "markdown"), "utf-8");
+}
+
+function writeRepairFeedback(report: AxintRepairReport): void {
+  const dir = resolve(report.cwd, ".axint/feedback");
+  mkdirSync(dir, { recursive: true });
+  const packetPath = join(dir, `${report.feedbackPacket.id}.json`);
+  const latestPath = join(dir, "latest.json");
+  report.artifacts.feedback = packetPath;
+  writeFileSync(
+    packetPath,
+    `${JSON.stringify(report.feedbackPacket, null, 2)}\n`,
+    "utf-8"
+  );
+  writeFileSync(
+    latestPath,
+    `${JSON.stringify(report.feedbackPacket, null, 2)}\n`,
+    "utf-8"
+  );
+}
+
+function compactRepairReport(report: AxintRepairReport): AxintRepairReport {
+  return {
+    ...report,
+    cloudCheck: report.cloudCheck
+      ? {
+          ...report.cloudCheck,
+          swiftCode: undefined,
+        }
+      : undefined,
+  };
+}
+
+function resolveRepairStatus(input: {
+  sourcePayload?: unknown;
+  cloudCheck?: CloudCheckReport;
+  hypotheses: AxintRepairHypothesis[];
+  filesToInspect: AxintRepairFileTarget[];
+}): AxintRepairStatus {
+  if (input.cloudCheck?.status === "fail") return "fix_required";
+  if (!input.sourcePayload && input.filesToInspect.length === 0) return "needs_context";
+  if (input.hypotheses.some((hypothesis) => hypothesis.confidence === "high")) {
+    return "fix_required";
+  }
+  return "ready_to_prove";
+}
+
+function buildRepairConfidence(input: {
+  sourcePayload?: unknown;
+  cloudCheck?: CloudCheckReport;
+  hypotheses: AxintRepairHypothesis[];
+  projectContext: ProjectContextIndex;
+}): AxintRepairReport["confidence"] {
+  if (
+    input.cloudCheck &&
+    input.hypotheses.some((hypothesis) => hypothesis.confidence === "high")
+  ) {
+    return {
+      level: "high",
+      detail:
+        "Axint has source/evidence plus a project context map, so the repair plan is specific enough to act on.",
+    };
+  }
+  if (input.sourcePayload || input.projectContext.files.swift > 0) {
+    return {
+      level: "medium",
+      detail:
+        "Axint has project structure, but sharper Xcode/UI/runtime evidence would improve root-cause confidence.",
+    };
+  }
+  return {
+    level: "low",
+    detail:
+      "Axint needs a source file, project index, build log, UI-test failure, or runtime evidence to get specific.",
+  };
+}
+
+function inferPriority(
+  issueClass: string,
+  cloudCheck: CloudCheckReport | undefined,
+  evidence: string
+): AxintRepairPriority {
+  if (cloudCheck?.errors && cloudCheck.errors > 0) return "p1";
+  if (
+    /\b(crash|data loss|security|privacy|freeze|hang|cannot type|can't type|cannot tap|can't tap)\b/i.test(
+      evidence
+    )
+  ) {
+    return "p1";
+  }
+  if (issueClass.includes("swiftui") || issueClass.includes("ui-test")) return "p2";
+  return "p3";
+}
+
+function focusScoreForIssue(issueClass: string, file: ProjectContextFileSummary): number {
+  let score = file.riskScore;
+  if (issueClass === "swiftui-input-interaction") {
+    if (file.hasInputControls) score += 8;
+    if (file.hasOverlay) score += 5;
+    if (file.hasDisabledState) score += 5;
+    if (file.hasGestureCapture) score += 4;
+    if (file.hasFocusState) score += 4;
+  }
+  if (issueClass === "swiftui-hit-testing" || issueClass === "ui-test-accessibility") {
+    if (file.hasListOrScroll) score += 4;
+    if (file.hasZIndex) score += 4;
+    if (file.hasModalPresentation) score += 4;
+    if (file.hasAccessibilityQueries) score += 5;
+    if (file.hasContentShape) score += 2;
+  }
+  return score;
+}
+
+function repairFileTarget(
+  file: ProjectContextFileSummary,
+  why: string
+): AxintRepairFileTarget {
+  return {
+    path: file.path,
+    riskScore: file.riskScore,
+    reasons: file.reasons,
+    why,
+  };
+}
+
+function findContextFile(
+  projectContext: ProjectContextIndex,
+  path?: string
+): ProjectContextFileSummary | undefined {
+  if (!path) return undefined;
+  const normalized = path.replace(/\\/g, "/");
+  return (
+    projectContext.files.catalog.find((file) => file.path === normalized) ??
+    projectContext.files.catalog.find((file) => normalized.endsWith(file.path)) ??
+    projectContext.files.catalog.find((file) => basename(file.path) === basename(path))
+  );
+}
+
+function suggestOwner(
+  issueClass: string,
+  cloudCheck: CloudCheckReport | undefined
+): string {
+  if (
+    cloudCheck?.diagnostics.some((diagnostic) => diagnostic.code.startsWith("AXCLOUD"))
+  ) {
+    return "cloud-repair-classifier";
+  }
+  if (issueClass.includes("swiftui") || issueClass.includes("ui-test")) {
+    return "project-repair-intelligence";
+  }
+  if (issueClass.includes("build")) return "swift-validator";
+  return "repair-workflow";
+}
+
+function suggestProductAction(
+  issueClass: string,
+  cloudCheck: CloudCheckReport | undefined
+): string {
+  if (!cloudCheck) {
+    return "Improve project-only repair ranking and ask for the minimum source/evidence needed.";
+  }
+  if (issueClass === "swiftui-input-interaction") {
+    return "Add or refine SwiftUI input-interaction classifiers and focused proof suggestions.";
+  }
+  if (issueClass === "swiftui-hit-testing") {
+    return "Add more macOS UI-test hit-testing phrases and foreground/window-state repair recipes.";
+  }
+  return "Cluster repeated feedback packets into a new diagnostic or repair-pack rule.";
+}
+
+function redactEvidence(value: string, cwd: string): string {
+  return value
+    .replaceAll(cwd, "$PROJECT")
+    .replace(new RegExp(process.env.HOME ?? "__NO_HOME__", "g"), "~")
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[email]")
+    .replace(/\b[A-Fa-f0-9]{24,}\b/g, "[hex]")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 1200);
+}
+
+function projectContextPath(cwd: string): string {
+  return join(cwd, ".axint/context/latest.json");
+}
+
+function relativeOrAbsolute(root: string, value: string): string {
+  const rel = relative(root, value).replace(/\\/g, "/");
+  return rel && !rel.startsWith("..") ? rel : value;
+}
+
+function quote(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function uniqueStrings(values: Array<string | undefined>): string[] {
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value))));
+}
+
+function hashString(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+function packageVersion(): string {
+  try {
+    const packagePath = resolve(
+      dirname(new URL(import.meta.url).pathname),
+      "../../package.json"
+    );
+    const pkg = JSON.parse(readFileSync(packagePath, "utf-8")) as { version?: string };
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}

--- a/src/run/job-store.ts
+++ b/src/run/job-store.ts
@@ -1,0 +1,406 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import type { AxintRunKind } from "./project-runner.js";
+
+export type AxintRunJobState =
+  | "running"
+  | "cancel_requested"
+  | "cancelled"
+  | "pass"
+  | "needs_review"
+  | "fail"
+  | "unknown";
+
+export interface AxintRunJobCommand {
+  id: string;
+  label: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  pid?: number;
+  startedAt: string;
+  endedAt?: string;
+  exitCode?: number | null;
+  signal?: string | null;
+  timedOut?: boolean;
+  cancelled?: boolean;
+}
+
+export interface AxintRunJobRecord {
+  schema: "https://axint.ai/schemas/run-job.v1.json";
+  id: string;
+  cwd: string;
+  kind: AxintRunKind;
+  projectName: string;
+  status: AxintRunJobState;
+  createdAt: string;
+  updatedAt: string;
+  currentCommand?: AxintRunJobCommand;
+  commands: AxintRunJobCommand[];
+  artifacts?: {
+    json?: string;
+    markdown?: string;
+  };
+  cancelRequestedAt?: string;
+  finishedAt?: string;
+}
+
+export interface AxintRunJobStatusResult {
+  status: AxintRunJobState | "none";
+  cwd: string;
+  id?: string;
+  jobPath?: string;
+  job?: AxintRunJobRecord;
+  latestReport?: {
+    id?: string;
+    status?: string;
+    createdAt?: string;
+    gate?: { decision?: string; reason?: string };
+  };
+  activePids: number[];
+  message: string;
+}
+
+export interface AxintRunCancelResult {
+  status: "cancel_requested" | "nothing_to_cancel" | "not_found" | "error";
+  cwd: string;
+  id?: string;
+  jobPath?: string;
+  killedPids: number[];
+  errors: string[];
+  message: string;
+}
+
+export type AxintRunJobOutputFormat = "markdown" | "json";
+
+export function createRunJobRecord(input: {
+  id: string;
+  cwd: string;
+  kind: AxintRunKind;
+  projectName: string;
+}): AxintRunJobRecord {
+  const now = new Date().toISOString();
+  const job: AxintRunJobRecord = {
+    schema: "https://axint.ai/schemas/run-job.v1.json",
+    id: input.id,
+    cwd: input.cwd,
+    kind: input.kind,
+    projectName: input.projectName,
+    status: "running",
+    createdAt: now,
+    updatedAt: now,
+    commands: [],
+  };
+  writeRunJobRecord(job);
+  writeLatestActiveJob(job);
+  return job;
+}
+
+export function markRunJobCommandStarted(
+  job: AxintRunJobRecord | undefined,
+  command: Omit<AxintRunJobCommand, "startedAt">
+): void {
+  if (!job) return;
+  const started: AxintRunJobCommand = {
+    ...command,
+    startedAt: new Date().toISOString(),
+  };
+  job.status = job.status === "cancel_requested" ? "cancel_requested" : "running";
+  job.currentCommand = started;
+  job.commands.push(started);
+  touch(job);
+}
+
+export function markRunJobCommandFinished(
+  job: AxintRunJobRecord | undefined,
+  commandId: string,
+  result: {
+    exitCode: number | null;
+    signal: string | null;
+    timedOut: boolean;
+    cancelled?: boolean;
+  }
+): void {
+  if (!job) return;
+  const command = job.commands.find((item) => item.id === commandId);
+  if (command) {
+    command.endedAt = new Date().toISOString();
+    command.exitCode = result.exitCode;
+    command.signal = result.signal;
+    command.timedOut = result.timedOut;
+    command.cancelled = result.cancelled;
+  }
+  if (job.currentCommand?.id === commandId) {
+    job.currentCommand = undefined;
+  }
+  if (result.cancelled) {
+    job.status = "cancelled";
+  }
+  touch(job);
+}
+
+export function finishRunJobRecord(
+  job: AxintRunJobRecord | undefined,
+  input: {
+    status: "pass" | "needs_review" | "fail";
+    artifacts?: { json?: string; markdown?: string };
+  }
+): void {
+  if (!job) return;
+  job.status = job.status === "cancelled" ? "cancelled" : input.status;
+  job.artifacts = input.artifacts;
+  job.finishedAt = new Date().toISOString();
+  job.currentCommand = undefined;
+  touch(job);
+  writeLatestActiveJob(job);
+}
+
+export function readRunJobRecord(cwd: string, id: string): AxintRunJobRecord | undefined {
+  return readJson(jobPath(cwd, id)) as AxintRunJobRecord | undefined;
+}
+
+export function getRunJobStatus(
+  input: {
+    cwd?: string;
+    id?: string;
+  } = {}
+): AxintRunJobStatusResult {
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const job = input.id ? readRunJobRecord(cwd, input.id) : readLatestActiveJob(cwd);
+  if (job) {
+    const activePids = activeJobCommands(job)
+      .map((command) => command.pid)
+      .filter((pid): pid is number => typeof pid === "number");
+    return {
+      status: job.status,
+      cwd,
+      id: job.id,
+      jobPath: jobPath(cwd, job.id),
+      job,
+      activePids,
+      message:
+        activePids.length > 0
+          ? `Axint run ${job.id} is ${job.status} with active pid(s): ${activePids.join(", ")}.`
+          : `Axint run ${job.id} is ${job.status}.`,
+    };
+  }
+
+  const latestReport = readLatestReport(cwd);
+  if (latestReport) {
+    return {
+      status: (latestReport.status as AxintRunJobState | undefined) ?? "unknown",
+      cwd,
+      id: latestReport.id,
+      latestReport,
+      activePids: [],
+      message: `Latest Axint run report is ${latestReport.status ?? "unknown"}.`,
+    };
+  }
+
+  return {
+    status: "none",
+    cwd,
+    activePids: [],
+    message: "No Axint run job or latest report was found.",
+  };
+}
+
+export function cancelRunJob(
+  input: {
+    cwd?: string;
+    id?: string;
+  } = {}
+): AxintRunCancelResult {
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const job = input.id ? readRunJobRecord(cwd, input.id) : readLatestActiveJob(cwd);
+  if (!job) {
+    return {
+      status: input.id ? "not_found" : "nothing_to_cancel",
+      cwd,
+      id: input.id,
+      killedPids: [],
+      errors: [],
+      message: input.id
+        ? `No Axint run job found for ${input.id}.`
+        : "No active Axint run job was found.",
+    };
+  }
+
+  const active = activeJobCommands(job).filter(
+    (command) => typeof command.pid === "number"
+  );
+  if (active.length === 0) {
+    return {
+      status: "nothing_to_cancel",
+      cwd,
+      id: job.id,
+      jobPath: jobPath(cwd, job.id),
+      killedPids: [],
+      errors: [],
+      message: `Axint run ${job.id} has no active child process to cancel.`,
+    };
+  }
+
+  const killedPids: number[] = [];
+  const errors: string[] = [];
+  for (const command of active) {
+    const pid = command.pid!;
+    const error = killProcessGroup(pid);
+    if (error) {
+      errors.push(`${pid}: ${error}`);
+    } else {
+      killedPids.push(pid);
+      command.cancelled = true;
+    }
+  }
+
+  job.status = killedPids.length > 0 ? "cancel_requested" : "running";
+  job.cancelRequestedAt = new Date().toISOString();
+  touch(job);
+  writeLatestActiveJob(job);
+
+  return {
+    status: errors.length > 0 && killedPids.length === 0 ? "error" : "cancel_requested",
+    cwd,
+    id: job.id,
+    jobPath: jobPath(cwd, job.id),
+    killedPids,
+    errors,
+    message:
+      killedPids.length > 0
+        ? `Cancel requested for Axint run ${job.id}; killed pid group(s): ${killedPids.join(", ")}.`
+        : `Axint run ${job.id} could not be cancelled.`,
+  };
+}
+
+export function renderRunJobStatus(
+  result: AxintRunJobStatusResult,
+  format: AxintRunJobOutputFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(result, null, 2);
+  return [
+    `# Axint Run Status: ${result.status}`,
+    "",
+    `- CWD: ${result.cwd}`,
+    result.id ? `- Run: ${result.id}` : "- Run: none",
+    result.jobPath ? `- Job file: ${result.jobPath}` : undefined,
+    result.activePids.length > 0
+      ? `- Active pid(s): ${result.activePids.join(", ")}`
+      : "- Active pid(s): none",
+    `- Message: ${result.message}`,
+    result.job?.currentCommand
+      ? `- Current command: ${result.job.currentCommand.label} · ${result.job.currentCommand.command} ${result.job.currentCommand.args.join(" ")}`
+      : undefined,
+    result.latestReport?.gate?.decision
+      ? `- Latest gate: ${result.latestReport.gate.decision}`
+      : undefined,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+}
+
+export function renderRunCancelResult(
+  result: AxintRunCancelResult,
+  format: AxintRunJobOutputFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(result, null, 2);
+  return [
+    `# Axint Run Cancel: ${result.status}`,
+    "",
+    `- CWD: ${result.cwd}`,
+    result.id ? `- Run: ${result.id}` : "- Run: none",
+    result.jobPath ? `- Job file: ${result.jobPath}` : undefined,
+    result.killedPids.length > 0
+      ? `- Killed pid group(s): ${result.killedPids.join(", ")}`
+      : "- Killed pid group(s): none",
+    result.errors.length > 0 ? `- Errors: ${result.errors.join("; ")}` : "- Errors: none",
+    `- Message: ${result.message}`,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+}
+
+function activeJobCommands(job: AxintRunJobRecord): AxintRunJobCommand[] {
+  return job.commands.filter((command) => !command.endedAt);
+}
+
+function touch(job: AxintRunJobRecord): void {
+  job.updatedAt = new Date().toISOString();
+  writeRunJobRecord(job);
+  writeLatestActiveJob(job);
+}
+
+function writeRunJobRecord(job: AxintRunJobRecord): void {
+  const path = jobPath(job.cwd, job.id);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(job, null, 2)}\n`, "utf-8");
+}
+
+function writeLatestActiveJob(job: AxintRunJobRecord): void {
+  const path = latestActivePath(job.cwd);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(job, null, 2)}\n`, "utf-8");
+}
+
+function readLatestActiveJob(cwd: string): AxintRunJobRecord | undefined {
+  const direct = readJson(latestActivePath(cwd)) as AxintRunJobRecord | undefined;
+  if (direct) return direct;
+
+  const dir = jobsDir(cwd);
+  if (!existsSync(dir)) return undefined;
+  const latest = readdirSync(dir)
+    .filter((file) => file.endsWith(".json"))
+    .sort()
+    .at(-1);
+  return latest
+    ? (readJson(join(dir, latest)) as AxintRunJobRecord | undefined)
+    : undefined;
+}
+
+function readLatestReport(cwd: string): AxintRunJobStatusResult["latestReport"] {
+  const latest = readJson(resolve(cwd, ".axint/run/latest.json")) as
+    | AxintRunJobStatusResult["latestReport"]
+    | undefined;
+  if (!latest) return undefined;
+  return {
+    id: latest.id,
+    status: latest.status,
+    createdAt: latest.createdAt,
+    gate: latest.gate,
+  };
+}
+
+function readJson(path: string): unknown | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function jobsDir(cwd: string): string {
+  return resolve(cwd, ".axint/run/jobs");
+}
+
+function jobPath(cwd: string, id: string): string {
+  return join(jobsDir(cwd), `${basename(id)}.json`);
+}
+
+function latestActivePath(cwd: string): string {
+  return resolve(cwd, ".axint/run/latest-active.json");
+}
+
+function killProcessGroup(pid: number): string | undefined {
+  try {
+    process.kill(-pid, "SIGTERM");
+    return undefined;
+  } catch (groupError) {
+    try {
+      process.kill(pid, "SIGTERM");
+      return undefined;
+    } catch (pidError) {
+      return `${(groupError as Error).message}; ${(pidError as Error).message}`;
+    }
+  }
+}

--- a/src/run/project-runner.ts
+++ b/src/run/project-runner.ts
@@ -8,7 +8,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, extname, join, resolve } from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { runCloudCheck, type CloudCheckReport } from "../cloud/check.js";
 import { writeProjectContextIndex } from "../project/context-index.js";
 import { startAxintSession } from "../project/session.js";
@@ -19,13 +19,25 @@ import {
   runWorkflowCheck,
   type WorkflowCheckReport,
 } from "../mcp/workflow-check.js";
+import {
+  createRunJobRecord,
+  finishRunJobRecord,
+  markRunJobCommandFinished,
+  markRunJobCommandStarted,
+  type AxintRunJobRecord,
+} from "./job-store.js";
 
 export type AxintRunFormat = "markdown" | "json" | "prompt";
 export type AxintRunPlatform = "macOS" | "iOS" | "watchOS" | "visionOS" | "all";
 export type AxintRunStepState = "pass" | "warn" | "fail" | "skipped";
 export type AxintRunKind = "local" | "byo-runner";
 
+export interface AxintRunRenderOptions {
+  includeSource?: boolean;
+}
+
 export interface AxintRunInput {
+  id?: string;
   cwd?: string;
   kind?: AxintRunKind;
   projectName?: string;
@@ -63,6 +75,7 @@ export interface AxintRunCommandResult {
   stderr: string;
   durationMs: number;
   dryRun?: boolean;
+  cancelled?: boolean;
 }
 
 export interface AxintRunStep {
@@ -90,6 +103,12 @@ export interface AxintRunReport {
   session: {
     token: string;
     path: string;
+  };
+  job: {
+    id: string;
+    path: string;
+    statusCommand: string;
+    cancelCommand: string;
   };
   workflow: WorkflowCheckReport;
   swiftValidation: {
@@ -129,9 +148,16 @@ export async function runAxintProject(
   input: AxintRunInput = {}
 ): Promise<AxintRunReport> {
   const startedAt = Date.now();
+  const runId = input.id ?? `axrun_${randomUUID()}`;
   const cwd = resolve(input.cwd ?? process.cwd());
   const platform = input.platform ?? inferPlatform(input.destination);
   const projectName = input.projectName ?? inferProjectName(cwd);
+  const job = createRunJobRecord({
+    id: runId,
+    cwd,
+    kind: input.kind ?? "local",
+    projectName,
+  });
   const session = startAxintSession({
     targetDir: cwd,
     projectName,
@@ -210,21 +236,6 @@ export async function runAxintProject(
         : `Ran ${cloudChecks.length} Cloud Check report${cloudChecks.length === 1 ? "" : "s"}.`,
   });
 
-  const workflow = runWorkflowCheck({
-    cwd,
-    stage: "pre-build",
-    sessionStarted: true,
-    sessionToken: session.session.token,
-    readAgentInstructions: true,
-    readDocsContext: true,
-    readRehydrationContext: true,
-    ranStatus: true,
-    ranSuggest: true,
-    ranSwiftValidate: swiftFiles.length > 0,
-    ranCloudCheck: cloudChecks.length > 0,
-    modifiedFiles: swiftFiles.map((file) => relativeOrAbsolute(cwd, file)),
-  });
-
   const commands: AxintRunReport["commands"] = {};
   let plan: XcodePlan | undefined;
   try {
@@ -239,10 +250,11 @@ export async function runAxintProject(
 
   if (plan && !input.skipBuild) {
     const buildArgs = buildXcodeArgs(plan, "build");
-    commands.build = runCommand("xcodebuild", buildArgs, {
+    commands.build = await runCommand("Xcode build", "xcodebuild", buildArgs, {
       cwd,
       timeoutSeconds: input.timeoutSeconds ?? 600,
       dryRun: input.dryRun,
+      job,
     });
     steps.push(stepFromCommand("Xcode build", commands.build));
   } else if (input.skipBuild) {
@@ -255,10 +267,11 @@ export async function runAxintProject(
 
   if (plan && !input.skipTests && !input.skipBuild) {
     const testArgs = buildXcodeArgs(plan, "test");
-    commands.test = runCommand("xcodebuild", testArgs, {
+    commands.test = await runCommand("Xcode test", "xcodebuild", testArgs, {
       cwd,
       timeoutSeconds: input.timeoutSeconds ?? 900,
       dryRun: input.dryRun,
+      job,
     });
     steps.push(stepFromCommand("Xcode test", commands.test));
   } else if (input.skipTests) {
@@ -270,7 +283,7 @@ export async function runAxintProject(
   }
 
   if (plan && input.runtime && platform === "macOS" && !input.dryRun) {
-    const runtime = runMacRuntimeProbe(cwd, plan, input);
+    const runtime = await runMacRuntimeProbe(cwd, plan, input, job);
     commands.buildSettings = runtime.buildSettings;
     commands.runtime = runtime.launch;
     steps.push(
@@ -296,7 +309,8 @@ export async function runAxintProject(
     });
   }
 
-  const xcodeEvidence = buildXcodeEvidence(commands);
+  const xcodeEvidence = buildXcodeEvidence(commands, plan);
+  const focusedBehavior = buildFocusedTestBehavior(plan, commands.test);
   if (xcodeEvidence && cloudTargets.length > 0) {
     cloudChecks.splice(
       0,
@@ -308,8 +322,8 @@ export async function runAxintProject(
           xcodeBuildLog: xcodeEvidence,
           runtimeFailure:
             input.runtimeFailure ?? runtimeFailureFromCommand(commands.runtime),
-          expectedBehavior: input.expectedBehavior,
-          actualBehavior: input.actualBehavior,
+          expectedBehavior: input.expectedBehavior ?? focusedBehavior?.expectedBehavior,
+          actualBehavior: input.actualBehavior ?? focusedBehavior?.actualBehavior,
           projectContext: projectContext.index,
         })
       )
@@ -319,9 +333,25 @@ export async function runAxintProject(
     });
   }
 
+  const workflow = runWorkflowCheck({
+    cwd,
+    stage: "pre-build",
+    sessionStarted: true,
+    sessionToken: session.session.token,
+    readAgentInstructions: true,
+    readDocsContext: true,
+    readRehydrationContext: true,
+    ranStatus: true,
+    ranSwiftValidate: swiftFiles.length > 0,
+    ranCloudCheck: cloudChecks.length > 0,
+    xcodeBuildPassed: commandPassed(commands.build),
+    xcodeTestsPassed: commandPassed(commands.test),
+    modifiedFiles: swiftFiles.map((file) => relativeOrAbsolute(cwd, file)),
+  });
+
   const status = summarizeStatus(steps, workflow, validationDiagnostics, cloudChecks);
   const report: AxintRunReport = {
-    id: `axrun_${randomUUID()}`,
+    id: runId,
     kind: input.kind ?? "local",
     status,
     gate: gateForStatus(status, steps),
@@ -334,6 +364,12 @@ export async function runAxintProject(
     session: {
       token: session.session.token,
       path: session.sessionPath,
+    },
+    job: {
+      id: runId,
+      path: resolve(cwd, ".axint/run/jobs", `${runId}.json`),
+      statusCommand: `axint run status --dir ${shellQuote(cwd)} --id ${runId}`,
+      cancelCommand: `axint run cancel --dir ${shellQuote(cwd)} --id ${runId}`,
     },
     workflow,
     swiftValidation: {
@@ -365,15 +401,25 @@ export async function runAxintProject(
     const artifacts = writeRunArtifacts(report);
     report.artifacts = artifacts;
   }
+  finishRunJobRecord(job, {
+    status,
+    artifacts: {
+      json: report.artifacts.json,
+      markdown: report.artifacts.markdown,
+    },
+  });
 
   return report;
 }
 
 export function renderAxintRunReport(
   report: AxintRunReport,
-  format: AxintRunFormat = "markdown"
+  format: AxintRunFormat = "markdown",
+  options: AxintRunRenderOptions = {}
 ): string {
-  if (format === "json") return JSON.stringify(report, null, 2);
+  if (format === "json") {
+    return JSON.stringify(compactRunReport(report, options), null, 2);
+  }
   if (format === "prompt") return report.repairPrompt;
 
   const lines = [
@@ -386,6 +432,9 @@ export function renderAxintRunReport(
     `- Gate: ${report.gate.decision}`,
     `- Reason: ${report.gate.reason}`,
     `- Session: ${report.session.token}`,
+    `- Job: ${report.job.id}`,
+    `- Status command: \`${report.job.statusCommand}\``,
+    `- Cancel command: \`${report.job.cancelCommand}\``,
     "",
     "## Steps",
     ...report.steps.map(
@@ -511,17 +560,32 @@ function formatOnlyTestingArg(selector: string): string {
   return selector.startsWith("-only-testing:") ? selector : `-only-testing:${selector}`;
 }
 
-function runCommand(
+async function runCommand(
+  label: string,
   command: string,
   args: string[],
   options: {
     cwd: string;
     timeoutSeconds: number;
     dryRun?: boolean;
+    job?: AxintRunJobRecord;
   }
-): AxintRunCommandResult {
+): Promise<AxintRunCommandResult> {
   const started = Date.now();
+  const commandId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   if (options.dryRun) {
+    markRunJobCommandStarted(options.job, {
+      id: commandId,
+      label,
+      command,
+      args,
+      cwd: options.cwd,
+    });
+    markRunJobCommandFinished(options.job, commandId, {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+    });
     return {
       command,
       args,
@@ -535,42 +599,96 @@ function runCommand(
       dryRun: true,
     };
   }
-  const result = spawnSync(command, args, {
-    cwd: options.cwd,
-    encoding: "utf-8",
-    timeout: options.timeoutSeconds * 1000,
-    maxBuffer: 8 * 1024 * 1024,
+
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let settled = false;
+    let spawnError: Error | undefined;
+
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    markRunJobCommandStarted(options.job, {
+      id: commandId,
+      label,
+      command,
+      args,
+      cwd: options.cwd,
+      pid: child.pid,
+    });
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout = appendCommandOutput(stdout, chunk.toString("utf-8"));
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr = appendCommandOutput(stderr, chunk.toString("utf-8"));
+    });
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      if (child.pid) killProcessGroup(child.pid, "SIGTERM");
+    }, options.timeoutSeconds * 1000);
+
+    child.once("error", (error) => {
+      spawnError = error;
+      finish(null, null);
+    });
+    child.once("close", (code, signal) => {
+      finish(code, signal);
+    });
+
+    function finish(code: number | null, signal: NodeJS.Signals | null) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      const cancelled = signal === "SIGTERM" && !timedOut;
+      markRunJobCommandFinished(options.job, commandId, {
+        exitCode: code,
+        signal,
+        timedOut,
+        cancelled,
+      });
+      resolve({
+        command,
+        args,
+        cwd: options.cwd,
+        exitCode: code,
+        signal,
+        timedOut,
+        stdout,
+        stderr: spawnError
+          ? `${stderr}\n${spawnError.name}: ${spawnError.message}`.trim()
+          : stderr,
+        durationMs: Date.now() - started,
+        cancelled,
+      });
+    }
   });
-  return {
-    command,
-    args,
-    cwd: options.cwd,
-    exitCode: result.status,
-    signal: result.signal,
-    timedOut: Boolean(result.error && result.error.message.includes("ETIMEDOUT")),
-    stdout: result.stdout ?? "",
-    stderr:
-      result.stderr ??
-      (result.error ? `${result.error.name}: ${result.error.message}` : ""),
-    durationMs: Date.now() - started,
-  };
 }
 
-function runMacRuntimeProbe(
+async function runMacRuntimeProbe(
   cwd: string,
   plan: XcodePlan,
-  input: AxintRunInput
-): {
+  input: AxintRunInput,
+  job?: AxintRunJobRecord
+): Promise<{
   buildSettings?: AxintRunCommandResult;
   launch?: AxintRunCommandResult;
   detail: string;
-} {
-  const settings = runCommand(
+}> {
+  const settings = await runCommand(
+    "Xcode build settings",
     "xcodebuild",
     [...buildXcodeArgs(plan, "build").slice(0, -1), "-showBuildSettings", "-json"],
     {
       cwd,
       timeoutSeconds: 90,
+      job,
     }
   );
   if (settings.exitCode !== 0) {
@@ -586,7 +704,12 @@ function runMacRuntimeProbe(
       detail: "Build settings did not resolve to a built .app bundle.",
     };
   }
-  const launch = runRuntimeLaunchProbe(cwd, appPath, input.runtimeTimeoutSeconds ?? 8);
+  const launch = await runRuntimeLaunchProbe(
+    cwd,
+    appPath,
+    input.runtimeTimeoutSeconds ?? 8,
+    job
+  );
   return {
     buildSettings: settings,
     launch,
@@ -594,29 +717,33 @@ function runMacRuntimeProbe(
   };
 }
 
-function runRuntimeLaunchProbe(
+async function runRuntimeLaunchProbe(
   cwd: string,
   appPath: string,
-  waitSeconds: number
-): AxintRunCommandResult {
+  waitSeconds: number,
+  job?: AxintRunJobRecord
+): Promise<AxintRunCommandResult> {
   const started = Date.now();
   const appName = basename(appPath, ".app");
-  const openResult = runCommand("open", ["-n", appPath], {
+  const openResult = await runCommand("Runtime open", "open", ["-n", appPath], {
     cwd,
     timeoutSeconds: 15,
+    job,
   });
   if (openResult.exitCode !== 0) return openResult;
 
   const boundedWait = String(Math.min(Math.max(Math.round(waitSeconds), 1), 60));
-  spawnSync("sleep", [boundedWait], {
-    cwd,
-    encoding: "utf-8",
-    timeout: (Number(boundedWait) + 2) * 1000,
-  });
-  const processCheck = runCommand("pgrep", ["-x", appName], {
-    cwd,
-    timeoutSeconds: 5,
-  });
+  await delay(Number(boundedWait) * 1000);
+  const processCheck = await runCommand(
+    "Runtime process check",
+    "pgrep",
+    ["-x", appName],
+    {
+      cwd,
+      timeoutSeconds: 5,
+      job,
+    }
+  );
   return {
     command: "axint-runtime-probe",
     args: [appPath, "--process", appName, "--wait", boundedWait],
@@ -757,17 +884,30 @@ function stepFromCommand(name: string, result: AxintRunCommandResult): AxintRunS
   const printable = [result.command, ...result.args].map(shellQuote).join(" ");
   return {
     name,
-    state: result.exitCode === 0 && !result.timedOut ? "pass" : "fail",
+    state:
+      result.exitCode === 0 && !result.timedOut && !result.cancelled ? "pass" : "fail",
     detail: result.dryRun
       ? "Dry run planned the command without executing it."
-      : result.timedOut
-        ? `Command timed out after ${Math.round(result.durationMs / 1000)}s.`
-        : result.exitCode === 0
-          ? "Command completed successfully."
-          : `Command exited with ${result.exitCode ?? result.signal ?? "unknown"}.`,
+      : result.cancelled
+        ? "Command was cancelled through Axint run cancellation."
+        : result.timedOut
+          ? `Command timed out after ${Math.round(result.durationMs / 1000)}s.`
+          : result.exitCode === 0
+            ? "Command completed successfully."
+            : `Command exited with ${result.exitCode ?? result.signal ?? "unknown"}.`,
     command: printable,
     durationMs: result.durationMs,
   };
+}
+
+function commandPassed(result?: AxintRunCommandResult): boolean {
+  return Boolean(
+    result &&
+    !result.dryRun &&
+    result.exitCode === 0 &&
+    !result.timedOut &&
+    !result.cancelled
+  );
 }
 
 function updateCloudCheckStep(
@@ -793,13 +933,64 @@ function updateCloudCheckStep(
         : `Ran ${cloudChecks.length} Cloud Check report${cloudChecks.length === 1 ? "" : "s"}.`;
 }
 
-function buildXcodeEvidence(commands: AxintRunReport["commands"]): string | undefined {
+function buildXcodeEvidence(
+  commands: AxintRunReport["commands"],
+  plan?: XcodePlan
+): string | undefined {
   const chunks = [
     commandEvidence("Xcode build", commands.build),
+    focusedTestEvidence(commands.test, plan),
     commandEvidence("Xcode test", commands.test),
     commandEvidence("Runtime launch", commands.runtime),
   ].filter(Boolean);
   return chunks.length > 0 ? chunks.join("\n\n") : undefined;
+}
+
+function focusedTestEvidence(
+  result?: AxintRunCommandResult,
+  plan?: XcodePlan
+): string | undefined {
+  const selectors = plan?.onlyTesting ?? [];
+  if (!result || result.dryRun || selectors.length === 0) return undefined;
+  const state = result.exitCode === 0 && !result.timedOut ? "passed" : "failed";
+  const command = plan
+    ? ["xcodebuild", ...buildXcodeArgs(plan, "test")].map(shellQuote).join(" ")
+    : undefined;
+  const relevantOutput = focusedTestOutput(result, selectors);
+  return [
+    `Focused Xcode test proof ${state}.`,
+    command ? `Command: ${command}` : undefined,
+    `Selectors: ${selectors.map(formatOnlyTestingArg).join(", ")}`,
+    state === "passed" ? "** TEST SUCCEEDED **" : "** TEST FAILED **",
+    relevantOutput ? `Relevant test output:\n${relevantOutput}` : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function buildFocusedTestBehavior(
+  plan?: XcodePlan,
+  result?: AxintRunCommandResult
+):
+  | {
+      expectedBehavior: string;
+      actualBehavior: string;
+    }
+  | undefined {
+  if (!plan || plan.onlyTesting.length === 0 || !result || result.dryRun) {
+    return undefined;
+  }
+  const selectors = plan.onlyTesting.join(", ");
+  if (result.exitCode !== 0 || result.timedOut) {
+    return {
+      expectedBehavior: `Focused test selector(s) should pass: ${selectors}.`,
+      actualBehavior: `Focused test selector(s) did not pass through axint run --only-testing: ${selectors}.`,
+    };
+  }
+  return {
+    expectedBehavior: `Focused test selector(s) should pass: ${selectors}.`,
+    actualBehavior: `Focused test selector(s) passed through axint run --only-testing: ${selectors}.`,
+  };
 }
 
 function commandEvidence(
@@ -814,6 +1005,32 @@ function commandEvidence(
   }.`;
   const output = trimCommandEvidence([result.stdout, result.stderr].join("\n"));
   return output ? `${header}\n${output}` : header;
+}
+
+function focusedTestOutput(
+  result: AxintRunCommandResult,
+  selectors: string[]
+): string | undefined {
+  const output = [result.stdout, result.stderr].join("\n");
+  if (!output.trim()) return undefined;
+  const selectorTerms = selectors.flatMap((selector) => {
+    const normalized = selector.replace(/^-only-testing:/, "");
+    const parts = normalized.split("/");
+    return [normalized, parts.at(-1) ?? normalized].filter(Boolean);
+  });
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const selectedLines = lines.filter((line) => {
+    const lower = line.toLowerCase();
+    return (
+      /\*\*\s*test\s+(?:succeeded|failed)\s*\*\*/i.test(line) ||
+      /\bexecuted\s+\d+\s+tests?,?\s+with\s+\d+\s+failures?\b/i.test(line) ||
+      selectorTerms.some((term) => lower.includes(term.toLowerCase()))
+    );
+  });
+  return trimCommandEvidence(unique(selectedLines).join("\n") || output, 4000);
 }
 
 function runtimeFailureFromCommand(result?: AxintRunCommandResult): string | undefined {
@@ -835,6 +1052,29 @@ function trimCommandEvidence(value: string, maxChars = 12000): string {
   const head = text.slice(0, 1600).trimEnd();
   const tail = text.slice(-(maxChars - head.length - 80)).trimStart();
   return `${head}\n\n[... axint trimmed long command evidence ...]\n\n${tail}`;
+}
+
+function appendCommandOutput(current: string, next: string, maxChars = 8 * 1024 * 1024) {
+  const combined = `${current}${next}`;
+  if (combined.length <= maxChars) return combined;
+  const tail = combined.slice(-(maxChars - 80));
+  return `[... axint trimmed live command output ...]\n${tail}`;
+}
+
+function killProcessGroup(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // The process may have exited between timeout and signal delivery.
+    }
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function summarizeStatus(
@@ -915,6 +1155,32 @@ function buildRunRepairPrompt(input: {
   cloudChecks: CloudCheckReport[];
   commands: AxintRunReport["commands"];
 }) {
+  if (input.status === "pass") {
+    const passedCommands = Object.entries(input.commands)
+      .filter(([, result]) => result && result.exitCode === 0 && !result.timedOut)
+      .map(([label]) => label);
+    return [
+      "Axint Run passed for this Apple-native project.",
+      "Overall status: pass.",
+      "",
+      "Continue with the next proof, commit, or sprint item. Do not rerun Axint unless new code changes or new evidence appears.",
+      "",
+      "Evidence accepted:",
+      input.workflow.status === "ready"
+        ? "- Workflow gate is ready."
+        : "- Workflow gate has residual notes; inspect the run report before committing.",
+      input.validationDiagnostics.length === 0
+        ? "- Swift validation is clean."
+        : `- Swift validation has ${input.validationDiagnostics.length} non-blocking diagnostic(s).`,
+      input.cloudChecks.length > 0
+        ? `- Cloud Check reviewed ${input.cloudChecks.length} file${input.cloudChecks.length === 1 ? "" : "s"}.`
+        : "- Cloud Check had no source files to review.",
+      passedCommands.length > 0
+        ? `- Passed command evidence: ${passedCommands.join(", ")}.`
+        : "- No executed Xcode command evidence was required for this pass.",
+    ].join("\n");
+  }
+
   const lines = [
     "You are repairing an Apple-native project under Axint Run.",
     `Overall status: ${input.status}.`,
@@ -992,6 +1258,125 @@ function writeRunArtifacts(report: AxintRunReport) {
     projectContextJson: report.artifacts.projectContextJson,
     projectContextMarkdown: report.artifacts.projectContextMarkdown,
   };
+}
+
+function compactRunReport(
+  report: AxintRunReport,
+  options: AxintRunRenderOptions
+):
+  | AxintRunReport
+  | (Omit<AxintRunReport, "cloudChecks" | "commands"> & {
+      cloudChecks: Array<
+        Omit<CloudCheckReport, "swiftCode"> & {
+          sourceRedaction?: {
+            swiftCode: "omitted_from_axint_run_json";
+            reason: string;
+            sourceLines: number;
+            outputLines: number;
+          };
+        }
+      >;
+      commands: {
+        build?: CompactRunCommandResult;
+        test?: CompactRunCommandResult;
+        runtime?: CompactRunCommandResult;
+        buildSettings?: CompactRunCommandResult;
+      };
+      outputRedaction: {
+        mode: "compact";
+        reason: string;
+        includeSourceFlag: "--include-source";
+      };
+    }) {
+  if (options.includeSource) return report;
+
+  return {
+    ...report,
+    cloudChecks: report.cloudChecks.map(compactCloudCheckForRun),
+    commands: compactRunCommands(report.commands),
+    outputRedaction: {
+      mode: "compact" as const,
+      reason:
+        "Rendered axint.run JSON omits full Swift source and long command output by default so agents see verdict, evidence, diagnostics, artifact paths, and next steps first.",
+      includeSourceFlag: "--include-source" as const,
+    },
+  };
+}
+
+type CompactRunCommandResult = Omit<AxintRunCommandResult, "stdout" | "stderr"> & {
+  stdoutTail?: string;
+  stderrTail?: string;
+  outputRedaction?: {
+    stdout?: "trimmed_from_axint_run_json";
+    stderr?: "trimmed_from_axint_run_json";
+    reason: string;
+  };
+};
+
+function compactRunCommands(commands: AxintRunReport["commands"]): {
+  build?: CompactRunCommandResult;
+  test?: CompactRunCommandResult;
+  runtime?: CompactRunCommandResult;
+  buildSettings?: CompactRunCommandResult;
+} {
+  return {
+    build: compactRunCommand(commands.build),
+    test: compactRunCommand(commands.test),
+    runtime: compactRunCommand(commands.runtime),
+    buildSettings: compactRunCommand(commands.buildSettings),
+  };
+}
+
+function compactRunCommand(
+  result?: AxintRunCommandResult
+): CompactRunCommandResult | undefined {
+  if (!result) return undefined;
+  const { stdout, stderr, ...rest } = result;
+  const compact: CompactRunCommandResult = { ...rest };
+  if (stdout) compact.stdoutTail = tailText(stdout, 1200);
+  if (stderr) compact.stderrTail = tailText(stderr, 1200);
+  if (stdout || stderr) {
+    compact.outputRedaction = {
+      ...(stdout ? { stdout: "trimmed_from_axint_run_json" as const } : {}),
+      ...(stderr ? { stderr: "trimmed_from_axint_run_json" as const } : {}),
+      reason:
+        "Full command output is available in Axint artifacts or the terminal. Compact JSON keeps long agent conversations readable.",
+    };
+  }
+  return compact;
+}
+
+function compactCloudCheckForRun(report: CloudCheckReport): Omit<
+  CloudCheckReport,
+  "swiftCode"
+> & {
+  sourceRedaction?: {
+    swiftCode: "omitted_from_axint_run_json";
+    reason: string;
+    sourceLines: number;
+    outputLines: number;
+  };
+} {
+  const { swiftCode, ...rest } = report;
+  return {
+    ...rest,
+    ...(swiftCode
+      ? {
+          sourceRedaction: {
+            swiftCode: "omitted_from_axint_run_json" as const,
+            reason:
+              "Full Swift source is omitted from axint.run JSON by default. Use --include-source only when an agent explicitly needs inline source.",
+            sourceLines: report.sourceLines,
+            outputLines: report.outputLines,
+          },
+        }
+      : {}),
+  };
+}
+
+function tailText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `[... ${value.length - maxChars} chars trimmed ...]\n${value.slice(-maxChars)}`;
 }
 
 function relativeOrAbsolute(cwd: string, path: string) {

--- a/tests/cli/status.test.ts
+++ b/tests/cli/status.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from "vitest";
 import { renderCliStatus } from "../../src/cli/status.js";
 
 describe("axint status", () => {
-  it("prints local version and Xcode restart guidance", () => {
+  it("prints local version and same-thread reload guidance", () => {
     const output = renderCliStatus("9.9.9", "markdown");
 
     expect(output).toContain("@axint/compiler@9.9.9");
     expect(output).toContain("Call axint.status");
-    expect(output).toContain("Restart the Xcode Claude Agent chat");
+    expect(output).toContain("axint upgrade --apply");
+    expect(output).toContain("Keep the current Codex or Claude thread");
   });
 
   it("can emit the startup prompt for Claude in Xcode", () => {
@@ -15,6 +16,7 @@ describe("axint status", () => {
 
     expect(output).toContain("Call axint.status");
     expect(output).toContain("Expected local package version: 9.9.9");
+    expect(output).toContain("axint.upgrade");
     expect(output).toContain("axint.cloud.check");
   });
 });

--- a/tests/cloud/check.test.ts
+++ b/tests/cloud/check.test.ts
@@ -292,6 +292,111 @@ struct DiscoverTabView: View {
     expect(report.repairPrompt).not.toContain("This is not a runtime pass");
   });
 
+  it("does not keep stale accessibility warnings after focused UI proof passes", () => {
+    const report = runCloudCheck({
+      fileName: "BreakawayComposerView.swift",
+      platform: "macOS",
+      source: `
+import SwiftUI
+
+struct BreakawayComposerView: View {
+    @State private var draft = ""
+
+    var body: some View {
+        VStack {
+            TextField("Message", text: $draft)
+                .accessibilityIdentifier("breakaway-composer-field")
+            Button("Send") {}
+                .accessibilityIdentifier("breakaway-send")
+        }
+    }
+}
+`,
+      expectedBehavior:
+        "The breakaway corner entry opens the messenger window and keeps the composer text field hittable.",
+      actualBehavior:
+        "Focused UI proof passed with the accessibility identifiers attached to the queried text field and send button.",
+      xcodeBuildLog: [
+        "Test Suite 'SwarmUITests' started.",
+        "Test Case '-[SwarmUITests testBreakawayCornerEntryOpensMessengerWindow]' passed (1.42 seconds).",
+        "only-testing:SwarmUITests/SwarmUITests/testBreakawayCornerEntryOpensMessengerWindow",
+        "** TEST SUCCEEDED **",
+        "Executed 1 test, with 0 failures",
+      ].join("\n"),
+    });
+
+    expect(report.diagnostics.map((d) => d.code)).not.toContain(
+      "AXCLOUD-UI-ACCESSIBILITY-ID"
+    );
+    expect(report.status).toBe("pass");
+    expect(report.gate.decision).toBe("ready_to_ship");
+  });
+
+  it("classifies macOS UI proof where a scrolled control is visible but not hittable", () => {
+    const report = runCloudCheck({
+      fileName: "ProjectCommandCenter.swift",
+      platform: "macOS",
+      source: `
+import SwiftUI
+
+struct ProjectCommandCenter: View {
+    var body: some View {
+        ScrollView {
+            Button("Manage Axint Core") {}
+                .accessibilityIdentifier("discover-project-manage-axint-core")
+        }
+    }
+}
+`,
+      testFailure:
+        "XCTAssertTrue failed: discover-project-manage-axint-core should be hittable after scrolling. Element is not foreground and does not allow background interaction.",
+    });
+
+    expect(report.status).toBe("fail");
+    expect(report.diagnostics.map((d) => d.code)).toContain(
+      "AXCLOUD-UI-HIT-TEST-BLOCKER"
+    );
+    expect(report.diagnostics.map((d) => d.code)).not.toContain(
+      "AXCLOUD-EVIDENCE-UNCLASSIFIED"
+    );
+    expect(report.repairPrompt).toContain("hit-testing");
+  });
+
+  it("treats intentional absence assertions as passing behavior proof", () => {
+    const report = runCloudCheck({
+      fileName: "ProjectCommandCenter.swift",
+      platform: "macOS",
+      source: `
+import SwiftUI
+
+struct ProjectCommandCenter: View {
+    var body: some View {
+        VStack {
+            Button("Manage") {}
+            Button("Open") {}
+        }
+    }
+}
+`,
+      expectedBehavior:
+        "Owned projects should show Manage and Open actions and should not show Join or Follow.",
+      actualBehavior:
+        "Focused UI proof passed and asserted Join and Follow did not exist for owned projects while Manage and Open were hittable.",
+      xcodeBuildLog: [
+        "Test Suite 'SwarmUITests' started.",
+        "Test Case '-[SwarmUITests testOwnedProjectActionsHideJoinAndFollow]' passed (1.04 seconds).",
+        "** TEST SUCCEEDED **",
+        "Executed 1 test, with 0 failures",
+      ].join("\n"),
+    });
+
+    expect(report.diagnostics.map((d) => d.code)).not.toContain(
+      "AXCLOUD-BEHAVIOR-MISMATCH"
+    );
+    expect(report.status).toBe("pass");
+    expect(report.gate.decision).toBe("ready_to_ship");
+  });
+
   it("flags behavior evidence only when the actual text describes a failure", () => {
     const report = runCloudCheck({
       fileName: "HomeCommandLayer.swift",
@@ -470,7 +575,13 @@ struct HomeComposer: View {
     expect(report.diagnostics.map((d) => d.code)).toContain(
       "AXCLOUD-UI-HIT-TEST-BLOCKER"
     );
+    expect(report.repairIntelligence?.issueClass).toBe("swiftui-input-interaction");
+    expect(report.repairIntelligence?.summary).toContain("existing iOS Apple repair");
+    expect(report.repairPlan.map((step) => step.title).join("\n")).toContain(
+      "Senior Apple repair read"
+    );
     expect(report.repairPrompt).toContain("allowsHitTesting(false)");
+    expect(report.repairPrompt).toContain("Senior Apple repair read");
     expect(report.learningSignal?.signals).toContain("ui-interaction-evidence");
   });
 

--- a/tests/core/swift-validator.test.ts
+++ b/tests/core/swift-validator.test.ts
@@ -815,6 +815,33 @@ describe("swift validator — AX739 undeclared SwiftUI body references", () => {
     );
   });
 
+  it("ignores lowercase words that appear only inside string literals", () => {
+    const source = `
+      import SwiftUI
+
+      struct ProjectMembersView: View {
+          let role = "Admin"
+
+          var body: some View {
+              VStack {
+                  Button {
+                      let label = "\\(role) invite"
+                      print(label)
+                      print("invite")
+                  } label: {
+                      Text("Send invite")
+                  }
+                  .tag("invite")
+              }
+          }
+      }
+    `;
+
+    expect(validate(source).diagnostics.filter((d) => d.code === "AX739")).toHaveLength(
+      0
+    );
+  });
+
   it("accepts private helper methods declared on the view", () => {
     const source = `
       import SwiftUI

--- a/tests/mcp/feature.test.ts
+++ b/tests/mcp/feature.test.ts
@@ -384,6 +384,58 @@ describe("axint.feature", () => {
     );
   });
 
+  it("does not treat context-file symbols as requested output components", () => {
+    const result = generateFeature({
+      description:
+        "Create a focused composer safety strip for the existing Breakaway messenger home screen. Keep it compact, preserve the current screen, and only add the new strip.",
+      context: `
+struct BreakawayMessengerView: View {
+    var body: some View {
+        ZStack {
+            ThreadList()
+            ComposerBox()
+            ProjectLogoView()
+            BuilderAvatarView()
+            MessengerCornerPill()
+        }
+    }
+}
+
+struct ThreadList: View {}
+struct ComposerBox: View {}
+struct ProjectLogoView: View {}
+struct BuilderAvatarView: View {}
+struct MessengerCornerPill: View {}
+`,
+      surfaces: ["component"],
+      name: "ComposerSafetyStrip",
+      componentKind: "semanticPanel",
+      platform: "macOS",
+      tokenNamespace: "SwarmDesignTokens",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.diagnostics.join("\n")).not.toContain("AX850");
+
+    const paths = result.files.map((f) => f.path).join("\n");
+    expect(paths).toContain("Sources/Components/ComposerSafetyStrip.swift");
+    expect(paths).not.toContain("BreakawayMessengerView.swift");
+    expect(paths).not.toContain("ThreadList.swift");
+    expect(paths).not.toContain("ProjectLogoView.swift");
+    expect(paths).not.toContain("BuilderAvatarView.swift");
+    expect(paths).not.toContain("MessengerCornerPill.swift");
+
+    const component = result.files.find(
+      (f) => f.path === "Sources/Components/ComposerSafetyStrip.swift"
+    );
+    expect(component).toBeDefined();
+    expect(component!.content).toContain("struct ComposerSafetyStrip: View");
+    expect(component!.content).toContain("SwarmDesignTokens.");
+    expect(validateSwiftSource(component!.content, component!.path).diagnostics).toEqual(
+      []
+    );
+  });
+
   it("extracts named component kits instead of returning one generic scaffold", () => {
     const result = generateFeature({
       description:
@@ -496,6 +548,130 @@ describe("axint.feature", () => {
     expect(view!.content).toContain("@State private var appearanceMode");
     expect(view!.content).not.toContain("Device:");
     expect(validateSwiftSource(view!.content, view!.path).diagnostics).toEqual([]);
+  });
+
+  it("keeps operating-model settings prompts out of generic feed-card output", () => {
+    const result = generateFeature({
+      description:
+        "Project operating model settings view with visibility, invite policy, public modules, invite limits, member permissions, agent permissions, privacy posture, and integration readiness controls.",
+      surfaces: ["component"],
+      name: "ProjectOperatingModelSettings",
+      componentKind: "settingsView",
+      platform: "macOS",
+      tokenNamespace: "SwarmTokens",
+    });
+
+    expect(result.success).toBe(true);
+    const component = result.files.find(
+      (f) => f.path === "Sources/Components/ProjectOperatingModelSettings.swift"
+    );
+    expect(component).toBeDefined();
+    expect(component!.content).toContain('Picker("Visibility"');
+    expect(component!.content).toContain('Picker("Invite policy"');
+    expect(component!.content).toContain('Stepper("Invite limit');
+    expect(component!.content).toContain('Toggle("Public modules enabled"');
+    expect(component!.content).toContain('Toggle("Agents can publish drafts"');
+    expect(component!.content).toContain('Picker("Privacy posture"');
+    expect(component!.content).not.toContain("authorName");
+    expect(component!.content).not.toContain("reactionCount");
+    expect(component!.content).not.toContain("commentCount");
+    expect(validateSwiftSource(component!.content, component!.path).diagnostics).toEqual(
+      []
+    );
+  });
+
+  it("lets trust-posture semantics outrank a generic context-panel hint", () => {
+    const result = generateFeature({
+      description:
+        "CommandTrustPosture macOS component with ProjectOperatingModel visibility, invite policy, public modules, member permissions, agent permissions, privacy posture, reduced motion, and a primary route to Project Settings.",
+      surfaces: ["component"],
+      name: "CommandTrustPosture",
+      componentKind: "contextPanel",
+      platform: "macOS",
+      tokenNamespace: "SwarmTokens",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.diagnostics.join("\n")).not.toContain("AX853");
+    const component = result.files.find(
+      (f) => f.path === "Sources/Components/CommandTrustPosture.swift"
+    );
+    expect(component).toBeDefined();
+    expect(component!.content).toContain("Trust posture");
+    expect(component!.content).toContain("Text(visibility)");
+    expect(component!.content).toContain("Text(invitePolicy)");
+    expect(component!.content).toContain("publicModulesEnabled");
+    expect(component!.content).toContain("membersCanInvite");
+    expect(component!.content).toContain("agentsCanPublish");
+    expect(component!.content).toContain("Project Settings");
+    expect(component!.content).not.toContain("North Star");
+    expect(validateSwiftSource(component!.content, component!.path).diagnostics).toEqual(
+      []
+    );
+  });
+
+  it("generates purpose-aware sparse states instead of a generic context panel", () => {
+    const result = generateFeature({
+      description:
+        "Create a PurposeAwareSparseState macOS component that reuses Swarm empty-state patterns and produces purpose-aware sparse states for project command surfaces.",
+      surfaces: ["component"],
+      name: "PurposeAwareSparseState",
+      componentKind: "contextPanel",
+      platform: "macOS",
+      tokenNamespace: "SwarmTokens",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.diagnostics.join("\n")).not.toContain("AX853");
+    const component = result.files.find(
+      (f) => f.path === "Sources/Components/PurposeAwareSparseState.swift"
+    );
+    expect(component).toBeDefined();
+    expect(component!.content).toContain("Purpose-aware sparse state");
+    expect(component!.content).toContain("Empty command surfaces");
+    expect(component!.content).toContain("Create command");
+    expect(component!.content).toContain("Attach context");
+    expect(component!.content).not.toContain("North Star");
+    expect(validateSwiftSource(component!.content, component!.path).diagnostics).toEqual(
+      []
+    );
+  });
+
+  it("fails closed instead of emitting semantically thin generic UI", () => {
+    const result = generateFeature({
+      description:
+        "Create an Apple signing reliability console with provisioning profile mismatch, certificate expiry, notarization backlog, privacy manifest coverage, entitlement drift, and release captain escalation.",
+      surfaces: ["component"],
+      name: "SigningReliabilityConsole",
+      componentKind: "custom",
+      platform: "macOS",
+      tokenNamespace: "SwarmTokens",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.files).toEqual([]);
+    expect(result.summary).toContain("Generation quality gate stopped output");
+    expect(result.summary).toContain("none emitted");
+    expect(result.diagnostics.join("\n")).toContain("[AX853] error");
+    expect(result.diagnostics.join("\n")).toContain("Do not emit a generic scaffold");
+  });
+
+  it("refuses existing-product repair prompts instead of replacing a working screen", () => {
+    const result = generateFeature({
+      description:
+        "Fix the existing SwiftUI home feed where the comment box is visible but cannot be tapped, focused, or typed into after the new feature landed.",
+      surfaces: ["component"],
+      name: "HomeComposerRepair",
+      componentKind: "custom",
+      platform: "iOS",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.files).toEqual([]);
+    expect(result.summary).toContain("existing-product Apple repair");
+    expect(result.summary).toContain("none emitted");
+    expect(result.diagnostics.join("\n")).toContain("[AX854] error");
+    expect(result.diagnostics.join("\n")).toContain("axint.repair");
   });
 
   it("generates a token-aware inbox view from search, filter, composer, and list cues", () => {
@@ -682,6 +858,26 @@ describe("axint.suggest", () => {
     expect(routing!.featurePrompt).toMatch(/capture|run agent|launch check|open vault/i);
     expect(routing!.featurePrompt).toMatch(/tab routing|hittable|route/i);
     expect(routing!.nextStep).toMatch(/--only-testing/);
+  });
+
+  it("returns interaction blocker repair guidance when a visible composer stops accepting input", () => {
+    const suggestions = suggestFeatures({
+      appDescription:
+        "Existing Home feed comment composer box is visible, but after adding a feature it no longer accepts taps or typing; likely overlay or disabled state is blocking TextEditor focus.",
+      platform: "iOS",
+      limit: 4,
+    });
+
+    const blocker = suggestions.find((suggestion) =>
+      /Interaction Blockers/i.test(suggestion.name)
+    );
+
+    expect(suggestions[0].domain).toBe("repair");
+    expect(blocker).toBeDefined();
+    expect(blocker!.featurePrompt).toMatch(
+      /allowsHitTesting|disabled|zIndex|FocusState|overlay/i
+    );
+    expect(blocker!.nextStep).toContain("axint project index");
   });
 
   it("uses broader app context instead of falling back to collaboration for recipes", () => {

--- a/tests/mcp/machine.test.ts
+++ b/tests/mcp/machine.test.ts
@@ -67,6 +67,29 @@ describe("Axint project machine", () => {
     ).toContain("workflowCheckRequiresToken");
   });
 
+  it("generates Codex start packs without Xcode-only write requirements", () => {
+    const dir = tempDir();
+    const pack = buildProjectStartPack({
+      targetDir: dir,
+      projectName: "Swarm",
+      version: "9.9.9",
+      agent: "codex",
+    });
+
+    expect(pack.startPrompt).toContain("Active agent lane: Codex");
+    expect(pack.startPrompt).toContain("apply_patch, then axint.swift.validate");
+    expect(pack.startPrompt).toContain("Do not call axint.xcode.guard");
+
+    const projectJson = pack.files.find(
+      (file) => file.path === ".axint/project.json"
+    )?.content;
+    expect(projectJson).toContain('"agent": "codex"');
+    expect(projectJson).toContain("host-native patch/edit lane");
+    expect(projectJson).not.toContain(
+      "axint.xcode.write for guarded file writes when available"
+    );
+  });
+
   it("writes the project start pack conservatively", () => {
     const dir = tempDir();
     const result = writeProjectStartPack({
@@ -136,7 +159,7 @@ describe("Axint project machine", () => {
         status: "fail",
       })
     );
-    expect(report.nextSteps.join("\n")).toContain("restart the Xcode agent chat");
+    expect(report.nextSteps.join("\n")).toContain("reload or reconnect");
   });
 
   it("exposes project pack and doctor through MCP", async () => {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -15,6 +15,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { writeProjectStartPack } from "../../src/project/start-pack.js";
+import { startAxintSession } from "../../src/project/session.js";
 
 describe("axint.status tool", () => {
   it("reports the running MCP server version and restart instructions", async () => {
@@ -38,7 +39,28 @@ describe("axint.status tool", () => {
 
     expect(result.content[0].text).toContain("# Axint MCP Status");
     expect(result.content[0].text).toContain("Call axint.status");
-    expect(result.content[0].text).toContain("Restart the Xcode Claude Agent");
+    expect(result.content[0].text).toContain("axint upgrade");
+    expect(result.content[0].text).toContain("same Codex or Claude thread");
+  });
+
+  it("plans a same-thread upgrade through MCP", async () => {
+    const result = await handleToolCall("axint.upgrade", {
+      targetVersion: "9.9.10",
+      latestVersion: "9.9.10",
+      format: "json",
+    });
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      status: string;
+      targetVersion: string;
+      commands: Array<{ display: string }>;
+      sameThreadPrompt: string;
+    };
+    expect(payload.status).toBe("ready");
+    expect(payload.targetVersion).toBe("9.9.10");
+    expect(payload.commands[0].display).toBe("npm install -g @axint/compiler@9.9.10");
+    expect(payload.sameThreadPrompt).toContain("Keep this chat/thread");
   });
 });
 
@@ -61,6 +83,8 @@ describe("axint.run tool", () => {
 
     expect(result.isError).not.toBe(true);
     const payload = JSON.parse(result.content[0].text) as {
+      id: string;
+      status: string;
       session: { token: string };
       commands: { build: { dryRun: boolean } };
       cloudChecks: unknown[];
@@ -68,6 +92,112 @@ describe("axint.run tool", () => {
     expect(payload.session.token).toMatch(/^axsess_/);
     expect(payload.commands.build.dryRun).toBe(true);
     expect(payload.cloudChecks.length).toBe(1);
+
+    const statusResult = await handleToolCall("axint.run.status", {
+      cwd: dir,
+      id: payload.id,
+      format: "json",
+    });
+    const statusPayload = JSON.parse(statusResult.content[0].text) as {
+      status: string;
+      activePids: number[];
+    };
+    expect(statusPayload.status).toBe(payload.status);
+    expect(statusPayload.activePids).toEqual([]);
+  });
+
+  it("can start axint.run in the background with a resumable job id", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-mcp-run-bg-"));
+    const schemeDir = join(dir, "Demo.xcodeproj", "xcshareddata", "xcschemes");
+    mkdirSync(schemeDir, { recursive: true });
+    writeFileSync(join(schemeDir, "Demo.xcscheme"), "<Scheme></Scheme>\n");
+    writeFileSync(
+      join(dir, "ContentView.swift"),
+      'import SwiftUI\nstruct ContentView: View { var body: some View { Text("Hi") } }\n'
+    );
+
+    const result = await handleToolCall("axint.run", {
+      cwd: dir,
+      dryRun: true,
+      background: true,
+      format: "json",
+    });
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      id: string;
+      status: string;
+      statusCommand: string;
+      cancelCommand: string;
+      jobPath: string;
+    };
+    expect(payload.id).toMatch(/^axrun_/);
+    expect(payload.status).toBe("running");
+    expect(payload.statusCommand).toContain(`--id ${payload.id}`);
+    expect(payload.cancelCommand).toContain(`--id ${payload.id}`);
+    expect(payload.jobPath).toContain(`${payload.id}.json`);
+
+    const statusResult = await handleToolCall("axint.run.status", {
+      cwd: dir,
+      id: payload.id,
+      format: "json",
+    });
+    const statusPayload = JSON.parse(statusResult.content[0].text) as {
+      status: string;
+    };
+    expect(["running", "pass", "needs_review", "fail"]).toContain(statusPayload.status);
+  });
+});
+
+describe("axint.repair tool", () => {
+  it("returns a host-aware repair plan and feedback packet", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-mcp-repair-"));
+    writeFileSync(
+      join(dir, "HomeComposer.swift"),
+      [
+        "import SwiftUI",
+        "",
+        "struct HomeComposer: View {",
+        '    @State private var draft = ""',
+        "    var body: some View {",
+        "        TextEditor(text: $draft)",
+        '            .overlay { Text("Write a comment") }',
+        "    }",
+        "}",
+        "",
+      ].join("\n")
+    );
+
+    const result = await handleToolCall("axint.repair", {
+      cwd: dir,
+      issue: "The comment box is visible but cannot be tapped or typed into.",
+      sourcePath: "HomeComposer.swift",
+      agent: "codex",
+      runtimeFailure: "Visible comment box cannot be tapped or typed into.",
+      format: "json",
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      issueClass: string;
+      agent: { agent: string };
+      feedbackPacket: { privacy: { redaction: string } };
+      filesToInspect: Array<{ path: string }>;
+    };
+    expect(payload.issueClass).toBe("swiftui-input-interaction");
+    expect(payload.agent.agent).toBe("codex");
+    expect(payload.feedbackPacket.privacy.redaction).toBe("source_not_included");
+    expect(payload.filesToInspect.map((file) => file.path)).toContain(
+      "HomeComposer.swift"
+    );
+
+    const latest = await handleToolCall("axint.feedback.create", {
+      cwd: dir,
+      latest: true,
+      format: "json",
+    });
+    expect(latest.isError).not.toBe(true);
+    expect(latest.content[0].text).toContain("swiftui-input-interaction");
   });
 });
 
@@ -101,6 +231,214 @@ describe("axint.xcode.guard tool", () => {
     expect(payload.latestEvidence.kind).toBe("session");
     expect(existsSync(payload.proofFiles.json)).toBe(true);
     expect(existsSync(payload.proofFiles.markdown)).toBe(true);
+  });
+
+  it("does not force context recovery when drift notes already have fresh recovery state", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-mcp-guard-drift-"));
+    writeProjectStartPack({
+      targetDir: dir,
+      projectName: "DriftDemo",
+      version: "0.4.9",
+      force: true,
+    });
+
+    const result = await handleToolCall("axint.xcode.guard", {
+      cwd: dir,
+      projectName: "DriftDemo",
+      stage: "planning",
+      notes: "This chat was compacted, so check for Axint drift before planning.",
+      lastAxintTool: "axint.status",
+      lastAxintResult: "Axint MCP Status: running version 0.4.12.",
+      format: "json",
+    });
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      status: string;
+      required: string[];
+      checked: string[];
+    };
+    expect(payload.status).toBe("ready");
+    expect(payload.required.join("\n")).not.toContain("Run context recovery");
+    expect(payload.checked.join("\n")).toContain(
+      "active session, project memory, and fresh Axint evidence are present"
+    );
+  });
+
+  it("accepts workflow pre-commit proof instead of forcing redundant axint.run at finish", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-mcp-guard-finish-"));
+    writeProjectStartPack({
+      targetDir: dir,
+      projectName: "FinishDemo",
+      version: "0.4.9",
+      force: true,
+    });
+
+    const workflowProof = [
+      "# Axint Workflow Check: ready",
+      "",
+      "- Stage: pre-commit",
+      "- Score: 100/100",
+      "",
+      "## Checked",
+      "- axint.swift.validate was run.",
+      "- axint.cloud.check was run.",
+      "- Xcode build evidence passed.",
+      "- Xcode test evidence passed.",
+    ].join("\n");
+
+    const result = await handleToolCall("axint.xcode.guard", {
+      cwd: dir,
+      projectName: "FinishDemo",
+      stage: "finish",
+      modifiedFiles: ["Sources/ContentView.swift"],
+      lastAxintTool: "axint.workflow.check",
+      lastAxintResult: workflowProof,
+      format: "json",
+    });
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      status: string;
+      required: string[];
+      checked: string[];
+    };
+    expect(payload.status).toBe("ready");
+    expect(payload.required.join("\n")).not.toContain("Call axint.run");
+    expect(payload.checked.join("\n")).toContain(
+      "accepted fresh axint.workflow.check pre-commit proof"
+    );
+  });
+
+  it("accepts a token-scoped session when another agent overwrote current.json", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-mcp-guard-token-history-"));
+    writeProjectStartPack({
+      targetDir: dir,
+      projectName: "TokenHistoryDemo",
+      version: "0.4.9",
+      force: true,
+    });
+    const parent = startAxintSession({
+      targetDir: dir,
+      projectName: "TokenHistoryDemo",
+      expectedVersion: "0.4.9",
+      platform: "macOS",
+      agent: "codex",
+    });
+    startAxintSession({
+      targetDir: dir,
+      projectName: "TokenHistoryDemo",
+      expectedVersion: "0.4.9",
+      platform: "macOS",
+      agent: "claude-code",
+    });
+
+    const result = await handleToolCall("axint.xcode.guard", {
+      cwd: dir,
+      projectName: "TokenHistoryDemo",
+      stage: "planning",
+      sessionToken: parent.session.token,
+      lastAxintTool: "axint.workflow.check",
+      lastAxintResult: "Workflow check: ready.",
+      format: "json",
+    });
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      status: string;
+      session?: { token: string; path: string };
+      checked: string[];
+    };
+    expect(payload.status).toBe("ready");
+    expect(payload.session?.token).toBe(parent.session.token);
+    expect(payload.session?.path).toContain(".axint/session/sessions/");
+    expect(payload.checked.join("\n")).toContain("token-scoped session history");
+  });
+
+  it("accepts fresh ready_to_ship CLI axint.run proof at finish", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-mcp-guard-run-ready-"));
+    writeProjectStartPack({
+      targetDir: dir,
+      projectName: "RunReadyDemo",
+      version: "0.4.9",
+      force: true,
+    });
+    mkdirSync(join(dir, ".axint", "run"), { recursive: true });
+    writeFileSync(
+      join(dir, ".axint", "run", "latest.json"),
+      `${JSON.stringify(
+        {
+          createdAt: new Date().toISOString(),
+          status: "pass",
+          gate: { decision: "ready_to_ship" },
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    const result = await handleToolCall("axint.xcode.guard", {
+      cwd: dir,
+      projectName: "RunReadyDemo",
+      stage: "finish",
+      modifiedFiles: ["Sources/ContentView.swift"],
+      format: "json",
+    });
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      status: string;
+      required: string[];
+      checked: string[];
+    };
+    expect(payload.status).toBe("ready");
+    expect(payload.required.join("\n")).not.toContain("Call axint.run");
+    expect(payload.checked.join("\n")).toContain(
+      "accepted fresh ready_to_ship axint.run proof"
+    );
+  });
+
+  it("blocks finish when the freshest axint.run proof failed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-mcp-guard-run-failed-"));
+    writeProjectStartPack({
+      targetDir: dir,
+      projectName: "RunFailedDemo",
+      version: "0.4.9",
+      force: true,
+    });
+    mkdirSync(join(dir, ".axint", "run"), { recursive: true });
+    writeFileSync(
+      join(dir, ".axint", "run", "latest.json"),
+      `${JSON.stringify(
+        {
+          createdAt: new Date().toISOString(),
+          status: "fail",
+          gate: { decision: "fix_required" },
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    const result = await handleToolCall("axint.xcode.guard", {
+      cwd: dir,
+      projectName: "RunFailedDemo",
+      stage: "finish",
+      modifiedFiles: ["Sources/ContentView.swift"],
+      format: "json",
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      status: string;
+      required: string[];
+      checked: string[];
+    };
+    expect(payload.status).toBe("needs_action");
+    expect(payload.required.join("\n")).toContain(
+      "Latest axint.run proof is fail · fix_required"
+    );
+    expect(payload.checked.join("\n")).not.toContain("ready_to_ship axint.run proof");
   });
 
   it("writes Swift through the guarded Xcode path", async () => {

--- a/tests/mcp/suggest.test.ts
+++ b/tests/mcp/suggest.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { suggestFeatures } from "../../src/mcp/suggest.js";
+
+describe("axint.suggest", () => {
+  it("routes existing SwiftUI input bugs into proof-first repair suggestions", () => {
+    const suggestions = suggestFeatures({
+      appDescription:
+        "Existing SwiftUI home feed bug: the comment box is visible but after adding a feature I cannot tap it, focus it, or type into it anymore.",
+      platform: "iOS",
+      limit: 3,
+    });
+
+    expect(suggestions[0]?.domain).toBe("repair");
+    expect(suggestions[0]?.name).toContain("Repair Existing");
+    expect(suggestions[0]?.rationale).toContain("swiftui-input-interaction");
+    expect(suggestions[0]?.featurePrompt).toContain("existing iOS Apple repair");
+    expect(suggestions[0]?.featurePrompt).toContain("Inspect first");
+    expect(suggestions.map((suggestion) => suggestion.name).join("\n")).toContain(
+      "Trace Input Interaction Blockers"
+    );
+    expect(suggestions[0]?.featurePrompt).not.toContain("Create a new");
+  });
+});

--- a/tests/mcp/workflow-check.test.ts
+++ b/tests/mcp/workflow-check.test.ts
@@ -75,6 +75,40 @@ describe("axint.workflow.check", () => {
     expect(report.required.join("\n")).toMatch(/axint\.suggest/);
   });
 
+  it("accepts an older token-scoped session after another agent starts a session", () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-workflow-multi-agent-"));
+    tempDirs.push(dir);
+    const parent = startAxintSession({
+      targetDir: dir,
+      projectName: "Swarm",
+      expectedVersion: "9.9.9",
+      platform: "macOS",
+      agent: "codex",
+    });
+    startAxintSession({
+      targetDir: dir,
+      projectName: "Swarm",
+      expectedVersion: "9.9.9",
+      platform: "macOS",
+      agent: "claude-code",
+    });
+
+    const report = runWorkflowCheck({
+      cwd: dir,
+      sessionStarted: true,
+      sessionToken: parent.session.token,
+      stage: "context-recovery",
+      readRehydrationContext: true,
+      readAgentInstructions: true,
+      readDocsContext: true,
+      ranStatus: true,
+    });
+
+    expect(report.status).toBe("ready");
+    expect(report.required).toEqual([]);
+    expect(report.checked.join("\n")).toContain("token-scoped session history");
+  });
+
   it("requires validation and Cloud Check before a SwiftUI build gate", () => {
     const report = runWorkflowCheck({
       ...sessionArgs(),
@@ -95,6 +129,7 @@ describe("axint.workflow.check", () => {
   it("detects drift language and forces rehydration before continuing", () => {
     const report = runWorkflowCheck({
       ...sessionArgs(),
+      agent: "codex",
       stage: "before-write",
       surfaces: ["view"],
       ranSuggest: true,
@@ -111,6 +146,7 @@ describe("axint.workflow.check", () => {
   it("allows explicit feature bypasses while keeping validation gates", () => {
     const report = runWorkflowCheck({
       ...sessionArgs(),
+      agent: "codex",
       stage: "before-write",
       surfaces: ["view"],
       ranSuggest: true,
@@ -165,6 +201,7 @@ describe("axint.workflow.check", () => {
   it("sends a ready pre-commit gate to finish guard after tests pass", () => {
     const report = runWorkflowCheck({
       ...sessionArgs(),
+      agent: "xcode",
       stage: "pre-commit",
       modifiedFiles: ["HomeFeedView.swift"],
       ranSwiftValidate: true,
@@ -175,6 +212,40 @@ describe("axint.workflow.check", () => {
 
     expect(report.status).toBe("ready");
     expect(report.nextTool).toBe("axint.xcode.guard(stage=finish)");
+  });
+
+  it("keeps Codex in the patch-first lane instead of Xcode write", () => {
+    const report = runWorkflowCheck({
+      ...sessionArgs(),
+      agent: "codex",
+      stage: "before-write",
+      surfaces: ["view"],
+      ranSuggest: true,
+      featureBypassReason: "Repairing an existing SwiftUI screen with a small patch.",
+      modifiedFiles: ["HomeFeedView.swift"],
+    });
+
+    expect(report.status).toBe("ready");
+    expect(report.nextTool).toBe("apply_patch, then axint.swift.validate");
+    expect(report.checked.join("\n")).toContain("Codex");
+    expect(report.recommended.join("\n")).toContain("small patch edit");
+  });
+
+  it("does not send Codex to Xcode finish guard after tests pass", () => {
+    const report = runWorkflowCheck({
+      ...sessionArgs(),
+      agent: "codex",
+      stage: "pre-commit",
+      modifiedFiles: ["HomeFeedView.swift"],
+      ranSwiftValidate: true,
+      ranCloudCheck: true,
+      xcodeBuildPassed: true,
+      xcodeTestsPassed: true,
+    });
+
+    expect(report.status).toBe("ready");
+    expect(report.nextTool).toContain("Summarize Axint validation");
+    expect(report.nextTool).not.toBe("axint.xcode.guard(stage=finish)");
   });
 
   it("returns the next Axint action even when context recovery is satisfied", () => {

--- a/tests/project/context-index.test.ts
+++ b/tests/project/context-index.test.ts
@@ -39,10 +39,16 @@ describe("project context index", () => {
         "struct HomeView: View {",
         '    @State private var draft = ""',
         "    var body: some View {",
-        "        TextEditor(text: $draft)",
-        "            .overlay {",
-        '                Text("Comment")',
+        "        ZStack {",
+        "            TextEditor(text: $draft)",
+        "                .overlay {",
+        '                    Text("Comment")',
+        "                        .allowsHitTesting(false)",
+        "                }",
+        "                .contentShape(Rectangle())",
+        "                .zIndex(1)",
         "            }",
+        "        }",
         "    }",
         "}",
         "",
@@ -76,10 +82,60 @@ describe("project context index", () => {
     expect(result.index.topInteractionRiskFiles.map((file) => file.path)).toContain(
       "HomeView.swift"
     );
-    expect(readFileSync(result.jsonPath, "utf-8")).toContain('"projectName": "Swarm"');
-    expect(readFileSync(result.markdownPath, "utf-8")).toContain(
-      "## Interaction Risk Files"
+    const home = result.index.files.catalog.find(
+      (file) => file.path === "HomeView.swift"
     );
+    expect(home?.hasHitTestingOverride).toBe(true);
+    expect(home?.hasContentShape).toBe(true);
+    expect(home?.hasZIndex).toBe(true);
+    expect(home?.hasLayeringStack).toBe(true);
+    expect(home?.accessibilityIdentifiers).toEqual([]);
+    expect(readFileSync(result.jsonPath, "utf-8")).toContain('"projectName": "Swarm"');
+    const markdown = readFileSync(result.markdownPath, "utf-8");
+    expect(markdown).toContain("## Interaction Risk Files");
+    expect(markdown).toContain("hit-testing");
+    expect(markdown).toContain("zIndex");
+  });
+
+  it("captures UI-test selectors and accessibility identifiers without storing source", () => {
+    const dir = tempProject();
+    writeFileSync(
+      join(dir, "ProjectRoomView.swift"),
+      [
+        "import SwiftUI",
+        "struct ProjectRoomView: View {",
+        "    var body: some View {",
+        '        Button("Manage") {}',
+        '            .accessibilityIdentifier("project-manage-button")',
+        "    }",
+        "}",
+        "",
+      ].join("\n")
+    );
+    writeFileSync(
+      join(dir, "SwarmUITests.swift"),
+      [
+        "import XCTest",
+        "final class SwarmUITests: XCTestCase {",
+        "    func testProjectManageButtonIsHittable() {",
+        "        let app = XCUIApplication()",
+        '        XCTAssertTrue(app.buttons["project-manage-button"].exists)',
+        "    }",
+        "}",
+        "",
+      ].join("\n")
+    );
+
+    const index = buildProjectContextIndex({ targetDir: dir });
+    const view = index.files.catalog.find(
+      (file) => file.path === "ProjectRoomView.swift"
+    );
+    const tests = index.files.catalog.find((file) => file.path === "SwarmUITests.swift");
+
+    expect(view?.accessibilityIdentifiers).toContain("project-manage-button");
+    expect(tests?.xctest).toBe(true);
+    expect(tests?.hasAccessibilityQueries).toBe(true);
+    expect(tests?.testCases).toContain("testProjectManageButtonIsHittable");
   });
 
   it("builds related-file hints for input interaction failures", () => {
@@ -106,8 +162,13 @@ describe("project context index", () => {
         "struct FeedScreen: View {",
         "    @State private var gate = false",
         "    var body: some View {",
-        "        HomeComposer()",
-        "            .disabled(gate)",
+        "        ZStack {",
+        "            HomeComposer()",
+        "                .disabled(gate)",
+        "            Color.clear",
+        "                .allowsHitTesting(gate)",
+        "                .zIndex(2)",
+        "        }",
         "    }",
         "}",
         "",
@@ -126,5 +187,7 @@ describe("project context index", () => {
 
     expect(hint?.relatedFiles.map((file) => file.path)).toContain("FeedScreen.swift");
     expect(hint?.summary.join("\n")).toContain("Changed files: FeedScreen.swift");
+    expect(hint?.summary.join("\n")).toContain("Interaction map:");
+    expect(hint?.summary.join("\n")).toMatch(/hit-testing override|z-index layering/);
   });
 });

--- a/tests/project/upgrade.test.ts
+++ b/tests/project/upgrade.test.ts
@@ -1,0 +1,97 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  renderAxintUpgradeReport,
+  runAxintUpgrade,
+  type AxintUpgradeCommandResult,
+} from "../../src/project/upgrade.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+
+function tempProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "axint-upgrade-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("Axint same-thread upgrade", () => {
+  it("plans an upgrade without applying it", () => {
+    const dir = tempProject();
+    const report = runAxintUpgrade({
+      cwd: dir,
+      currentVersion: "0.4.11",
+      latestVersion: "0.4.12",
+    });
+
+    expect(report.status).toBe("ready");
+    expect(report.updateAvailable).toBe(true);
+    expect(report.commands.map((command) => command.display)).toContain(
+      "npm install -g @axint/compiler@0.4.12"
+    );
+    expect(report.commands.map((command) => command.command)).not.toContain("axint");
+    expect(report.sameThreadPrompt).toContain("Keep this chat/thread");
+    expect(report.sameThreadPrompt).toContain("Reload or reconnect");
+  });
+
+  it("applies an upgrade, refreshes optional Xcode wiring, and writes artifacts", () => {
+    const dir = tempProject();
+    const calls: Array<{ command: string; args: string[]; cwd: string }> = [];
+
+    const report = runAxintUpgrade(
+      {
+        cwd: dir,
+        currentVersion: "0.4.11",
+        latestVersion: "0.4.12",
+        apply: true,
+        reinstallXcode: true,
+      },
+      {
+        runCommand(command, args, options): AxintUpgradeCommandResult {
+          calls.push({ command, args, cwd: options.cwd });
+          return { status: 0, stdout: "ok" };
+        },
+      }
+    );
+
+    expect(report.status).toBe("upgraded");
+    expect(calls).toEqual([
+      {
+        command: "npm",
+        args: ["install", "-g", "@axint/compiler@0.4.12"],
+        cwd: dir,
+      },
+      {
+        command: "axint",
+        args: ["xcode", "install", "--project", dir],
+        cwd: dir,
+      },
+    ]);
+    expect(report.artifacts?.json).toBe(join(dir, ".axint", "upgrade", "latest.json"));
+    expect(report.artifacts?.markdown).toBe(join(dir, ".axint", "upgrade", "latest.md"));
+    expect(existsSync(report.artifacts?.json ?? "")).toBe(true);
+    expect(readFileSync(report.artifacts?.markdown ?? "", "utf-8")).toContain(
+      "Same-Thread Continuation"
+    );
+  });
+
+  it("reports current when the requested version is already installed", () => {
+    const dir = tempProject();
+    const report = runAxintUpgrade({
+      cwd: dir,
+      currentVersion: "0.4.12",
+      latestVersion: "0.4.12",
+      apply: true,
+    });
+
+    expect(report.status).toBe("current");
+    expect(report.commands).toHaveLength(0);
+    expect(renderAxintUpgradeReport(report, "prompt")).toContain("already current");
+  });
+});

--- a/tests/repair/project-repair.test.ts
+++ b/tests/repair/project-repair.test.ts
@@ -1,0 +1,170 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  readLatestRepairFeedback,
+  renderAxintRepairReport,
+  runAxintRepair,
+} from "../../src/repair/project-repair.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+
+function tempProject(): string {
+  const dir = mkdirTemp("axint-repair-");
+  tempDirs.push(dir);
+  return dir;
+}
+
+function mkdirTemp(prefix: string): string {
+  const path = join(tmpdir(), `${prefix}${Math.random().toString(36).slice(2)}`);
+  mkdirSync(path, { recursive: true });
+  return path;
+}
+
+describe("project repair", () => {
+  it("plans an input-interaction repair with privacy-safe feedback", () => {
+    const dir = tempProject();
+    mkdirSync(join(dir, "Swarm.xcodeproj", "xcshareddata", "xcschemes"), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(dir, "Swarm.xcodeproj", "xcshareddata", "xcschemes", "Swarm.xcscheme"),
+      "<Scheme></Scheme>\n"
+    );
+    writeFileSync(
+      join(dir, "HomeComposer.swift"),
+      [
+        "import SwiftUI",
+        "",
+        "struct HomeComposer: View {",
+        '    @State private var draft = ""',
+        "    var body: some View {",
+        "        TextEditor(text: $draft)",
+        '            .accessibilityIdentifier("home-composer")',
+        "            .overlay {",
+        '                Text("Write a comment")',
+        "            }",
+        "    }",
+        "}",
+        "",
+      ].join("\n")
+    );
+    writeFileSync(
+      join(dir, "FeedScreen.swift"),
+      [
+        "import SwiftUI",
+        "",
+        "struct FeedScreen: View {",
+        "    @State private var isLoading = false",
+        "    var body: some View {",
+        "        ZStack {",
+        "            HomeComposer()",
+        "                .disabled(isLoading)",
+        "            Color.clear",
+        "                .allowsHitTesting(isLoading)",
+        "                .zIndex(3)",
+        "        }",
+        "    }",
+        "}",
+        "",
+      ].join("\n")
+    );
+
+    const report = runAxintRepair({
+      cwd: dir,
+      issue:
+        "The comment box is visible on the home feed but I cannot tap it or type anymore.",
+      sourcePath: "HomeComposer.swift",
+      platform: "iOS",
+      agent: "codex",
+      expectedBehavior: "The composer should accept focus and typing.",
+      runtimeFailure:
+        "The home feed renders, but the comment box is visible and cannot be tapped or typed into.",
+      changedFiles: ["FeedScreen.swift"],
+    });
+
+    expect(report.issueClass).toBe("swiftui-input-interaction");
+    expect(report.status).toBe("fix_required");
+    expect(report.repairIntelligence.summary).toContain("existing iOS Apple repair");
+    expect(report.repairIntelligence.inspectionChecklist.join("\n")).toContain(
+      "Parent wrappers"
+    );
+    expect(report.hypotheses.map((item) => item.title).join("\n")).toContain(
+      "Overlay or z-index layer"
+    );
+    expect(report.filesToInspect.map((file) => file.path)).toContain("FeedScreen.swift");
+    expect(report.agent.agent).toBe("codex");
+    expect(report.repairPrompt).toContain("Senior Apple repair read");
+    expect(report.repairPrompt).toContain("Do not claim the bug is fixed");
+    expect(report.feedbackPacket.privacy.redaction).toBe("source_not_included");
+    expect(JSON.stringify(report.feedbackPacket)).not.toContain("TextEditor(text");
+    expect(existsSync(join(dir, ".axint/repair/latest.json"))).toBe(true);
+    expect(existsSync(join(dir, ".axint/feedback/latest.json"))).toBe(true);
+    expect(readLatestRepairFeedback({ cwd: dir })?.classification.issueClass).toBe(
+      "swiftui-input-interaction"
+    );
+    expect(renderAxintRepairReport(report)).toContain("Privacy-Safe Feedback Packet");
+    expect(renderAxintRepairReport(report)).toContain("Senior Repair Read");
+    expect(readFileSync(join(dir, ".axint/context/latest.md"), "utf-8")).toContain(
+      "home-composer"
+    );
+  });
+
+  it("classifies macOS hit-testing evidence without requiring source", () => {
+    const dir = tempProject();
+    writeFileSync(
+      join(dir, "ProjectRoomView.swift"),
+      [
+        "import SwiftUI",
+        "",
+        "struct ProjectRoomView: View {",
+        "    var body: some View {",
+        "        ScrollView {",
+        '            Button("Manage Axint Core") {}',
+        '                .accessibilityIdentifier("discover-project-manage-axint-core")',
+        "        }",
+        "    }",
+        "}",
+        "",
+      ].join("\n")
+    );
+    writeFileSync(
+      join(dir, "SwarmUITests.swift"),
+      [
+        "import XCTest",
+        "final class SwarmUITests: XCTestCase {",
+        "    func testProjectCommandCenterPrimaryActionsRouteToCoreTabs() {",
+        "        let app = XCUIApplication()",
+        '        XCTAssertTrue(app.buttons["discover-project-manage-axint-core"].exists)',
+        "    }",
+        "}",
+        "",
+      ].join("\n")
+    );
+
+    const report = runAxintRepair({
+      cwd: dir,
+      issue:
+        "discover-project-manage-axint-core should be hittable after scrolling but is not foreground and does not allow background interaction",
+      platform: "macOS",
+      testFailure:
+        "XCTAssertTrue failed: discover-project-manage-axint-core should be hittable after scrolling. Button is not foreground and does not allow background interaction.",
+      writeReport: false,
+      writeFeedback: false,
+    });
+
+    expect(report.issueClass).toBe("swiftui-hit-testing");
+    expect(report.hypotheses[0]?.title).toContain("UI test is hitting");
+    expect(report.filesToInspect.map((file) => file.path)).toContain(
+      "SwarmUITests.swift"
+    );
+    expect(report.evidenceToCollect.join("\n")).toContain("source");
+    expect(report.feedbackPacket.privacy.localPaths).toBe("project_relative_only");
+  });
+});

--- a/tests/run/project-runner.test.ts
+++ b/tests/run/project-runner.test.ts
@@ -1,8 +1,9 @@
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import { renderAxintRunReport, runAxintProject } from "../../src/run/project-runner.js";
+import { cancelRunJob, getRunJobStatus } from "../../src/run/job-store.js";
 
 function makeFakeXcodeProject() {
   const dir = mkdtempSync(join(tmpdir(), "axint-run-"));
@@ -43,12 +44,23 @@ describe("runAxintProject", () => {
     expect(report.commands.test?.dryRun).toBe(true);
     expect(report.commands.build?.args).toContain("-project");
     expect(report.commands.build?.args).toContain("Swarm");
+    expect(report.job.id).toBe(report.id);
+    expect(report.job.statusCommand).toContain("axint run status");
+    expect(report.job.cancelCommand).toContain("axint run cancel");
     expect(report.artifacts.json).toBeDefined();
     expect(report.artifacts.projectContextJson).toBeDefined();
     expect(readFileSync(report.artifacts.projectContextJson!, "utf-8")).toContain(
       '"schema": "https://axint.ai/schemas/project-context-index.v1.json"'
     );
     expect(readFileSync(report.artifacts.json!, "utf-8")).toContain('"status"');
+
+    const status = getRunJobStatus({ cwd: dir, id: report.id });
+    expect(status.status).toBe(report.status);
+    expect(status.activePids).toEqual([]);
+    expect(status.job?.commands.map((command) => command.label)).toEqual([
+      "Xcode build",
+      "Xcode test",
+    ]);
   });
 
   it("renders a repair prompt for agents", async () => {
@@ -63,6 +75,94 @@ describe("runAxintProject", () => {
     const prompt = renderAxintRunReport(report, "prompt");
     expect(prompt).toContain("You are repairing an Apple-native project");
     expect(prompt).toContain("After repairing, rerun `axint run`");
+  });
+
+  it("does not claim suggest was used and advances past axint.run after passing build proof", async () => {
+    const dir = makeFakeXcodeProject();
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const xcodebuild = join(binDir, "xcodebuild");
+    writeFileSync(
+      xcodebuild,
+      ["#!/bin/sh", "echo axint fake xcodebuild", "exit 0", ""].join("\n")
+    );
+    chmodSync(xcodebuild, 0o755);
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    try {
+      const report = await runAxintProject({
+        cwd: dir,
+        writeReport: false,
+      });
+      const rendered = renderAxintRunReport(report);
+
+      expect(report.commands.build?.exitCode).toBe(0);
+      expect(report.commands.test?.exitCode).toBe(0);
+      expect(report.workflow.checked.join("\n")).not.toContain("axint.suggest");
+      expect(report.workflow.nextTool).toBe("axint.workflow.check(stage=pre-commit)");
+      expect(rendered).not.toContain("- axint.run\n");
+    } finally {
+      process.env.PATH = previousPath;
+    }
+  });
+
+  it("renders compact status-aware JSON by default with source as opt-in", async () => {
+    const dir = makeFakeXcodeProject();
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const xcodebuild = join(binDir, "xcodebuild");
+    writeFileSync(
+      xcodebuild,
+      [
+        "#!/bin/sh",
+        "echo axint fake xcodebuild with enough output for compact json",
+        "echo '** TEST SUCCEEDED **'",
+        "exit 0",
+        "",
+      ].join("\n")
+    );
+    chmodSync(xcodebuild, 0o755);
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    try {
+      const report = await runAxintProject({
+        cwd: dir,
+        writeReport: false,
+      });
+
+      const compact = JSON.parse(renderAxintRunReport(report, "json")) as {
+        cloudChecks: Array<{ swiftCode?: string; sourceRedaction?: unknown }>;
+        commands: { build?: { stdout?: string; stdoutTail?: string } };
+        outputRedaction?: { mode: string; includeSourceFlag: string };
+        repairPrompt: string;
+      };
+      expect(compact.cloudChecks[0]?.swiftCode).toBeUndefined();
+      expect(compact.cloudChecks[0]?.sourceRedaction).toBeDefined();
+      expect(compact.commands.build?.stdout).toBeUndefined();
+      expect(compact.commands.build?.stdoutTail).toContain("fake xcodebuild");
+      expect(compact.outputRedaction?.mode).toBe("compact");
+      expect(compact.outputRedaction?.includeSourceFlag).toBe("--include-source");
+
+      const full = JSON.parse(
+        renderAxintRunReport(report, "json", { includeSource: true })
+      ) as {
+        cloudChecks: Array<{ swiftCode?: string }>;
+        commands: { build?: { stdout?: string } };
+      };
+      expect(full.cloudChecks[0]?.swiftCode).toContain("struct ContentView");
+      expect(full.commands.build?.stdout).toContain("fake xcodebuild");
+
+      if (report.status === "pass") {
+        const prompt = renderAxintRunReport(report, "prompt");
+        expect(prompt).toContain("Axint Run passed");
+        expect(prompt).toContain("Continue with the next proof");
+        expect(prompt).not.toContain("Do not continue ordinary coding");
+      }
+    } finally {
+      process.env.PATH = previousPath;
+    }
   });
 
   it("plans focused Xcode UI tests with only-testing selectors", async () => {
@@ -86,5 +186,115 @@ describe("runAxintProject", () => {
     expect(report.commands.test?.args).toContain(
       "-only-testing:SwarmUITests/SwarmUITests/testOpenVaultRoutes"
     );
+  });
+
+  it("feeds passing focused UI proof into every post-test Cloud Check", async () => {
+    const dir = makeFakeXcodeProject();
+    mkdirSync(join(dir, "Swarm", "Views"), { recursive: true });
+    mkdirSync(join(dir, "Swarm", "Models"), { recursive: true });
+    mkdirSync(join(dir, "Swarm", "Stores"), { recursive: true });
+    mkdirSync(join(dir, "SwarmUITests"), { recursive: true });
+    writeFileSync(
+      join(dir, "Swarm", "Views", "DiscoverView.swift"),
+      [
+        "import SwiftUI",
+        "",
+        "struct DiscoverView: View {",
+        "  var body: some View {",
+        '    ScrollView { Text("Discover") }',
+        "  }",
+        "}",
+        "",
+      ].join("\n")
+    );
+    writeFileSync(
+      join(dir, "Swarm", "Models", "SocialModels.swift"),
+      "import Foundation\nstruct DiscoverCard: Identifiable { let id = UUID(); var title: String }\n"
+    );
+    writeFileSync(
+      join(dir, "Swarm", "Stores", "DiscoveryStore.swift"),
+      'import Foundation\nfinal class DiscoveryStore { var selectedIntent = "All" }\n'
+    );
+    writeFileSync(
+      join(dir, "SwarmUITests", "SwarmUITests.swift"),
+      "import XCTest\nfinal class SwarmUITests: XCTestCase {}\n"
+    );
+
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const xcodebuild = join(binDir, "xcodebuild");
+    writeFileSync(
+      xcodebuild,
+      [
+        "#!/bin/sh",
+        'if echo " $* " | grep -q " test "; then',
+        "  echo \"Test Suite 'SwarmUITests' started.\"",
+        "  echo \"Test Case '-[SwarmUITests testDiscoverPrimaryTabsStartAtTopAfterScrolling]' passed (1.01 seconds).\"",
+        "  echo \"Test Case '-[SwarmUITests testDiscoverIntentFiltersRouteAndUpdatePrioritySummary]' passed (1.12 seconds).\"",
+        "  echo \"Test Case '-[SwarmUITests testDiscoverPrimaryCardsAndAgentActionsAreClickable]' passed (0.98 seconds).\"",
+        '  echo "** TEST SUCCEEDED **"',
+        '  echo "Executed 3 tests, with 0 failures"',
+        "else",
+        '  echo "** BUILD SUCCEEDED **"',
+        "fi",
+        "exit 0",
+        "",
+      ].join("\n")
+    );
+    chmodSync(xcodebuild, 0o755);
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    try {
+      const report = await runAxintProject({
+        cwd: dir,
+        writeReport: false,
+        modifiedFiles: [
+          "Swarm/Views/DiscoverView.swift",
+          "Swarm/Models/SocialModels.swift",
+          "Swarm/Stores/DiscoveryStore.swift",
+          "SwarmUITests/SwarmUITests.swift",
+        ],
+        onlyTesting: [
+          "SwarmUITests/SwarmUITests/testDiscoverPrimaryTabsStartAtTopAfterScrolling",
+          "SwarmUITests/SwarmUITests/testDiscoverIntentFiltersRouteAndUpdatePrioritySummary",
+          "SwarmUITests/SwarmUITests/testDiscoverPrimaryCardsAndAgentActionsAreClickable",
+        ],
+        expectedBehavior:
+          "Discover tabs reset to the top hero, intent chips route to the expected sections, project cards open details, and agent primary actions remain clickable.",
+        actualBehavior:
+          "Focused UITest transcript attached for the current branch repair proof.",
+      });
+
+      expect(report.commands.test?.exitCode).toBe(0);
+      expect(report.cloudChecks).toHaveLength(4);
+      for (const check of report.cloudChecks) {
+        const codes = check.diagnostics.map((diagnostic) => diagnostic.code);
+        expect(codes).not.toContain("AXCLOUD-BEHAVIOR-MISMATCH");
+        const evidenceSummary = check.evidence.summary.join("\n");
+        expect(evidenceSummary).toContain("Focused Xcode test proof passed");
+        expect(evidenceSummary).toContain(
+          "testDiscoverIntentFiltersRouteAndUpdatePrioritySummary"
+        );
+        expect(evidenceSummary).toContain("TEST SUCCEEDED");
+      }
+    } finally {
+      process.env.PATH = previousPath;
+    }
+  });
+
+  it("reports nothing to cancel when the latest run has already finished", async () => {
+    const dir = makeFakeXcodeProject();
+    const report = await runAxintProject({
+      cwd: dir,
+      dryRun: true,
+      writeReport: false,
+    });
+
+    const result = cancelRunJob({ cwd: dir, id: report.id });
+
+    expect(result.status).toBe("nothing_to_cancel");
+    expect(result.killedPids).toEqual([]);
+    expect(result.message).toContain("no active child process");
   });
 });

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.11";
+const VERSION = "0.4.12";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary

Strengthens Axint's project-repair workflow so existing Apple app bugs are handled as targeted repair/proof loops instead of generic generation tasks.

## What changed

- Adds a shared Apple repair intelligence layer for input-focus, hit-testing, routing/state, layout, runtime freeze, accessibility, and Xcode build failures.
- Routes broken existing SwiftUI flows away from broad feature scaffolding and toward `axint repair`.
- Improves `axint.suggest`, `axint.cloud.check`, and `axint.repair` so they share the same diagnosis, checklist, root-cause read, and proof plan.
- Adds same-thread upgrade, CLI workflow fallback, durable run job status/cancel, compact `axint run` JSON, token-scoped sessions, and repair/feedback CLIs.
- Updates README, docs/truth metrics, MCP manifest, tests, and package surfaces for v0.4.12.

## Validation

- `npm test` passed: 74 files, 1054 tests.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm run build` passed.
- `npm run metrics:emit && npm run metrics:check` passed.
- `npm run docs:check` passed.
- `npm run versions:check` passed.
- `npm run release:check` passed.
- Workspace `truth:sync` and `truth:check` passed.
- Docs site `check`, `verify`, and `build` passed.

## Notes

Public truth now resolves to `v0.4.12 · 29 MCP tools + 5 prompts · 183 diagnostic codes · 1165 tests`. Site/profile truth updates are held outside this PR until the compiler PR is green and merged.
