### PR TITLE
Harden MCP registry publish

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -28,6 +28,58 @@ jobs:
       - name: Validate server.json
         run: ./mcp-publisher validate
 
+      - name: Wait for npm package visibility
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require("node:fs");
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+          async function main() {
+            const server = JSON.parse(fs.readFileSync("server.json", "utf8"));
+            const packages = server.packages || [];
+
+            const npmPackages = packages
+              .filter((pkg) => pkg.registryType === "npm")
+              .map((pkg) => ({ name: pkg.identifier, version: pkg.version }));
+
+            if (npmPackages.length === 0) {
+              console.log("server.json does not declare npm packages; skipping npm visibility wait.");
+              return;
+            }
+
+            for (const pkg of npmPackages) {
+              const encoded = encodeURIComponent(pkg.name).replace(/^%40/, "@");
+              const url = `https://registry.npmjs.org/${encoded}/${pkg.version}`;
+              let ok = false;
+
+              for (let attempt = 1; attempt <= 12; attempt += 1) {
+                const res = await fetch(url);
+                if (res.ok) {
+                  console.log(`${pkg.name}@${pkg.version} is visible on npm.`);
+                  ok = true;
+                  break;
+                }
+
+                console.log(
+                  `${pkg.name}@${pkg.version} not visible on npm yet (${res.status}); retry ${attempt}/12.`
+                );
+                await sleep(10_000);
+              }
+
+              if (!ok) {
+                console.error(`${pkg.name}@${pkg.version} was not visible on npm before MCP publish.`);
+                process.exit(1);
+              }
+            }
+          }
+
+          main().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
+
       - name: Authenticate with GitHub OIDC
         run: ./mcp-publisher login github-oidc
 

--- a/scripts/check-readme-mcp-docs.mjs
+++ b/scripts/check-readme-mcp-docs.mjs
@@ -8,10 +8,12 @@ import { fileURLToPath } from "node:url";
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const README = resolve(ROOT, "README.md");
 const METRICS = resolve(ROOT, "metrics.json");
+const SERVER_JSON = resolve(ROOT, "server.json");
 const PUBLIC_TRUTH = resolve(ROOT, "..", "public-truth", "public-truth.json");
 
 const readme = readFileSync(README, "utf-8");
 const metrics = JSON.parse(readFileSync(METRICS, "utf-8"));
+const serverJson = JSON.parse(readFileSync(SERVER_JSON, "utf-8"));
 const publicTruth = existsSync(PUBLIC_TRUTH)
   ? JSON.parse(readFileSync(PUBLIC_TRUTH, "utf-8"))
   : null;
@@ -27,6 +29,18 @@ for (const promptName of metrics.mcpPromptNames ?? []) {
   if (!readme.includes(`\`${promptName}\``)) {
     failures.push(`README is missing MCP prompt reference: ${promptName}`);
   }
+}
+
+if (serverJson.capabilities?.tools !== metrics.mcpTools) {
+  failures.push(
+    `server.json capabilities.tools is ${serverJson.capabilities?.tools}, expected ${metrics.mcpTools}`,
+  );
+}
+
+if (serverJson.capabilities?.prompts !== metrics.mcpPrompts) {
+  failures.push(
+    `server.json capabilities.prompts is ${serverJson.capabilities?.prompts}, expected ${metrics.mcpPrompts}`,
+  );
 }
 
 const proofMatch = readme.match(

--- a/server.json
+++ b/server.json
@@ -35,7 +35,7 @@
     }
   ],
   "capabilities": {
-    "tools": 20,
+    "tools": 29,
     "prompts": 5
   }
 }


### PR DESCRIPTION
## Summary
- wait for released npm packages to be visible before publishing server.json to the MCP registry
- sync server.json capability metadata with the current MCP tool count
- extend docs checks so server.json MCP capabilities cannot drift from metrics.json

## Validation
- npm run versions:check
- npm run metrics:check
- npm run docs:check
- local npm visibility smoke for @axint/compiler@0.4.12