### PR TITLE
Release Axint 0.4.14 repair intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ the same facts.
 ```bash
 npm install -g @axint/compiler
 
+# initialize Axint inside an existing Apple/Xcode project
+axint init --apple-project /path/to/MyApp --agent codex
+
 # compile a single file
 axint compile my-intent.ts --out ios/Intents/
 
@@ -247,7 +250,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.13 · 29 MCP tools + 5 prompts · 184 diagnostic codes · 1172 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.14 · 33 MCP tools + 5 prompts · 188 diagnostic codes · 1194 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -276,14 +279,17 @@ axint workflow check --dir /path/to/MyApp --agent codex --stage context-recovery
 axint xcode setup --agent claude --guarded --project /path/to/MyApp --name MyApp
 axint xcode setup --agent claude --guarded --local-build --project /path/to/MyApp --name MyApp
 axint xcode guard --dir /path/to/MyApp --stage context-recovery
-axint run --dir /path/to/MyApp --scheme MyApp --destination "platform=macOS"
-axint run --dir /path/to/MyApp --scheme MyApp --only-testing MyAppUITests/MyAppUITests/testComposerStillAcceptsInput
-axint run --dir /path/to/MyApp --scheme MyApp --runtime
+axint agent install --dir /path/to/MyApp --agent codex
+axint agent advice --dir /path/to/MyApp --agent codex --changed Sources/HomeComposer.swift Tests/HomeComposerUITests.swift
+axint memory index --dir /path/to/MyApp --changed Sources/HomeComposer.swift Tests/HomeComposerUITests.swift
+axint run --dir /path/to/MyApp --agent codex --scheme MyApp --destination "platform=macOS"
+axint run --dir /path/to/MyApp --agent codex --scheme MyApp --changed Sources/HomeComposer.swift --only-testing MyAppUITests/MyAppUITests/testComposerStillAcceptsInput
+axint run --dir /path/to/MyApp --agent codex --scheme MyApp --runtime
 axint run status --dir /path/to/MyApp
 axint run cancel --dir /path/to/MyApp --id axrun_...
-axint run --dir /path/to/MyApp --scheme MyApp --format json
-axint run --dir /path/to/MyApp --scheme MyApp --format json --include-source
-axint runner once --dir /path/to/MyApp --scheme MyApp
+axint run --dir /path/to/MyApp --agent codex --scheme MyApp --format json
+axint run --dir /path/to/MyApp --agent codex --scheme MyApp --format json --include-source
+axint runner once --dir /path/to/MyApp --agent codex --scheme MyApp
 ```
 
 `axint xcode setup --guarded` configures the Xcode Claude Agent with durable MCP paths, writes the project memory pack, starts a session, and creates `.axint/guard/latest.json` plus `.axint/guard/latest.md`. That guard report is the audit trail for the problem where an Xcode agent works for a long block, compacts context, and silently stops using Axint.
@@ -294,11 +300,15 @@ Agent lanes are explicit now. Codex, Claude Code, Cursor, and Cowork should use 
 
 When an Xcode MCP agent is creating a new Swift file, use `axint.xcode.write` instead of a raw file write. The tool writes inside the project root, validates Swift, runs Cloud Check, and updates the guard proof in one call. Outside Xcode, do not route routine edits through `axint.xcode.write`; patch surgically in the active client and let Axint validate the result.
 
-The run starts an Axint session, refreshes the project recovery context, validates changed Swift, runs Cloud Check, executes `xcodebuild build` and `xcodebuild test`, optionally launches a macOS app for runtime proof, and writes `.axint/run/latest.json` plus `.axint/run/latest.md`. Passing focused `--only-testing` selectors are also fed back into Cloud Check so stale UI/accessibility warnings do not override real focused test proof.
+The run starts an agent-specific Axint session, refreshes the project recovery context, validates changed Swift, runs Cloud Check, executes `xcodebuild build` and `xcodebuild test`, optionally launches a macOS app for runtime proof, writes `.axint/run/latest.json` plus `.axint/run/latest.md`, and stores source-free Cloud learning packets under `.axint/feedback` when repeated failure shapes appear. Passing focused `--only-testing` selectors are fed back into Cloud Check so stale UI/accessibility warnings do not override real focused test proof. Failing Xcode tests are extracted from command output and `.xcresult` when available, then printed under `## Xcode Test Failures` with test name, file/line, assertion, likely source area, and identifier so the next repair starts from the real failure.
+
+`axint memory index` turns the local proof trail into `.axint/memory/latest.json` and `.axint/memory/latest.md`. It summarizes risky SwiftUI files, changed files, latest run status, failing tests, latest repair packet, and privacy-safe learning packets so Codex, Claude, Cursor, Xcode, and humans can rehydrate the same project state.
+
+For a repeatable first-use demo, inspect `examples/wow/composer-blocker`. It models a real SwiftUI bug where an invisible overlay blocks a composer text field and includes a focused UI-test failure for Axint to diagnose.
 
 Long runs also write `.axint/run/jobs/<id>.json` and `.axint/run/latest-active.json`. If a client disconnects, an MCP transport times out, or an agent needs to rejoin a build in the same thread, use `axint run status` to see active process IDs and `axint run cancel` to stop the child process group without restarting the whole chat.
 
-Rendered `axint run --format json` is compact by default: it keeps verdict, evidence, diagnostics, artifact paths, and next actions visible while omitting full Swift source and trimming long command output. Use `--include-source` only when the active agent explicitly needs inline Swift/code output in the response.
+Rendered `axint run --format json` is compact by default: it keeps verdict, evidence, diagnostics, artifact paths, feedback packet paths, and next actions visible while omitting full Swift source and trimming long command output. Use `--include-source` only when the active agent explicitly needs inline Swift/code output in the response.
 
 Use `--dry-run` to prove the harness and planned `xcodebuild` commands before letting a local or BYO Mac runner execute the job.
 
@@ -376,6 +386,10 @@ MCP tools and built-in prompts:
 | `axint.cloud.check` | Run an agent-callable Cloud Check report against Swift or TypeScript source |
 | `axint.repair` | Plan a project-aware Apple repair loop for existing app bugs, with likely files, root causes, host-aware patch guidance, proof commands, and feedback packet |
 | `axint.feedback.create` | Create or read a privacy-safe, source-free feedback packet users can inspect before sending to Axint Cloud |
+| `axint.agent.install` | Install the local multi-agent project brain so Codex, Claude, Cursor, Xcode, and humans share one `.axint` truth layer |
+| `axint.agent.advice` | Return host-specific next moves from project context, active claims, latest proof, and latest repair artifacts |
+| `axint.agent.claim` | Claim files before an agent edits them so other agents avoid conflicting patches |
+| `axint.agent.release` | Release local file claims after an agent finishes or abandons a task |
 | `axint.run` | Run the enforced Apple build loop: session, workflow gate, Swift validation, Cloud Check, xcodebuild build/test, optional runtime launch, and `.axint/run` artifacts |
 | `axint.run.status` | Read the latest or selected Axint run job, including active child process IDs, after client disconnects or long-running builds |
 | `axint.run.cancel` | Cancel the latest or selected active Axint run by stopping child process groups |

--- a/docs/CASE_STUDY_SWARM.md
+++ b/docs/CASE_STUDY_SWARM.md
@@ -1,0 +1,53 @@
+# Swarm Dogfooding Case Study
+
+Status: internal proof draft. Publish only after the matching SWARM screenshots,
+run artifacts, and user-approved narrative are ready.
+
+## What Changed
+
+Swarm used Axint during a real frontend hardening pass across SwiftUI product
+surfaces. The useful loop was:
+
+1. `axint suggest` recognized existing-product repair instead of suggesting a
+   new feature brainstorm.
+2. `axint project index` highlighted risky SwiftUI surfaces such as Home,
+   Breakaway, Discover, Chat, composer, and route/test files.
+3. `axint run` bundled Swift validation, Cloud Check, Xcode build, focused UI
+   tests, full-suite proof, repair prompts, run artifacts, and feedback packets.
+4. The agent could not stop at the first passing focused test because Axint kept
+   the broader proof loop visible.
+
+## Before
+
+- Agents could treat static validation as enough and stop too early.
+- Failing Xcode UI details lived inside `.xcresult` or long logs.
+- Cloud Check could sound too confident from prose-only UI evidence.
+- MCP transport failures forced agents to manually infer CLI fallback commands.
+
+## After This Sprint
+
+- `axint run` extracts failing test names, assertions, files, lines,
+  identifiers, likely causes, and repair hints.
+- Direct Cloud Check no longer treats prose-only SwiftUI layout evidence as
+  ready to ship.
+- Runtime state-transition hangs point toward heavy SwiftUI animations,
+  pinned headers, and collection recomputation.
+- `axint run` accepts MCP-style CLI aliases such as `--cwd`,
+  `--modified-files`, and `--project-name`.
+- A local `.axint/memory/latest.*` index keeps project context, proof, repair,
+  and source-free learning packets together.
+
+## Proof Points To Capture Before Publishing
+
+- One failing UI run where Axint names the failing test and repair hint.
+- One passing run artifact after the repair.
+- One privacy-safe learning packet with `source_not_included`.
+- One screenshot or screen recording showing the final repaired Swarm surface.
+
+## Public Story
+
+Axint made the agent better at Apple-native repair work. It did not replace
+developer taste or Xcode proof. It made the loop harder to fake and easier to
+finish: understand the surface, patch the smallest area, run proof, learn from
+the failure shape, and keep going until the evidence is real.
+

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -687,6 +687,117 @@ Task { @MainActor in
 }
 ```
 
+### AX764 — SwiftUI input overlay may block hit testing
+
+**Trigger**
+
+```swift
+TextEditor(text: $draft)
+    .overlay {
+        Text("Write a comment")
+    }
+```
+
+**Fix**
+
+```swift
+TextEditor(text: $draft)
+    .overlay {
+        Text("Write a comment")
+            .allowsHitTesting(false)
+    }
+```
+
+### AX765 — Invalid SwiftUI `frame(maxWidth:height:)` overload
+
+**Trigger**
+
+```swift
+Text("Card")
+    .frame(maxWidth: .infinity, height: 320, alignment: .topLeading)
+```
+
+**Fix**
+
+```swift
+Text("Card")
+    .frame(maxWidth: .infinity, alignment: .topLeading)
+    .frame(height: 320, alignment: .topLeading)
+```
+
+### AX766 — Project modifier after SwiftUI type erasure
+
+**Trigger**
+
+```swift
+Label("New Chat", systemImage: "plus")
+    .labelStyle(.iconOnly)
+    .swarmIcon(size: 18)
+```
+
+**Fix**
+
+```swift
+Label("New Chat", systemImage: "plus")
+    .swarmIcon(size: 18)
+    .labelStyle(.iconOnly)
+```
+
+If the custom modifier should work after `.labelStyle`, `.buttonStyle`,
+`.background`, or `.overlay`, rewrite it as a generic `View` modifier.
+
+### AX767 — `some View` helper needs explicit `return`
+
+**Trigger**
+
+```swift
+private func projectLoadMoreFooter() -> some View {
+    let label = "Load more"
+    Button(label) { }
+}
+```
+
+**Fix**
+
+```swift
+private func projectLoadMoreFooter() -> some View {
+    let label = "Load more"
+    return Button(label) { }
+}
+```
+
+Alternatively, add `@ViewBuilder` when the helper intentionally uses
+result-builder statements.
+
+### AX854 — Existing-product repair should not use `axint.feature`
+
+**Trigger**
+
+Asking `axint.feature` to rewrite or replace a mature SwiftUI screen, store, or
+app surface when the prompt describes a bug, an existing screen, or a repair.
+
+**Fix**
+
+Use `axint repair`, `axint suggest`, `axint project index`, and `axint run` so
+the agent patches the smallest existing surface and proves it with Xcode.
+
+### AX855 — Generated UI references missing project tokens
+
+**Trigger**
+
+```text
+Generate a SwiftUI surface using the real Swarm design system.
+```
+
+The request supplies a token namespace such as `Swarm`, but the project context
+does not contain the matching `enum`, `struct`, `class`, or `actor`.
+
+**Fix**
+
+Pass the real token/component source as context, use the correct token
+namespace, or switch to `axint repair` / `axint project index` for a patch-first
+plan.
+
 ## When To File A Bug
 
 Please open an issue if:

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,47 @@
 # Release Notes
 
+## 2026-04-29 — Agent-aware run loop and first-use wow fixture
+
+This release wave makes Axint feel more like a project brain for Apple-native agents instead of a set of separate commands.
+
+### Added
+
+- `axint init --apple-project`
+  - Initializes Axint inside an existing Apple/Xcode project.
+  - Writes the project start pack and installs the local multi-agent brain in one command.
+- `axint run --agent <agent>`
+  - Starts the run with the active host lane: `codex`, `claude`, `cursor`, `cowork`, `xcode`, or `all`.
+  - Returns host-safe repair guidance instead of generic “try this” instructions.
+- `axint.agent.*`
+  - Installs `.axint/agent.json`, project context, local file claims, and a coordination ledger.
+  - Gives Codex, Claude, Cursor, Xcode, and humans one shared local truth layer.
+- `axint memory index`
+  - Writes `.axint/memory/latest.json` and `.axint/memory/latest.md` from project context, latest run proof, latest repair packet, and source-free learning packets.
+  - Gives agents a compact project memory after context compaction or when multiple tools are working in the same project.
+- `examples/wow/composer-blocker`
+  - A small SwiftUI interaction-repair fixture where an invisible overlay blocks a composer text field.
+  - Includes a focused UI-test failure log so Axint can demonstrate project-aware diagnosis without private dogfooding notes.
+
+### Improved
+
+- `axint.run` now embeds the active agent profile in markdown, JSON, and repair-prompt output.
+- `axint.run` now accepts MCP-style CLI aliases such as `--cwd`, `--modified`, `--modified-files`, and `--project-name` so fallback commands work when MCP transport is closed.
+- `axint.run` now writes privacy-safe Cloud learning packets from Cloud Check signals to `.axint/feedback`.
+- Compact JSON keeps the important verdict, diagnostics, artifact paths, agent lane, and next moves visible while still omitting source by default.
+- The repair prompt now includes the host lane, local brain status, file-claim guidance, and the smallest proof loop to rerun next.
+- Direct Cloud Check no longer treats prose-only SwiftUI behavior notes as runtime proof. View/app checks stay at `evidence_required` until build, UI-test, runtime, or `axint run` evidence is supplied.
+- Swift validation adds `AX767` for non-`@ViewBuilder` `some View` helpers that declare locals but forget an explicit `return`.
+- Generation self-audit adds `AX855` so existing-app UI generation refuses to invent a requested project token namespace that is not present in the supplied context.
+
+### Why it matters
+
+The first-use story is now clearer:
+
+1. Point Axint at an existing Apple project.
+2. Let Axint index the app and install the local project brain.
+3. Ask Codex, Claude, Cursor, Xcode, or terminal for the same repair loop.
+4. Run focused proof and keep the result in `.axint/run/latest.*`.
+
 ## 2026-04-20 — Xcode repair loop and Apple coverage expansion
 
 This release wave sharpens the Xcode workflow and expands Apple-native Swift coverage in places where generic coding assistants usually feel soft.

--- a/examples/wow/composer-blocker/ComposerBlocker.xcodeproj/xcshareddata/xcschemes/ComposerBlocker.xcscheme
+++ b/examples/wow/composer-blocker/ComposerBlocker.xcodeproj/xcshareddata/xcschemes/ComposerBlocker.xcscheme
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+</Scheme>

--- a/examples/wow/composer-blocker/README.md
+++ b/examples/wow/composer-blocker/README.md
@@ -1,0 +1,34 @@
+# Axint Wow Fixture: Composer Blocker
+
+This fixture demonstrates the repair loop Axint should make obvious for a real Apple UI bug:
+
+1. The text input exists on screen.
+2. A nearly invisible overlay captures taps.
+3. The UI test fails because the composer is not hittable.
+4. Axint should classify this as an existing SwiftUI interaction repair, point at the likely overlay surface, and ask for focused UI proof before claiming done.
+
+## Try The Loop
+
+```bash
+axint init --apple-project examples/wow/composer-blocker --agent codex --force
+axint agent advice --dir examples/wow/composer-blocker --agent codex --changed App/HomeView.swift UITests/ComposerBlockerUITests.swift
+axint repair "Home composer text field exists but is not hittable because a translucent overlay is blocking input" --dir examples/wow/composer-blocker --agent codex --changed App/HomeView.swift UITests/ComposerBlockerUITests.swift
+axint run --dir examples/wow/composer-blocker --agent codex --dry-run --project ComposerBlocker.xcodeproj --scheme ComposerBlocker --only-testing ComposerBlockerUITests/ComposerBlockerUITests/testComposerTextFieldAcceptsInput
+```
+
+## Expected Diagnosis
+
+Axint should not suggest a new feature. It should say this is an existing SwiftUI interaction repair and focus the agent on:
+
+- The overlay in `App/HomeView.swift`.
+- The `composer-input` accessibility identifier.
+- The failing focused UI test in `UITests/ComposerBlockerUITests.swift`.
+- The proof command that reruns only `testComposerTextFieldAcceptsInput`.
+
+## Sample Failure
+
+The file `.axint-demo/failure.log` contains a representative Xcode UI-test failure that Axint can parse into a repair packet:
+
+```text
+XCTAssertTrue failed - composer-input should be hittable
+```

--- a/examples/wow/composer-blocker/axint-demo.json
+++ b/examples/wow/composer-blocker/axint-demo.json
@@ -1,0 +1,20 @@
+{
+  "schema": "https://axint.ai/schemas/wow-demo.v1.json",
+  "name": "composer-blocker",
+  "title": "Invisible overlay blocks a SwiftUI composer",
+  "issueClass": "swiftui_interaction_repair",
+  "expectedBehavior": "The home composer text field should accept focus and typed text.",
+  "actualBehavior": "The composer exists, but a transparent overlay steals taps and the UI test reports composer-input is not hittable.",
+  "likelyFiles": [
+    "App/HomeView.swift",
+    "UITests/ComposerBlockerUITests.swift"
+  ],
+  "focusedProof": {
+    "command": "axint run --dir examples/wow/composer-blocker --agent codex --project ComposerBlocker.xcodeproj --scheme ComposerBlocker --only-testing ComposerBlockerUITests/ComposerBlockerUITests/testComposerTextFieldAcceptsInput",
+    "failureLog": ".axint-demo/failure.log"
+  },
+  "privacy": {
+    "sourceSharing": "never_by_default",
+    "cloudLearning": "redacted_fingerprints_only"
+  }
+}

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.4.13",
-  "mcpTools": 29,
+  "version": "0.4.14",
+  "mcpTools": 33,
   "mcpToolNames": [
     "axint.status",
     "axint.upgrade",
@@ -22,6 +22,10 @@
     "axint.cloud.check",
     "axint.repair",
     "axint.feedback.create",
+    "axint.agent.install",
+    "axint.agent.advice",
+    "axint.agent.claim",
+    "axint.agent.release",
     "axint.run",
     "axint.run.status",
     "axint.run.cancel",
@@ -41,7 +45,7 @@
     "axint.create-intent"
   ],
   "bundledTemplates": 26,
-  "diagnostics": 184,
+  "diagnostics": 188,
   "xcodeFixRules": 33,
   "xcodeFixRuleCodes": [
     "AX701",
@@ -79,7 +83,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1058,
+    "typescript": 1080,
     "python": 114
   },
   "registryPackages": 14,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.13"
+__version__ = "0.4.14"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.13"
+version = "0.4.14"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "transport": {
         "type": "stdio"
       }
@@ -28,14 +28,14 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "transport": {
         "type": "stdio"
       }
     }
   ],
   "capabilities": {
-    "tools": 29,
+    "tools": 33,
     "prompts": 5
   }
 }

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1,0 +1,258 @@
+import type { Command } from "commander";
+import {
+  buildAxintAgentAdvice,
+  claimAxintAgentFiles,
+  installAxintLocalAgent,
+  releaseAxintAgentClaims,
+  renderAxintAgentAdviceReport,
+  renderAxintAgentClaimReport,
+  renderAxintAgentInstallReport,
+  renderAxintAgentReleaseReport,
+  type AxintLocalAgentFormat,
+  type AxintLocalAgentPrivacyMode,
+  type AxintLocalAgentProviderMode,
+} from "../project/local-agent.js";
+import {
+  normalizeAxintAgent,
+  type AxintAgentProfileName,
+} from "../project/agent-profile.js";
+
+export function registerAgent(program: Command) {
+  const agent = program
+    .command("agent")
+    .description(
+      "Install and query the local Axint multi-agent brain for one Apple project"
+    );
+
+  agent
+    .command("install")
+    .description(
+      "Write .axint/agent.json plus coordination files so Codex, Claude, Cursor, and Xcode share one project brain"
+    )
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--name <name>", "Project name")
+    .option(
+      "--agent <agent>",
+      "Agent lane: codex, claude, cursor, cowork, xcode, all",
+      parseAgent,
+      "all" as AxintAgentProfileName
+    )
+    .option(
+      "--privacy <mode>",
+      "Privacy mode: local_only, redacted_cloud, source_opt_in",
+      parsePrivacyMode,
+      "local_only" as AxintLocalAgentPrivacyMode
+    )
+    .option(
+      "--provider <mode>",
+      "Provider mode: none, bring_your_own_key, axint_cloud",
+      parseProviderMode,
+      "none" as AxintLocalAgentProviderMode
+    )
+    .option("--force", "Rewrite the local agent config")
+    .option("--json", "Shortcut for --format json")
+    .option("--prompt", "Shortcut for --format prompt")
+    .option(
+      "--format <format>",
+      "Output format: markdown, json, or prompt",
+      parseFormat,
+      "markdown" as AxintLocalAgentFormat
+    )
+    .action(
+      (options: {
+        dir: string;
+        name?: string;
+        agent: AxintAgentProfileName;
+        privacy: AxintLocalAgentPrivacyMode;
+        provider: AxintLocalAgentProviderMode;
+        force?: boolean;
+        json?: boolean;
+        prompt?: boolean;
+        format: AxintLocalAgentFormat;
+      }) => {
+        const report = installAxintLocalAgent({
+          cwd: options.dir,
+          projectName: options.name,
+          agent: options.agent,
+          privacyMode: options.privacy,
+          providerMode: options.provider,
+          force: options.force,
+        });
+        console.log(renderAxintAgentInstallReport(report, cliFormat(options)));
+      }
+    );
+
+  agent
+    .command("advice")
+    .description(
+      "Return host-specific next moves from the shared local project brain and proof ledger"
+    )
+    .argument("[issue]", "Optional bug, feature, or repair goal")
+    .option("--dir <dir>", "Project directory", ".")
+    .option(
+      "--agent <agent>",
+      "Agent lane: codex, claude, cursor, cowork, xcode, all",
+      parseAgent,
+      "all" as AxintAgentProfileName
+    )
+    .option("--changed <file...>", "Files in scope for this pass")
+    .option("--json", "Shortcut for --format json")
+    .option("--prompt", "Shortcut for --format prompt")
+    .option(
+      "--format <format>",
+      "Output format: markdown, json, or prompt",
+      parseFormat,
+      "markdown" as AxintLocalAgentFormat
+    )
+    .action(
+      (
+        issue: string | undefined,
+        options: {
+          dir: string;
+          agent: AxintAgentProfileName;
+          changed?: string[];
+          json?: boolean;
+          prompt?: boolean;
+          format: AxintLocalAgentFormat;
+        }
+      ) => {
+        const report = buildAxintAgentAdvice({
+          cwd: options.dir,
+          issue,
+          agent: options.agent,
+          changedFiles: options.changed,
+        });
+        console.log(renderAxintAgentAdviceReport(report, cliFormat(options)));
+        if (report.status === "blocked") process.exitCode = 1;
+      }
+    );
+
+  agent
+    .command("claim")
+    .description("Claim files before an agent edits them so other agents avoid conflicts")
+    .argument("<files...>", "Files to claim")
+    .option("--dir <dir>", "Project directory", ".")
+    .option(
+      "--agent <agent>",
+      "Agent lane: codex, claude, cursor, cowork, xcode, all",
+      parseAgent,
+      "all" as AxintAgentProfileName
+    )
+    .option("--task <task>", "Task or issue this claim covers")
+    .option("--ttl <minutes>", "Claim TTL in minutes", parsePositiveInt)
+    .option("--json", "Shortcut for --format json")
+    .option("--prompt", "Shortcut for --format prompt")
+    .option(
+      "--format <format>",
+      "Output format: markdown, json, or prompt",
+      parseFormat,
+      "markdown" as AxintLocalAgentFormat
+    )
+    .action(
+      (
+        files: string[],
+        options: {
+          dir: string;
+          agent: AxintAgentProfileName;
+          task?: string;
+          ttl?: number;
+          json?: boolean;
+          prompt?: boolean;
+          format: AxintLocalAgentFormat;
+        }
+      ) => {
+        const report = claimAxintAgentFiles({
+          cwd: options.dir,
+          agent: options.agent,
+          task: options.task,
+          files,
+          ttlMinutes: options.ttl,
+        });
+        console.log(renderAxintAgentClaimReport(report, cliFormat(options)));
+        if (report.status === "blocked") process.exitCode = 1;
+      }
+    );
+
+  agent
+    .command("release")
+    .description("Release active Axint file claims for this agent")
+    .argument("[files...]", "Files to release. Omit to release this agent's claims.")
+    .option("--dir <dir>", "Project directory", ".")
+    .option(
+      "--agent <agent>",
+      "Agent lane: codex, claude, cursor, cowork, xcode, all",
+      parseAgent,
+      "all" as AxintAgentProfileName
+    )
+    .option("--all", "Release all matching claims")
+    .option("--json", "Shortcut for --format json")
+    .option("--prompt", "Shortcut for --format prompt")
+    .option(
+      "--format <format>",
+      "Output format: markdown, json, or prompt",
+      parseFormat,
+      "markdown" as AxintLocalAgentFormat
+    )
+    .action(
+      (
+        files: string[] | undefined,
+        options: {
+          dir: string;
+          agent: AxintAgentProfileName;
+          all?: boolean;
+          json?: boolean;
+          prompt?: boolean;
+          format: AxintLocalAgentFormat;
+        }
+      ) => {
+        const report = releaseAxintAgentClaims({
+          cwd: options.dir,
+          agent: options.agent,
+          files,
+          all: options.all,
+        });
+        console.log(renderAxintAgentReleaseReport(report, cliFormat(options)));
+      }
+    );
+}
+
+function parseAgent(value: string): AxintAgentProfileName {
+  const agent = normalizeAxintAgent(value);
+  if (agent === value) return agent;
+  throw new Error(`invalid agent: ${value}`);
+}
+
+function parseFormat(value: string): AxintLocalAgentFormat {
+  if (value === "markdown" || value === "json" || value === "prompt") return value;
+  throw new Error(`invalid agent format: ${value}`);
+}
+
+function parsePrivacyMode(value: string): AxintLocalAgentPrivacyMode {
+  if (value === "local_only" || value === "redacted_cloud" || value === "source_opt_in") {
+    return value;
+  }
+  throw new Error(`invalid privacy mode: ${value}`);
+}
+
+function parseProviderMode(value: string): AxintLocalAgentProviderMode {
+  if (value === "none" || value === "bring_your_own_key" || value === "axint_cloud") {
+    return value;
+  }
+  throw new Error(`invalid provider mode: ${value}`);
+}
+
+function parsePositiveInt(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  throw new Error(`invalid positive integer: ${value}`);
+}
+
+function cliFormat(options: {
+  json?: boolean;
+  prompt?: boolean;
+  format: AxintLocalAgentFormat;
+}): AxintLocalAgentFormat {
+  if (options.prompt) return "prompt";
+  if (options.json) return "json";
+  return options.format;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,9 @@
  *   axint suggest <description>   Suggest Apple-native features when MCP is unavailable
  *   axint feature <description>   Generate a multi-file feature package
  *   axint repair <issue>          Plan a project-aware Apple repair loop
+ *   axint agent install           Install the local multi-agent project brain
+ *   axint agent advice            Ask the local brain for host-specific next moves
+ *   axint memory index            Build local project memory from context, proofs, repairs, and feedback
  *   axint feedback create         Create privacy-safe repair feedback packets
  *   axint publish                 Publish an intent to the Registry
  *   axint add <package>           Install a template from the Registry
@@ -69,6 +72,8 @@ import { registerSchema } from "./schema.js";
 import { registerSuggest } from "./suggest.js";
 import { registerFeature } from "./feature.js";
 import { registerRepair } from "./repair.js";
+import { registerAgent } from "./agent.js";
+import { registerMemory } from "./memory.js";
 import { registerFeedback } from "./feedback.js";
 import { registerPublish } from "./publish.js";
 import { registerAdd } from "./add.js";
@@ -82,6 +87,16 @@ import { registerSession } from "./session.js";
 import { registerWorkflow } from "./workflow.js";
 import { registerRun } from "./run.js";
 import { registerXcodeGuard } from "./xcode-guard.js";
+import {
+  renderProjectStartPack,
+  writeProjectStartPack,
+  type ProjectAgent,
+  type ProjectMcpMode,
+} from "../project/start-pack.js";
+import {
+  installAxintLocalAgent,
+  renderAxintAgentInstallReport,
+} from "../project/local-agent.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(resolve(__dirname, "../../package.json"), "utf-8"));
@@ -91,6 +106,15 @@ const program = new Command();
 const XCODE_PACKET_KINDS = ["any", "compile", "validate"] as const;
 const XCODE_CHECK_FORMATS = ["markdown", "json", "prompt", "path"] as const;
 const XCODE_PACKET_FORMATS = ["markdown", "prompt", "json", "path"] as const;
+const INIT_AGENT_CHOICES = [
+  "all",
+  "claude",
+  "codex",
+  "cowork",
+  "cursor",
+  "xcode",
+] as const;
+const INIT_MCP_MODE_CHOICES = ["local", "remote"] as const;
 
 function parseChoice<T extends string>(
   label: string,
@@ -118,7 +142,9 @@ program
 
 program
   .command("init")
-  .description("Scaffold a new Axint project (zero-config, ready to compile)")
+  .description(
+    "Scaffold a new Axint project, or initialize Axint inside an existing Apple/Xcode project"
+  )
   .argument("[dir]", "Project directory (defaults to current dir)", ".")
   .option(
     "-t, --template <name>",
@@ -127,15 +153,77 @@ program
   )
   .option("--no-install", "Skip running `npm install`")
   .option("--name <name>", "Project name (defaults to the directory name)")
+  .option(
+    "--apple-project",
+    "Initialize Axint in an existing Apple/Xcode project instead of scaffolding a new compiler package"
+  )
+  .option(
+    "--agent <agent>",
+    "Agent host lane for existing Apple projects: all, claude, codex, cowork, cursor, or xcode",
+    (value) => parseChoice("agent", value, INIT_AGENT_CHOICES),
+    "all" as ProjectAgent
+  )
+  .option(
+    "--mode <mode>",
+    "MCP mode for existing Apple projects: local or remote",
+    (value) => parseChoice("mode", value, INIT_MCP_MODE_CHOICES),
+    "local" as ProjectMcpMode
+  )
+  .option(
+    "--force",
+    "Overwrite existing Axint project-start files when using --apple-project"
+  )
   .action(
     async (
       dir: string,
-      options: { template: string; install: boolean; name?: string }
+      options: {
+        template: string;
+        install: boolean;
+        name?: string;
+        appleProject?: boolean;
+        agent: ProjectAgent;
+        mode: ProjectMcpMode;
+        force?: boolean;
+      }
     ) => {
       const targetDir = resolve(dir);
       const projectName = options.name ?? basename(targetDir);
 
       try {
+        if (options.appleProject) {
+          const pack = writeProjectStartPack({
+            targetDir,
+            projectName,
+            agent: options.agent,
+            mode: options.mode,
+            version: VERSION,
+            force: options.force ?? false,
+          });
+          const localAgent = installAxintLocalAgent({
+            cwd: targetDir,
+            projectName,
+            agent: options.agent,
+            force: options.force ?? false,
+          });
+
+          console.log(renderProjectStartPack(pack));
+          console.log();
+          console.log(renderAxintAgentInstallReport(localAgent));
+          console.log(
+            `  \x1b[38;5;208m◆\x1b[0m \x1b[1mAxint\x1b[0m · existing Apple project ready`
+          );
+          console.log();
+          console.log(`  \x1b[1mNext:\x1b[0m`);
+          console.log(
+            `    axint agent advice --dir ${targetDir} --agent ${options.agent}`
+          );
+          console.log(
+            `    axint run --dir ${targetDir} --agent ${options.agent} --dry-run`
+          );
+          console.log();
+          return;
+        }
+
         const result = await scaffoldProject({
           targetDir,
           projectName,
@@ -189,6 +277,8 @@ registerSchema(program);
 registerSuggest(program);
 registerFeature(program);
 registerRepair(program);
+registerAgent(program);
+registerMemory(program);
 registerFeedback(program);
 registerPublish(program, VERSION);
 registerAdd(program, VERSION);

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1,0 +1,56 @@
+import type { Command } from "commander";
+import {
+  renderProjectMemoryIndex,
+  writeProjectMemoryIndex,
+  type AxintProjectMemoryFormat,
+} from "../project/memory-index.js";
+
+export function registerMemory(program: Command) {
+  const memory = program
+    .command("memory")
+    .description("Build and inspect Axint's local project memory index");
+
+  memory
+    .command("index")
+    .description(
+      "Write .axint/memory/latest.* from project context, runs, repairs, and learning packets"
+    )
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--cwd <dir>", "Alias for --dir when copying MCP-style fallback commands")
+    .option("--project-name <name>", "Project name label")
+    .option("--changed <file...>", "Changed files to seed memory context")
+    .option("--modified <file...>", "Alias for --changed")
+    .option("--modified-files <file...>", "Alias for --changed")
+    .option("--json", "Shortcut for --format json")
+    .option(
+      "--format <format>",
+      "Output format: markdown or json",
+      parseMemoryFormat,
+      "markdown" as AxintProjectMemoryFormat
+    )
+    .action(
+      (options: {
+        dir: string;
+        cwd?: string;
+        projectName?: string;
+        changed?: string[];
+        modified?: string[];
+        modifiedFiles?: string[];
+        json?: boolean;
+        format: AxintProjectMemoryFormat;
+      }) => {
+        const result = writeProjectMemoryIndex({
+          cwd: options.cwd ?? options.dir,
+          projectName: options.projectName,
+          changedFiles: options.modifiedFiles ?? options.modified ?? options.changed,
+        });
+        const format = options.json ? "json" : options.format;
+        console.log(renderProjectMemoryIndex(result.index, format));
+      }
+    );
+}
+
+function parseMemoryFormat(value: string): AxintProjectMemoryFormat {
+  if (value === "markdown" || value === "json") return value;
+  throw new Error(`invalid memory format: ${value}`);
+}

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -5,6 +5,7 @@ import {
   type AxintRunFormat,
   type AxintRunPlatform,
 } from "../run/project-runner.js";
+import { normalizeAxintAgent } from "../project/agent-profile.js";
 import {
   cancelRunJob,
   getRunJobStatus,
@@ -22,6 +23,8 @@ export function registerRun(program: Command, version: string) {
 
   run
     .option("--dir <dir>", "Project directory", ".")
+    .option("--cwd <dir>", "Alias for --dir when copying MCP-style fallback commands")
+    .option("--project-name <name>", "Project name label. Normally inferred from --dir.")
     .option("--scheme <scheme>", "Xcode scheme")
     .option("--workspace <path>", "Path to .xcworkspace")
     .option("--project <path>", "Path to .xcodeproj")
@@ -38,7 +41,14 @@ export function registerRun(program: Command, version: string) {
       "Target platform: macOS, iOS, watchOS, visionOS, all",
       parsePlatform
     )
+    .option(
+      "--agent <agent>",
+      "Agent host lane: all, codex, claude, cursor, cowork, or xcode",
+      "all"
+    )
     .option("--changed <file...>", "Changed Swift files to validate/check")
+    .option("--modified <file...>", "Alias for --changed")
+    .option("--modified-files <file...>", "Alias for --changed")
     .option("--skip-build", "Skip xcodebuild build")
     .option("--skip-tests", "Skip xcodebuild test")
     .option("--runtime", "Launch the built macOS app and capture runtime evidence")
@@ -64,6 +74,8 @@ export function registerRun(program: Command, version: string) {
     .action(
       async (options: {
         dir: string;
+        cwd?: string;
+        projectName?: string;
         scheme?: string;
         workspace?: string;
         project?: string;
@@ -73,7 +85,10 @@ export function registerRun(program: Command, version: string) {
         testPlan?: string;
         onlyTesting?: string[];
         platform?: AxintRunPlatform;
+        agent?: string;
         changed?: string[];
+        modified?: string[];
+        modifiedFiles?: string[];
         skipBuild?: boolean;
         skipTests?: boolean;
         runtime?: boolean;
@@ -89,11 +104,15 @@ export function registerRun(program: Command, version: string) {
         prompt?: boolean;
         format: AxintRunFormat;
       }) => {
+        const runDir = options.cwd ?? options.dir;
+        const changedFiles = options.modifiedFiles ?? options.modified ?? options.changed;
         const report = await runAxintProject({
-          cwd: options.dir,
+          cwd: runDir,
           kind: "local",
+          projectName: options.projectName,
           expectedVersion: version,
           platform: options.platform,
+          agent: normalizeAxintAgent(options.agent),
           scheme: options.scheme,
           workspace: options.workspace,
           project: options.project,
@@ -102,7 +121,7 @@ export function registerRun(program: Command, version: string) {
           derivedDataPath: options.derivedData,
           testPlan: options.testPlan,
           onlyTesting: options.onlyTesting,
-          modifiedFiles: options.changed,
+          modifiedFiles: changedFiles,
           skipBuild: options.skipBuild,
           skipTests: options.skipTests,
           runtime: options.runtime,
@@ -198,6 +217,11 @@ export function registerRun(program: Command, version: string) {
     .option("--scheme <scheme>", "Xcode scheme")
     .option("--destination <destination>", "xcodebuild destination")
     .option(
+      "--agent <agent>",
+      "Agent host lane: all, codex, claude, cursor, cowork, or xcode",
+      "all"
+    )
+    .option(
       "--only-testing <selector...>",
       "Focused xcodebuild -only-testing selector(s)"
     )
@@ -219,6 +243,7 @@ export function registerRun(program: Command, version: string) {
         dir: string;
         scheme?: string;
         destination?: string;
+        agent?: string;
         onlyTesting?: string[];
         skipTests?: boolean;
         runtime?: boolean;
@@ -230,6 +255,7 @@ export function registerRun(program: Command, version: string) {
           cwd: options.dir,
           kind: "byo-runner",
           expectedVersion: version,
+          agent: normalizeAxintAgent(options.agent),
           scheme: options.scheme,
           destination: options.destination,
           onlyTesting: options.onlyTesting,

--- a/src/cli/workflow.ts
+++ b/src/cli/workflow.ts
@@ -76,6 +76,7 @@ export function registerWorkflow(program: Command) {
     )
     .option("--read-docs-context", "Mark that .axint/AXINT_DOCS_CONTEXT.md was read")
     .option("--ran-feature", "Mark that axint.feature was used")
+    .option("--ran-repair", "Mark that axint.repair was used")
     .option(
       "--feature-bypass-reason <reason>",
       "Why generation was intentionally bypassed"
@@ -114,6 +115,7 @@ export function registerWorkflow(program: Command) {
         readAgentInstructions?: boolean;
         readDocsContext?: boolean;
         ranFeature?: boolean;
+        ranRepair?: boolean;
         featureBypassReason?: string;
         ranSwiftValidate?: boolean;
         ranCloudCheck?: boolean;
@@ -139,6 +141,7 @@ export function registerWorkflow(program: Command) {
           readAgentInstructions: options.readAgentInstructions,
           readDocsContext: options.readDocsContext,
           ranFeature: options.ranFeature,
+          ranRepair: options.ranRepair,
           featureBypassReason: options.featureBypassReason,
           ranSwiftValidate: options.ranSwiftValidate,
           ranCloudCheck: options.ranCloudCheck,

--- a/src/cloud/check.ts
+++ b/src/cloud/check.ts
@@ -169,8 +169,22 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
   let outputPath: string | undefined;
   let diagnostics: Diagnostic[];
   let generated = false;
+  const nonAppleArtifact = language === "unknown" && isNonAppleArtifact(fileName, source);
 
-  if (language === "swift") {
+  if (nonAppleArtifact) {
+    surface = inferNonAppleArtifactSurface(fileName, source);
+    diagnostics = [
+      {
+        code: "AXCLOUD-NON-APPLE-ARTIFACT",
+        severity: "info",
+        file: fileName,
+        message:
+          "Cloud Check received a document or web artifact instead of Swift, Axint TypeScript, or Apple-native source.",
+        suggestion:
+          "Use browser/render/link verification for this artifact, then run Cloud Check on the Swift or Axint source that implements the Apple-facing behavior.",
+      },
+    ];
+  } else if (language === "swift") {
     diagnostics = validateSwiftSource(source, fileName).diagnostics;
     swiftCode = source;
   } else {
@@ -223,63 +237,86 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
   const infos = diagnostics.filter((d) => d.severity === "info").length;
   const runtimeCoverageRequired = requiresRuntimeCoverage(language, surface, swiftCode);
   const runtimeEvidenceProvided = hasRuntimeEvidence(evidence);
-  const status: CloudCheckStatus =
-    errors > 0
+  const status: CloudCheckStatus = nonAppleArtifact
+    ? "needs_review"
+    : errors > 0
       ? "fail"
       : warnings > 0 || (runtimeCoverageRequired && !runtimeEvidenceProvided)
         ? "needs_review"
         : "pass";
   const outputLines = swiftCode ? swiftCode.split("\n").length : 0;
 
-  const checks = [
-    {
-      label: language === "swift" ? "Swift source loaded" : "Source parse",
-      state: diagnostics.some((d) => d.code === "AX001") ? "fail" : "pass",
-      detail:
-        language === "swift"
-          ? "Axint loaded Swift source directly for Apple-specific validation."
-          : generated
-            ? "The source parsed into Axint IR and generated Swift."
-            : "Axint could not produce Swift from this source.",
-    },
-    {
-      label: language === "swift" ? "Swift validation" : "Swift generation",
-      state: swiftCode ? "pass" : "fail",
-      detail: swiftCode
-        ? `${generated ? "Generated" : "Checked"} ${outputLines} line${outputLines === 1 ? "" : "s"} of Swift.`
-        : "No Swift output was available for validation.",
-    },
-    {
-      label: "Apple-specific findings",
-      state: errors > 0 ? "fail" : warnings > 0 ? "warn" : "pass",
-      detail:
-        errors > 0
-          ? `${errors} error${errors === 1 ? "" : "s"} must be fixed before this is safe to ship.`
-          : warnings > 0
-            ? `${warnings} warning${warnings === 1 ? "" : "s"} need review.`
-            : "No blocking static Apple-facing issues were found.",
-    },
-    ...(runtimeCoverageRequired
+  const checks = (
+    nonAppleArtifact
       ? [
           {
-            label: "Runtime and UI coverage",
-            state: runtimeEvidenceProvided ? ("pass" as const) : ("warn" as const),
-            detail: runtimeEvidenceProvided
-              ? "Cloud Check inspected supplied Xcode/test/runtime evidence in addition to static source checks."
-              : "Static Cloud Check does not execute Xcode builds, UI tests, accessibility flows, route transitions, or runtime state. Do not treat this as proof that the app flow works.",
+            label: "Document/web artifact detected",
+            state: "warn" as const,
+            detail:
+              "This input is not Swift or Axint source, so Apple compiler diagnostics are not the right proof surface.",
           },
-        ]
-      : []),
-    ...(projectContext
-      ? [
           {
-            label: "Project context pack",
+            label: "Apple-specific findings",
             state: "pass" as const,
-            detail: projectContext.summary.join(" "),
+            detail:
+              "No Apple-native compiler rules were applied. Verify this artifact through browser/render/link evidence instead.",
           },
         ]
-      : []),
-  ] satisfies CloudCheckReport["checks"];
+      : [
+          {
+            label: language === "swift" ? "Swift source loaded" : "Source parse",
+            state: diagnostics.some((d) => d.code === "AX001")
+              ? ("fail" as const)
+              : ("pass" as const),
+            detail:
+              language === "swift"
+                ? "Axint loaded Swift source directly for Apple-specific validation."
+                : generated
+                  ? "The source parsed into Axint IR and generated Swift."
+                  : "Axint could not produce Swift from this source.",
+          },
+          {
+            label: language === "swift" ? "Swift validation" : "Swift generation",
+            state: swiftCode ? ("pass" as const) : ("fail" as const),
+            detail: swiftCode
+              ? `${generated ? "Generated" : "Checked"} ${outputLines} line${outputLines === 1 ? "" : "s"} of Swift.`
+              : "No Swift output was available for validation.",
+          },
+          {
+            label: "Apple-specific findings",
+            state:
+              errors > 0
+                ? ("fail" as const)
+                : warnings > 0
+                  ? ("warn" as const)
+                  : ("pass" as const),
+            detail:
+              errors > 0
+                ? `${errors} error${errors === 1 ? "" : "s"} must be fixed before this is safe to ship.`
+                : warnings > 0
+                  ? `${warnings} warning${warnings === 1 ? "" : "s"} need review.`
+                  : "No blocking static Apple-facing issues were found.",
+          },
+          ...(runtimeCoverageRequired
+            ? [
+                {
+                  label: "Runtime and UI coverage",
+                  state: runtimeEvidenceProvided ? ("pass" as const) : ("warn" as const),
+                  detail: runtimeEvidenceProvided
+                    ? "Cloud Check inspected supplied Xcode/test/runtime evidence in addition to static source checks."
+                    : "Static Cloud Check does not execute Xcode builds, UI tests, accessibility flows, route transitions, or runtime state. Do not treat this as proof that the app flow works.",
+                },
+              ]
+            : []),
+        ]
+  ) satisfies CloudCheckReport["checks"];
+  if (projectContext) {
+    checks.push({
+      label: "Project context pack",
+      state: "pass",
+      detail: projectContext.summary.join(" "),
+    });
+  }
   const coverage = buildCloudCoverage({
     language,
     surface,
@@ -289,6 +326,7 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
     evidenceProvided: evidence.provided.length > 0,
     runtimeEvidenceProvided,
     projectContextLoaded: Boolean(projectContext),
+    nonAppleArtifact,
   });
   const confidence = buildCloudConfidence({
     status,
@@ -297,6 +335,7 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
     runtimeCoverageRequired,
     evidenceProvided: evidence.provided.length > 0,
     runtimeEvidenceProvided,
+    nonAppleArtifact,
   });
   const gate = buildCloudGate({
     status,
@@ -305,6 +344,7 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
     runtimeCoverageRequired,
     runtimeEvidenceProvided,
     evidenceProvided: evidence.provided.length > 0,
+    nonAppleArtifact,
   });
 
   const nextSteps = diagnostics
@@ -317,6 +357,7 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
     runtimeEvidenceProvided,
     fileName,
     projectContext,
+    nonAppleArtifact,
     repairIntelligence:
       repairIntelligence.isExistingProductRepair ||
       diagnostics.some((d) => d.severity !== "info")
@@ -325,7 +366,14 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
   });
 
   if (nextSteps.length === 0) {
-    if (runtimeCoverageRequired) {
+    if (nonAppleArtifact) {
+      nextSteps.push(
+        "Verify this document or web artifact with a browser/render smoke test instead of treating Cloud Check as an Apple compiler verdict."
+      );
+      nextSteps.push(
+        "Run Cloud Check on the Swift or Axint source files that implement the Apple-facing behavior referenced by the artifact."
+      );
+    } else if (runtimeCoverageRequired) {
       nextSteps.push(
         "Treat this as a static source check only. Run the Xcode build plus the relevant unit/UI tests before claiming the bug is gone."
       );
@@ -603,6 +651,27 @@ function inferLanguage(fileName: string, source: string): CloudCheckLanguage {
   return "unknown";
 }
 
+function isNonAppleArtifact(fileName: string, source: string): boolean {
+  if (/\.(html?|md|mdx|txt|pdf)$/i.test(fileName)) return true;
+  if (/\b<!doctype\s+html\b|\b<html[\s>]/i.test(source)) return true;
+  if (
+    /^\s*#\s+\S+/m.test(source) &&
+    !/\bdefine(Intent|View|Widget|App)\s*\(/.test(source)
+  ) {
+    return true;
+  }
+  return /\b(sprint|audit|roadmap|north star|north-star|appendix)\b/i.test(fileName);
+}
+
+function inferNonAppleArtifactSurface(fileName: string, source: string): string {
+  if (/\.(html?|mdx?)$/i.test(fileName) || /\b<html[\s>]/i.test(source)) {
+    return "document";
+  }
+  if (/\b(sprint|roadmap)\b/i.test(fileName)) return "sprint-artifact";
+  if (/\b(audit|north star|north-star)\b/i.test(fileName)) return "audit-artifact";
+  return "document-artifact";
+}
+
 function inferSwiftSurface(source: string): string {
   if (/\bAppIntent\b/.test(source)) return "intent";
   if (/\bWidget\b/.test(source) || /\bTimelineProvider\b/.test(source)) return "widget";
@@ -648,13 +717,7 @@ function collectCloudEvidence(input: CloudCheckInput): CloudCheckReport["evidenc
 
 function hasRuntimeEvidence(evidence: CloudCheckReport["evidence"]): boolean {
   return evidence.provided.some((label) =>
-    [
-      "xcodeBuildLog",
-      "testFailure",
-      "runtimeFailure",
-      "expectedBehavior",
-      "actualBehavior",
-    ].includes(label)
+    ["xcodeBuildLog", "testFailure", "runtimeFailure"].includes(label)
   );
 }
 
@@ -729,6 +792,9 @@ function inferEvidenceDiagnostics(input: {
       source,
       file
     )
+  );
+  diagnostics.push(
+    ...diagnosticsFromStateTransitionHangEvidence(evidenceText, source, file)
   );
 
   if (
@@ -831,6 +897,7 @@ function buildCloudRepairPlan(input: {
   fileName: string;
   projectContext?: ProjectContextHint;
   repairIntelligence?: AppleRepairIntelligence;
+  nonAppleArtifact?: boolean;
 }): CloudCheckReport["repairPlan"] {
   const actionable = input.diagnostics.filter((d) => d.severity !== "info");
   const intelligenceSteps: CloudCheckReport["repairPlan"] = input.repairIntelligence
@@ -849,6 +916,21 @@ function buildCloudRepairPlan(input: {
           : []),
       ]
     : [];
+
+  if (input.nonAppleArtifact) {
+    return [
+      {
+        title: "Use the right proof surface",
+        detail:
+          "This is a document or web artifact, so browser rendering, link checks, screenshots, and console output are the useful proof instead of Swift compiler diagnostics.",
+      },
+      {
+        title: "Check related Apple source only if needed",
+        detail:
+          "If the artifact describes Swift, App Intents, Xcode, or runtime behavior changes, run Cloud Check against the related Swift or Axint source file, not the HTML/Markdown report.",
+      },
+    ];
+  }
 
   if (actionable.length === 0) {
     return [
@@ -893,6 +975,14 @@ function buildCloudRepairPlan(input: {
           "Open the sample output, find Thread 0, and look for the first frame from your app module. Rerun Cloud Check with that source file and the sample excerpt.",
       }
     );
+  }
+
+  if (input.diagnostics.some((d) => d.code === "AXCLOUD-RUNTIME-STATE-TRANSITION-HANG")) {
+    steps.unshift({
+      title: "Trim SwiftUI transition work first",
+      detail:
+        "Remove broad `withAnimation` or `.animation` around filter, sort, and list updates before chasing unrelated fixes. Keep pinned headers stable, move expensive filtering/sorting out of View.body, and prove the repair with the focused UI test that scrolls and switches state.",
+    });
   }
 
   if (input.projectContext?.relatedFiles.length) {
@@ -944,15 +1034,22 @@ function diagnosticsFromBuildLog(buildLog: string, file: string): Diagnostic[] {
     });
   }
 
-  if (/\b(?:type|value)\s+'[^']+'\s+has no member\s+'[^']+'/.test(text)) {
+  const missingMember = text.match(
+    /\b(?:(?:value\s+of\s+type)|type|value)\s+'([^']+)'\s+has\s+no\s+member\s+'([^']+)'/
+  );
+  if (missingMember) {
+    const resolvedType = missingMember[1] ?? "the resolved type";
+    const member = missingMember[2] ?? "member";
+    const isTypeErasedSwiftUI =
+      resolvedType === "some view" || resolvedType === "some swiftui.view";
     diagnostics.push({
       code: "AXCLOUD-BUILD-MISSING-MEMBER",
       severity: "error",
       file,
-      message:
-        "Xcode build evidence reports a member reference that does not exist on the resolved type.",
-      suggestion:
-        "Rename the generated enum case, static token, or type member to match the project symbol. If Axint generated it, feed the declaring type or design-token file as context before regenerating.",
+      message: `Xcode build evidence reports .${member} on ${resolvedType}, but that member does not exist on the resolved type.`,
+      suggestion: isTypeErasedSwiftUI
+        ? "A SwiftUI modifier earlier in the chain likely erased the concrete type. Move the project-specific modifier before `.labelStyle`, `.buttonStyle`, `.background`, `.overlay`, or rewrite the modifier as a generic View extension."
+        : "Rename the generated enum case, static token, or type member to match the project symbol. If Axint generated it, feed the declaring type or design-token file as context before regenerating.",
     });
   }
 
@@ -1018,7 +1115,23 @@ function diagnosticsFromTestFailure(
   const diagnostics: Diagnostic[] = [];
 
   if (
-    /\b(no matches|no matching|not found|failed to get matching|element.*not.*exist|wait.*timed out)\b/.test(
+    /\bxct(?:assert|fail|waiter)[a-z]*\s+failed\b|\btest case\b.*\bfailed\b|\bfailing test\b|\bis not equal to\b|\bfailed assertion\b/.test(
+      text
+    )
+  ) {
+    diagnostics.push({
+      code: "AXCLOUD-XCTEST-FAILURE",
+      severity: "error",
+      file,
+      message:
+        "Supplied XCTest evidence contains an explicit failing assertion, so Cloud Check cannot return a pass.",
+      suggestion:
+        "Patch the behavior that the failing assertion names, rerun the focused XCTest, and include the passing test log before claiming the repair is fixed.",
+    });
+  }
+
+  if (
+    /\b(no matches|no matching|not found|failed to get matching|element.*not.*exist|should exist|wait.*timed out)\b/.test(
       text
     )
   ) {
@@ -1051,7 +1164,7 @@ function diagnosticsFromTestFailure(
   }
 
   if (
-    /\b(should be hittable after scrolling|not hittable|not tappable|not foreground|does not allow background interaction|background interaction|failed to synthesize event|hit point|scroll.*hittable)\b/.test(
+    /\b(should be hittable|should be tappable|not hittable|not tappable|not foreground|does not allow background interaction|background interaction|failed to synthesize event|hit point|scroll.*hittable)\b/.test(
       text
     )
   ) {
@@ -1189,6 +1302,98 @@ function diagnosticsFromInputInteractivityEvidence(
   }
 
   return dedupeDiagnostics(diagnostics);
+}
+
+function diagnosticsFromStateTransitionHangEvidence(
+  evidenceText: string,
+  source: string,
+  file: string
+): Diagnostic[] {
+  const text = normalizeTextForEvidence(evidenceText);
+  if (!looksLikeStateTransitionMainThreadHang(text, source)) {
+    return [];
+  }
+
+  return [
+    {
+      code: "AXCLOUD-RUNTIME-STATE-TRANSITION-HANG",
+      severity: "error",
+      file,
+      line: findLikelyStateTransitionHangLine(source),
+      message:
+        "Runtime or UI-test evidence says the app main thread became busy after a UI state transition, which often comes from heavy SwiftUI list animations, pinned-header updates, or expensive body recomputation.",
+      suggestion:
+        "Treat this as a SwiftUI state-transition hang. Remove broad or per-card spring animations from filter/sort/list changes, keep pinned headers outside animated collection updates, move expensive filtering/sorting into a cached model or store, and rerun the focused UI test that scrolls and switches state.",
+    },
+  ];
+}
+
+function looksLikeStateTransitionMainThreadHang(
+  evidenceText: string,
+  source: string
+): boolean {
+  if (!evidenceText) return false;
+
+  const mainThreadBusy =
+    /\b(?:app|application)?\s*main thread\b.{0,90}\b(?:busy|blocked|stuck|unresponsive|not responding)\b/.test(
+      evidenceText
+    ) ||
+    /\bmain thread was busy\b/.test(evidenceText) ||
+    /\bbusy for \d+\s*(?:second|seconds|sec|secs)\b/.test(evidenceText) ||
+    /\btimed out waiting for (?:the )?(?:app|application) to idle\b/.test(evidenceText);
+  if (!mainThreadBusy) return false;
+
+  const transitionEvidence =
+    /\b(?:after|while|when|during)\b.{0,90}\b(?:filter|filters|sort|sorting|switch|switching|select|selection|selected|segment|tab|scroll|scrolling|pinned|header|list|feed|collection|animation|spring|transition|state change|state transition)\b/.test(
+      evidenceText
+    ) ||
+    /\b(?:filter|filters|sort|sorting|switching|selected|selection|pinned header|list update|feed update|collection update|animation|spring|transition)\b.{0,90}\b(?:busy|blocked|hang|hung|freeze|frozen|unresponsive|not responding)\b/.test(
+      evidenceText
+    );
+
+  return transitionEvidence || sourceHasStateTransitionHangShape(source);
+}
+
+function sourceHasStateTransitionHangShape(source: string): boolean {
+  const text = normalizeTextForEvidence(source);
+  if (!text) return false;
+
+  const hasCollection = /\b(?:list|lazyvstack|lazyhstack|foreach|scrollview|grid)\b/.test(
+    text
+  );
+  const hasStateMutation =
+    /\b(?:@state|@observable|@published|withanimation|\.onchange|selected|selection|filter|sort|sorted)\b/.test(
+      text
+    );
+  const hasHeavyTransition =
+    /\b(?:withanimation|\.animation|\.transition|spring|bouncy|matchedgeometryeffect|pinnedviews|pinnedviews:|section\s*\(|\.filter\s*\(|\.sorted\s*\()\b/.test(
+      text
+    );
+
+  return hasCollection && hasStateMutation && hasHeavyTransition;
+}
+
+function findLikelyStateTransitionHangLine(source: string): number | undefined {
+  const needles = [
+    "withAnimation",
+    ".animation",
+    ".transition",
+    ".matchedGeometryEffect",
+    "pinnedViews",
+    ".onChange",
+    ".filter",
+    ".sorted",
+    "LazyVStack",
+    "List",
+    "ForEach",
+  ];
+
+  for (const needle of needles) {
+    const line = findLine(source, needle);
+    if (line) return line;
+  }
+
+  return undefined;
 }
 
 function looksLikeInputInteractivityFailure(text: string): boolean {
@@ -1693,20 +1898,32 @@ function buildCloudCoverage(input: {
   evidenceProvided: boolean;
   runtimeEvidenceProvided: boolean;
   projectContextLoaded: boolean;
+  nonAppleArtifact: boolean;
 }): CloudCheckReport["coverage"] {
   const coverage: CloudCheckReport["coverage"] = [];
 
   coverage.push({
-    label:
-      input.language === "typescript" ? "Axint parse and lowering" : "Source loading",
+    label: input.nonAppleArtifact
+      ? "Document/web artifact routing"
+      : input.language === "typescript"
+        ? "Axint parse and lowering"
+        : "Source loading",
     state: "checked",
-    detail:
-      input.language === "typescript"
+    detail: input.nonAppleArtifact
+      ? "Detected that this input is not Swift or Axint source, so Cloud Check skipped Apple-native compilation instead of emitting a fake intent diagnostic."
+      : input.language === "typescript"
         ? "Parsed the Axint source and attempted to lower it into Swift before validation."
         : "Loaded the Swift source directly and ran static Apple-facing validation.",
   });
 
-  if (input.hasSwiftCode) {
+  if (input.nonAppleArtifact) {
+    coverage.push({
+      label: "Swift validator rule engine",
+      state: "not_applicable",
+      detail:
+        "This artifact needs browser/render/link proof, not Swift validator diagnostics.",
+    });
+  } else if (input.hasSwiftCode) {
     coverage.push({
       label: "Swift validator rule engine",
       state: "checked",
@@ -1760,7 +1977,21 @@ function buildCloudConfidence(input: {
   runtimeCoverageRequired: boolean;
   evidenceProvided: boolean;
   runtimeEvidenceProvided: boolean;
+  nonAppleArtifact: boolean;
 }): CloudCheckReport["confidence"] {
+  if (input.nonAppleArtifact) {
+    return {
+      level: "medium",
+      detail:
+        "Cloud Check correctly identified this as a document/web artifact, not an Apple-native compiler target.",
+      missingEvidence: [
+        "Browser/render smoke test",
+        "Link or route verification",
+        "Cloud Check on the related Swift or Axint source if Apple behavior changed",
+      ],
+    };
+  }
+
   if (input.errors > 0) {
     return {
       level: "high",
@@ -1820,7 +2051,22 @@ function buildCloudGate(input: {
   runtimeCoverageRequired: boolean;
   runtimeEvidenceProvided: boolean;
   evidenceProvided: boolean;
+  nonAppleArtifact: boolean;
 }): CloudCheckReport["gate"] {
+  if (input.nonAppleArtifact) {
+    return {
+      decision: "evidence_required",
+      canClaimFixed: false,
+      reason:
+        "Cloud Check is not applicable as the final proof for a document or web artifact.",
+      requiredEvidence: [
+        "Rendered browser verification",
+        "Relevant route/link checks",
+        "Apple-source Cloud Check only if Swift or Axint source changed",
+      ],
+    };
+  }
+
   if (input.errors > 0 || input.warnings > 0 || input.status === "fail") {
     return {
       decision: "fix_required",
@@ -1871,6 +2117,22 @@ function buildCloudRepairPrompt(report: CloudCheckReport): string {
   const actionable = report.diagnostics.filter((d) => d.severity !== "info").slice(0, 4);
 
   if (actionable.length === 0) {
+    if (report.diagnostics.some((d) => d.code === "AXCLOUD-NON-APPLE-ARTIFACT")) {
+      return [
+        `Review ${report.fileName}.`,
+        "Axint Cloud Check identified this as a document or web artifact, not an Apple-native source file.",
+        `Ship gate: ${report.gate.decision}. ${report.gate.reason}`,
+        `Checked: ${checkedCoverageSummary(report)}.`,
+        "Use browser/render/link proof for this artifact.",
+        "Run Cloud Check on the related Swift or Axint source only if Apple-facing behavior changed.",
+        "",
+        "Repair plan:",
+        ...report.repairPlan.map(
+          (step, index) => `${index + 1}. ${step.title}: ${step.detail}`
+        ),
+      ].join("\n");
+    }
+
     if (hasRuntimeCoverageWarning(report)) {
       return [
         `Review ${report.fileName}.`,
@@ -2063,8 +2325,11 @@ function inferLearningSignals(report: CloudCheckReport): string[] {
   if (/\bAXCLOUD-RUNTIME-FREEZE\b/i.test(body)) {
     signals.push("runtime-freeze-evidence");
   }
+  if (/\bAXCLOUD-RUNTIME-STATE-TRANSITION-HANG\b/i.test(body)) {
+    signals.push("swiftui-state-transition-hang");
+  }
   if (
-    /\bAXCLOUD-RUNTIME-(MAIN-BLOCKER|MAIN-SYNC|BLOCKING-WAIT|SLEEP|INFINITE-LOOP|SYNC-IO|LIFECYCLE-BLOCKER)\b/i.test(
+    /\bAXCLOUD-RUNTIME-(MAIN-BLOCKER|MAIN-SYNC|BLOCKING-WAIT|SLEEP|INFINITE-LOOP|SYNC-IO|LIFECYCLE-BLOCKER|STATE-TRANSITION-HANG)\b/i.test(
       body
     )
   ) {
@@ -2120,6 +2385,7 @@ function inferLearningKind(
   signals: string[]
 ): CloudLearningKind {
   if (signals.includes("platform-availability-gap")) return "platform_gap";
+  if (signals.includes("swiftui-state-transition-hang")) return "validator_gap";
   if (signals.includes("runtime-freeze-evidence")) return "validator_gap";
   if (signals.includes("runtime-evidence-missing")) return "validator_gap";
   if (report.language === "swift") return "validator_gap";
@@ -2137,6 +2403,7 @@ function inferLearningOwner(
   signals: string[]
 ): CloudLearningOwner {
   if (signals.includes("platform-availability-gap")) return "swift-validator";
+  if (signals.includes("swiftui-state-transition-hang")) return "cloud";
   if (signals.includes("runtime-freeze-evidence")) return "cloud";
   if (signals.includes("runtime-evidence-missing")) return "cloud";
   if (signals.includes("ui-interaction-evidence")) return "cloud";
@@ -2171,6 +2438,9 @@ function titleForLearningSignal(
   if (diagnosticCodes.includes("AXCLOUD-RUNTIME-FREEZE")) {
     return "Runtime freeze evidence needs Cloud triage";
   }
+  if (diagnosticCodes.includes("AXCLOUD-RUNTIME-STATE-TRANSITION-HANG")) {
+    return "SwiftUI state-transition hang needs Cloud triage";
+  }
   if (diagnosticCodes.some((code) => code.startsWith("AXCLOUD-UI-"))) {
     return `UI interaction evidence needs Cloud triage (${codeList})`;
   }
@@ -2189,6 +2459,11 @@ function suggestedActionForLearningSignal(
 ): string {
   if (report.diagnostics.some((d) => d.code === "AXCLOUD-RUNTIME-FREEZE")) {
     return "Capture a freeze sample fixture, classify the first app-owned main-thread frame, and promote repeated freeze signatures into Cloud runtime diagnostics.";
+  }
+  if (
+    report.diagnostics.some((d) => d.code === "AXCLOUD-RUNTIME-STATE-TRANSITION-HANG")
+  ) {
+    return "Capture a focused UI-test fixture for scroll-plus-state transitions, then teach Cloud Check to map main-thread busy failures to SwiftUI animation, pinned-header, and collection recomputation repairs.";
   }
   if (report.diagnostics.some((d) => d.code.startsWith("AXCLOUD-UI-"))) {
     return "Turn repeated tap/focus/input regressions into UI-interaction fixtures so Cloud Check can classify overlay, disabled-state, and gesture-capture bugs immediately.";

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -719,6 +719,18 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticInfo> = {
     message: "Invalid SwiftUI frame(maxWidth:height:) overload",
     category: "swiftui-api-parity",
   },
+  AX766: {
+    code: "AX766",
+    severity: "warning",
+    message: "Project-specific SwiftUI modifier appears after a type-erasing modifier",
+    category: "swiftui-api-parity",
+  },
+  AX767: {
+    code: "AX767",
+    severity: "error",
+    message: "some View helper has local declarations but no explicit return",
+    category: "swiftui-api-parity",
+  },
   AX714: {
     code: "AX714",
     severity: "error",
@@ -967,6 +979,18 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticInfo> = {
     code: "AX853",
     severity: "error",
     message: "Generated UI has low semantic coverage of the prompt",
+    category: "generation-quality",
+  },
+  AX854: {
+    code: "AX854",
+    severity: "error",
+    message: "Existing-product repair prompt should use axint.repair",
+    category: "generation-quality",
+  },
+  AX855: {
+    code: "AX855",
+    severity: "error",
+    message: "Generated UI references a project token namespace missing from context",
     category: "generation-quality",
   },
 };

--- a/src/core/swift-validator.ts
+++ b/src/core/swift-validator.ts
@@ -77,6 +77,8 @@ export function validateSwiftSource(source: string, file: string): SwiftValidati
   checkContainerAccessibilityIdentifierPropagation(source, stripped, file, diagnostics);
   checkInteractiveInputOverlayHitTesting(source, stripped, file, diagnostics);
   checkInvalidSwiftUIFrameOverloads(source, stripped, file, diagnostics);
+  checkTypeErasedSwiftUIModifierChains(source, stripped, file, diagnostics);
+  checkOpaqueViewReturnsNeedExplicitReturn(source, stripped, file, diagnostics);
 
   return { file, diagnostics };
 }
@@ -210,6 +212,187 @@ function checkInvalidSwiftUIFrameOverloads(
       })
     );
   }
+}
+
+const TYPE_ERASING_SWIFTUI_MODIFIERS = new Set([
+  "labelStyle",
+  "buttonStyle",
+  "controlSize",
+  "background",
+  "overlay",
+  "mask",
+  "clipShape",
+  "popover",
+  "sheet",
+  "toolbar",
+]);
+
+const KNOWN_SWIFTUI_VIEW_MODIFIERS = new Set([
+  "accessibilityIdentifier",
+  "accessibilityLabel",
+  "accessibilityHint",
+  "accessibilityValue",
+  "animation",
+  "bold",
+  "clipShape",
+  "controlSize",
+  "disabled",
+  "font",
+  "foregroundColor",
+  "foregroundStyle",
+  "frame",
+  "help",
+  "id",
+  "labelStyle",
+  "layoutPriority",
+  "opacity",
+  "padding",
+  "position",
+  "shadow",
+  "tint",
+]);
+
+function checkTypeErasedSwiftUIModifierChains(
+  source: string,
+  stripped: string,
+  file: string,
+  diagnostics: Diagnostic[]
+) {
+  const expressionStart = /\b(Label|Button|Image|TextField|TextEditor)\s*\(/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = expressionStart.exec(stripped)) !== null) {
+    const callOpen = stripped.indexOf("(", match.index);
+    const callClose = findMatchingParen(stripped, callOpen);
+    if (callOpen === -1 || callClose === -1) continue;
+
+    const chain = stripped.slice(callClose + 1, callClose + 900);
+    const modifiers = collectLeadingModifierChain(chain);
+    const firstTypeEraser = modifiers.findIndex((modifier) =>
+      TYPE_ERASING_SWIFTUI_MODIFIERS.has(modifier.name)
+    );
+    if (firstTypeEraser < 0) continue;
+
+    const risky = modifiers
+      .slice(firstTypeEraser + 1)
+      .find((modifier) => looksLikeProjectSpecificModifier(modifier.name));
+    if (!risky) continue;
+
+    diagnostics.push(
+      makeDiagnostic(
+        "AX766",
+        file,
+        1 + countNewlinesUpTo(source, callClose + 1 + risky.offset),
+        {
+          message: `.${risky.name}(...) appears after .${modifiers[firstTypeEraser]!.name}(...), which can erase the concrete SwiftUI type before a project-specific modifier runs`,
+          suggestion:
+            "Move the project-specific modifier before the type-erasing SwiftUI modifier, or rewrite it as a generic View modifier so Xcode does not report `value of type 'some View' has no member ...`.",
+        }
+      )
+    );
+  }
+}
+
+function checkOpaqueViewReturnsNeedExplicitReturn(
+  source: string,
+  stripped: string,
+  file: string,
+  diagnostics: Diagnostic[]
+) {
+  const declaration =
+    /\b(?:(func)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*\)|(var)\s+([A-Za-z_][A-Za-z0-9_]*))\s*(?:async\s+)?(?:throws\s+)?(?:->|:)\s*some\s+View\s*\{/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = declaration.exec(stripped)) !== null) {
+    const kind = match[1] ? "func" : "var";
+    const name = match[2] ?? match[4] ?? "unnamed";
+    if (kind === "var" && name === "body") continue;
+    if (hasViewBuilderAttribute(stripped, match.index)) continue;
+
+    const openBrace = stripped.indexOf("{", match.index);
+    const closeBrace = findMatchingBrace(stripped, openBrace);
+    if (openBrace === -1 || closeBrace === -1) continue;
+
+    const body = stripped.slice(openBrace + 1, closeBrace);
+    if (!/\b(?:let|var)\s+[A-Za-z_][A-Za-z0-9_]*\b/.test(body)) continue;
+    if (hasTopLevelReturn(body)) continue;
+    if (!endsWithLikelyViewExpression(body)) continue;
+
+    diagnostics.push(
+      makeDiagnostic("AX767", file, 1 + countNewlinesUpTo(source, match.index), {
+        message: `${kind} '${name}' returns some View after local declarations but has no explicit return`,
+        suggestion:
+          "Add `return` before the final view expression, or mark the helper with `@ViewBuilder` if it intentionally contains multiple result-builder statements.",
+      })
+    );
+  }
+}
+
+function hasViewBuilderAttribute(stripped: string, declarationIndex: number): boolean {
+  const prefix = stripped.slice(Math.max(0, declarationIndex - 180), declarationIndex);
+  return /@ViewBuilder\s*(?:\n|\s)*(?:private|fileprivate|internal|public|static|\s)*$/.test(
+    prefix
+  );
+}
+
+function hasTopLevelReturn(body: string): boolean {
+  let depth = 0;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === "{" || ch === "(" || ch === "[") depth++;
+    if (ch === "}" || ch === ")" || ch === "]") depth = Math.max(0, depth - 1);
+    if (
+      depth === 0 &&
+      /\breturn\b/.test(body.slice(i, i + 12)) &&
+      !/[A-Za-z0-9_]/.test(body[i - 1] ?? "") &&
+      !/[A-Za-z0-9_]/.test(body[i + 6] ?? "")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function endsWithLikelyViewExpression(body: string): boolean {
+  const cleaned = body.trim().replace(/;+\s*$/, "");
+  return /(?:VStack|HStack|ZStack|Text|Button|ScrollView|List|LazyVStack|LazyHStack|Group|Section|ForEach|AnyView|Image|Label|Form|NavigationStack|NavigationSplitView|HSplitView|VSplitView)\s*(?:\(|\{)/.test(
+    cleaned
+  );
+}
+
+function collectLeadingModifierChain(
+  source: string
+): Array<{ name: string; offset: number }> {
+  const modifiers: Array<{ name: string; offset: number }> = [];
+  let index = 0;
+
+  while (index < source.length) {
+    const prefix = source.slice(index).match(/^\s*\.([A-Za-z_][A-Za-z0-9_]*)\s*/);
+    if (!prefix) break;
+    const name = prefix[1]!;
+    const nameOffset = index + prefix[0].lastIndexOf(name);
+    index += prefix[0].length;
+
+    if (source[index] === "(") {
+      const close = findMatchingParen(source, index);
+      if (close === -1) break;
+      index = close + 1;
+    } else if (source[index] === "{") {
+      const close = findMatchingBrace(source, index);
+      if (close === -1) break;
+      index = close + 1;
+    }
+
+    modifiers.push({ name, offset: nameOffset });
+  }
+
+  return modifiers;
+}
+
+function looksLikeProjectSpecificModifier(name: string): boolean {
+  if (KNOWN_SWIFTUI_VIEW_MODIFIERS.has(name)) return false;
+  if (!/^[a-z][A-Za-z0-9_]*$/.test(name)) return false;
+  return /(?:Icon|Pill|Card|Badge|Chip|Row|Tile|Avatar|Swarm|Agent|Project)/.test(name);
 }
 
 function findMatchingParen(source: string, openIndex: number): number {

--- a/src/mcp/feature.ts
+++ b/src/mcp/feature.ts
@@ -351,7 +351,7 @@ export function generateFeature(input: FeatureInput): FeatureResult {
   diagnostics.push(...auditGeneratedFeature(input, files));
 
   const success = !diagnostics.some((d) => /^\[AX[^\]]+\]\s+error\b/.test(d));
-  const qualityGateBlocked = diagnostics.some((d) => /^\[AX85[023]\]\s+error\b/.test(d));
+  const qualityGateBlocked = diagnostics.some((d) => /^\[AX85[0235]\]\s+error\b/.test(d));
   const emittedFiles = qualityGateBlocked ? [] : files;
   const surfaceList = surfaces.join(", ");
   const fileCount = emittedFiles.filter((f) => f.type === "swift").length;

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -795,6 +795,11 @@ export const TOOL_MANIFEST = [
           type: "boolean",
           description: "Whether axint.feature was used for a new surface scaffold.",
         },
+        ranRepair: {
+          type: "boolean",
+          description:
+            "Whether axint.repair was used for an existing-code repair plan. This satisfies planning for patch-first SwiftUI/store repairs when axint.suggest is unavailable or generation is not useful.",
+        },
         featureBypassReason: {
           type: "string",
           description:
@@ -1328,6 +1333,188 @@ export const TOOL_MANIFEST = [
     },
   },
   {
+    name: "axint.agent.install",
+    description:
+      "Install the local Axint multi-agent project brain. Writes .axint/agent.json, " +
+      ".axint/context/latest.*, and .axint/coordination files so Codex, Claude, Cursor, " +
+      "Xcode, OpenClaw, and humans coordinate through the same local truth layer.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cwd: {
+          type: "string",
+          description: "Project directory. Defaults to the MCP process cwd.",
+        },
+        projectName: {
+          type: "string",
+          description: "Optional project name override.",
+        },
+        agent: {
+          type: "string",
+          enum: ["all", "claude", "codex", "cowork", "cursor", "xcode"],
+          description: "Active host/tool lane. Defaults to all.",
+        },
+        privacyMode: {
+          type: "string",
+          enum: ["local_only", "redacted_cloud", "source_opt_in"],
+          description:
+            "Privacy posture for this project. Defaults to local_only; source sharing is never enabled by default.",
+        },
+        providerMode: {
+          type: "string",
+          enum: ["none", "bring_your_own_key", "axint_cloud"],
+          description:
+            "Optional model-provider posture for future AI-enhanced advice. Defaults to none.",
+        },
+        force: {
+          type: "boolean",
+          description: "Rewrite the existing local agent config if present.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json", "prompt"],
+          description: "Output format. Defaults to markdown.",
+        },
+      },
+    },
+  },
+  {
+    name: "axint.agent.advice",
+    description:
+      "Ask the local Axint project brain what this agent should do next. Reads project " +
+      "context, latest run proof, latest repair plan, and active file claims, then returns " +
+      "host-specific guidance for Codex, Claude, Cursor, Xcode, or another agent lane.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cwd: {
+          type: "string",
+          description: "Project directory. Defaults to the MCP process cwd.",
+        },
+        issue: {
+          type: "string",
+          description:
+            "Optional bug, feature, or repair goal to turn into project-aware next moves.",
+        },
+        agent: {
+          type: "string",
+          enum: ["all", "claude", "codex", "cowork", "cursor", "xcode"],
+          description:
+            "Active host/tool lane. Axint adapts advice to the tools this agent can actually use.",
+        },
+        changedFiles: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Files in scope. Axint uses these to detect claim conflicts and recommend proof.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json", "prompt"],
+          description: "Output format. Defaults to markdown.",
+        },
+      },
+    },
+  },
+  {
+    name: "axint.agent.claim",
+    description:
+      "Claim files before an agent edits them so other agents do not patch the same " +
+      "SwiftUI/App files concurrently. Claims are local, short-lived, and stored in " +
+      ".axint/coordination/claims.json.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      required: ["files"],
+      properties: {
+        cwd: {
+          type: "string",
+          description: "Project directory. Defaults to the MCP process cwd.",
+        },
+        agent: {
+          type: "string",
+          enum: ["all", "claude", "codex", "cowork", "cursor", "xcode"],
+          description: "Agent lane creating the claim.",
+        },
+        task: {
+          type: "string",
+          description: "Task, bug, or repair pass this claim covers.",
+        },
+        files: {
+          type: "array",
+          items: { type: "string" },
+          description: "Files to claim before editing.",
+        },
+        ttlMinutes: {
+          type: "number",
+          description: "Claim TTL in minutes. Defaults to 30.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json", "prompt"],
+          description: "Output format. Defaults to markdown.",
+        },
+      },
+    },
+  },
+  {
+    name: "axint.agent.release",
+    description:
+      "Release active local Axint file claims for this agent after finishing or abandoning " +
+      "a task. This keeps Codex, Claude, Cursor, and Xcode from blocking each other on stale claims.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cwd: {
+          type: "string",
+          description: "Project directory. Defaults to the MCP process cwd.",
+        },
+        agent: {
+          type: "string",
+          enum: ["all", "claude", "codex", "cowork", "cursor", "xcode"],
+          description: "Agent lane releasing claims.",
+        },
+        files: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional files to release. Omit to release this agent's claims.",
+        },
+        all: {
+          type: "boolean",
+          description: "Release all matching active claims.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json", "prompt"],
+          description: "Output format. Defaults to markdown.",
+        },
+      },
+    },
+  },
+  {
     name: "axint.run",
     description:
       "Run the enforced Axint Apple build loop outside the Xcode UI. Starts or refreshes " +
@@ -1361,6 +1548,12 @@ export const TOOL_MANIFEST = [
           enum: ["macOS", "iOS", "watchOS", "visionOS", "all"],
           description:
             "Target Apple platform. Defaults to macOS unless inferred from destination.",
+        },
+        agent: {
+          type: "string",
+          enum: ["all", "claude", "codex", "cowork", "cursor", "xcode"],
+          description:
+            "Current agent host lane. Axint uses this to start the right session profile and return host-safe repair guidance.",
         },
         scheme: {
           type: "string",

--- a/src/mcp/semantic-planner.ts
+++ b/src/mcp/semantic-planner.ts
@@ -242,6 +242,21 @@ export function auditGeneratedFeature(
 
   if (
     (surfaces.includes("view") || surfaces.includes("component")) &&
+    input.context?.trim() &&
+    input.tokenNamespace &&
+    swiftFiles.length > 0 &&
+    looksLikeStrictExistingDesignSystemRequest(description) &&
+    !new RegExp(
+      `\\b(?:enum|struct|class|actor)\\s+${escapeRegExp(input.tokenNamespace)}\\b`
+    ).test(input.context)
+  ) {
+    diagnostics.push(
+      `[AX855] error: Generated UI references token namespace ${input.tokenNamespace}, but that symbol was not visible in the supplied project context\n  help: Existing-app generation must not invent project APIs. Pass the real token/component source as context, use the correct token namespace, or switch to axint.repair/project index for a patch-first plan.`
+    );
+  }
+
+  if (
+    (surfaces.includes("view") || surfaces.includes("component")) &&
     hasGenericPlaceholder(swiftText)
   ) {
     diagnostics.push(
@@ -265,6 +280,12 @@ export function auditGeneratedFeature(
   }
 
   return diagnostics;
+}
+
+function looksLikeStrictExistingDesignSystemRequest(description: string): boolean {
+  return /\b(reuse|reuses|using|use|match|matches|preserve|preserves)\b.{0,80}\b(real|actual|existing|project-specific)\b.{0,80}\b(design system|tokens|theme|styling|api|component api)\b/i.test(
+    description
+  );
 }
 
 function extractComponentNames(description: string): string[] {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,6 +20,9 @@
  *   - axint.fix-packet: Read the latest emitted Fix Packet / AI repair prompt
  *   - axint.cloud.check:     Run an agent-callable Cloud Check report
  *   - axint.repair:          Plan a project-aware Apple repair loop
+ *   - axint.agent.install:   Install the local multi-agent project brain
+ *   - axint.agent.advice:    Return host-specific next moves from local proof
+ *   - axint.agent.claim:     Claim files before multi-agent edits
  *   - axint.feedback.create: Create source-free learning packets for repair gaps
  *   - axint.run:             Run enforced build/test/runtime loop outside Xcode UI
  *   - axint.tokens.ingest:    Convert design tokens into SwiftUI token enums
@@ -129,6 +132,19 @@ import {
   runAxintRepair,
   type AxintRepairFormat,
 } from "../repair/project-repair.js";
+import {
+  buildAxintAgentAdvice,
+  claimAxintAgentFiles,
+  installAxintLocalAgent,
+  releaseAxintAgentClaims,
+  renderAxintAgentAdviceReport,
+  renderAxintAgentClaimReport,
+  renderAxintAgentInstallReport,
+  renderAxintAgentReleaseReport,
+  type AxintLocalAgentFormat,
+  type AxintLocalAgentPrivacyMode,
+  type AxintLocalAgentProviderMode,
+} from "../project/local-agent.js";
 import {
   cancelRunJob,
   getRunJobStatus,
@@ -282,11 +298,43 @@ type FeedbackArgs = Omit<RepairArgs, "format"> & {
   format?: "json" | "markdown";
   latest?: boolean;
 };
+type AgentInstallArgs = {
+  cwd?: string;
+  projectName?: string;
+  agent?: AxintSessionAgent;
+  privacyMode?: AxintLocalAgentPrivacyMode;
+  providerMode?: AxintLocalAgentProviderMode;
+  force?: boolean;
+  format?: AxintLocalAgentFormat;
+};
+type AgentAdviceArgs = {
+  cwd?: string;
+  issue?: string;
+  agent?: AxintSessionAgent;
+  changedFiles?: string[];
+  format?: AxintLocalAgentFormat;
+};
+type AgentClaimArgs = {
+  cwd?: string;
+  agent?: AxintSessionAgent;
+  task?: string;
+  files?: string[];
+  ttlMinutes?: number;
+  format?: AxintLocalAgentFormat;
+};
+type AgentReleaseArgs = {
+  cwd?: string;
+  agent?: AxintSessionAgent;
+  files?: string[];
+  all?: boolean;
+  format?: AxintLocalAgentFormat;
+};
 type AxintRunArgs = {
   cwd?: string;
   projectName?: string;
   expectedVersion?: string;
   platform?: AxintRunPlatform;
+  agent?: AxintSessionAgent;
   scheme?: string;
   workspace?: string;
   project?: string;
@@ -883,6 +931,76 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
     };
   }
 
+  if (name === "axint.agent.install") {
+    const a = args as AgentInstallArgs | undefined;
+    const report = installAxintLocalAgent({
+      cwd: a?.cwd,
+      projectName: a?.projectName,
+      agent: a?.agent,
+      privacyMode: a?.privacyMode,
+      providerMode: a?.providerMode,
+      force: a?.force,
+    });
+    return diagnosticsText(
+      renderAxintAgentInstallReport(report, a?.format ?? "markdown")
+    );
+  }
+
+  if (name === "axint.agent.advice") {
+    const a = args as AgentAdviceArgs | undefined;
+    const report = buildAxintAgentAdvice({
+      cwd: a?.cwd,
+      issue: a?.issue,
+      agent: a?.agent,
+      changedFiles: a?.changedFiles,
+    });
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: renderAxintAgentAdviceReport(report, a?.format ?? "markdown"),
+        },
+      ],
+      isError: report.status === "blocked",
+    };
+  }
+
+  if (name === "axint.agent.claim") {
+    const a = args as AgentClaimArgs;
+    if (!a.files?.length) {
+      return errorText("Error: 'files' is required for axint.agent.claim");
+    }
+    const report = claimAxintAgentFiles({
+      cwd: a.cwd,
+      agent: a.agent,
+      task: a.task,
+      files: a.files,
+      ttlMinutes: a.ttlMinutes,
+    });
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: renderAxintAgentClaimReport(report, a.format ?? "markdown"),
+        },
+      ],
+      isError: report.status === "blocked",
+    };
+  }
+
+  if (name === "axint.agent.release") {
+    const a = args as AgentReleaseArgs | undefined;
+    const report = releaseAxintAgentClaims({
+      cwd: a?.cwd,
+      agent: a?.agent,
+      files: a?.files,
+      all: a?.all,
+    });
+    return diagnosticsText(
+      renderAxintAgentReleaseReport(report, a?.format ?? "markdown")
+    );
+  }
+
   if (name === "axint.feedback.create") {
     const a = args as FeedbackArgs;
     if (a.latest) {
@@ -928,6 +1046,7 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
       projectName: a.projectName,
       expectedVersion: a.expectedVersion ?? pkg.version,
       platform: a.platform,
+      agent: a.agent,
       scheme: a.scheme,
       workspace: a.workspace,
       project: a.project,

--- a/src/mcp/workflow-check.ts
+++ b/src/mcp/workflow-check.ts
@@ -30,6 +30,7 @@ export interface WorkflowCheckInput {
   readDocsContext?: boolean;
   ranFeature?: boolean;
   featureBypassReason?: string;
+  ranRepair?: boolean;
   ranSwiftValidate?: boolean;
   ranCloudCheck?: boolean;
   xcodeBuildPassed?: boolean;
@@ -61,6 +62,7 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
   const agent = normalizeAxintAgent(input.agent);
   const profile = buildAgentToolProfile(agent);
   const patchFirstRepair = looksLikePatchFirstRepair(input);
+  const documentOnlyArtifact = looksLikeDocumentOnlyArtifact(input);
   const availableTools = normalizeAvailableTools(input.availableTools);
 
   checked.push(
@@ -101,6 +103,9 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
     );
   }
   if (input.ranFeature) checked.push("axint.feature was used for scaffolding.");
+  if (input.ranRepair) {
+    checked.push("axint.repair was used for an existing-code repair plan.");
+  }
   if (input.featureBypassReason) {
     checked.push(
       `axint.feature was intentionally bypassed: ${input.featureBypassReason}`
@@ -110,6 +115,11 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
   if (input.ranCloudCheck) checked.push("axint.cloud.check was run.");
   if (input.xcodeBuildPassed) checked.push("Xcode build evidence passed.");
   if (input.xcodeTestsPassed) checked.push("Xcode test evidence passed.");
+  if (documentOnlyArtifact) {
+    checked.push(
+      "Document/web artifact mode detected; Apple compiler gates are not the final proof surface."
+    );
+  }
 
   if (looksLikeContextDrift(input.notes)) {
     if (!input.readRehydrationContext || !input.ranStatus) {
@@ -148,7 +158,7 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
         "Read .axint/AXINT_REHYDRATE.md once at the start of the planning pass so the checkpoint survives compaction."
       );
     }
-    if (!input.ranSuggest) {
+    if (!input.ranSuggest && !input.ranRepair && !documentOnlyArtifact) {
       required.push(
         "Run axint.suggest with the current app description before choosing the feature plan. If MCP transport is closed, use the CLI fallback: axint suggest <app-description>."
       );
@@ -156,7 +166,7 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
   }
 
   if (stage === "before-write") {
-    if (!input.ranSuggest) {
+    if (!input.ranSuggest && !input.ranRepair && !documentOnlyArtifact) {
       required.push(
         "Run axint.suggest before writing a new Apple-native surface so the plan is not ordinary hand-coded Swift by default. If MCP transport is closed, use the CLI fallback: axint suggest <app-description>."
       );
@@ -166,7 +176,12 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
         ["view", "component", "intent", "widget"].includes(surface)
       )
     ) {
-      if (!input.ranFeature && !input.featureBypassReason) {
+      if (
+        !input.ranFeature &&
+        !input.featureBypassReason &&
+        !input.ranRepair &&
+        !documentOnlyArtifact
+      ) {
         required.push(
           "Run axint.feature for the new surface, or pass featureBypassReason with a concrete reason this is an edit to existing code and generation is not useful."
         );
@@ -182,10 +197,19 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
         `This is ${profile.label}; use its native patch/edit tool for existing files, then run axint.swift.validate and axint.cloud.check. Do not route normal Codex/Claude/Cowork edits through axint.xcode.write.`
       );
     }
+    if (documentOnlyArtifact) {
+      recommended.push(
+        "For document or web artifacts, use browser/render/link proof instead of an Apple-native generation gate."
+      );
+    }
   }
 
   if (stage === "pre-build" || stage === "pre-commit") {
-    if (
+    if (documentOnlyArtifact) {
+      recommended.push(
+        "Document/web artifact mode: verify the rendered HTML/Markdown route, screenshots, links, or browser console instead of forcing axint.cloud.check."
+      );
+    } else if (
       modifiedFiles.some((file) => file.endsWith(".swift")) &&
       !input.ranSwiftValidate
     ) {
@@ -194,24 +218,24 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
       );
     }
 
-    if (!input.ranCloudCheck) {
+    if (!documentOnlyArtifact && !input.ranCloudCheck) {
       required.push(
         "Run axint.cloud.check with the modified source and any Xcode/test/runtime evidence."
       );
     }
 
-    if (!input.xcodeBuildPassed) {
+    if (!documentOnlyArtifact && !input.xcodeBuildPassed) {
       recommended.push(
         "Run the Xcode build after static validation; Cloud Check is not runtime proof by itself."
       );
     }
 
-    if (stage === "pre-commit" && !input.xcodeTestsPassed) {
+    if (stage === "pre-commit" && !documentOnlyArtifact && !input.xcodeTestsPassed) {
       recommended.push("Run focused unit/UI tests before calling the pass complete.");
     }
   }
 
-  if (surfaces.includes("view") && !input.ranCloudCheck) {
+  if (surfaces.includes("view") && !input.ranCloudCheck && !documentOnlyArtifact) {
     recommended.push(
       "For SwiftUI views, include Xcode build or UI-test evidence in Cloud Check so the report can mark runtime coverage honestly."
     );
@@ -229,6 +253,8 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
           xcodeTestsPassed: Boolean(input.xcodeTestsPassed),
           agent,
           patchFirstRepair,
+          repairMode: Boolean(input.ranRepair),
+          documentOnlyArtifact,
         });
   const reconciledNextTool = reconcileNextToolAvailability(nextTool, {
     availableTools,
@@ -350,6 +376,9 @@ function reconcileNextToolAvailability(
     if (input.availableTools.has("axint.xcode.write")) return "axint.xcode.write";
     return input.profile.defaultWriteAction;
   }
+  if (base === "axint.suggest") {
+    return "axint suggest <app-description> (CLI fallback), or axint.repair for existing-code repair";
+  }
   if (base === "axint.xcode.write") return input.profile.defaultWriteAction;
   if (base === "axint.xcode.guard") {
     if (input.availableTools.has("axint.workflow.check"))
@@ -387,6 +416,8 @@ function nextToolForSatisfiedStage(input: {
   xcodeTestsPassed: boolean;
   agent: AxintAgentProfileName;
   patchFirstRepair: boolean;
+  repairMode: boolean;
+  documentOnlyArtifact: boolean;
 }): string | undefined {
   const {
     stage,
@@ -396,12 +427,22 @@ function nextToolForSatisfiedStage(input: {
     xcodeTestsPassed,
     agent,
     patchFirstRepair,
+    repairMode,
+    documentOnlyArtifact,
   } = input;
   const profile = buildAgentToolProfile(agent);
   if (stage === "session-start" || stage === "context-recovery") {
     return "axint.suggest";
   }
+  if (documentOnlyArtifact) {
+    if (stage === "planning") return "browser/render proof for the document artifact";
+    if (stage === "before-write") return profile.defaultWriteAction;
+    if (stage === "pre-build" || stage === "pre-commit") {
+      return "Summarize rendered artifact verification and link/console proof";
+    }
+  }
   if (stage === "planning") {
+    if (repairMode) return profile.defaultWriteAction;
     return surfaces.some((surface) =>
       ["view", "component", "intent", "widget", "app", "store"].includes(surface)
     )
@@ -438,6 +479,8 @@ function looksLikeContextDrift(notes: string | undefined): boolean {
 }
 
 function looksLikePatchFirstRepair(input: WorkflowCheckInput): boolean {
+  if (input.ranRepair) return true;
+
   const text = [input.featureBypassReason, input.notes, ...(input.modifiedFiles ?? [])]
     .filter(Boolean)
     .join(" ")
@@ -453,4 +496,25 @@ function looksLikePatchFirstRepair(input: WorkflowCheckInput): boolean {
   const existingBypass = Boolean(input.featureBypassReason);
 
   return patchMode && (existingBypass || fullFileRisk || text.includes(".swift"));
+}
+
+function looksLikeDocumentOnlyArtifact(input: WorkflowCheckInput): boolean {
+  const files = input.modifiedFiles ?? [];
+  if (files.length > 0 && files.every(isDocumentArtifactPath)) return true;
+
+  const text = [input.featureBypassReason, input.notes, ...files]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  if (!text) return false;
+
+  return (
+    /\b(document-only|docs-only|audit|sprint|html report|markdown report|north star|north-star|browser proof|rendered artifact)\b/.test(
+      text
+    ) && !/\.(swift|intent\.ts|view\.ts|widget\.ts)\b/.test(text)
+  );
+}
+
+function isDocumentArtifactPath(file: string): boolean {
+  return /\.(html?|md|mdx|txt)$/i.test(file);
 }

--- a/src/project/docs-context.ts
+++ b/src/project/docs-context.ts
@@ -90,6 +90,7 @@ Use Axint for:
 - Design-token ingestion for generated SwiftUI.
 - Swift validation, Cloud Check, fix packets, and repair prompts.
 - Project startup, context recovery, and workflow gates.
+- Local multi-agent memory, file claims, latest proof, latest repair, and privacy-safe learning packets.
 
 ## The Axint Authoring Loop
 
@@ -113,7 +114,8 @@ Use this loop before ordinary hand-written Swift:
 16. \`axint.swift.fix\` applies mechanical Swift repairs when safe.
 17. \`axint.cloud.check\` runs coverage-aware Cloud Check with source plus build/test/runtime evidence.
 18. \`axint.fix-packet\` reads the latest AI-ready repair packet.
-19. Xcode build and tests provide runtime proof.
+19. \`axint.agent.advice\` and \`axint memory index\` reload the project-local brain after compaction or multi-agent handoff.
+20. Xcode build and tests provide runtime proof.
 
 ## Axint Language And Input Surfaces
 

--- a/src/project/local-agent.ts
+++ b/src/project/local-agent.ts
@@ -1,0 +1,1102 @@
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import {
+  buildAgentToolProfile,
+  normalizeAxintAgent,
+  type AxintAgentProfileName,
+  type AxintAgentToolProfile,
+} from "./agent-profile.js";
+import {
+  readProjectContextIndex,
+  writeProjectContextIndex,
+  type ProjectContextIndex,
+} from "./context-index.js";
+import { writeProjectMemoryIndex } from "./memory-index.js";
+
+export type AxintLocalAgentFormat = "markdown" | "json" | "prompt";
+export type AxintLocalAgentPrivacyMode =
+  | "local_only"
+  | "redacted_cloud"
+  | "source_opt_in";
+export type AxintLocalAgentProviderMode = "none" | "bring_your_own_key" | "axint_cloud";
+export type AxintLocalAgentEventKind =
+  | "installed"
+  | "advice"
+  | "claim_created"
+  | "claim_released";
+
+export interface AxintLocalAgentConfig {
+  schema: "https://axint.ai/schemas/local-agent.v1.json";
+  createdAt: string;
+  updatedAt: string;
+  projectName: string;
+  targetDir: string;
+  privacy: {
+    mode: AxintLocalAgentPrivacyMode;
+    sourceSharing: "never_by_default";
+    cloudLearning: "redacted_fingerprints_only";
+    userCanInspectBeforeSend: true;
+  };
+  provider: {
+    mode: AxintLocalAgentProviderMode;
+    note: string;
+  };
+  permissions: {
+    allow: string[];
+    deny: string[];
+  };
+  lanes: Record<AxintAgentProfileName, AxintAgentToolProfile>;
+  commands: {
+    advice: string;
+    claim: string;
+    projectIndex: string;
+    proofRun: string;
+  };
+}
+
+export interface AxintAgentClaim {
+  id: string;
+  agent: AxintAgentProfileName;
+  task: string;
+  files: string[];
+  createdAt: string;
+  expiresAt: string;
+  releasedAt?: string;
+}
+
+export interface AxintAgentClaimsFile {
+  schema: "https://axint.ai/schemas/local-agent-claims.v1.json";
+  updatedAt: string;
+  claims: AxintAgentClaim[];
+}
+
+export interface AxintAgentLedgerEvent {
+  id: string;
+  kind: AxintLocalAgentEventKind;
+  agent: AxintAgentProfileName;
+  createdAt: string;
+  summary: string;
+  files?: string[];
+  task?: string;
+  artifact?: string;
+}
+
+export interface AxintAgentLedger {
+  schema: "https://axint.ai/schemas/local-agent-ledger.v1.json";
+  updatedAt: string;
+  events: AxintAgentLedgerEvent[];
+}
+
+export interface AxintAgentInstallInput {
+  cwd?: string;
+  projectName?: string;
+  agent?: AxintAgentProfileName;
+  privacyMode?: AxintLocalAgentPrivacyMode;
+  providerMode?: AxintLocalAgentProviderMode;
+  force?: boolean;
+  format?: AxintLocalAgentFormat;
+}
+
+export interface AxintAgentAdviceInput {
+  cwd?: string;
+  issue?: string;
+  agent?: AxintAgentProfileName;
+  changedFiles?: string[];
+  format?: AxintLocalAgentFormat;
+  claimTtlMinutes?: number;
+}
+
+export interface AxintAgentClaimInput {
+  cwd?: string;
+  agent?: AxintAgentProfileName;
+  task?: string;
+  files: string[];
+  ttlMinutes?: number;
+  format?: AxintLocalAgentFormat;
+}
+
+export interface AxintAgentReleaseInput {
+  cwd?: string;
+  agent?: AxintAgentProfileName;
+  files?: string[];
+  all?: boolean;
+  format?: AxintLocalAgentFormat;
+}
+
+export interface AxintAgentInstallReport {
+  status: "installed" | "already_installed";
+  cwd: string;
+  projectName: string;
+  agent: AxintAgentProfileName;
+  configPath: string;
+  contextPath: string;
+  claimsPath: string;
+  ledgerPath: string;
+  written: string[];
+  nextCommands: string[];
+  config: AxintLocalAgentConfig;
+}
+
+export interface AxintAgentAdviceMove {
+  title: string;
+  priority: "p0" | "p1" | "p2" | "p3";
+  detail: string;
+  command?: string;
+}
+
+export interface AxintAgentAdviceReport {
+  status: "ready" | "needs_setup" | "blocked";
+  cwd: string;
+  agent: AxintAgentProfileName;
+  profile: AxintAgentToolProfile;
+  projectName: string;
+  summary: string[];
+  warnings: string[];
+  activeClaims: AxintAgentClaim[];
+  conflictingClaims: AxintAgentClaim[];
+  latestProof?: LatestProofSummary;
+  latestRepair?: LatestRepairSummary;
+  moves: AxintAgentAdviceMove[];
+  artifacts: {
+    config?: string;
+    context?: string;
+    memory?: string;
+    claims?: string;
+    ledger?: string;
+    latestRun?: string;
+    latestRepair?: string;
+  };
+}
+
+export interface AxintAgentClaimReport {
+  status: "claimed" | "blocked";
+  cwd: string;
+  agent: AxintAgentProfileName;
+  task: string;
+  files: string[];
+  claim?: AxintAgentClaim;
+  conflicts: AxintAgentClaim[];
+  claimsPath: string;
+}
+
+export interface AxintAgentReleaseReport {
+  status: "released" | "none";
+  cwd: string;
+  agent: AxintAgentProfileName;
+  released: AxintAgentClaim[];
+  claimsPath: string;
+}
+
+interface LatestProofSummary {
+  path: string;
+  status: string;
+  gate?: string;
+  runId?: string;
+  updatedAt?: string;
+  failingStep?: string;
+  nextSteps: string[];
+}
+
+interface LatestRepairSummary {
+  path: string;
+  status: string;
+  issueClass?: string;
+  priority?: string;
+  filesToInspect: string[];
+  commands: string[];
+}
+
+const AGENT_NAMES: AxintAgentProfileName[] = [
+  "all",
+  "claude",
+  "codex",
+  "cowork",
+  "cursor",
+  "xcode",
+];
+
+const DEFAULT_ALLOW = [
+  "read_project",
+  "write_project_files",
+  "run_validation",
+  "run_build",
+  "run_tests",
+];
+const DEFAULT_DENY = [
+  "publish_packages",
+  "spend_money",
+  "read_secrets",
+  "post_social",
+  "deploy_live",
+  "destructive_git",
+];
+
+export function installAxintLocalAgent(
+  input: AxintAgentInstallInput = {}
+): AxintAgentInstallReport {
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const now = new Date().toISOString();
+  const configPath = agentConfigPath(cwd);
+  const force = input.force ?? false;
+  const existing = readAgentConfig(cwd);
+
+  if (existing && !force) {
+    return {
+      status: "already_installed",
+      cwd,
+      projectName: existing.projectName,
+      agent: normalizeAxintAgent(input.agent),
+      configPath,
+      contextPath: projectContextPath(cwd),
+      claimsPath: claimsPath(cwd),
+      ledgerPath: ledgerPath(cwd),
+      written: [],
+      nextCommands: nextAgentCommands(cwd, normalizeAxintAgent(input.agent)),
+      config: existing,
+    };
+  }
+
+  const context = writeProjectContextIndex({
+    targetDir: cwd,
+    projectName: input.projectName,
+  }).index;
+  const memory = writeProjectMemoryIndex({
+    cwd,
+    projectName: input.projectName ?? context.projectName,
+  });
+  const config = buildLocalAgentConfig({
+    cwd,
+    projectName: input.projectName ?? context.projectName,
+    now,
+    privacyMode: input.privacyMode ?? "local_only",
+    providerMode: input.providerMode ?? "none",
+  });
+  writeJson(configPath, config);
+  ensureClaimsFile(cwd);
+  appendLedgerEvent(cwd, {
+    kind: "installed",
+    agent: normalizeAxintAgent(input.agent),
+    summary:
+      "Axint local multi-agent brain installed. Project context, claims, and ledger are ready.",
+  });
+
+  return {
+    status: "installed",
+    cwd,
+    projectName: config.projectName,
+    agent: normalizeAxintAgent(input.agent),
+    configPath,
+    contextPath: projectContextPath(cwd),
+    claimsPath: claimsPath(cwd),
+    ledgerPath: ledgerPath(cwd),
+    written: [
+      relativeOrAbsolute(cwd, configPath),
+      ".axint/context/latest.json",
+      ".axint/context/latest.md",
+      ...memory.written,
+      ".axint/coordination/claims.json",
+      ".axint/coordination/ledger.json",
+    ],
+    nextCommands: nextAgentCommands(cwd, normalizeAxintAgent(input.agent)),
+    config,
+  };
+}
+
+export function buildAxintAgentAdvice(
+  input: AxintAgentAdviceInput = {}
+): AxintAgentAdviceReport {
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const agent = normalizeAxintAgent(input.agent);
+  const profile = buildAgentToolProfile(agent);
+  const config = readAgentConfig(cwd);
+  const context = loadOrCreateContext(cwd, config?.projectName, input.changedFiles);
+  const memory = writeProjectMemoryIndex({
+    cwd,
+    projectName: config?.projectName ?? context.projectName,
+    changedFiles: input.changedFiles,
+  }).index;
+  const claimsFile = ensureClaimsFile(cwd);
+  const activeClaims = activeAgentClaims(claimsFile, input.claimTtlMinutes);
+  const changedFiles = normalizeFiles(cwd, input.changedFiles ?? []);
+  const conflictingClaims = findConflictingClaims({
+    claims: activeClaims,
+    agent,
+    files: changedFiles,
+  });
+  const latestProof = readLatestProof(cwd);
+  const latestRepair = readLatestRepair(cwd);
+  const warnings = buildAdviceWarnings({
+    config,
+    conflictingClaims,
+    latestProof,
+    latestRepair,
+    changedFiles,
+    agent,
+  });
+  const moves = buildAdviceMoves({
+    cwd,
+    issue: input.issue,
+    agent,
+    profile,
+    context,
+    config,
+    changedFiles,
+    conflictingClaims,
+    latestProof,
+    latestRepair,
+  });
+  const status =
+    conflictingClaims.length > 0 ? "blocked" : config ? "ready" : "needs_setup";
+
+  appendLedgerEvent(cwd, {
+    kind: "advice",
+    agent,
+    summary: input.issue
+      ? `Advice requested for: ${input.issue}`
+      : "General Axint agent advice requested.",
+    files: changedFiles,
+  });
+
+  return {
+    status,
+    cwd,
+    agent,
+    profile,
+    projectName: context.projectName,
+    summary: [
+      `${context.projectName}: ${context.files.swift} Swift files, ${context.files.swiftUI} SwiftUI files, ${context.files.inputCapable} input-capable files.`,
+      `Agent lane: ${profile.label} (${profile.editingMode}).`,
+      latestProof
+        ? `Latest proof: ${latestProof.status}${latestProof.gate ? ` · ${latestProof.gate}` : ""}.`
+        : "No Axint run proof found yet.",
+      activeClaims.length > 0
+        ? `${activeClaims.length} active file/task claim${activeClaims.length === 1 ? "" : "s"} in the project.`
+        : "No active file/task claims.",
+      memory.learningPackets.length > 0
+        ? `${memory.learningPackets.length} privacy-safe learning packet${memory.learningPackets.length === 1 ? "" : "s"} available for Axint to learn from.`
+        : "No local learning packets yet.",
+    ],
+    warnings,
+    activeClaims,
+    conflictingClaims,
+    latestProof,
+    latestRepair,
+    moves,
+    artifacts: {
+      config: existsSync(agentConfigPath(cwd)) ? agentConfigPath(cwd) : undefined,
+      context: projectContextPath(cwd),
+      memory: resolve(cwd, ".axint/memory/latest.json"),
+      claims: claimsPath(cwd),
+      ledger: ledgerPath(cwd),
+      latestRun: latestProof?.path,
+      latestRepair: latestRepair?.path,
+    },
+  };
+}
+
+export function claimAxintAgentFiles(input: AxintAgentClaimInput): AxintAgentClaimReport {
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const agent = normalizeAxintAgent(input.agent);
+  const files = normalizeFiles(cwd, input.files);
+  if (files.length === 0) {
+    throw new Error("axint agent claim requires at least one file.");
+  }
+  const claimsFile = ensureClaimsFile(cwd);
+  const activeClaims = activeAgentClaims(claimsFile);
+  const conflicts = findConflictingClaims({ claims: activeClaims, agent, files });
+  const task = input.task?.trim() || "Unspecified Axint agent task";
+
+  if (conflicts.length > 0) {
+    return {
+      status: "blocked",
+      cwd,
+      agent,
+      task,
+      files,
+      conflicts,
+      claimsPath: claimsPath(cwd),
+    };
+  }
+
+  const now = new Date();
+  const claim: AxintAgentClaim = {
+    id: `axclaim_${hashString(`${agent}:${task}:${files.join("|")}:${now.toISOString()}`)}`,
+    agent,
+    task,
+    files,
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + minutes(input.ttlMinutes ?? 30)).toISOString(),
+  };
+  const nextClaims: AxintAgentClaimsFile = {
+    schema: "https://axint.ai/schemas/local-agent-claims.v1.json",
+    updatedAt: now.toISOString(),
+    claims: [...claimsFile.claims, claim],
+  };
+  writeJson(claimsPath(cwd), nextClaims);
+  appendLedgerEvent(cwd, {
+    kind: "claim_created",
+    agent,
+    summary: `${agent} claimed ${files.join(", ")} for ${task}.`,
+    files,
+    task,
+  });
+
+  return {
+    status: "claimed",
+    cwd,
+    agent,
+    task,
+    files,
+    claim,
+    conflicts: [],
+    claimsPath: claimsPath(cwd),
+  };
+}
+
+export function releaseAxintAgentClaims(
+  input: AxintAgentReleaseInput = {}
+): AxintAgentReleaseReport {
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const agent = normalizeAxintAgent(input.agent);
+  const files = normalizeFiles(cwd, input.files ?? []);
+  const claimsFile = ensureClaimsFile(cwd);
+  const now = new Date().toISOString();
+  const released: AxintAgentClaim[] = [];
+  const claims = claimsFile.claims.map((claim) => {
+    const sameAgent = claim.agent === agent || agent === "all";
+    const fileMatch =
+      input.all || files.length === 0 || files.some((file) => claim.files.includes(file));
+    if (!claim.releasedAt && sameAgent && fileMatch) {
+      const releasedClaim = { ...claim, releasedAt: now };
+      released.push(releasedClaim);
+      return releasedClaim;
+    }
+    return claim;
+  });
+  writeJson(claimsPath(cwd), {
+    schema: "https://axint.ai/schemas/local-agent-claims.v1.json",
+    updatedAt: now,
+    claims,
+  } satisfies AxintAgentClaimsFile);
+
+  if (released.length > 0) {
+    appendLedgerEvent(cwd, {
+      kind: "claim_released",
+      agent,
+      summary: `${agent} released ${released.length} Axint claim${released.length === 1 ? "" : "s"}.`,
+      files: uniqueStrings(released.flatMap((claim) => claim.files)),
+    });
+  }
+
+  return {
+    status: released.length > 0 ? "released" : "none",
+    cwd,
+    agent,
+    released,
+    claimsPath: claimsPath(cwd),
+  };
+}
+
+export function renderAxintAgentInstallReport(
+  report: AxintAgentInstallReport,
+  format: AxintLocalAgentFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(report, null, 2);
+  if (format === "prompt") {
+    return [
+      `Axint local brain is ${report.status} for ${report.projectName}.`,
+      `Use: axint agent advice --dir ${quote(report.cwd)} --agent ${report.agent}`,
+      "Before editing, claim risky files with axint agent claim.",
+    ].join("\n");
+  }
+
+  return [
+    `# Axint Local Agent: ${report.status}`,
+    "",
+    `- Project: ${report.projectName}`,
+    `- Agent lane: ${report.agent}`,
+    `- Config: ${report.configPath}`,
+    `- Context: ${report.contextPath}`,
+    `- Claims: ${report.claimsPath}`,
+    `- Ledger: ${report.ledgerPath}`,
+    `- Privacy: ${report.config.privacy.mode}; source sharing is ${report.config.privacy.sourceSharing}`,
+    "",
+    "## Written",
+    ...(report.written.length > 0
+      ? report.written.map((item) => `- ${item}`)
+      : ["- Existing install reused."]),
+    "",
+    "## Next Commands",
+    ...report.nextCommands.map((command) => `- \`${command}\``),
+    "",
+  ].join("\n");
+}
+
+export function renderAxintAgentAdviceReport(
+  report: AxintAgentAdviceReport,
+  format: AxintLocalAgentFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(report, null, 2);
+  if (format === "prompt") {
+    return [
+      `Axint agent advice for ${report.profile.label}: ${report.status}.`,
+      ...report.warnings.map((warning) => `Warning: ${warning}`),
+      "Next moves:",
+      ...report.moves.map((move, index) => {
+        const command = move.command ? ` Command: ${move.command}` : "";
+        return `${index + 1}. ${move.title}: ${move.detail}${command}`;
+      }),
+    ].join("\n");
+  }
+
+  return [
+    `# Axint Agent Advice: ${report.status}`,
+    "",
+    `- Project: ${report.projectName}`,
+    `- Agent: ${report.profile.label}`,
+    `- Editing lane: ${report.profile.editingMode}`,
+    "",
+    "## Summary",
+    ...report.summary.map((item) => `- ${item}`),
+    "",
+    "## Warnings",
+    ...(report.warnings.length > 0
+      ? report.warnings.map((item) => `- ${item}`)
+      : ["- None."]),
+    "",
+    "## Next Moves",
+    ...report.moves.map(
+      (move) =>
+        `- ${move.priority.toUpperCase()} ${move.title}: ${move.detail}${move.command ? ` Command: \`${move.command}\`` : ""}`
+    ),
+    "",
+    "## Active Claims",
+    ...(report.activeClaims.length > 0
+      ? report.activeClaims.map(
+          (claim) =>
+            `- ${claim.agent}: ${claim.files.join(", ")} — ${claim.task} (expires ${claim.expiresAt})`
+        )
+      : ["- None."]),
+    "",
+  ].join("\n");
+}
+
+export function renderAxintAgentClaimReport(
+  report: AxintAgentClaimReport,
+  format: AxintLocalAgentFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(report, null, 2);
+  if (format === "prompt") {
+    if (report.status === "blocked") {
+      return `Axint claim blocked for ${report.files.join(", ")}. Another active agent claim exists.`;
+    }
+    return `Axint claim created for ${report.files.join(", ")}. Release it when done with axint agent release.`;
+  }
+
+  return [
+    `# Axint Agent Claim: ${report.status}`,
+    "",
+    `- Agent: ${report.agent}`,
+    `- Task: ${report.task}`,
+    `- Files: ${report.files.join(", ")}`,
+    `- Claims file: ${report.claimsPath}`,
+    "",
+    ...(report.conflicts.length > 0
+      ? [
+          "## Conflicts",
+          ...report.conflicts.map(
+            (claim) =>
+              `- ${claim.agent}: ${claim.files.join(", ")} — ${claim.task} (expires ${claim.expiresAt})`
+          ),
+        ]
+      : report.claim
+        ? ["## Claim", `- ID: ${report.claim.id}`, `- Expires: ${report.claim.expiresAt}`]
+        : []),
+    "",
+  ].join("\n");
+}
+
+export function renderAxintAgentReleaseReport(
+  report: AxintAgentReleaseReport,
+  format: AxintLocalAgentFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(report, null, 2);
+  if (format === "prompt") {
+    return report.status === "released"
+      ? `Released ${report.released.length} Axint claim${report.released.length === 1 ? "" : "s"}.`
+      : "No matching Axint claims were active.";
+  }
+
+  return [
+    `# Axint Agent Release: ${report.status}`,
+    "",
+    `- Agent: ${report.agent}`,
+    `- Claims file: ${report.claimsPath}`,
+    "",
+    ...(report.released.length > 0
+      ? report.released.map(
+          (claim) => `- ${claim.id}: ${claim.files.join(", ")} — ${claim.task}`
+        )
+      : ["- No matching active claims."]),
+    "",
+  ].join("\n");
+}
+
+function buildLocalAgentConfig(input: {
+  cwd: string;
+  projectName: string;
+  now: string;
+  privacyMode: AxintLocalAgentPrivacyMode;
+  providerMode: AxintLocalAgentProviderMode;
+}): AxintLocalAgentConfig {
+  const lanes = Object.fromEntries(
+    AGENT_NAMES.map((agent) => [agent, buildAgentToolProfile(agent)])
+  ) as Record<AxintAgentProfileName, AxintAgentToolProfile>;
+
+  return {
+    schema: "https://axint.ai/schemas/local-agent.v1.json",
+    createdAt: input.now,
+    updatedAt: input.now,
+    projectName: input.projectName,
+    targetDir: input.cwd,
+    privacy: {
+      mode: input.privacyMode,
+      sourceSharing: "never_by_default",
+      cloudLearning: "redacted_fingerprints_only",
+      userCanInspectBeforeSend: true,
+    },
+    provider: {
+      mode: input.providerMode,
+      note:
+        input.providerMode === "none"
+          ? "No model provider is configured. Axint uses local project state, diagnostics, and proof artifacts for advice."
+          : "Provider configuration is project-local and should never be committed with secrets.",
+    },
+    permissions: {
+      allow: DEFAULT_ALLOW,
+      deny: DEFAULT_DENY,
+    },
+    lanes,
+    commands: {
+      advice: "axint agent advice --agent <agent>",
+      claim: "axint agent claim <files...> --agent <agent> --task <task>",
+      projectIndex: "axint project index",
+      proofRun: "axint run --changed <files> --only-testing <focused-selector>",
+    },
+  };
+}
+
+function buildAdviceWarnings(input: {
+  config?: AxintLocalAgentConfig;
+  conflictingClaims: AxintAgentClaim[];
+  latestProof?: LatestProofSummary;
+  latestRepair?: LatestRepairSummary;
+  changedFiles: string[];
+  agent: AxintAgentProfileName;
+}): string[] {
+  const warnings: string[] = [];
+  if (!input.config) {
+    warnings.push(
+      "Axint local brain is not installed yet. Run `axint agent install` so all tools share one project brain."
+    );
+  }
+  for (const claim of input.conflictingClaims) {
+    warnings.push(
+      `${claim.agent} already claimed ${claim.files.join(", ")} for ${claim.task}. Do not edit those files until the claim is released or expires.`
+    );
+  }
+  if (input.latestProof?.status === "fail") {
+    warnings.push(
+      `Freshest Axint run failed${input.latestProof.gate ? ` at ${input.latestProof.gate}` : ""}. Repair that proof before broad new work.`
+    );
+  }
+  if (input.latestProof?.status === "running") {
+    warnings.push(
+      "An Axint run is still active. Poll `axint run status` before trusting older proof."
+    );
+  }
+  if (input.agent === "xcode" && input.changedFiles.length > 0) {
+    warnings.push(
+      "Xcode lane should write guard proof before and after broad Swift edits."
+    );
+  }
+  if (input.latestRepair?.status === "fix_required") {
+    warnings.push(
+      `Latest repair plan is still fix_required for ${input.latestRepair.issueClass ?? "an Apple repair"}.`
+    );
+  }
+  return uniqueStrings(warnings);
+}
+
+function buildAdviceMoves(input: {
+  cwd: string;
+  issue?: string;
+  agent: AxintAgentProfileName;
+  profile: AxintAgentToolProfile;
+  context: ProjectContextIndex;
+  config?: AxintLocalAgentConfig;
+  changedFiles: string[];
+  conflictingClaims: AxintAgentClaim[];
+  latestProof?: LatestProofSummary;
+  latestRepair?: LatestRepairSummary;
+}): AxintAgentAdviceMove[] {
+  const moves: AxintAgentAdviceMove[] = [];
+  const dir = quote(input.cwd);
+  const changed =
+    input.changedFiles.length > 0 ? input.changedFiles.map(quote).join(" ") : "<files>";
+
+  if (!input.config) {
+    moves.push({
+      title: "Install the shared Axint project brain",
+      priority: "p0",
+      detail:
+        "This writes .axint/agent.json, project context, and coordination files so every agent uses the same local truth.",
+      command: `axint agent install --dir ${dir} --agent ${input.agent}`,
+    });
+  }
+
+  if (input.conflictingClaims.length > 0) {
+    moves.push({
+      title: "Resolve active file claim before editing",
+      priority: "p0",
+      detail:
+        "Another agent has an active claim on one or more changed files. Read the claim or coordinate before patching.",
+      command: `axint agent advice --dir ${dir} --agent ${input.agent} --format json`,
+    });
+    return moves;
+  }
+
+  if (input.changedFiles.length > 0) {
+    moves.push({
+      title: "Claim changed files before patching",
+      priority: "p0",
+      detail:
+        "Create a short-lived claim so Claude/Codex/Cursor/Xcode do not edit the same files at the same time.",
+      command: `axint agent claim --dir ${dir} --agent ${input.agent} --task ${quote(input.issue ?? "Apple repair pass")} ${changed}`,
+    });
+  }
+
+  if (input.latestProof?.status === "running") {
+    moves.push({
+      title: "Poll active Axint proof",
+      priority: "p0",
+      detail:
+        "A proof run is active. Do not trust stale status until the run resolves or is cancelled.",
+      command: `axint run status --dir ${dir}`,
+    });
+  } else if (input.latestProof?.status === "fail") {
+    moves.push({
+      title: "Repair the failed proof first",
+      priority: "p0",
+      detail:
+        input.latestProof.failingStep ??
+        "The freshest proof failed. Use the latest run and repair report as the next source of truth.",
+      command: input.issue
+        ? `axint repair ${quote(input.issue)} --dir ${dir} --agent ${input.agent}`
+        : `axint repair ${quote("Repair the latest failed Axint proof")} --dir ${dir} --agent ${input.agent}`,
+    });
+  }
+
+  if (input.issue) {
+    moves.push({
+      title: "Run project-aware repair advice",
+      priority: "p1",
+      detail:
+        "Convert the issue into likely files, root causes, proof requirements, and host-safe patch instructions.",
+      command: `axint repair ${quote(input.issue)} --dir ${dir} --agent ${input.agent}${
+        input.changedFiles.length > 0 ? ` --changed ${changed}` : ""
+      }`,
+    });
+  }
+
+  moves.push({
+    title: "Refresh project context",
+    priority: "p1",
+    detail:
+      "Keep the local project map current before asking any agent to inspect or patch Apple-native files.",
+    command: `axint project index --dir ${dir}${
+      input.changedFiles.length > 0 ? ` --changed ${changed}` : ""
+    }`,
+  });
+
+  moves.push({
+    title: "Use the correct host lane",
+    priority: "p1",
+    detail: `${input.profile.label}: ${input.profile.defaultWriteAction}. ${input.profile.proofAction}`,
+  });
+
+  const scheme = input.context.xcode.inferredScheme
+    ? ` --scheme ${quote(input.context.xcode.inferredScheme)}`
+    : "";
+  const container = input.context.xcode.workspace
+    ? ` --workspace ${quote(input.context.xcode.workspace)}`
+    : input.context.xcode.project
+      ? ` --project ${quote(input.context.xcode.project)}`
+      : "";
+  moves.push({
+    title: "Run the smallest proof loop",
+    priority: "p2",
+    detail:
+      "After patching, use focused proof before claiming done. Static validation alone is not runtime/UI proof.",
+    command: `axint run --dir ${dir}${container}${scheme}${
+      input.changedFiles.length > 0 ? ` --changed ${changed}` : " --changed <files>"
+    } --only-testing <focused-selector>`,
+  });
+
+  return moves.slice(0, 8);
+}
+
+function loadOrCreateContext(
+  cwd: string,
+  projectName: string | undefined,
+  changedFiles: string[] | undefined
+): ProjectContextIndex {
+  const path = projectContextPath(cwd);
+  const context = existsSync(path) ? readProjectContextIndex(path) : undefined;
+  if (context && (!changedFiles || changedFiles.length === 0)) return context;
+  return writeProjectContextIndex({
+    targetDir: cwd,
+    projectName,
+    changedFiles,
+  }).index;
+}
+
+function readAgentConfig(cwd: string): AxintLocalAgentConfig | undefined {
+  const path = agentConfigPath(cwd);
+  if (!existsSync(path)) return undefined;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as AxintLocalAgentConfig;
+  } catch {
+    return undefined;
+  }
+}
+
+function ensureClaimsFile(cwd: string): AxintAgentClaimsFile {
+  const path = claimsPath(cwd);
+  if (existsSync(path)) {
+    try {
+      return JSON.parse(readFileSync(path, "utf-8")) as AxintAgentClaimsFile;
+    } catch {
+      // fall through and rewrite a valid coordination file
+    }
+  }
+  const file: AxintAgentClaimsFile = {
+    schema: "https://axint.ai/schemas/local-agent-claims.v1.json",
+    updatedAt: new Date().toISOString(),
+    claims: [],
+  };
+  writeJson(path, file);
+  return file;
+}
+
+function appendLedgerEvent(
+  cwd: string,
+  event: Omit<AxintAgentLedgerEvent, "id" | "createdAt">
+): void {
+  const path = ledgerPath(cwd);
+  const existing = readLedger(cwd);
+  const createdAt = new Date().toISOString();
+  const next: AxintAgentLedger = {
+    schema: "https://axint.ai/schemas/local-agent-ledger.v1.json",
+    updatedAt: createdAt,
+    events: [
+      ...existing.events.slice(-199),
+      {
+        id: `axevent_${hashString(`${event.kind}:${event.agent}:${createdAt}:${randomUUID()}`)}`,
+        createdAt,
+        ...event,
+      },
+    ],
+  };
+  writeJson(path, next);
+}
+
+function readLedger(cwd: string): AxintAgentLedger {
+  const path = ledgerPath(cwd);
+  if (existsSync(path)) {
+    try {
+      return JSON.parse(readFileSync(path, "utf-8")) as AxintAgentLedger;
+    } catch {
+      // fall through and rewrite a valid ledger
+    }
+  }
+  return {
+    schema: "https://axint.ai/schemas/local-agent-ledger.v1.json",
+    updatedAt: new Date().toISOString(),
+    events: [],
+  };
+}
+
+function activeAgentClaims(
+  file: AxintAgentClaimsFile,
+  ttlMinutes: number | undefined = undefined
+): AxintAgentClaim[] {
+  const now = Date.now();
+  const ttlMs = ttlMinutes ? minutes(ttlMinutes) : undefined;
+  return file.claims.filter((claim) => {
+    if (claim.releasedAt) return false;
+    if (new Date(claim.expiresAt).getTime() <= now) return false;
+    if (!ttlMs) return true;
+    return now - new Date(claim.createdAt).getTime() <= ttlMs;
+  });
+}
+
+function findConflictingClaims(input: {
+  claims: AxintAgentClaim[];
+  agent: AxintAgentProfileName;
+  files: string[];
+}): AxintAgentClaim[] {
+  if (input.files.length === 0) return [];
+  return input.claims.filter(
+    (claim) =>
+      claim.agent !== input.agent &&
+      claim.agent !== "all" &&
+      input.files.some((file) => claim.files.includes(file))
+  );
+}
+
+function readLatestProof(cwd: string): LatestProofSummary | undefined {
+  const path = join(cwd, ".axint/run/latest.json");
+  const payload = readJsonRecord(path);
+  if (!payload) return undefined;
+  const nextSteps = stringArray(payload.nextSteps);
+  return {
+    path,
+    status: stringValue(payload.status, "unknown"),
+    gate: recordValue(payload.gate)
+      ? stringValue(recordValue(payload.gate)?.decision, undefined)
+      : undefined,
+    runId: stringValue(payload.id, undefined),
+    updatedAt: stringValue(payload.createdAt, undefined),
+    failingStep: inferFailingStep(payload),
+    nextSteps,
+  };
+}
+
+function readLatestRepair(cwd: string): LatestRepairSummary | undefined {
+  const path = join(cwd, ".axint/repair/latest.json");
+  const payload = readJsonRecord(path);
+  if (!payload) return undefined;
+  return {
+    path,
+    status: stringValue(payload.status, "unknown"),
+    issueClass: stringValue(payload.issueClass, undefined),
+    priority: stringValue(payload.priority, undefined),
+    filesToInspect: arrayOfRecords(payload.filesToInspect)
+      .map((item) => stringValue(item.path, undefined))
+      .filter((item): item is string => Boolean(item)),
+    commands: stringArray(payload.commands),
+  };
+}
+
+function inferFailingStep(payload: Record<string, unknown>): string | undefined {
+  const steps = arrayOfRecords(payload.steps);
+  const failed = steps.find((step) => stringValue(step.status, "") === "fail");
+  if (failed) {
+    return stringValue(failed.detail, undefined) ?? stringValue(failed.name, undefined);
+  }
+  const cloudChecks = arrayOfRecords(payload.cloudChecks);
+  const failedCloud = cloudChecks.find(
+    (check) => stringValue(check.status, "") === "fail"
+  );
+  if (failedCloud) {
+    return `Cloud Check failed${stringValue(failedCloud.gate, undefined) ? `: ${String(failedCloud.gate)}` : ""}.`;
+  }
+  return undefined;
+}
+
+function nextAgentCommands(cwd: string, agent: AxintAgentProfileName): string[] {
+  const dir = quote(cwd);
+  return [
+    `axint agent advice --dir ${dir} --agent ${agent}`,
+    `axint agent claim --dir ${dir} --agent ${agent} --task ${quote("next Apple repair")} <files...>`,
+    `axint run --dir ${dir} --changed <files> --only-testing <focused-selector>`,
+  ];
+}
+
+function normalizeFiles(cwd: string, files: string[]): string[] {
+  return uniqueStrings(
+    files
+      .filter(Boolean)
+      .map((file) => (file.startsWith("/") ? relative(cwd, file) : file))
+      .map((file) => file.replace(/\\/g, "/"))
+  );
+}
+
+function readJsonRecord(path: string): Record<string, unknown> | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    const value = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    return recordValue(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function arrayOfRecords(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => Boolean(recordValue(item)))
+    : [];
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function stringValue(value: unknown, fallback: string): string;
+function stringValue(value: unknown, fallback: undefined): string | undefined;
+function stringValue(value: unknown, fallback: string | undefined): string | undefined {
+  return typeof value === "string" && value.trim() ? value : fallback;
+}
+
+function agentConfigPath(cwd: string): string {
+  return join(cwd, ".axint/agent.json");
+}
+
+function claimsPath(cwd: string): string {
+  return join(cwd, ".axint/coordination/claims.json");
+}
+
+function ledgerPath(cwd: string): string {
+  return join(cwd, ".axint/coordination/ledger.json");
+}
+
+function projectContextPath(cwd: string): string {
+  return join(cwd, ".axint/context/latest.json");
+}
+
+function minutes(value: number): number {
+  return Math.max(1, value) * 60 * 1000;
+}
+
+function hashString(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 10);
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function relativeOrAbsolute(cwd: string, path: string): string {
+  const rel = relative(cwd, path);
+  return rel && !rel.startsWith("..") ? rel : path;
+}
+
+function quote(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/src/project/memory-index.ts
+++ b/src/project/memory-index.ts
@@ -1,0 +1,363 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import {
+  buildProjectContextIndex,
+  readProjectContextIndex,
+  type ProjectContextIndex,
+} from "./context-index.js";
+
+export type AxintProjectMemoryFormat = "markdown" | "json";
+
+export interface AxintProjectMemoryInput {
+  cwd?: string;
+  projectName?: string;
+  changedFiles?: string[];
+  write?: boolean;
+}
+
+export interface AxintProjectMemoryIndex {
+  schema: "https://axint.ai/schemas/project-memory.v1.json";
+  createdAt: string;
+  cwd: string;
+  projectName: string;
+  summary: string[];
+  context: {
+    swiftFiles: number;
+    swiftUIFiles: number;
+    inputCapableFiles: number;
+    changedFiles: string[];
+    riskyFiles: Array<{
+      path: string;
+      riskScore: number;
+      reasons: string[];
+    }>;
+  };
+  latestRun?: {
+    path: string;
+    status?: string;
+    gate?: string;
+    runId?: string;
+    failedTests: Array<{
+      testName?: string;
+      message?: string;
+      file?: string;
+      line?: number;
+      repairHint?: string;
+    }>;
+    nextSteps: string[];
+  };
+  latestRepair?: {
+    path: string;
+    status?: string;
+    issueClass?: string;
+    filesToInspect: string[];
+    proofCommands: string[];
+  };
+  learningPackets: Array<{
+    path: string;
+    fingerprint?: string;
+    priority?: string;
+    owner?: string;
+    title?: string;
+    diagnosticCodes: string[];
+    redaction?: string;
+  }>;
+  nextCommands: string[];
+}
+
+export interface WriteAxintProjectMemoryResult {
+  index: AxintProjectMemoryIndex;
+  jsonPath: string;
+  markdownPath: string;
+  written: string[];
+}
+
+export function buildProjectMemoryIndex(
+  input: AxintProjectMemoryInput = {}
+): AxintProjectMemoryIndex {
+  const cwd = resolve(input.cwd ?? process.cwd());
+  const context = loadContext(cwd, input);
+  const latestRun = readLatestRunMemory(cwd);
+  const latestRepair = readLatestRepairMemory(cwd);
+  const learningPackets = readLearningPackets(cwd);
+  const projectName = input.projectName ?? context.projectName ?? basename(cwd);
+
+  const summary = [
+    `${projectName}: ${context.files.swift} Swift files, ${context.files.swiftUI} SwiftUI files, ${context.files.inputCapable} input-capable files.`,
+    latestRun
+      ? `Latest run: ${latestRun.status ?? "unknown"}${latestRun.gate ? ` · ${latestRun.gate}` : ""}.`
+      : "No Axint run proof found yet.",
+    latestRepair
+      ? `Latest repair: ${latestRepair.issueClass ?? latestRepair.status ?? "available"}.`
+      : "No Axint repair packet found yet.",
+    learningPackets.length > 0
+      ? `${learningPackets.length} privacy-safe learning packet${learningPackets.length === 1 ? "" : "s"} available.`
+      : "No privacy-safe learning packets found yet.",
+  ];
+
+  return {
+    schema: "https://axint.ai/schemas/project-memory.v1.json",
+    createdAt: new Date().toISOString(),
+    cwd,
+    projectName,
+    summary,
+    context: {
+      swiftFiles: context.files.swift,
+      swiftUIFiles: context.files.swiftUI,
+      inputCapableFiles: context.files.inputCapable,
+      changedFiles: context.git.changedFiles,
+      riskyFiles: context.topInteractionRiskFiles.slice(0, 10).map((file) => ({
+        path: file.path,
+        riskScore: file.riskScore,
+        reasons: file.reasons,
+      })),
+    },
+    latestRun,
+    latestRepair,
+    learningPackets,
+    nextCommands: [
+      `axint agent advice --dir ${shellQuote(cwd)}`,
+      `axint project index --dir ${shellQuote(cwd)}`,
+      `axint run --dir ${shellQuote(cwd)} --agent codex --dry-run`,
+    ],
+  };
+}
+
+export function writeProjectMemoryIndex(
+  input: AxintProjectMemoryInput = {}
+): WriteAxintProjectMemoryResult {
+  const index = buildProjectMemoryIndex(input);
+  const jsonPath = resolve(index.cwd, ".axint/memory/latest.json");
+  const markdownPath = resolve(index.cwd, ".axint/memory/latest.md");
+  const written: string[] = [];
+
+  if (input.write !== false) {
+    mkdirSync(dirname(jsonPath), { recursive: true });
+    writeFileSync(jsonPath, `${JSON.stringify(index, null, 2)}\n`, "utf-8");
+    writeFileSync(markdownPath, renderProjectMemoryIndex(index), "utf-8");
+    written.push(".axint/memory/latest.json", ".axint/memory/latest.md");
+  }
+
+  return { index, jsonPath, markdownPath, written };
+}
+
+export function renderProjectMemoryIndex(
+  index: AxintProjectMemoryIndex,
+  format: AxintProjectMemoryFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(index, null, 2);
+
+  const lines = [
+    "# Axint Project Memory",
+    "",
+    `- Project: ${index.projectName}`,
+    `- Root: ${index.cwd}`,
+    `- Created: ${index.createdAt}`,
+    "",
+    "## Summary",
+    ...index.summary.map((item) => `- ${item}`),
+    "",
+    "## Risky Files",
+    ...(index.context.riskyFiles.length > 0
+      ? index.context.riskyFiles.map(
+          (file) =>
+            `- ${file.path}: score ${file.riskScore}${file.reasons.length > 0 ? ` — ${file.reasons.join(", ")}` : ""}`
+        )
+      : ["- None detected yet."]),
+    "",
+    "## Latest Run",
+    ...(index.latestRun
+      ? [
+          `- Status: ${index.latestRun.status ?? "unknown"}`,
+          `- Gate: ${index.latestRun.gate ?? "unknown"}`,
+          `- Path: ${index.latestRun.path}`,
+          ...(index.latestRun.failedTests.length > 0
+            ? [
+                "- Failed tests:",
+                ...index.latestRun.failedTests.map(
+                  (failure) =>
+                    `  - ${failure.testName ?? "unknown test"}${failure.file ? ` (${failure.file}${failure.line ? `:${failure.line}` : ""})` : ""}: ${failure.message ?? "no message"}${failure.repairHint ? ` Repair: ${failure.repairHint}` : ""}`
+                ),
+              ]
+            : ["- Failed tests: none recorded."]),
+        ]
+      : ["- No run found."]),
+    "",
+    "## Latest Repair",
+    ...(index.latestRepair
+      ? [
+          `- Status: ${index.latestRepair.status ?? "unknown"}`,
+          `- Issue class: ${index.latestRepair.issueClass ?? "unknown"}`,
+          `- Path: ${index.latestRepair.path}`,
+          ...(index.latestRepair.filesToInspect.length > 0
+            ? [
+                "- Files to inspect:",
+                ...index.latestRepair.filesToInspect.map((file) => `  - ${file}`),
+              ]
+            : []),
+        ]
+      : ["- No repair packet found."]),
+    "",
+    "## Privacy-Safe Learning Packets",
+    ...(index.learningPackets.length > 0
+      ? index.learningPackets.map(
+          (packet) =>
+            `- ${packet.fingerprint ?? basename(packet.path)}: ${packet.priority ?? "p?"} · ${packet.owner ?? "unknown owner"} · ${packet.diagnosticCodes.join(", ") || "no codes"} · ${packet.redaction ?? "source_not_included"}`
+        )
+      : ["- None yet."]),
+    "",
+    "## Next Commands",
+    ...index.nextCommands.map((command) => `- \`${command}\``),
+    "",
+  ];
+
+  return lines.join("\n");
+}
+
+function loadContext(cwd: string, input: AxintProjectMemoryInput): ProjectContextIndex {
+  const contextPath = join(cwd, ".axint/context/latest.json");
+  return (
+    readProjectContextIndex(contextPath) ??
+    buildProjectContextIndex({
+      targetDir: cwd,
+      projectName: input.projectName,
+      changedFiles: input.changedFiles,
+      includeGit: true,
+    })
+  );
+}
+
+function readLatestRunMemory(cwd: string): AxintProjectMemoryIndex["latestRun"] {
+  const path = join(cwd, ".axint/run/latest.json");
+  const json = readJson(path);
+  if (!json) return undefined;
+  const failedTests = Array.isArray(json.xcodeTestFailures)
+    ? json.xcodeTestFailures.slice(0, 8).map((failure: Record<string, unknown>) => ({
+        testName: stringValue(failure.testName),
+        message: stringValue(failure.message),
+        file: stringValue(failure.file),
+        line: numberValue(failure.line),
+        repairHint: stringValue(failure.repairHint),
+      }))
+    : [];
+
+  return {
+    path,
+    status: stringValue(json.status),
+    gate:
+      typeof json.gate === "object" && json.gate
+        ? stringValue((json.gate as Record<string, unknown>).decision)
+        : undefined,
+    runId: stringValue(json.id),
+    failedTests,
+    nextSteps: Array.isArray(json.nextSteps)
+      ? json.nextSteps.map(String).slice(0, 8)
+      : [],
+  };
+}
+
+function readLatestRepairMemory(cwd: string): AxintProjectMemoryIndex["latestRepair"] {
+  const path = join(cwd, ".axint/repair/latest.json");
+  const json = readJson(path);
+  if (!json) return undefined;
+  const filesToInspect = Array.isArray(json.filesToInspect)
+    ? json.filesToInspect.map(String).slice(0, 12)
+    : Array.isArray(json.candidateFiles)
+      ? json.candidateFiles
+          .map((file: unknown) =>
+            typeof file === "string"
+              ? file
+              : String((file as Record<string, unknown>).path ?? "")
+          )
+          .filter(Boolean)
+          .slice(0, 12)
+      : [];
+  const proofCommands = Array.isArray(json.proofCommands)
+    ? json.proofCommands.map(String).slice(0, 8)
+    : [];
+
+  return {
+    path,
+    status: stringValue(json.status),
+    issueClass:
+      stringValue(json.issueClass) ??
+      (typeof json.repairIntelligence === "object" && json.repairIntelligence
+        ? stringValue((json.repairIntelligence as Record<string, unknown>).issueClass)
+        : undefined),
+    filesToInspect,
+    proofCommands,
+  };
+}
+
+function readLearningPackets(cwd: string): AxintProjectMemoryIndex["learningPackets"] {
+  const dir = join(cwd, ".axint/feedback");
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => join(dir, file))
+    .sort((a, b) => mtimeMs(b) - mtimeMs(a))
+    .slice(0, 12)
+    .flatMap((path) => {
+      const json = readJson(path);
+      if (!json) return [];
+      return [
+        {
+          path,
+          fingerprint: stringValue(json.fingerprint),
+          priority: stringValue(json.priority),
+          owner: stringValue(json.suggestedOwner),
+          title: stringValue(json.title),
+          diagnosticCodes: Array.isArray(json.diagnosticCodes)
+            ? json.diagnosticCodes.map(String).slice(0, 8)
+            : [],
+          redaction:
+            stringValue(json.redaction) ??
+            (typeof json.privacy === "object" && json.privacy
+              ? stringValue((json.privacy as Record<string, unknown>).redaction)
+              : undefined),
+        },
+      ];
+    });
+}
+
+function readJson(path: string): Record<string, unknown> | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function mtimeMs(path: string): number {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function relativeOrAbsolute(root: string, file: string): string {
+  const rel = relative(root, file);
+  return rel && !rel.startsWith("..") && !resolve(file).startsWith("..") ? rel : file;
+}

--- a/src/repair/project-repair.ts
+++ b/src/repair/project-repair.ts
@@ -323,7 +323,7 @@ export function renderAxintRepairReport(
     `- Project: ${report.projectContext.swiftFiles} Swift files, ${report.projectContext.swiftUIFiles} SwiftUI files, ${report.projectContext.inputCapableFiles} input-capable files`,
     "",
     "## Senior Repair Read",
-    ...formatAppleRepairRead(report.repairIntelligence).map((item) => `- ${item}`),
+    ...formatAppleRepairOverview(report.repairIntelligence).map((item) => `- ${item}`),
     "- Inspect:",
     ...report.repairIntelligence.inspectionChecklist
       .slice(0, 6)
@@ -879,7 +879,7 @@ function buildRepairPrompt(report: AxintRepairReport): string {
     "Host/tool lane:",
     renderAgentToolProfile(report.agent),
     "",
-    ...formatAppleRepairRead(report.repairIntelligence),
+    ...formatAppleRepairOverview(report.repairIntelligence),
     "",
     "Likely root causes:",
     ...report.hypotheses.map(
@@ -895,6 +895,12 @@ function buildRepairPrompt(report: AxintRepairReport): string {
     "",
     "Do not claim the bug is fixed until focused build/UI/runtime proof passes.",
   ].join("\n");
+}
+
+function formatAppleRepairOverview(analysis: AppleRepairIntelligence): string[] {
+  const formatted = formatAppleRepairRead(analysis);
+  const rootCauseIndex = formatted.indexOf("Likely root causes:");
+  return rootCauseIndex >= 0 ? formatted.slice(0, rootCauseIndex) : formatted;
 }
 
 function writeRepairArtifacts(report: AxintRepairReport): void {

--- a/src/run/project-runner.ts
+++ b/src/run/project-runner.ts
@@ -9,9 +9,19 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, extname, join, resolve } from "node:path";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { runCloudCheck, type CloudCheckReport } from "../cloud/check.js";
+import { writeCloudFeedbackSignal } from "../cloud/feedback-store.js";
+import {
+  buildAgentToolProfile,
+  type AxintAgentProfileName,
+  type AxintAgentToolProfile,
+} from "../project/agent-profile.js";
 import { writeProjectContextIndex } from "../project/context-index.js";
+import {
+  buildAxintAgentAdvice,
+  type AxintAgentAdviceReport,
+} from "../project/local-agent.js";
 import { startAxintSession } from "../project/session.js";
 import { validateSwiftSource } from "../core/swift-validator.js";
 import type { Diagnostic } from "../core/types.js";
@@ -44,6 +54,7 @@ export interface AxintRunInput {
   projectName?: string;
   expectedVersion?: string;
   platform?: AxintRunPlatform;
+  agent?: AxintAgentProfileName;
   scheme?: string;
   workspace?: string;
   project?: string;
@@ -81,6 +92,19 @@ export interface AxintRunCommandResult {
   cancelled?: boolean;
 }
 
+export interface AxintRunXcodeTestFailure {
+  testName?: string;
+  suiteName?: string;
+  file?: string;
+  line?: number;
+  message: string;
+  identifier?: string;
+  likelyArea?: string;
+  likelyCause?: string;
+  repairHint?: string;
+  source: "xcodebuild-output" | "xcresult";
+}
+
 export interface AxintRunStep {
   name: string;
   state: AxintRunStepState;
@@ -100,6 +124,7 @@ export interface AxintRunReport {
   cwd: string;
   projectName: string;
   platform: AxintRunPlatform;
+  agent: AxintAgentToolProfile;
   scheme?: string;
   destination: string;
   createdAt: string;
@@ -114,6 +139,7 @@ export interface AxintRunReport {
     cancelCommand: string;
   };
   workflow: WorkflowCheckReport;
+  agentAdvice?: AxintAgentAdviceReport;
   swiftValidation: {
     filesChecked: number;
     diagnostics: Diagnostic[];
@@ -125,12 +151,14 @@ export interface AxintRunReport {
     runtime?: AxintRunCommandResult;
     buildSettings?: AxintRunCommandResult;
   };
+  xcodeTestFailures: AxintRunXcodeTestFailure[];
   steps: AxintRunStep[];
   artifacts: {
     json?: string;
     markdown?: string;
     projectContextJson?: string;
     projectContextMarkdown?: string;
+    feedbackSignals?: string[];
   };
   nextSteps: string[];
   repairPrompt: string;
@@ -155,6 +183,7 @@ export async function runAxintProject(
   const cwd = resolve(input.cwd ?? process.cwd());
   const platform = input.platform ?? inferPlatform(input.destination);
   const projectName = input.projectName ?? inferProjectName(cwd);
+  const agentProfile = buildAgentToolProfile(input.agent);
   const job = createRunJobRecord({
     id: runId,
     cwd,
@@ -166,7 +195,7 @@ export async function runAxintProject(
     projectName,
     expectedVersion: input.expectedVersion ?? "unknown",
     platform,
-    agent: "all",
+    agent: agentProfile.agent,
   });
   const projectContext = writeProjectContextIndex({
     targetDir: cwd,
@@ -313,8 +342,14 @@ export async function runAxintProject(
     });
   }
 
-  const xcodeEvidence = buildXcodeEvidence(commands, plan);
-  const focusedBehavior = buildFocusedTestBehavior(plan, commands.test);
+  const xcodeTestFailures = collectXcodeTestFailures(commands.test);
+  const xcodeFailureEvidence = formatXcodeTestFailuresForEvidence(xcodeTestFailures);
+  const xcodeEvidence = buildXcodeEvidence(commands, plan, xcodeTestFailures);
+  const focusedBehavior = buildFocusedTestBehavior(
+    plan,
+    commands.test,
+    xcodeTestFailures
+  );
   if (xcodeEvidence && cloudTargets.length > 0) {
     cloudChecks.splice(
       0,
@@ -324,6 +359,7 @@ export async function runAxintProject(
           sourcePath: file,
           platform,
           xcodeBuildLog: xcodeEvidence,
+          testFailure: xcodeFailureEvidence,
           runtimeFailure:
             input.runtimeFailure ?? runtimeFailureFromCommand(commands.runtime),
           expectedBehavior: input.expectedBehavior ?? focusedBehavior?.expectedBehavior,
@@ -340,6 +376,7 @@ export async function runAxintProject(
   const workflow = runWorkflowCheck({
     cwd,
     stage: "pre-build",
+    agent: agentProfile.agent,
     sessionStarted: true,
     sessionToken: session.session.token,
     readAgentInstructions: true,
@@ -354,7 +391,8 @@ export async function runAxintProject(
   });
 
   const status = summarizeStatus(steps, workflow, validationDiagnostics, cloudChecks);
-  const report: AxintRunReport = {
+  const feedbackSignals = writeRunFeedbackSignals(cwd, cloudChecks);
+  let report: AxintRunReport = {
     id: runId,
     kind: input.kind ?? "local",
     status,
@@ -362,6 +400,7 @@ export async function runAxintProject(
     cwd,
     projectName,
     platform,
+    agent: agentProfile,
     scheme: plan?.scheme,
     destination: plan?.destination ?? defaultDestination(platform),
     createdAt: new Date().toISOString(),
@@ -381,6 +420,7 @@ export async function runAxintProject(
       diagnostics: validationDiagnostics,
     },
     cloudChecks,
+    xcodeTestFailures,
     commands,
     steps: steps.map((step) =>
       step.durationMs === undefined && step.name === "Axint session"
@@ -390,14 +430,17 @@ export async function runAxintProject(
     artifacts: {
       projectContextJson: projectContext.jsonPath,
       projectContextMarkdown: projectContext.markdownPath,
+      feedbackSignals,
     },
-    nextSteps: buildNextSteps(status, steps, workflow, cloudChecks),
+    nextSteps: buildNextSteps(status, steps, workflow, cloudChecks, xcodeTestFailures),
     repairPrompt: buildRunRepairPrompt({
       status,
       workflow,
       validationDiagnostics,
       cloudChecks,
       commands,
+      xcodeTestFailures,
+      agent: agentProfile,
     }),
   };
 
@@ -405,6 +448,47 @@ export async function runAxintProject(
     const artifacts = writeRunArtifacts(report);
     report.artifacts = artifacts;
   }
+
+  const agentAdvice = buildAxintAgentAdvice({
+    cwd,
+    agent: agentProfile.agent,
+    changedFiles:
+      input.modifiedFiles ??
+      swiftFiles.map((file) => relativeOrAbsolute(cwd, file)).slice(0, 20),
+    issue:
+      input.runtimeFailure ??
+      input.actualBehavior ??
+      input.expectedBehavior ??
+      "Axint run proof loop",
+  });
+  report = {
+    ...report,
+    agentAdvice,
+    nextSteps: buildNextSteps(
+      status,
+      steps,
+      workflow,
+      cloudChecks,
+      xcodeTestFailures,
+      agentAdvice
+    ),
+  };
+  report.repairPrompt = buildRunRepairPrompt({
+    status,
+    workflow,
+    validationDiagnostics,
+    cloudChecks,
+    commands,
+    xcodeTestFailures,
+    agent: agentProfile,
+    agentAdvice,
+  });
+
+  if (input.writeReport !== false) {
+    const artifacts = writeRunArtifacts(report);
+    report.artifacts = artifacts;
+  }
+
   finishRunJobRecord(job, {
     status,
     artifacts: {
@@ -431,6 +515,7 @@ export function renderAxintRunReport(
     "",
     `- Project: ${report.projectName}`,
     `- Platform: ${report.platform}`,
+    `- Agent lane: ${report.agent.label}`,
     `- Scheme: ${report.scheme ?? "not detected"}`,
     `- Destination: ${report.destination}`,
     `- Gate: ${report.gate.decision}`,
@@ -452,6 +537,27 @@ export function renderAxintRunReport(
     "",
     renderWorkflowCheckReport(report.workflow),
     "",
+    "## Agent Lane",
+    "",
+    `- Host: ${report.agent.label}`,
+    `- Editing lane: ${report.agent.editingMode}`,
+    `- Default write action: ${report.agent.defaultWriteAction}`,
+    `- Proof action: ${report.agent.proofAction}`,
+    ...(report.agentAdvice
+      ? [
+          `- Local brain: ${report.agentAdvice.status}`,
+          ...report.agentAdvice.warnings.map((warning) => `- Warning: ${warning}`),
+          ...report.agentAdvice.moves
+            .slice(0, 4)
+            .map(
+              (move) =>
+                `- ${move.priority.toUpperCase()} ${move.title}: ${move.detail}${
+                  move.command ? ` Command: \`${move.command}\`` : ""
+                }`
+            ),
+        ]
+      : ["- Local brain: not requested."]),
+    "",
     "## Swift Diagnostics",
     ...(report.swiftValidation.diagnostics.length > 0
       ? report.swiftValidation.diagnostics
@@ -460,6 +566,11 @@ export function renderAxintRunReport(
             (diagnostic) =>
               `- ${diagnostic.severity.toUpperCase()} ${diagnostic.code}: ${diagnostic.message}`
           )
+      : ["- None."]),
+    "",
+    "## Xcode Test Failures",
+    ...(report.xcodeTestFailures.length > 0
+      ? report.xcodeTestFailures.slice(0, 8).map(renderXcodeTestFailureLine)
       : ["- None."]),
     "",
     "## Cloud Checks",
@@ -495,9 +606,30 @@ export function renderAxintRunReport(
         `- Project context Markdown: ${report.artifacts.projectContextMarkdown}`
       );
     }
+    if (report.artifacts.feedbackSignals?.length) {
+      lines.push(
+        ...report.artifacts.feedbackSignals.map((path) => `- Feedback signal: ${path}`)
+      );
+    }
   }
 
   return lines.join("\n");
+}
+
+function writeRunFeedbackSignals(cwd: string, cloudChecks: CloudCheckReport[]): string[] {
+  const written: string[] = [];
+  const seen = new Set<string>();
+  for (const check of cloudChecks) {
+    const signal = check.learningSignal;
+    if (!signal || seen.has(signal.fingerprint)) continue;
+    seen.add(signal.fingerprint);
+    try {
+      written.push(writeCloudFeedbackSignal(signal, { cwd }).path);
+    } catch {
+      // Privacy-safe feedback should never make the proof loop itself fail.
+    }
+  }
+  return written;
 }
 
 function createXcodePlan(
@@ -980,11 +1112,13 @@ function updateCloudCheckStep(
 
 function buildXcodeEvidence(
   commands: AxintRunReport["commands"],
-  plan?: XcodePlan
+  plan?: XcodePlan,
+  failures: AxintRunXcodeTestFailure[] = []
 ): string | undefined {
   const chunks = [
     commandEvidence("Xcode build", commands.build),
     focusedTestEvidence(commands.test, plan),
+    xcodeFailureEvidence(failures),
     commandEvidence("Xcode test", commands.test),
     commandEvidence("Runtime launch", commands.runtime),
   ].filter(Boolean);
@@ -1015,7 +1149,8 @@ function focusedTestEvidence(
 
 function buildFocusedTestBehavior(
   plan?: XcodePlan,
-  result?: AxintRunCommandResult
+  result?: AxintRunCommandResult,
+  failures: AxintRunXcodeTestFailure[] = []
 ):
   | {
       expectedBehavior: string;
@@ -1027,15 +1162,498 @@ function buildFocusedTestBehavior(
   }
   const selectors = plan.onlyTesting.join(", ");
   if (result.exitCode !== 0 || result.timedOut) {
+    const firstFailure = failures[0];
     return {
       expectedBehavior: `Focused test selector(s) should pass: ${selectors}.`,
-      actualBehavior: `Focused test selector(s) did not pass through axint run --only-testing: ${selectors}.`,
+      actualBehavior: firstFailure
+        ? `Focused test selector(s) did not pass through axint run --only-testing: ${selectors}. First failure: ${formatXcodeFailureOneLine(firstFailure)}.`
+        : `Focused test selector(s) did not pass through axint run --only-testing: ${selectors}.`,
     };
   }
   return {
     expectedBehavior: `Focused test selector(s) should pass: ${selectors}.`,
     actualBehavior: `Focused test selector(s) passed through axint run --only-testing: ${selectors}.`,
   };
+}
+
+function collectXcodeTestFailures(
+  result?: AxintRunCommandResult
+): AxintRunXcodeTestFailure[] {
+  if (!result || result.dryRun || (result.exitCode === 0 && !result.timedOut)) {
+    return [];
+  }
+  const outputText = [result.stdout, result.stderr, readCommandLogTail(result.logPath)]
+    .filter(Boolean)
+    .join("\n");
+  const failures = [
+    ...extractXcodeTestFailuresFromXcresult(result.resultBundlePath, result.cwd),
+    ...extractXcodeTestFailuresFromText(outputText),
+  ];
+  return dedupeXcodeTestFailures(failures).slice(0, 12);
+}
+
+function extractXcodeTestFailuresFromText(text: string): AxintRunXcodeTestFailure[] {
+  if (!text.trim()) return [];
+
+  const failures: AxintRunXcodeTestFailure[] = [];
+  const lines = text.split(/\r?\n/);
+  let currentSuite: string | undefined;
+  let currentTest: string | undefined;
+  const pendingMessages: string[] = [];
+
+  for (const rawLine of lines) {
+    const line = stripAnsi(rawLine).trim();
+    if (!line) continue;
+
+    const suiteMatch = line.match(/Test Suite '([^']+)' (?:started|failed|passed)/i);
+    if (suiteMatch) currentSuite = suiteMatch[1];
+
+    const testCaseMatch = line.match(
+      /Test Case '-\[(?<suite>[^\s\]]+)\s+(?<test>[^\]]+)\]' (?<state>failed|started|passed)/i
+    );
+    if (testCaseMatch?.groups) {
+      currentSuite = testCaseMatch.groups.suite;
+      currentTest = testCaseMatch.groups.test;
+      if (testCaseMatch.groups.state.toLowerCase() === "failed") {
+        const message = pendingMessages.pop() ?? "Xcode reported this test case failed.";
+        const alreadyCaptured = failures.some(
+          (failure) => failure.testName === currentTest && failure.message === message
+        );
+        if (!alreadyCaptured) {
+          failures.push(
+            enrichXcodeTestFailure({
+              suiteName: currentSuite,
+              testName: currentTest,
+              message,
+              source: "xcodebuild-output",
+            })
+          );
+        }
+      }
+      continue;
+    }
+
+    const swiftFailure = parseSwiftFailureLine(line, currentSuite, currentTest);
+    if (swiftFailure) {
+      failures.push(swiftFailure);
+      pendingMessages.push(swiftFailure.message);
+      continue;
+    }
+
+    if (
+      /^\*\*\s*TEST\s+FAILED\s*\*\*$/i.test(line) ||
+      /^Executed\s+\d+\s+tests?,?\s+with\s+\d+\s+failures?/i.test(line)
+    ) {
+      continue;
+    }
+
+    if (looksLikeAssertionFailure(line)) {
+      const failure = enrichXcodeTestFailure({
+        suiteName: currentSuite,
+        testName: currentTest,
+        message: cleanXcodeFailureMessage(line),
+        source: "xcodebuild-output",
+      });
+      failures.push(failure);
+      pendingMessages.push(failure.message);
+    }
+  }
+
+  return failures;
+}
+
+function parseSwiftFailureLine(
+  line: string,
+  fallbackSuite?: string,
+  fallbackTest?: string
+): AxintRunXcodeTestFailure | undefined {
+  const match = line.match(
+    /(?<file>(?:[A-Za-z]:)?[^:\n]+\.swift):(?<line>\d+):\s*(?:error:\s*)?(?:(?:-\[(?<suite>[^\s\]]+)\s+(?<test>[^\]]+)\]\s*:)\s*)?(?<message>.+)$/i
+  );
+  if (!match?.groups) return undefined;
+  const message = cleanXcodeFailureMessage(match.groups.message);
+  if (!message || !looksLikeAssertionFailure(message)) return undefined;
+  return enrichXcodeTestFailure({
+    suiteName: match.groups.suite ?? fallbackSuite,
+    testName: match.groups.test ?? fallbackTest,
+    file: match.groups.file.trim(),
+    line: Number(match.groups.line),
+    message,
+    source: "xcodebuild-output",
+  });
+}
+
+function extractXcodeTestFailuresFromXcresult(
+  resultBundlePath?: string,
+  cwd?: string
+): AxintRunXcodeTestFailure[] {
+  if (!resultBundlePath || !existsSync(resultBundlePath)) return [];
+
+  const commandVariants = [
+    [
+      "xcresulttool",
+      "get",
+      "test-results",
+      "summary",
+      "--path",
+      resultBundlePath,
+      "--format",
+      "json",
+    ],
+    [
+      "xcresulttool",
+      "get",
+      "object",
+      "--legacy",
+      "--path",
+      resultBundlePath,
+      "--format",
+      "json",
+    ],
+  ];
+
+  for (const args of commandVariants) {
+    const result = spawnSync("xcrun", args, {
+      cwd,
+      encoding: "utf-8",
+      timeout: 4000,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    if (result.status !== 0 || !result.stdout.trim()) continue;
+    try {
+      const parsed = JSON.parse(result.stdout) as unknown;
+      const failures = extractFailuresFromXcresultJson(parsed);
+      if (failures.length > 0) return failures;
+    } catch {
+      continue;
+    }
+  }
+
+  return [];
+}
+
+function extractFailuresFromXcresultJson(value: unknown): AxintRunXcodeTestFailure[] {
+  const failures: AxintRunXcodeTestFailure[] = [];
+
+  function visit(node: unknown, inheritedTest?: string, inheritedSuite?: string): void {
+    if (!node || typeof node !== "object") return;
+    if (Array.isArray(node)) {
+      for (const item of node) visit(item, inheritedTest, inheritedSuite);
+      return;
+    }
+
+    const record = node as Record<string, unknown>;
+    const suite =
+      xcresultString(record.suiteName) ??
+      xcresultString(record.className) ??
+      xcresultString(record.testSuiteName) ??
+      inheritedSuite;
+    const test =
+      xcresultString(record.testName) ??
+      xcresultString(record.testCaseName) ??
+      xcresultString(record.identifier) ??
+      inheritedTest;
+
+    const summaryNodes = [
+      record.testFailureSummaries,
+      record.failureSummaries,
+      record.failures,
+    ];
+    for (const summaryNode of summaryNodes) {
+      if (Array.isArray(summaryNode)) {
+        for (const item of summaryNode) {
+          const failure = failureFromXcresultSummary(item, test, suite);
+          if (failure) failures.push(failure);
+        }
+      }
+    }
+
+    if (record.issueType || record.message || record.failureMessage) {
+      const failure = failureFromXcresultSummary(record, test, suite);
+      if (failure) failures.push(failure);
+    }
+
+    for (const child of Object.values(record)) {
+      visit(child, test, suite);
+    }
+  }
+
+  visit(value);
+  return dedupeXcodeTestFailures(failures);
+}
+
+function failureFromXcresultSummary(
+  value: unknown,
+  fallbackTest?: string,
+  fallbackSuite?: string
+): AxintRunXcodeTestFailure | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  const message =
+    xcresultString(record.message) ??
+    xcresultString(record.failureMessage) ??
+    xcresultString(record.summary) ??
+    xcresultString(record.issueType);
+  if (!message || !looksLikeAssertionFailure(message)) return undefined;
+  const documentLocation = parseXcresultDocumentLocation(
+    record.documentLocationInCreatingWorkspace
+  );
+  return enrichXcodeTestFailure({
+    suiteName:
+      xcresultString(record.suiteName) ??
+      xcresultString(record.className) ??
+      fallbackSuite,
+    testName:
+      xcresultString(record.testName) ??
+      xcresultString(record.testCaseName) ??
+      fallbackTest,
+    file: xcresultString(record.fileName) ?? documentLocation.file,
+    line: xcresultNumber(record.lineNumber) ?? documentLocation.line,
+    message: cleanXcodeFailureMessage(message),
+    source: "xcresult",
+  });
+}
+
+function xcresultString(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if (typeof record._value === "string") return record._value;
+    if (typeof record.value === "string") return record.value;
+    if (typeof record.name === "string") return record.name;
+    if (record.url) return xcresultString(record.url);
+  }
+  return undefined;
+}
+
+function parseXcresultDocumentLocation(value: unknown): {
+  file?: string;
+  line?: number;
+} {
+  const location = xcresultString(value);
+  if (!location) return {};
+  const [rawPath, fragment = ""] = location.split("#");
+  let file = rawPath;
+  if (rawPath.startsWith("file://")) {
+    try {
+      file = decodeURIComponent(new URL(rawPath).pathname);
+    } catch {
+      file = rawPath.replace(/^file:\/\//, "");
+    }
+  }
+  const lineMatch = fragment.match(/(?:Starting|Ending)LineNumber=(\d+)/);
+  const line = lineMatch ? Number(lineMatch[1]) : undefined;
+  return {
+    file: file || undefined,
+    line: line && Number.isFinite(line) ? line : undefined,
+  };
+}
+
+function xcresultNumber(value: unknown): number | undefined {
+  if (typeof value === "number") return value;
+  const stringValue = xcresultString(value);
+  if (!stringValue) return undefined;
+  const parsed = Number(stringValue);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function enrichXcodeTestFailure(
+  failure: Omit<
+    AxintRunXcodeTestFailure,
+    "identifier" | "likelyArea" | "likelyCause" | "repairHint"
+  >
+): AxintRunXcodeTestFailure {
+  const message = cleanXcodeFailureMessage(failure.message);
+  const identifier = extractXcodeFailureIdentifier(message);
+  const repair = inferXcodeFailureRepair({
+    ...failure,
+    message,
+    identifier,
+  });
+  return {
+    ...failure,
+    message,
+    identifier,
+    likelyArea: inferXcodeFailureArea({
+      ...failure,
+      message,
+      identifier,
+    }),
+    likelyCause: repair.likelyCause,
+    repairHint: repair.repairHint,
+  };
+}
+
+function dedupeXcodeTestFailures(
+  failures: AxintRunXcodeTestFailure[]
+): AxintRunXcodeTestFailure[] {
+  const seen = new Set<string>();
+  const uniqueFailures: AxintRunXcodeTestFailure[] = [];
+  for (const failure of failures) {
+    const key = [
+      failure.testName ?? "",
+      failure.file ?? "",
+      failure.line ?? "",
+      failure.message,
+    ].join("|");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    uniqueFailures.push(failure);
+  }
+  return uniqueFailures;
+}
+
+function readCommandLogTail(path?: string): string | undefined {
+  if (!path || !existsSync(path)) return undefined;
+  try {
+    return tailText(readFileSync(path, "utf-8"), 24000);
+  } catch {
+    return undefined;
+  }
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(new RegExp(String.raw`\x1B\[[0-9;]*m`, "g"), "");
+}
+
+function looksLikeAssertionFailure(value: string): boolean {
+  return /\b(xct(?:assert|fail|waiter)[a-z]*\s+failed|failed assertion|failure|failed to get matching|no matches|not hittable|not tappable|does not exist|should exist|should be hittable|should be tappable|wait.*timed out|is not equal to|test case\b.*\bfailed)\b/i.test(
+    value
+  );
+}
+
+function cleanXcodeFailureMessage(value: string): string {
+  return stripAnsi(value)
+    .replace(/^error:\s*/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractXcodeFailureIdentifier(message: string): string | undefined {
+  const quoted =
+    message.match(/\[\s*"([^"]+)"\s*\]/)?.[1] ??
+    message.match(/identifier ["']([^"']+)["']/i)?.[1] ??
+    message.match(/["']([A-Za-z0-9_.:-]+)["']\s+(?:should|does|is|was)\b/i)?.[1];
+  if (quoted) return quoted;
+  const shouldExist = message.match(
+    /\b([A-Za-z][A-Za-z0-9_.:-]{2,})\s+should\s+exist\b/i
+  );
+  if (shouldExist) return shouldExist[1];
+  const shouldInteract = message.match(
+    /\b([A-Za-z][A-Za-z0-9_.:-]{2,})\s+should\s+be\s+(?:hittable|tappable)\b/i
+  );
+  return shouldInteract?.[1];
+}
+
+function inferXcodeFailureArea(
+  failure: Omit<AxintRunXcodeTestFailure, "likelyArea" | "likelyCause" | "repairHint">
+): string | undefined {
+  const haystack = [failure.testName, failure.file, failure.message, failure.identifier]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  const areaMap: Array<[RegExp, string]> = [
+    [/\bbuilder|creator|profile\b/, "Builder or creator profile interaction surface"],
+    [/\bdiscover|feed|card\b/, "Discover/feed interaction surface"],
+    [/\bchat|composer|message|comment|post\b/, "Chat, composer, or posting surface"],
+    [/\bhome|tab-home|tab bar|tabbar\b/, "Home tab routing surface"],
+    [/\bproject|command center|room\b/, "Project command center surface"],
+    [/\bvault|memory\b/, "Vault or memory surface"],
+    [/\bbreakaway|messenger\b/, "Breakaway messenger surface"],
+    [/\bsettings|account|billing\b/, "Settings/account surface"],
+  ];
+  for (const [pattern, area] of areaMap) {
+    if (pattern.test(haystack)) return area;
+  }
+  if (failure.file) return `${basename(failure.file, ".swift")} surface`;
+  return undefined;
+}
+
+function inferXcodeFailureRepair(
+  failure: Omit<AxintRunXcodeTestFailure, "likelyArea" | "likelyCause" | "repairHint">
+): {
+  likelyCause?: string;
+  repairHint?: string;
+} {
+  const haystack = [failure.testName, failure.file, failure.message, failure.identifier]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  if (
+    /\bnot hittable|should be hittable|not tappable|should be tappable\b/.test(haystack)
+  ) {
+    return {
+      likelyCause:
+        "The control exists, but another layer, disabled state, hit-testing override, transition, or offscreen layout is preventing interaction.",
+      repairHint:
+        "Inspect nearby ZStack/overlay/contentShape/allowsHitTesting/zIndex/disabled/scroll layout code before changing the UI test.",
+    };
+  }
+
+  if (
+    /\bdoes not exist|should exist|no matches|failed to get matching\b/.test(haystack)
+  ) {
+    return {
+      likelyCause:
+        "The UI element is missing from the accessibility tree or has a stale identifier/query.",
+      repairHint:
+        "Verify the accessibilityIdentifier, conditional rendering path, navigation state, and test launch setup.",
+    };
+  }
+
+  if (/\bwait.*timed out|timeout|timed out\b/.test(haystack)) {
+    return {
+      likelyCause:
+        "The UI state did not settle before the test deadline, often from async loading, animation, navigation, or blocked state transition.",
+      repairHint:
+        "Check loading state, animation completion, route transition, mocked data availability, and focused wait predicates.",
+    };
+  }
+
+  if (/\bis not equal to|expected .* got|mismatch\b/.test(haystack)) {
+    return {
+      likelyCause: "The UI rendered a value that disagrees with the test expectation.",
+      repairHint:
+        "Trace the source of truth, formatter, localization, default state, and any async store update behind the displayed value.",
+    };
+  }
+
+  return {};
+}
+
+function xcodeFailureEvidence(failures: AxintRunXcodeTestFailure[]): string | undefined {
+  const formatted = formatXcodeTestFailuresForEvidence(failures);
+  return formatted ? `Extracted Xcode test failure evidence:\n${formatted}` : undefined;
+}
+
+function formatXcodeTestFailuresForEvidence(
+  failures: AxintRunXcodeTestFailure[]
+): string | undefined {
+  if (failures.length === 0) return undefined;
+  return failures.slice(0, 8).map(formatXcodeFailureOneLine).join("\n");
+}
+
+function renderXcodeTestFailureLine(failure: AxintRunXcodeTestFailure): string {
+  const detail = [
+    failure.file ? `${failure.file}${failure.line ? `:${failure.line}` : ""}` : undefined,
+    failure.likelyArea ? `likely area: ${failure.likelyArea}` : undefined,
+    failure.likelyCause ? `likely cause: ${failure.likelyCause}` : undefined,
+    failure.repairHint ? `repair hint: ${failure.repairHint}` : undefined,
+    failure.identifier ? `identifier: ${failure.identifier}` : undefined,
+    `source: ${failure.source}`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  return `- ${formatXcodeFailureOneLine(failure)}${detail ? `\n  - ${detail}` : ""}`;
+}
+
+function formatXcodeFailureOneLine(failure: AxintRunXcodeTestFailure): string {
+  const name = failure.testName ?? failure.suiteName ?? "Unknown Xcode test";
+  const location = failure.file
+    ? ` (${failure.file}${failure.line ? `:${failure.line}` : ""})`
+    : "";
+  return `${name}${location}: ${failure.message}`;
 }
 
 function commandEvidence(
@@ -1212,12 +1830,42 @@ function buildNextSteps(
   status: AxintRunReport["status"],
   steps: AxintRunStep[],
   workflow: WorkflowCheckReport,
-  cloudChecks: CloudCheckReport[]
+  cloudChecks: CloudCheckReport[],
+  xcodeTestFailures: AxintRunXcodeTestFailure[] = [],
+  agentAdvice?: AxintAgentAdviceReport
 ): string[] {
   if (status === "pass") {
-    return ["Commit the generated Axint Run artifacts with the related code change."];
+    const passingNext = [
+      "Commit the generated Axint Run artifacts with the related code change.",
+    ];
+    if (agentAdvice?.status === "needs_setup") {
+      passingNext.push(
+        "Install the shared local project brain so future agents inherit this proof: axint agent install."
+      );
+    }
+    return passingNext;
   }
   const next = new Set<string>();
+  if (agentAdvice?.status === "needs_setup") {
+    const installMove = agentAdvice.moves.find((move) => /install/i.test(move.title));
+    next.add(
+      installMove?.command
+        ? `Install the shared Axint project brain: ${installMove.command}`
+        : "Install the shared Axint project brain with axint agent install."
+    );
+  }
+  if (agentAdvice?.status === "blocked") {
+    next.add(
+      "Resolve the active Axint file claim before editing, or wait for the claim to expire."
+    );
+  }
+  for (const failure of xcodeTestFailures.slice(0, 3)) {
+    next.add(
+      `Fix failing Xcode test ${failure.testName ?? "unknown"}${
+        failure.file ? ` at ${failure.file}${failure.line ? `:${failure.line}` : ""}` : ""
+      }: ${failure.message}${failure.repairHint ? ` ${failure.repairHint}` : ""}`
+    );
+  }
   for (const item of workflow.required) next.add(item);
   for (const check of cloudChecks) {
     for (const item of check.nextSteps) next.add(item);
@@ -1239,6 +1887,9 @@ function buildRunRepairPrompt(input: {
   validationDiagnostics: Diagnostic[];
   cloudChecks: CloudCheckReport[];
   commands: AxintRunReport["commands"];
+  xcodeTestFailures?: AxintRunXcodeTestFailure[];
+  agent?: AxintAgentToolProfile;
+  agentAdvice?: AxintAgentAdviceReport;
 }) {
   if (input.status === "pass") {
     const passedCommands = Object.entries(input.commands)
@@ -1247,6 +1898,9 @@ function buildRunRepairPrompt(input: {
     return [
       "Axint Run passed for this Apple-native project.",
       "Overall status: pass.",
+      input.agent
+        ? `Host/tool lane: ${input.agent.label}. ${input.agent.finishAction}`
+        : undefined,
       "",
       "Continue with the next proof, commit, or sprint item. Do not rerun Axint unless new code changes or new evidence appears.",
       "",
@@ -1263,14 +1917,23 @@ function buildRunRepairPrompt(input: {
       passedCommands.length > 0
         ? `- Passed command evidence: ${passedCommands.join(", ")}.`
         : "- No executed Xcode command evidence was required for this pass.",
+      input.agentAdvice
+        ? `- Local project brain: ${input.agentAdvice.status}.`
+        : undefined,
     ].join("\n");
   }
 
   const lines = [
     "You are repairing an Apple-native project under Axint Run.",
     `Overall status: ${input.status}.`,
+    input.agent
+      ? `Host/tool lane: ${input.agent.label}. Use this lane: ${input.agent.defaultWriteAction}`
+      : undefined,
     "",
     "Do not continue ordinary coding until the Axint Run failures are addressed.",
+    input.agent
+      ? `Proof expectation for this host: ${input.agent.proofAction}`
+      : undefined,
     "",
     "Workflow gate:",
     ...input.workflow.required.map((item) => `- REQUIRED: ${item}`),
@@ -1300,7 +1963,38 @@ function buildRunRepairPrompt(input: {
               ),
           ])
       : ["- None."]),
+    "",
+    "Xcode test failures:",
+    ...(input.xcodeTestFailures && input.xcodeTestFailures.length > 0
+      ? input.xcodeTestFailures
+          .slice(0, 8)
+          .map(
+            (failure) =>
+              `- ${formatXcodeFailureOneLine(failure)}${
+                failure.repairHint ? ` Repair hint: ${failure.repairHint}` : ""
+              }`
+          )
+      : [
+          "- None extracted. If Xcode failed, inspect the command log or .xcresult artifact.",
+        ]),
   ];
+
+  if (input.agentAdvice) {
+    lines.push(
+      "",
+      "Agent brain:",
+      `- Status: ${input.agentAdvice.status}`,
+      ...input.agentAdvice.warnings.map((warning) => `- Warning: ${warning}`),
+      ...input.agentAdvice.moves
+        .slice(0, 6)
+        .map(
+          (move) =>
+            `- ${move.priority.toUpperCase()} ${move.title}: ${move.detail}${
+              move.command ? ` Command: ${move.command}` : ""
+            }`
+        )
+    );
+  }
 
   for (const [label, result] of Object.entries(input.commands)) {
     if (!result || result.exitCode === 0) continue;
@@ -1333,6 +2027,7 @@ function writeRunArtifacts(report: AxintRunReport) {
       markdown: markdownPath,
       projectContextJson: report.artifacts.projectContextJson,
       projectContextMarkdown: report.artifacts.projectContextMarkdown,
+      feedbackSignals: report.artifacts.feedbackSignals,
     },
   };
   writeFileSync(jsonPath, `${JSON.stringify(serializable, null, 2)}\n`, "utf-8");
@@ -1342,6 +2037,7 @@ function writeRunArtifacts(report: AxintRunReport) {
     markdown: markdownPath,
     projectContextJson: report.artifacts.projectContextJson,
     projectContextMarkdown: report.artifacts.projectContextMarkdown,
+    feedbackSignals: report.artifacts.feedbackSignals,
   };
 }
 

--- a/tests/cloud/check.test.ts
+++ b/tests/cloud/check.test.ts
@@ -272,6 +272,40 @@ struct HomeCommandLayer: View {
     expect(report.gate.decision).toBe("ready_to_ship");
   });
 
+  it("does not mark SwiftUI view changes ready to ship from prose-only behavior evidence", () => {
+    const report = runCloudCheck({
+      fileName: "ProjectRoomContentView.swift",
+      platform: "macOS",
+      source: `
+import SwiftUI
+
+struct ProjectRoomContentView: View {
+    var body: some View {
+        VStack {
+            Text("Project room")
+            Button("Launch") { }
+        }
+    }
+}
+`,
+      expectedBehavior:
+        "Project room uses black and cream brand colors, no orange button fills, and uniform command-center card heights.",
+      actualBehavior:
+        "Source patch adds black/cream palette constants and updates the button styles. Focused UI proof will run next.",
+    });
+
+    expect(report.status).toBe("needs_review");
+    expect(report.gate.decision).toBe("evidence_required");
+    expect(report.gate.canClaimFixed).toBe(false);
+    expect(report.confidence.missingEvidence).toContain("Xcode build");
+    expect(report.coverage).toContainEqual(
+      expect.objectContaining({
+        label: "Xcode build, UI tests, and runtime behavior",
+        state: "needs_runtime",
+      })
+    );
+  });
+
   it("trusts passing focused Xcode proof when behavior prose uses different wording", () => {
     const report = runCloudCheck({
       fileName: "DiscoverTabView.swift",
@@ -500,6 +534,84 @@ struct ProjectImportProgressView: View {
     expect(report.learningSignal?.signals).toContain("runtime-evidence-supplied");
   });
 
+  it("classifies SwiftUI type-erased modifier build logs as blocking evidence", () => {
+    const report = runCloudCheck({
+      fileName: "NewChatButton.swift",
+      source: `
+import SwiftUI
+
+struct NewChatButton: View {
+    var body: some View {
+        Label("New Chat", systemImage: "plus")
+            .labelStyle(.iconOnly)
+            .swarmIcon(size: 18)
+    }
+}
+`,
+      xcodeBuildLog: "error: value of type 'some View' has no member 'swarmIcon'",
+    });
+
+    expect(report.status).toBe("fail");
+    expect(report.diagnostics.map((d) => d.code)).toContain("AX766");
+    expect(report.diagnostics.map((d) => d.code)).toContain(
+      "AXCLOUD-BUILD-MISSING-MEMBER"
+    );
+    expect(report.nextSteps.join("\n")).toContain("type-erasing SwiftUI modifier");
+  });
+
+  it("treats explicit XCTest assertion failures as blocking evidence", () => {
+    const report = runCloudCheck({
+      fileName: "SprintP0TrustFixTests.swift",
+      source: `
+import SwiftUI
+
+struct InviteModel {
+    let visitorActionLabel = "Publish join call"
+}
+`,
+      testFailure:
+        'XCTAssertEqual failed: ("Publish join call") is not equal to ("Join the Swarm") - visitorActionLabel should be owner-aware.',
+    });
+
+    expect(report.status).toBe("fail");
+    expect(report.gate.decision).toBe("fix_required");
+    expect(report.gate.canClaimFixed).toBe(false);
+    expect(report.diagnostics.map((d) => d.code)).toContain("AXCLOUD-XCTEST-FAILURE");
+    expect(report.repairPrompt).toContain("failing assertion");
+  });
+
+  it("routes document-only artifacts away from Apple compiler diagnostics", () => {
+    const report = runCloudCheck({
+      fileName: "sprint-2026-04-20.html",
+      source: `
+<!doctype html>
+<html>
+  <body>
+    <h1>North Star Sprint</h1>
+    <p>Phase one continuity checklist.</p>
+  </body>
+</html>
+`,
+    });
+
+    expect(report.status).toBe("needs_review");
+    expect(report.surface).toBe("document");
+    expect(report.diagnostics.map((d) => d.code)).toContain("AXCLOUD-NON-APPLE-ARTIFACT");
+    expect(report.diagnostics.map((d) => d.code)).not.toContain("AX001");
+    expect(report.gate.decision).toBe("evidence_required");
+    expect(report.nextSteps.join("\n")).toContain("browser/render");
+    expect(report.repairPrompt).toContain("document or web artifact");
+    expect(report.repairPlan.map((step) => step.title)).toContain(
+      "Use the right proof surface"
+    );
+    expect(report.coverage).toContainEqual(
+      expect.objectContaining({
+        label: "Swift validator rule engine",
+        state: "not_applicable",
+      })
+    );
+  });
+
   it("classifies app freeze runtime evidence and likely main-thread blockers", () => {
     const report = runCloudCheck({
       fileName: "SwarmApp.swift",
@@ -567,6 +679,70 @@ struct ProfileDataView: View {
     expect(report.diagnostics.map((d) => d.code)).toContain("AXCLOUD-RUNTIME-FREEZE");
     expect(report.diagnostics.map((d) => d.code)).toContain("AXCLOUD-RUNTIME-SYNC-IO");
     expect(report.repairPrompt).toContain("Synchronous I/O");
+  });
+
+  it("classifies SwiftUI state-transition hangs from main-thread busy UI-test evidence", () => {
+    const report = runCloudCheck({
+      fileName: "HomeFeedView.swift",
+      platform: "iOS",
+      source: `
+import SwiftUI
+
+struct HomeFeedView: View {
+    @State private var selectedFilter = "All"
+    let items: [FeedItem]
+
+    var filteredItems: [FeedItem] {
+        items
+            .filter { selectedFilter == "All" || $0.kind == selectedFilter }
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(pinnedViews: [.sectionHeaders]) {
+                Section {
+                    ForEach(filteredItems) { item in
+                        FeedCard(item: item)
+                            .transition(.opacity.combined(with: .scale))
+                    }
+                } header: {
+                    HStack {
+                        ForEach(["All", "Following", "Popular"], id: \\.self) { filter in
+                            Button(filter) {
+                                withAnimation(.spring(response: 0.45, dampingFraction: 0.74)) {
+                                    selectedFilter = filter
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .animation(.spring(response: 0.45, dampingFraction: 0.74), value: selectedFilter)
+        }
+    }
+}
+`,
+      testFailure:
+        "XCTAssert failed: after scrolling the Home feed and switching filters, the app main thread was busy for 30 seconds and the UI test timed out waiting for the application to idle.",
+      expectedBehavior:
+        "The Home feed filter should switch after the user scrolls and taps another segment.",
+      actualBehavior:
+        "After scrolling and switching filters, the app main thread was busy for 30 seconds.",
+    });
+
+    const codes = report.diagnostics.map((d) => d.code);
+
+    expect(report.status).toBe("fail");
+    expect(codes).toContain("AXCLOUD-RUNTIME-STATE-TRANSITION-HANG");
+    expect(report.repairPrompt).toContain("state-transition hang");
+    expect(report.repairPrompt).toContain("pinned headers");
+    expect(report.repairPrompt).toContain("filter/sort/list changes");
+    expect(report.repairPlan.map((step) => step.title).join("\n")).toContain(
+      "Trim SwiftUI transition work first"
+    );
+    expect(report.learningSignal?.signals).toContain("swiftui-state-transition-hang");
+    expect(report.learningSignal?.suggestedOwner).toBe("cloud");
   });
 
   it("classifies overlay hit-testing blockers when a compose box stops accepting input", () => {

--- a/tests/core/swift-validator.test.ts
+++ b/tests/core/swift-validator.test.ts
@@ -153,6 +153,67 @@ describe("swift validator — robustness", () => {
   });
 });
 
+describe("swift validator — SwiftUI compiler parity", () => {
+  it("flags some View helpers with local declarations but no explicit return", () => {
+    const source = `
+      import SwiftUI
+
+      struct DiscoverView: View {
+          var body: some View { projectLoadMoreFooter() }
+
+          private func projectLoadMoreFooter() -> some View {
+              let label = "Load more"
+              Button(label) { }
+          }
+      }
+    `;
+
+    const { diagnostics } = validate(source);
+    expect(diagnostics.map((d) => d.code)).toContain("AX767");
+  });
+
+  it("accepts some View helpers that explicitly return the final expression", () => {
+    const source = `
+      import SwiftUI
+
+      struct DiscoverView: View {
+          var body: some View { projectLoadMoreFooter() }
+
+          private func projectLoadMoreFooter() -> some View {
+              let label = "Load more"
+              return Button(label) { }
+          }
+      }
+    `;
+
+    expect(validate(source).diagnostics.map((d) => d.code)).not.toContain("AX767");
+  });
+
+  it("flags nested SwiftUI views that reference parent-only helpers", () => {
+    const source = `
+      import SwiftUI
+
+      struct ProjectRoomContentView: View {
+          private var isAxintProject: Bool { true }
+          var body: some View { ProjectIntelligenceView() }
+      }
+
+      struct ProjectIntelligenceView: View {
+          var body: some View {
+              if isAxintProject {
+                  Text("Axint")
+              } else {
+                  Text("Project")
+              }
+          }
+      }
+    `;
+
+    const diagnostic = validate(source).diagnostics.find((d) => d.code === "AX739");
+    expect(diagnostic?.message).toContain("isAxintProject");
+  });
+});
+
 // ─── New rules: AX704 AppIntent title ─────────────────────────────
 
 describe("swift validator — AX704 AppIntent.title", () => {
@@ -999,6 +1060,64 @@ describe("swift validator — AX765 SwiftUI frame overload parity", () => {
     `;
 
     expect(validate(source).diagnostics.filter((d) => d.code === "AX765")).toHaveLength(
+      0
+    );
+  });
+});
+
+describe("swift validator — AX766 type-erased SwiftUI modifier chains", () => {
+  it("warns when a project-specific modifier follows Label labelStyle", () => {
+    const source = `
+      import SwiftUI
+
+      struct NewChatButton: View {
+          var body: some View {
+              Label("New Chat", systemImage: "plus")
+                  .labelStyle(.iconOnly)
+                  .swarmIcon(size: 18)
+          }
+      }
+    `;
+
+    const diagnostic = validate(source).diagnostics.find((d) => d.code === "AX766");
+    expect(diagnostic?.message).toContain("swarmIcon");
+    expect(diagnostic?.message).toContain("labelStyle");
+    expect(diagnostic?.suggestion).toContain("Move the project-specific modifier");
+  });
+
+  it("accepts the project-specific modifier before the type-erasing modifier", () => {
+    const source = `
+      import SwiftUI
+
+      struct NewChatButton: View {
+          var body: some View {
+              Label("New Chat", systemImage: "plus")
+                  .swarmIcon(size: 18)
+                  .labelStyle(.iconOnly)
+          }
+      }
+    `;
+
+    expect(validate(source).diagnostics.filter((d) => d.code === "AX766")).toHaveLength(
+      0
+    );
+  });
+
+  it("accepts known SwiftUI modifiers after labelStyle", () => {
+    const source = `
+      import SwiftUI
+
+      struct NewChatButton: View {
+          var body: some View {
+              Label("New Chat", systemImage: "plus")
+                  .labelStyle(.iconOnly)
+                  .font(.headline)
+                  .accessibilityIdentifier("new-chat")
+          }
+      }
+    `;
+
+    expect(validate(source).diagnostics.filter((d) => d.code === "AX766")).toHaveLength(
       0
     );
   });

--- a/tests/mcp/feature.test.ts
+++ b/tests/mcp/feature.test.ts
@@ -1009,6 +1009,26 @@ describe("axint.suggest", () => {
     );
   });
 
+  it("refuses existing-app UI generation when the requested token namespace is not in context", () => {
+    const result = generateFeature({
+      name: "ShareComposerView",
+      surfaces: ["view"],
+      platform: "macOS",
+      tokenNamespace: "Swarm",
+      description:
+        "Build an existing-product ShareComposer surface that reuses the real SWARM design system.",
+      context: [
+        "enum SwarmDesignTokens { enum Colors { static let accent = Color.orange } }",
+        "struct SharePayload { let title: String }",
+      ].join("\n"),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.files).toHaveLength(0);
+    expect(result.diagnostics.join("\n")).toContain("AX855");
+    expect(result.summary).toContain("Generation quality gate stopped output");
+  });
+
   it("includes description cues in suggestion rationales", () => {
     const suggestions = suggestFeatures({
       appDescription:

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -84,6 +84,7 @@ describe("axint.run tool", () => {
 
     const result = await handleToolCall("axint.run", {
       cwd: dir,
+      agent: "codex",
       dryRun: true,
       format: "json",
     });
@@ -93,10 +94,17 @@ describe("axint.run tool", () => {
       id: string;
       status: string;
       session: { token: string };
+      agent: { agent: string; label: string };
+      agentAdvice: { status: string; moves: Array<{ title: string }> };
       commands: { build: { dryRun: boolean } };
       cloudChecks: unknown[];
     };
     expect(payload.session.token).toMatch(/^axsess_/);
+    expect(payload.agent.agent).toBe("codex");
+    expect(payload.agent.label).toBe("Codex");
+    expect(payload.agentAdvice.moves.map((move) => move.title).join("\n")).toContain(
+      "Install the shared Axint project brain"
+    );
     expect(payload.commands.build.dryRun).toBe(true);
     expect(payload.cloudChecks.length).toBe(1);
 
@@ -264,6 +272,77 @@ describe("axint.repair tool", () => {
     });
     expect(latest.isError).not.toBe(true);
     expect(latest.content[0].text).toContain("swiftui-input-interaction");
+  });
+});
+
+describe("axint.agent tools", () => {
+  it("installs the local brain, returns advice, and blocks conflicting claims", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-mcp-agent-"));
+    writeFileSync(
+      join(dir, "HomeFeedView.swift"),
+      [
+        "import SwiftUI",
+        "",
+        "struct HomeFeedView: View {",
+        '    @State private var draft = ""',
+        "    var body: some View {",
+        "        TextEditor(text: $draft)",
+        '            .overlay { Text("Write a comment") }',
+        "    }",
+        "}",
+        "",
+      ].join("\n")
+    );
+
+    const install = await handleToolCall("axint.agent.install", {
+      cwd: dir,
+      projectName: "Demo",
+      agent: "codex",
+      format: "json",
+    });
+    expect(install.isError).not.toBe(true);
+    const installPayload = JSON.parse(install.content[0].text) as {
+      status: string;
+      config: { privacy: { sourceSharing: string } };
+    };
+    expect(installPayload.status).toBe("installed");
+    expect(installPayload.config.privacy.sourceSharing).toBe("never_by_default");
+
+    const claim = await handleToolCall("axint.agent.claim", {
+      cwd: dir,
+      agent: "claude",
+      task: "Repair composer focus",
+      files: ["HomeFeedView.swift"],
+      format: "json",
+    });
+    expect(claim.isError).not.toBe(true);
+
+    const advice = await handleToolCall("axint.agent.advice", {
+      cwd: dir,
+      agent: "codex",
+      changedFiles: ["HomeFeedView.swift"],
+      issue: "The composer is visible but cannot be typed into.",
+      format: "json",
+    });
+    expect(advice.isError).toBe(true);
+    const advicePayload = JSON.parse(advice.content[0].text) as {
+      status: string;
+      conflictingClaims: Array<{ agent: string }>;
+      moves: Array<{ title: string }>;
+    };
+    expect(advicePayload.status).toBe("blocked");
+    expect(advicePayload.conflictingClaims[0]?.agent).toBe("claude");
+    expect(advicePayload.moves[0]?.title).toBe(
+      "Resolve active file claim before editing"
+    );
+
+    const release = await handleToolCall("axint.agent.release", {
+      cwd: dir,
+      agent: "claude",
+      files: ["HomeFeedView.swift"],
+      format: "json",
+    });
+    expect(release.isError).not.toBe(true);
   });
 });
 

--- a/tests/mcp/workflow-check.test.ts
+++ b/tests/mcp/workflow-check.test.ts
@@ -232,6 +232,42 @@ describe("axint.workflow.check", () => {
     expect(report.recommended.join("\n")).toContain("small patch edit");
   });
 
+  it("allows axint.repair to satisfy planning for existing SwiftUI repair", () => {
+    const report = runWorkflowCheck({
+      ...sessionArgs(),
+      agent: "codex",
+      stage: "planning",
+      surfaces: ["view"],
+      ranSuggest: false,
+      ranRepair: true,
+      modifiedFiles: ["HomeComposerView.swift"],
+      notes: "Existing SwiftUI compose-box repair from failing UI evidence.",
+    });
+
+    expect(report.status).toBe("ready");
+    expect(report.required).toEqual([]);
+    expect(report.checked.join("\n")).toContain("axint.repair");
+    expect(report.nextTool).toBe("apply_patch, then axint.swift.validate");
+  });
+
+  it("bypasses Apple compiler gates for document-only artifacts", () => {
+    const report = runWorkflowCheck({
+      ...sessionArgs(),
+      agent: "codex",
+      stage: "pre-build",
+      modifiedFiles: ["sprint-2026-04-20.html"],
+      ranSuggest: false,
+      ranCloudCheck: false,
+      notes: "Document-only HTML sprint artifact.",
+    });
+
+    expect(report.status).toBe("ready");
+    expect(report.required).toEqual([]);
+    expect(report.checked.join("\n")).toContain("Document/web artifact mode");
+    expect(report.recommended.join("\n")).toContain("rendered HTML/Markdown");
+    expect(report.nextTool).toContain("rendered artifact verification");
+  });
+
   it("does not send Codex to Xcode finish guard after tests pass", () => {
     const report = runWorkflowCheck({
       ...sessionArgs(),
@@ -280,5 +316,20 @@ describe("axint.workflow.check", () => {
     expect(report.nextTool).not.toBe("axint.feature");
     expect(report.nextTool).toContain("axint.suggest");
     expect(report.recommended.join("\n")).toContain("axint.feature is not available");
+  });
+
+  it("uses CLI suggest or repair fallback when MCP suggest is unavailable", () => {
+    const report = runWorkflowCheck({
+      ...sessionArgs(),
+      stage: "planning",
+      surfaces: ["view"],
+      ranSuggest: false,
+      availableTools: ["axint.workflow.check", "axint.swift.validate"],
+    });
+
+    expect(report.status).toBe("needs_action");
+    expect(report.nextTool).toContain("axint suggest <app-description>");
+    expect(report.nextTool).toContain("axint.repair");
+    expect(report.recommended.join("\n")).toContain("axint.suggest is not available");
   });
 });

--- a/tests/project/local-agent.test.ts
+++ b/tests/project/local-agent.test.ts
@@ -1,0 +1,177 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildAxintAgentAdvice,
+  claimAxintAgentFiles,
+  installAxintLocalAgent,
+  releaseAxintAgentClaims,
+  renderAxintAgentAdviceReport,
+} from "../../src/project/local-agent.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+
+function tempProject(): string {
+  const dir = join(tmpdir(), `axint-local-agent-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeSwiftFixture(dir: string): void {
+  mkdirSync(join(dir, "Demo.xcodeproj", "xcshareddata", "xcschemes"), {
+    recursive: true,
+  });
+  writeFileSync(
+    join(dir, "Demo.xcodeproj", "xcshareddata", "xcschemes", "Demo.xcscheme"),
+    "<Scheme></Scheme>\n"
+  );
+  writeFileSync(
+    join(dir, "HomeFeedView.swift"),
+    [
+      "import SwiftUI",
+      "",
+      "struct HomeFeedView: View {",
+      '    @State private var draft = ""',
+      "    var body: some View {",
+      "        ScrollView {",
+      "            TextEditor(text: $draft)",
+      '                .accessibilityIdentifier("home-composer")',
+      '                .overlay { Text("Write a comment") }',
+      "        }",
+      "    }",
+      "}",
+      "",
+    ].join("\n")
+  );
+}
+
+describe("local Axint agent brain", () => {
+  it("installs a project-scoped multi-agent brain with privacy-first defaults", () => {
+    const dir = tempProject();
+    writeSwiftFixture(dir);
+
+    const report = installAxintLocalAgent({
+      cwd: dir,
+      projectName: "Demo",
+      agent: "codex",
+    });
+
+    expect(report.status).toBe("installed");
+    expect(report.config.privacy.mode).toBe("local_only");
+    expect(report.config.privacy.sourceSharing).toBe("never_by_default");
+    expect(report.config.provider.mode).toBe("none");
+    expect(report.config.permissions.deny).toContain("read_secrets");
+    expect(report.config.permissions.deny).toContain("destructive_git");
+    expect(report.config.lanes.codex.editingMode).toBe("patch-first");
+    expect(report.config.lanes.xcode.editingMode).toBe("xcode-guarded");
+    expect(existsSync(join(dir, ".axint/agent.json"))).toBe(true);
+    expect(existsSync(join(dir, ".axint/context/latest.json"))).toBe(true);
+    expect(existsSync(join(dir, ".axint/coordination/claims.json"))).toBe(true);
+    expect(existsSync(join(dir, ".axint/coordination/ledger.json"))).toBe(true);
+    expect(readFileSync(join(dir, ".axint/context/latest.md"), "utf-8")).toContain(
+      "HomeFeedView.swift"
+    );
+  });
+
+  it("returns host-specific next moves from context, repair, and failed proof", () => {
+    const dir = tempProject();
+    writeSwiftFixture(dir);
+    installAxintLocalAgent({ cwd: dir, projectName: "Demo", agent: "codex" });
+    mkdirSync(join(dir, ".axint/run"), { recursive: true });
+    writeFileSync(
+      join(dir, ".axint/run/latest.json"),
+      JSON.stringify(
+        {
+          id: "axrun_failed",
+          status: "fail",
+          gate: { decision: "fix_required" },
+          steps: [
+            {
+              name: "Xcode test",
+              status: "fail",
+              detail: "HomeFeedUITests/testComposerFocus failed.",
+            },
+          ],
+          nextSteps: ["Repair composer focus, then rerun focused UI test."],
+        },
+        null,
+        2
+      )
+    );
+
+    const report = buildAxintAgentAdvice({
+      cwd: dir,
+      issue: "The Home composer is visible but cannot be typed into.",
+      agent: "codex",
+      changedFiles: ["HomeFeedView.swift"],
+    });
+
+    expect(report.status).toBe("ready");
+    expect(report.profile.agent).toBe("codex");
+    expect(report.latestProof?.status).toBe("fail");
+    expect(report.warnings.join("\n")).toContain("Freshest Axint run failed");
+    expect(report.moves.map((move) => move.title)).toContain(
+      "Claim changed files before patching"
+    );
+    expect(report.moves.map((move) => move.title)).toContain(
+      "Repair the failed proof first"
+    );
+    expect(report.moves.map((move) => move.title)).toContain("Use the correct host lane");
+    expect(renderAxintAgentAdviceReport(report, "prompt")).toContain(
+      "Axint agent advice for Codex"
+    );
+  });
+
+  it("blocks conflicting file claims across agent lanes", () => {
+    const dir = tempProject();
+    writeSwiftFixture(dir);
+    installAxintLocalAgent({ cwd: dir, projectName: "Demo", agent: "claude" });
+
+    const claim = claimAxintAgentFiles({
+      cwd: dir,
+      agent: "claude",
+      task: "Repair composer focus",
+      files: ["HomeFeedView.swift"],
+      ttlMinutes: 30,
+    });
+    expect(claim.status).toBe("claimed");
+
+    const blockedClaim = claimAxintAgentFiles({
+      cwd: dir,
+      agent: "codex",
+      task: "Refactor home feed",
+      files: ["HomeFeedView.swift"],
+    });
+    expect(blockedClaim.status).toBe("blocked");
+    expect(blockedClaim.conflicts[0]?.agent).toBe("claude");
+
+    const advice = buildAxintAgentAdvice({
+      cwd: dir,
+      agent: "codex",
+      changedFiles: ["HomeFeedView.swift"],
+    });
+    expect(advice.status).toBe("blocked");
+    expect(advice.warnings.join("\n")).toContain("claude already claimed");
+
+    const release = releaseAxintAgentClaims({
+      cwd: dir,
+      agent: "claude",
+      files: ["HomeFeedView.swift"],
+    });
+    expect(release.status).toBe("released");
+
+    const afterRelease = buildAxintAgentAdvice({
+      cwd: dir,
+      agent: "codex",
+      changedFiles: ["HomeFeedView.swift"],
+    });
+    expect(afterRelease.status).toBe("ready");
+  });
+});

--- a/tests/project/memory-index.test.ts
+++ b/tests/project/memory-index.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  renderProjectMemoryIndex,
+  writeProjectMemoryIndex,
+} from "../../src/project/memory-index.js";
+
+describe("project memory index", () => {
+  it("summarizes context, latest proof, repair, and source-free learning packets", () => {
+    const dir = mkdtempSync(join(tmpdir(), "axint-memory-"));
+    try {
+      mkdirSync(join(dir, "Sources"), { recursive: true });
+      mkdirSync(join(dir, ".axint/run"), { recursive: true });
+      mkdirSync(join(dir, ".axint/repair"), { recursive: true });
+      mkdirSync(join(dir, ".axint/feedback"), { recursive: true });
+      writeFileSync(
+        join(dir, "Sources/HomeView.swift"),
+        [
+          "import SwiftUI",
+          "struct HomeView: View {",
+          '  @State private var draft = ""',
+          "  var body: some View {",
+          '    TextField("Post", text: $draft).overlay { Text("placeholder") }',
+          "  }",
+          "}",
+          "",
+        ].join("\n")
+      );
+      writeFileSync(
+        join(dir, ".axint/run/latest.json"),
+        JSON.stringify({
+          id: "axrun_demo",
+          status: "fail",
+          gate: { decision: "fix_required" },
+          xcodeTestFailures: [
+            {
+              testName: "testComposerIsHittable",
+              message: "composer-input should be hittable",
+              file: "SwarmUITests.swift",
+              line: 42,
+              repairHint: "Check overlays.",
+            },
+          ],
+          nextSteps: ["Patch overlay hit testing"],
+        })
+      );
+      writeFileSync(
+        join(dir, ".axint/repair/latest.json"),
+        JSON.stringify({
+          status: "fix_required",
+          issueClass: "swiftui-input-interaction",
+          filesToInspect: ["Sources/HomeView.swift"],
+          proofCommands: ["xcodebuild test"],
+        })
+      );
+      writeFileSync(
+        join(dir, ".axint/feedback/learn-demo.json"),
+        JSON.stringify({
+          fingerprint: "learn-demo",
+          priority: "p1",
+          suggestedOwner: "cloud",
+          title: "UI interaction evidence",
+          diagnosticCodes: ["AXCLOUD-UI-HIT-TEST-BLOCKER"],
+          redaction: "source_not_included",
+        })
+      );
+
+      const result = writeProjectMemoryIndex({ cwd: dir, projectName: "MemoryDemo" });
+      const markdown = renderProjectMemoryIndex(result.index);
+
+      expect(result.written).toContain(".axint/memory/latest.json");
+      expect(result.index.latestRun?.failedTests[0]?.testName).toBe(
+        "testComposerIsHittable"
+      );
+      expect(result.index.latestRepair?.issueClass).toBe("swiftui-input-interaction");
+      expect(result.index.learningPackets[0]?.redaction).toBe("source_not_included");
+      expect(markdown).toContain("Privacy-Safe Learning Packets");
+      expect(markdown).toContain("AXCLOUD-UI-HIT-TEST-BLOCKER");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/repair/project-repair.test.ts
+++ b/tests/repair/project-repair.test.ts
@@ -101,6 +101,7 @@ describe("project repair", () => {
     expect(report.filesToInspect.map((file) => file.path)).toContain("FeedScreen.swift");
     expect(report.agent.agent).toBe("codex");
     expect(report.repairPrompt).toContain("Senior Apple repair read");
+    expect(report.repairPrompt.match(/Likely root causes:/g)).toHaveLength(1);
     expect(report.repairPrompt).toContain("Do not claim the bug is fixed");
     expect(report.feedbackPacket.privacy.redaction).toBe("source_not_included");
     expect(JSON.stringify(report.feedbackPacket)).not.toContain("TextEditor(text");

--- a/tests/run/project-runner.test.ts
+++ b/tests/run/project-runner.test.ts
@@ -32,11 +32,15 @@ describe("runAxintProject", () => {
     const report = await runAxintProject({
       cwd: dir,
       expectedVersion: "0.0.0-test",
+      agent: "codex",
       dryRun: true,
       writeReport: true,
     });
 
     expect(report.session.token).toMatch(/^axsess_/);
+    expect(report.agent.agent).toBe("codex");
+    expect(report.agentAdvice?.status).toBe("needs_setup");
+    expect(report.repairPrompt).toContain("Host/tool lane: Codex");
     expect(report.workflow.status).toBe("ready");
     expect(report.swiftValidation.filesChecked).toBe(1);
     expect(report.cloudChecks).toHaveLength(1);
@@ -67,6 +71,7 @@ describe("runAxintProject", () => {
     const dir = makeFakeXcodeProject();
     const report = await runAxintProject({
       cwd: dir,
+      agent: "cursor",
       dryRun: true,
       runtime: true,
       writeReport: false,
@@ -74,6 +79,8 @@ describe("runAxintProject", () => {
 
     const prompt = renderAxintRunReport(report, "prompt");
     expect(prompt).toContain("You are repairing an Apple-native project");
+    expect(prompt).toContain("Host/tool lane: Cursor");
+    expect(prompt).toContain("Agent brain:");
     expect(prompt).toContain("After repairing, rerun `axint run`");
   });
 
@@ -284,6 +291,158 @@ describe("runAxintProject", () => {
         );
         expect(evidenceSummary).toContain("TEST SUCCEEDED");
       }
+    } finally {
+      process.env.PATH = previousPath;
+    }
+  });
+
+  it("extracts failing Xcode test details into the run report and Cloud Check", async () => {
+    const dir = makeFakeXcodeProject();
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const xcodebuild = join(binDir, "xcodebuild");
+    writeFileSync(
+      xcodebuild,
+      [
+        "#!/bin/sh",
+        'original="$*"',
+        'bundle=""',
+        'while [ "$#" -gt 0 ]; do',
+        '  if [ "$1" = "-resultBundlePath" ]; then',
+        "    shift",
+        '    bundle="$1"',
+        "  fi",
+        "  shift",
+        "done",
+        '[ -n "$bundle" ] && mkdir -p "$bundle"',
+        'if echo " $original " | grep -q " test "; then',
+        "  echo \"Test Suite 'SwarmUITests' started.\"",
+        "  echo \"Test Case '-[SwarmUITests testBuilderProfileOpensWithStableActionControls]' started.\"",
+        '  echo "$PWD/SwarmUITests/SwarmUITests.swift:793: error: -[SwarmUITests testBuilderProfileOpensWithStableActionControls] : XCTAssertTrue failed - builder-profile-scroll should exist"',
+        "  echo \"Test Case '-[SwarmUITests testBuilderProfileOpensWithStableActionControls]' failed (3.31 seconds).\"",
+        '  echo "** TEST FAILED **"',
+        '  echo "Executed 1 test, with 1 failure"',
+        "  exit 65",
+        "else",
+        '  echo "** BUILD SUCCEEDED **"',
+        "  exit 0",
+        "fi",
+        "",
+      ].join("\n")
+    );
+    chmodSync(xcodebuild, 0o755);
+    const xcrun = join(binDir, "xcrun");
+    writeFileSync(
+      xcrun,
+      [
+        "#!/bin/sh",
+        "cat <<JSON",
+        '{"testFailureSummaries":[{"message":{"_value":"XCTAssertTrue failed - builder-profile-scroll should exist"},"documentLocationInCreatingWorkspace":{"url":{"_value":"file://$PWD/SwarmUITests/SwarmUITests.swift#StartingLineNumber=793&EndingLineNumber=793"}},"testName":{"_value":"testBuilderProfileOpensWithStableActionControls"},"suiteName":{"_value":"SwarmUITests"}}]}',
+        "JSON",
+        "",
+      ].join("\n")
+    );
+    chmodSync(xcrun, 0o755);
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    try {
+      const report = await runAxintProject({
+        cwd: dir,
+        writeReport: false,
+        onlyTesting: [
+          "SwarmUITests/SwarmUITests/testBuilderProfileOpensWithStableActionControls",
+        ],
+        expectedBehavior: "Builder profile action controls should exist and be hittable.",
+        actualBehavior: "Axint should extract the exact failing XCTest assertion.",
+      });
+      const rendered = renderAxintRunReport(report);
+      const cloudCodes = report.cloudChecks.flatMap((check) =>
+        check.diagnostics.map((diagnostic) => diagnostic.code)
+      );
+
+      expect(report.status).toBe("fail");
+      expect(report.xcodeTestFailures).toHaveLength(1);
+      expect(report.xcodeTestFailures[0]).toMatchObject({
+        testName: "testBuilderProfileOpensWithStableActionControls",
+        line: 793,
+        identifier: "builder-profile-scroll",
+        likelyArea: "Builder or creator profile interaction surface",
+        likelyCause:
+          "The UI element is missing from the accessibility tree or has a stale identifier/query.",
+        repairHint:
+          "Verify the accessibilityIdentifier, conditional rendering path, navigation state, and test launch setup.",
+        source: "xcresult",
+      });
+      expect(report.xcodeTestFailures[0]?.file).toMatch(
+        /SwarmUITests\/SwarmUITests\.swift$/
+      );
+      expect(report.xcodeTestFailures[0]?.message).toContain(
+        "builder-profile-scroll should exist"
+      );
+      expect(report.nextSteps.join("\n")).toContain(
+        "testBuilderProfileOpensWithStableActionControls"
+      );
+      expect(report.repairPrompt).toContain("Xcode test failures");
+      expect(report.repairPrompt).toContain("builder-profile-scroll should exist");
+      expect(report.repairPrompt).toContain("Verify the accessibilityIdentifier");
+      expect(rendered).toContain("## Xcode Test Failures");
+      expect(rendered).toContain("SwarmUITests.swift:793");
+      expect(rendered).toContain("builder-profile-scroll should exist");
+      expect(cloudCodes).toContain("AXCLOUD-XCTEST-FAILURE");
+      expect(cloudCodes).toContain("AXCLOUD-UI-TEST-ELEMENT");
+    } finally {
+      process.env.PATH = previousPath;
+    }
+  });
+
+  it("classifies not-hittable UI failures as interaction-blocking repairs", async () => {
+    const dir = makeFakeXcodeProject();
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const xcodebuild = join(binDir, "xcodebuild");
+    writeFileSync(
+      xcodebuild,
+      [
+        "#!/bin/sh",
+        'if echo " $* " | grep -q " test "; then',
+        "  echo \"Test Suite 'ComposerBlockerUITests' started.\"",
+        "  echo \"Test Case '-[ComposerBlockerUITests testComposerTextFieldAcceptsInput]' started.\"",
+        '  echo "$PWD/ComposerBlockerUITests.swift:9: error: -[ComposerBlockerUITests testComposerTextFieldAcceptsInput] : XCTAssertTrue failed - composer-input should be hittable"',
+        "  echo \"Test Case '-[ComposerBlockerUITests testComposerTextFieldAcceptsInput]' failed (2.41 seconds).\"",
+        '  echo "** TEST FAILED **"',
+        "  exit 65",
+        "else",
+        '  echo "** BUILD SUCCEEDED **"',
+        "  exit 0",
+        "fi",
+        "",
+      ].join("\n")
+    );
+    chmodSync(xcodebuild, 0o755);
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    try {
+      const report = await runAxintProject({
+        cwd: dir,
+        agent: "codex",
+        writeReport: false,
+        onlyTesting: [
+          "ComposerBlockerUITests/ComposerBlockerUITests/testComposerTextFieldAcceptsInput",
+        ],
+      });
+
+      expect(report.xcodeTestFailures[0]).toMatchObject({
+        testName: "testComposerTextFieldAcceptsInput",
+        identifier: "composer-input",
+        likelyCause:
+          "The control exists, but another layer, disabled state, hit-testing override, transition, or offscreen layout is preventing interaction.",
+      });
+      expect(report.xcodeTestFailures[0]?.repairHint).toContain(
+        "ZStack/overlay/contentShape"
+      );
+      expect(report.repairPrompt).toContain("ZStack/overlay/contentShape");
     } finally {
       process.env.PATH = previousPath;
     }

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.13";
+const VERSION = "0.4.14";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary
- release Axint 0.4.14 with the dogfooding-driven repair loop upgrades
- add local project memory indexing, agent advice, run aliases, feedback signals, and stricter Cloud/SwiftUI proof handling
- sync diagnostics, metrics, README, release notes, server metadata, Python package version, and extension versions

## Validation
- npm run versions:check
- npm run metrics:check
- npm run docs:check
- npm run typecheck
- npm run lint
- npm run typecheck:examples
- npm run boundary:check
- npm test
- python3 -m pytest -q
- npm publish @axint/compiler@0.4.14 completed
- PyPI axint 0.4.14 completed
