### PR TITLE
Release Axint 0.4.15 runner recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+## [0.4.15] — 2026-04-29
+
+### Added
+
+- **`axint mcp recover`** — prints a same-thread recovery packet when an MCP client hits `Transport closed`, including version proof, project path, context-recovery commands, and the CLI fallback run loop.
+- **Xcode runner-health classification** — `axint run` now separates UI automation startup failures and hosted macOS test-runner hangs from real app assertion failures.
+- **`AX768` same-target Swift member validation** — when changed Swift files include a declaring type and a consumer, Axint warns on direct member mistakes such as `profile.detail` when the known type does not expose that member.
+- **Public page DSL manifest support** — `.axint` language files can now parse, lower, and print safe `page` / `module` declarations for host-rendered public project/profile surfaces.
+
+### Changed
+
+- **Cloud Check pending-proof handling** now downgrades build-only evidence when behavior text says UI/runtime proof is still pending, so agents cannot claim runtime fixes from prose alone.
+- **Focused test timeout guidance** now respects existing `--only-testing` selectors and tells agents to clean up/retry runner infrastructure instead of asking for another focused test when no assertion executed.
+
 ## [0.4.10] — 2026-04-27
 
 ### Added
@@ -309,7 +323,8 @@ The "it's a real compiler now" release. Everything the v0.1.x vision pointed at,
 - tsup for builds with separate CLI/MCP/library entry points
 - Vitest with snapshot testing and V8 coverage
 
-[Unreleased]: https://github.com/agenticempire/axint/compare/v0.3.4...HEAD
+[Unreleased]: https://github.com/agenticempire/axint/compare/v0.4.15...HEAD
+[0.4.15]: https://github.com/agenticempire/axint/compare/v0.4.14...v0.4.15
 [0.3.4]: https://github.com/agenticempire/axint/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/agenticempire/axint/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/agenticempire/axint/compare/v0.3.0...v0.3.2

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.14 · 33 MCP tools + 5 prompts · 188 diagnostic codes · 1194 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.15 · 33 MCP tools + 5 prompts · 189 diagnostic codes · 1204 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -32,6 +32,11 @@ This release wave makes Axint feel more like a project brain for Apple-native ag
 - Direct Cloud Check no longer treats prose-only SwiftUI behavior notes as runtime proof. View/app checks stay at `evidence_required` until build, UI-test, runtime, or `axint run` evidence is supplied.
 - Swift validation adds `AX767` for non-`@ViewBuilder` `some View` helpers that declare locals but forget an explicit `return`.
 - Generation self-audit adds `AX855` so existing-app UI generation refuses to invent a requested project token namespace that is not present in the supplied context.
+- `axint mcp recover` gives agents a same-thread fallback packet when MCP transport closes, including version proof, context-recovery commands, and the next CLI run command.
+- `axint.run` now classifies Xcode runner-health failures separately from app failures, including UI automation startup failures and hosted macOS `--only-testing` timeouts before assertions.
+- Cloud Check downgrades pending UI/runtime proof instead of treating build-only evidence plus prose as ready to ship.
+- Swift validation adds `AX768` for same-target changed files that reference members not declared on the known type.
+- The `.axint` language now has safe public-page manifest plumbing for `page` and `module` declarations, so future registry/profile surfaces can be rendered by a host without accepting arbitrary web code.
 
 ### Why it matters
 

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axint",
-  "version": "0.3.9",
+  "version": "0.4.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axint",
-      "version": "0.3.9",
+      "version": "0.4.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/vscode": "^1.102.0",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.14",
+  "version": "0.4.15",
   "mcpTools": 33,
   "mcpToolNames": [
     "axint.status",
@@ -45,7 +45,7 @@
     "axint.create-intent"
   ],
   "bundledTemplates": 26,
-  "diagnostics": 188,
+  "diagnostics": 189,
   "xcodeFixRules": 33,
   "xcodeFixRuleCodes": [
     "AX701",
@@ -83,7 +83,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1080,
+    "typescript": 1090,
     "python": 114
   },
   "registryPackages": 14,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.14"
+__version__ = "0.4.15"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.14"
+version = "0.4.15"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "transport": {
         "type": "stdio"
       }
@@ -28,7 +28,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "transport": {
         "type": "stdio"
       }

--- a/spec/language/grammar.md
+++ b/spec/language/grammar.md
@@ -33,7 +33,7 @@ Conventions (enforced by validator, not by grammar):
 Reserved words — cannot be used as identifiers:
 
 ```
-intent  entity  enum  param  property  summary  display  query
+intent  entity  enum  page  module  param  property  summary  display  query
 title   description  domain  category  default  options  dynamic
 case    default  when    then  otherwise  switch
 string  int  double  float  boolean  date  duration  url
@@ -79,7 +79,8 @@ file = { top-level-decl } .
 
 top-level-decl = enum-decl
                | entity-decl
-               | intent-decl .
+               | intent-decl
+               | page-decl .
 ```
 
 A file may contain zero or more top-level declarations in any order, except that an entity referenced by an intent must be declared in the same file (v1 is single-file). Convention: entities first, then intents.
@@ -159,6 +160,53 @@ entity Trail {
   query: property
 }
 ```
+
+### Public page declaration
+
+```
+page-decl        = "page" identifier "{" page-body "}" .
+page-body        = { page-field | page-module } .
+page-field       = identifier ":" page-value .
+page-module      = "module" identifier string-literal "{" { page-field } "}" .
+page-value       = string-literal
+                 | number-literal
+                 | boolean-literal
+                 | identifier .
+```
+
+`page` declares a safe, front-facing project/profile lander manifest. It does **not** accept arbitrary HTML, JavaScript, tracking pixels, or external code. A host app renders the declared modules inside its own sandbox and can reject modules by permission, domain, or scanner policy.
+
+The top-level fields are intentionally open-ended so a project can evolve its brand surface without forcing a compiler release for every design option. Common fields are:
+
+| Field     | Meaning                                                        |
+|-----------|----------------------------------------------------------------|
+| `title`   | Primary public-facing name.                                    |
+| `tagline` | One-line positioning statement.                                |
+| `theme`   | Host-defined theme token, e.g. `"black-cream"`.                |
+
+Modules use a stable identifier plus a human-facing title:
+
+```
+page AxintLander {
+  title: "Axint"
+  tagline: "Compiler-native project pages"
+  theme: "black-cream"
+
+  module emailCapture "Join the build" {
+    kind: emailCapture
+    permission: collectEmail
+    privacy: "Used only for Axint updates."
+  }
+
+  module shareCard "Launch card" {
+    kind: shareCard
+    output: "1200x630 PNG"
+    source: uploadedArtwork
+  }
+}
+```
+
+Repeated fields are allowed and lower to arrays. The main intended repeated field is `permission`, which lets a host scanner gate modules such as email capture, outbound links, QR rendering, install CTAs, MCP/NPM shelves, or animated share-card generation before anything is rendered.
 
 ### Intent declaration
 

--- a/spec/language/keywords.md
+++ b/spec/language/keywords.md
@@ -9,6 +9,15 @@ Every reserved word in the language, with a one-line semantic.
 | `intent`   | Declares an App Intent. Compiles to an `AppIntent` struct.               |
 | `entity`   | Declares an App Entity. Compiles to an `AppEntity` struct + `EntityQuery`. |
 | `enum`     | Declares a closed enum. Compiles to a Swift `enum` conforming to `AppEnum`. |
+| `page`     | Declares a safe custom public project/profile lander manifest.           |
+| `module`   | Declares a host-rendered module inside a `page`.                         |
+
+## Public page keywords
+
+| Keyword  | Role                                                                                     |
+|----------|------------------------------------------------------------------------------------------|
+| `page`   | Opens a custom public page manifest. It lowers to host-rendered IR, not arbitrary HTML.  |
+| `module` | Opens a sandboxed page module with an id, title, and manifest fields.                    |
 
 ## Intent body keywords
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -39,6 +39,7 @@
  *   axint runner once             Execute one BYO-Mac runner Axint job
  *   axint mcp                     Start the MCP server (stdio)
  *   axint mcp status              Show local MCP launch command and reload steps
+ *   axint mcp recover             Print same-thread CLI fallback when MCP transport closes
  *   axint xcode install           Install the full Axint Xcode workflow in one pass
  *   axint xcode setup             Configure Axint for Xcode agentic coding
  *   axint xcode guard             Check/write the Axint Xcode drift guard
@@ -79,7 +80,7 @@ import { registerPublish } from "./publish.js";
 import { registerAdd } from "./add.js";
 import { registerSearch } from "./search.js";
 import { registerWatch } from "./watch.js";
-import { registerStatus, renderCliStatus } from "./status.js";
+import { registerStatus, renderCliStatus, renderMcpRecoveryPacket } from "./status.js";
 import { registerUpgrade } from "./upgrade.js";
 import { registerDoctor } from "./doctor.js";
 import { registerProject } from "./project.js";
@@ -310,6 +311,22 @@ mcp
   .option("--format <format>", "Output format: markdown, json, or prompt", "markdown")
   .action((options: { format?: "markdown" | "json" | "prompt" }) => {
     console.log(renderCliStatus(VERSION, options.format ?? "markdown"));
+  });
+
+mcp
+  .command("recover")
+  .description("Print a same-thread CLI recovery packet when MCP transport closes")
+  .option("--dir <dir>", "Project directory", ".")
+  .option("--agent <agent>", "Agent host lane, e.g. codex, claude, cursor, xcode", "all")
+  .option("--session-token <token>", "Existing Axint session token if one is known")
+  .action((options: { dir?: string; agent?: string; sessionToken?: string }) => {
+    console.log(
+      renderMcpRecoveryPacket(VERSION, {
+        dir: options.dir,
+        agent: options.agent,
+        sessionToken: options.sessionToken,
+      })
+    );
   });
 
 // ─── xcode ──────────────────────────────────────────────────────────

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -6,6 +6,12 @@ import { fileURLToPath } from "node:url";
 
 type StatusFormat = "markdown" | "json" | "prompt";
 
+export interface McpRecoveryPacketInput {
+  dir?: string;
+  agent?: string;
+  sessionToken?: string;
+}
+
 export function registerStatus(program: Command, version: string) {
   program
     .command("status")
@@ -93,6 +99,57 @@ export function renderCliStatus(
   ].join("\n");
 }
 
+export function renderMcpRecoveryPacket(
+  version: string,
+  input: McpRecoveryPacketInput = {}
+): string {
+  const cwd = resolve(input.dir ?? process.cwd());
+  const agent = input.agent ?? "<host>";
+  const sessionToken = input.sessionToken ?? "<session-token>";
+  const npxPath = which("npx") ?? "npx";
+  const statusCommand = `${npxPath} -y @axint/compiler@${version} axint status --format json`;
+  const sessionCommand = `${npxPath} -y @axint/compiler@${version} axint session start --dir ${quote(
+    cwd
+  )} --agent ${quote(agent)}`;
+  const workflowCommand = `${npxPath} -y @axint/compiler@${version} axint workflow check --dir ${quote(
+    cwd
+  )} --stage context-recovery --agent ${quote(agent)} --session-token ${quote(
+    sessionToken
+  )} --read-rehydration-context --read-agent-instructions --read-docs-context --ran-status`;
+  const runCommand = `${npxPath} -y @axint/compiler@${version} axint run --cwd ${quote(
+    cwd
+  )} --agent ${quote(agent)} --changed <files> --only-testing <focused-selector>`;
+
+  return [
+    "# Axint MCP Recovery Packet",
+    "",
+    `- Axint package: @axint/compiler@${version}`,
+    `- Project: ${cwd}`,
+    `- Agent lane: ${agent}`,
+    `- npx: ${npxPath}`,
+    "",
+    "Use this when a client says `Transport closed`, keeps showing stale MCP tools, or cannot reconnect inside the current chat.",
+    "",
+    "## Safe Same-Thread Fallback",
+    "",
+    "```sh",
+    statusCommand,
+    sessionCommand,
+    workflowCommand,
+    "```",
+    "",
+    "## Continue The Proof Loop",
+    "",
+    "```sh",
+    runCommand,
+    "```",
+    "",
+    "## Reload Hint",
+    "",
+    "Reload only the Axint MCP server/tool process when your client supports it. If the host cannot reconnect tools in-place, keep this packet in the thread and continue through the CLI fallback until a new tool session is available.",
+  ].join("\n");
+}
+
 function parseFormat(value: string | undefined): StatusFormat {
   if (value === "json" || value === "prompt" || value === "markdown") return value;
   return "markdown";
@@ -108,6 +165,11 @@ function which(binary: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function quote(value: string): string {
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 function findPackageJsonPath(): string {

--- a/src/cli/validate-swift.ts
+++ b/src/cli/validate-swift.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import { readFileSync, statSync, readdirSync } from "node:fs";
 import { resolve, join, extname } from "node:path";
-import { validateSwiftSource } from "../core/swift-validator.js";
+import { validateSwiftSources } from "../core/swift-validator.js";
 import type { Diagnostic } from "../core/types.js";
 import { getAxintLoginState } from "../core/credentials.js";
 import {
@@ -69,11 +69,14 @@ export function registerValidateSwift(program: Command) {
         const all: Diagnostic[] = [];
         const filesToScan = [...files].sort();
 
-        for (const file of filesToScan) {
-          const source = readFileSync(file, "utf-8");
-          const result = validateSwiftSource(source, file);
-          all.push(...result.diagnostics);
-        }
+        all.push(
+          ...validateSwiftSources(
+            filesToScan.map((file) => ({
+              file,
+              source: readFileSync(file, "utf-8"),
+            }))
+          ).flatMap((result) => result.diagnostics)
+        );
 
         const errors = all.filter((d) => d.severity === "error");
         let repairArtifacts:

--- a/src/cloud/check.ts
+++ b/src/cloud/check.ts
@@ -236,7 +236,8 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
   const warnings = diagnostics.filter((d) => d.severity === "warning").length;
   const infos = diagnostics.filter((d) => d.severity === "info").length;
   const runtimeCoverageRequired = requiresRuntimeCoverage(language, surface, swiftCode);
-  const runtimeEvidenceProvided = hasRuntimeEvidence(evidence);
+  const runtimeEvidenceProvided =
+    hasRuntimeEvidence(evidence) && !hasPendingRuntimeProofSignal(input);
   const status: CloudCheckStatus = nonAppleArtifact
     ? "needs_review"
     : errors > 0
@@ -721,6 +722,26 @@ function hasRuntimeEvidence(evidence: CloudCheckReport["evidence"]): boolean {
   );
 }
 
+function hasPendingRuntimeProofSignal(input: CloudCheckInput): boolean {
+  const text = normalizeTextForEvidence(
+    [input.expectedBehavior, input.actualBehavior, input.xcodeBuildLog, input.testFailure]
+      .filter(Boolean)
+      .join("\n")
+  );
+  if (!text) return false;
+  return (
+    /\b(?:runtime|ui|xcode|focused|test|proof|verification|smoke)\s+(?:is\s+)?(?:pending|will run|will rerun|needs to run|not run yet|still pending)\b/.test(
+      text
+    ) ||
+    /\b(?:will run|will rerun|run next|proof pending|verification pending|xcode proof pending|ui proof pending|runtime proof pending)\b/.test(
+      text
+    ) ||
+    /\bno\s+(?:xcode|runtime|ui|focused test|test)\s+(?:proof|evidence|log|screenshot)\s+(?:attached|provided|yet)\b/.test(
+      text
+    )
+  );
+}
+
 function inferEvidenceDiagnostics(input: {
   input: CloudCheckInput;
   source: string;
@@ -803,6 +824,11 @@ function inferEvidenceDiagnostics(input: {
     behaviorEvidenceContradictsExpectation(
       input.input.expectedBehavior,
       input.input.actualBehavior
+    ) &&
+    diagnostics.every(
+      (d) =>
+        d.code !== "AXCLOUD-XCTEST-AUTOMATION-INFRASTRUCTURE" &&
+        d.code !== "AXCLOUD-XCTEST-RUNNER-HANG"
     ) &&
     !(
       passingXcodeProof &&
@@ -1020,6 +1046,40 @@ function diagnosticsFromBuildLog(buildLog: string, file: string): Diagnostic[] {
       message: "Xcode build evidence reports a duplicate or redeclared symbol.",
       suggestion:
         "Remove the duplicate declaration instead of adding a second fixed declaration. This usually means a generator or fixer inserted beside the original line.",
+    });
+  }
+
+  if (
+    /\btimed out while enabling automation mode\b/.test(text) ||
+    /\btest runner failed to initialize for ui testing\b/.test(text) ||
+    /\bfailed to initialize\b.{0,80}\bui testing\b/.test(text)
+  ) {
+    diagnostics.push({
+      code: "AXCLOUD-XCTEST-AUTOMATION-INFRASTRUCTURE",
+      severity: "error",
+      file,
+      message:
+        "Xcode UI automation failed before the UI test reached the app, so this is runner infrastructure evidence, not an app assertion failure.",
+      suggestion:
+        "Kill stale app/test-runner processes, retry the same focused UI test once, and report UI proof as blocked by XCTest infrastructure if the automation startup error repeats.",
+    });
+  }
+
+  if (
+    /\bcommand timed out after \d+s\b/.test(text) &&
+    /\b(?:focused xcode test proof failed|xcode test failed|test failed|sending sigterm)\b/.test(
+      text
+    ) &&
+    !/\bxct(?:assert|fail|waiter)|failed assertion|test case\b.*\bfailed\b/.test(text)
+  ) {
+    diagnostics.push({
+      code: "AXCLOUD-XCTEST-RUNNER-HANG",
+      severity: "error",
+      file,
+      message:
+        "Xcode test evidence timed out before any focused assertion output, which points to runner health rather than a proven app failure.",
+      suggestion:
+        "Do not write another focused test. Clean up stale hosted app, debugserver, or xcodebuild processes, then rerun the same --only-testing selector or use alternate build/unit proof.",
     });
   }
 

--- a/src/core/axint-dsl/ast.ts
+++ b/src/core/axint-dsl/ast.ts
@@ -23,7 +23,7 @@ export interface FileNode {
   readonly declarations: readonly TopLevelDecl[];
 }
 
-export type TopLevelDecl = IntentDecl | EntityDecl | EnumDecl;
+export type TopLevelDecl = IntentDecl | EntityDecl | EnumDecl | PageDecl;
 
 // ─── Identifier ──────────────────────────────────────────────────────
 
@@ -187,6 +187,36 @@ export interface QueryClause {
   readonly kind: "QueryClause";
   readonly span: TokenSpan;
   readonly queryKind: "all" | "id" | "string" | "property";
+}
+
+// ─── Public Page ─────────────────────────────────────────────────────
+
+/**
+ * A custom front-facing project/profile page. This is intentionally a safe
+ * manifest, not arbitrary web code: authors declare modules and fields that a
+ * host app can render inside its own sandbox.
+ */
+export interface PageDecl {
+  readonly kind: "PageDecl";
+  readonly span: TokenSpan;
+  readonly name: Ident;
+  readonly fields: readonly PageFieldDecl[];
+  readonly modules: readonly PageModuleDecl[];
+}
+
+export interface PageFieldDecl {
+  readonly kind: "PageFieldDecl";
+  readonly span: TokenSpan;
+  readonly name: Ident;
+  readonly value: LiteralNode;
+}
+
+export interface PageModuleDecl {
+  readonly kind: "PageModuleDecl";
+  readonly span: TokenSpan;
+  readonly id: Ident;
+  readonly title: StringLiteral;
+  readonly fields: readonly PageFieldDecl[];
 }
 
 // ─── Intent ──────────────────────────────────────────────────────────

--- a/src/core/axint-dsl/index.ts
+++ b/src/core/axint-dsl/index.ts
@@ -62,6 +62,10 @@ export type {
   DisplayImage,
   PropertyDecl,
   QueryClause,
+  // Public page
+  PageDecl,
+  PageFieldDecl,
+  PageModuleDecl,
   // Intent
   IntentDecl,
   MetaClause,

--- a/src/core/axint-dsl/lowering.ts
+++ b/src/core/axint-dsl/lowering.ts
@@ -33,6 +33,9 @@ import type {
   IntegerLiteral,
   IntentDecl,
   LiteralNode,
+  PageDecl,
+  PageFieldDecl,
+  PageModuleDecl,
   ParamDecl,
   PrimitiveType,
   PropertyDecl,
@@ -56,6 +59,9 @@ import type {
   IRParameter,
   IRParameterSummary,
   IRPrimitiveType,
+  IRPublicPage,
+  IRPublicPageFieldValue,
+  IRPublicPageModule,
   IRType,
 } from "../types.js";
 import { PARAM_TYPES } from "../types.js";
@@ -65,6 +71,7 @@ import { PARAM_TYPES } from "../types.js";
 export interface LowerResult {
   readonly intents: readonly IRIntent[];
   readonly entities: readonly IREntity[];
+  readonly pages: readonly IRPublicPage[];
   readonly diagnostics: readonly Diagnostic[];
 }
 
@@ -87,7 +94,7 @@ export function lower(file: FileNode, options?: LowerOptions): LowerResult {
         targetSpan: toProtocolSpan(zeroWidthAt(file.span)),
       },
     });
-    return ctx.finish([], []);
+    return ctx.finish([], [], []);
   }
 
   const index = buildNameIndex(file.declarations);
@@ -110,7 +117,14 @@ export function lower(file: FileNode, options?: LowerOptions): LowerResult {
     }
   }
 
-  return ctx.finish(intents, entities);
+  const pages: IRPublicPage[] = [];
+  for (const decl of file.declarations) {
+    if (decl.kind === "PageDecl") {
+      pages.push(lowerPage(decl, sourceFile));
+    }
+  }
+
+  return ctx.finish(intents, entities, pages);
 }
 
 // ─── Context + diagnostic emission ─────────────────────────────────────
@@ -139,8 +153,8 @@ class LowerContext {
     });
   }
 
-  finish(intents: IRIntent[], entities: IREntity[]): LowerResult {
-    return { intents, entities, diagnostics: this.diagnostics };
+  finish(intents: IRIntent[], entities: IREntity[], pages: IRPublicPage[]): LowerResult {
+    return { intents, entities, pages, diagnostics: this.diagnostics };
   }
 }
 
@@ -166,6 +180,82 @@ function buildNameIndex(decls: readonly TopLevelDecl[]): NameIndex {
     }
   }
   return { entities, enums };
+}
+
+// ─── Public page lowering ─────────────────────────────────────────────
+
+function lowerPage(decl: PageDecl, sourceFile: string): IRPublicPage {
+  const fields = lowerPageFields(decl.fields);
+  return {
+    name: decl.name.name,
+    title: singleStringField(fields, "title"),
+    tagline: singleStringField(fields, "tagline"),
+    theme: singleStringField(fields, "theme"),
+    fields,
+    modules: decl.modules.map((module) => lowerPageModule(module)),
+    sourceFile,
+  };
+}
+
+function lowerPageModule(decl: PageModuleDecl): IRPublicPageModule {
+  const fields = lowerPageFields(decl.fields);
+  return {
+    id: decl.id.name,
+    title: decl.title.value,
+    kind: singleStringField(fields, "kind"),
+    permissions: collectStringField(fields, "permission"),
+    fields,
+  };
+}
+
+function lowerPageFields(
+  fields: readonly PageFieldDecl[]
+): Record<string, IRPublicPageFieldValue | IRPublicPageFieldValue[]> {
+  const output: Record<string, IRPublicPageFieldValue | IRPublicPageFieldValue[]> = {};
+  for (const field of fields) {
+    const key = field.name.name;
+    const value = lowerPageFieldValue(field.value);
+    const existing = output[key];
+    if (existing === undefined) {
+      output[key] = value;
+    } else if (Array.isArray(existing)) {
+      output[key] = [...existing, value];
+    } else {
+      output[key] = [existing, value];
+    }
+  }
+  return output;
+}
+
+function lowerPageFieldValue(value: LiteralNode): IRPublicPageFieldValue {
+  switch (value.kind) {
+    case "StringLiteral":
+    case "IntegerLiteral":
+    case "DecimalLiteral":
+    case "BooleanLiteral":
+      return value.value;
+    case "IdentLiteral":
+      return value.name;
+  }
+}
+
+function collectStringField(
+  fields: Record<string, IRPublicPageFieldValue | IRPublicPageFieldValue[]>,
+  key: string
+): string[] {
+  const value = fields[key];
+  if (value === undefined) return [];
+  const values = Array.isArray(value) ? value : [value];
+  return values.map((item) => String(item));
+}
+
+function singleStringField(
+  fields: Record<string, IRPublicPageFieldValue | IRPublicPageFieldValue[]>,
+  key: string
+): string | undefined {
+  const value = fields[key];
+  if (Array.isArray(value)) return value.length > 0 ? String(value[0]) : undefined;
+  return value === undefined ? undefined : String(value);
 }
 
 // ─── Entity lowering ───────────────────────────────────────────────────

--- a/src/core/axint-dsl/parser.ts
+++ b/src/core/axint-dsl/parser.ts
@@ -39,6 +39,9 @@ import type {
   MetaClause,
   NamedType,
   OptionalType,
+  PageDecl,
+  PageFieldDecl,
+  PageModuleDecl,
   ParamDecl,
   PrimitiveKind,
   PrimitiveType,
@@ -98,6 +101,7 @@ const TOP_LEVEL_KEYWORDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
   "INTENT",
   "ENTITY",
   "ENUM",
+  "PAGE",
 ]);
 
 const INTENT_META_KEYWORDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
@@ -207,10 +211,12 @@ class Parser {
         return this.parseEntityDecl();
       case "ENUM":
         return this.parseEnumDecl();
+      case "PAGE":
+        return this.parsePageDecl();
       default: {
         this.emit({
           code: "AX001",
-          message: `unexpected ${describeToken(this.peek())} at top level, expected \`intent\`, \`entity\`, or \`enum\``,
+          message: `unexpected ${describeToken(this.peek())} at top level, expected \`intent\`, \`entity\`, \`enum\`, or \`page\``,
           span: this.peek().span,
           fix: this.fixInsert(this.zeroWidthBefore(this.peek().span)),
         });
@@ -545,6 +551,152 @@ class Parser {
       span: spanBetween(start.span, tok.span),
       queryKind: tok.value as QueryClause["queryKind"],
     };
+  }
+
+  // ─── Public Page ───────────────────────────────────────────────────
+
+  private parsePageDecl(): PageDecl | null {
+    const start = this.consume(); // PAGE
+    const name = this.expectIdent("AX002", "page name");
+    if (!name) {
+      this.recoverToTopLevel();
+      return null;
+    }
+
+    const lbrace = this.expectPunctuation("LBRACE", "`{` to start page body");
+    if (!lbrace) {
+      this.recoverToTopLevel();
+      return null;
+    }
+
+    const fields: PageFieldDecl[] = [];
+    const modules: PageModuleDecl[] = [];
+
+    while (!this.atEnd() && this.peekKind() !== "RBRACE") {
+      if (this.peekKind() === "MODULE") {
+        const module = this.parsePageModule();
+        if (module) modules.push(module);
+      } else if (this.isPageFieldStart()) {
+        const field = this.parsePageField();
+        if (field) fields.push(field);
+      } else {
+        this.emit({
+          code: "AX007",
+          message: `unexpected ${describeToken(this.peek())} in page body`,
+          span: this.peek().span,
+          fix: this.fixRemove(this.peek().span),
+        });
+        this.recoverToPageBoundary();
+      }
+    }
+
+    const rbrace = this.expectPunctuation("RBRACE", "`}` to close page body");
+    const endSpan = rbrace?.span ?? this.previousSpan();
+    return {
+      kind: "PageDecl",
+      span: spanBetween(start.span, endSpan),
+      name,
+      fields,
+      modules,
+    };
+  }
+
+  private parsePageModule(): PageModuleDecl | null {
+    const start = this.consume(); // MODULE
+    const id = this.expectIdent("AX007", "module id");
+    if (!id) {
+      this.recoverToPageBoundary();
+      return null;
+    }
+
+    const title = this.expectStringLiteral("module title");
+    if (!title) {
+      this.recoverToPageBoundary();
+      return null;
+    }
+
+    const lbrace = this.expectPunctuation("LBRACE", "`{` to start module body");
+    if (!lbrace) {
+      this.recoverToPageBoundary();
+      return null;
+    }
+
+    const fields: PageFieldDecl[] = [];
+    while (!this.atEnd() && this.peekKind() !== "RBRACE") {
+      if (this.isPageFieldStart()) {
+        const field = this.parsePageField();
+        if (field) fields.push(field);
+      } else {
+        this.emit({
+          code: "AX007",
+          message: `unexpected ${describeToken(this.peek())} in module body`,
+          span: this.peek().span,
+          fix: this.fixRemove(this.peek().span),
+        });
+        this.recoverToPageBoundary();
+      }
+    }
+
+    const rbrace = this.expectPunctuation("RBRACE", "`}` to close module body");
+    const endSpan = rbrace?.span ?? this.previousSpan();
+    return {
+      kind: "PageModuleDecl",
+      span: spanBetween(start.span, endSpan),
+      id,
+      title,
+      fields,
+    };
+  }
+
+  private parsePageField(): PageFieldDecl | null {
+    const nameToken = this.consume();
+    const name: Ident = { kind: "Ident", span: nameToken.span, name: nameToken.value };
+    if (!this.expectPunctuation("COLON", `\`:\` after \`${name.name}\``)) {
+      this.recoverToEndOfLine(nameToken.span.startLine);
+      return null;
+    }
+
+    const value = this.parsePageFieldValue();
+    if (!value) {
+      this.recoverToEndOfLine(nameToken.span.startLine);
+      return null;
+    }
+
+    return {
+      kind: "PageFieldDecl",
+      span: spanBetween(nameToken.span, value.span),
+      name,
+      value,
+    };
+  }
+
+  private parsePageFieldValue(): LiteralNode | null {
+    const tok = this.peek();
+    switch (tok.kind) {
+      case "STRING_LITERAL":
+      case "INTEGER_LITERAL":
+      case "DECIMAL_LITERAL":
+      case "TRUE":
+      case "FALSE":
+      case "IDENTIFIER":
+        return this.parseLiteral();
+      default:
+        // Public-page manifests use identifier-like symbols for values such as
+        // `permission: collectEmail` or `animation: breathe`. Allow reserved
+        // words as symbols here because this surface is a safe manifest, not
+        // Swift code.
+        if (isIdentifierLikeLexeme(tok.value)) {
+          this.advance();
+          return { kind: "IdentLiteral", span: tok.span, name: tok.value };
+        }
+        this.emit({
+          code: "AX007",
+          message: `expected page field value, got ${describeToken(tok)}`,
+          span: tok.span,
+          fix: this.fixRemove(tok.span),
+        });
+        return null;
+    }
   }
 
   // ─── Intent ────────────────────────────────────────────────────────
@@ -1378,6 +1530,10 @@ class Parser {
     return null;
   }
 
+  private isPageFieldStart(): boolean {
+    return isIdentifierLikeLexeme(this.peek().value) && this.peekKind(1) === "COLON";
+  }
+
   // ─── Spans + diagnostics ───────────────────────────────────────────
 
   private emit(args: {
@@ -1521,9 +1677,24 @@ class Parser {
       this.advance();
     }
   }
+
+  private recoverToPageBoundary(): void {
+    if (this.atEnd()) return;
+    this.advance();
+    while (!this.atEnd()) {
+      const kind = this.peekKind();
+      if (kind === "RBRACE" || kind === "MODULE" || TOP_LEVEL_KEYWORDS.has(kind)) return;
+      if (this.isPageFieldStart()) return;
+      this.advance();
+    }
+  }
 }
 
 // ─── Module helpers ──────────────────────────────────────────────────
+
+function isIdentifierLikeLexeme(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+}
 
 function spanBetween(a: TokenSpan, b: TokenSpan): TokenSpan {
   return {

--- a/src/core/axint-dsl/printer.ts
+++ b/src/core/axint-dsl/printer.ts
@@ -30,6 +30,9 @@ import type {
   IntentDecl,
   LiteralNode,
   MetaClause,
+  PageDecl,
+  PageFieldDecl,
+  PageModuleDecl,
   ParamDecl,
   PropertyDecl,
   ReturnTypeNode,
@@ -52,6 +55,9 @@ export function printDsl(file: FileNode): string {
         break;
       case "EnumDecl":
         printEnum(w, decl);
+        break;
+      case "PageDecl":
+        printPage(w, decl);
         break;
     }
   });
@@ -203,6 +209,39 @@ function printProperty(w: Writer, node: PropertyDecl) {
 function printEnum(w: Writer, node: EnumDecl) {
   const cases = node.cases.map((c) => c.name).join(" ");
   w.line(`enum ${node.name.name} { ${cases} }`);
+}
+
+// ─── Public Page ─────────────────────────────────────────────────────
+
+function printPage(w: Writer, node: PageDecl) {
+  w.line(`page ${node.name.name} {`);
+  w.indent();
+
+  for (const field of node.fields) {
+    printPageField(w, field);
+  }
+
+  for (const module of node.modules) {
+    if (node.fields.length > 0 || module !== node.modules[0]) w.blank();
+    printPageModule(w, module);
+  }
+
+  w.dedent();
+  w.line("}");
+}
+
+function printPageModule(w: Writer, node: PageModuleDecl) {
+  w.line(`module ${node.id.name} ${encodeString(node.title.value)} {`);
+  w.indent();
+  for (const field of node.fields) {
+    printPageField(w, field);
+  }
+  w.dedent();
+  w.line("}");
+}
+
+function printPageField(w: Writer, node: PageFieldDecl) {
+  w.line(`${node.name.name}: ${renderLiteral(node.value)}`);
 }
 
 // ─── Summary ─────────────────────────────────────────────────────────

--- a/src/core/axint-dsl/token.ts
+++ b/src/core/axint-dsl/token.ts
@@ -31,6 +31,8 @@ export type TokenKind =
   | "INTENT"
   | "ENTITY"
   | "ENUM"
+  | "PAGE"
+  | "MODULE"
 
   // Intent body keywords
   | "TITLE"
@@ -141,6 +143,8 @@ export const KEYWORDS: Readonly<Record<string, TokenKind>> = {
   intent: "INTENT",
   entity: "ENTITY",
   enum: "ENUM",
+  page: "PAGE",
+  module: "MODULE",
 
   title: "TITLE",
   description: "DESCRIPTION",

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -731,6 +731,13 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticInfo> = {
     message: "some View helper has local declarations but no explicit return",
     category: "swiftui-api-parity",
   },
+  AX768: {
+    code: "AX768",
+    severity: "warning",
+    message:
+      "Changed Swift files reference a member that is not declared on the known type",
+    category: "swift-member-resolution",
+  },
   AX714: {
     code: "AX714",
     severity: "error",

--- a/src/core/swift-validator.ts
+++ b/src/core/swift-validator.ts
@@ -35,6 +35,11 @@ export interface SwiftValidationResult {
   diagnostics: Diagnostic[];
 }
 
+export interface SwiftValidationInput {
+  file: string;
+  source: string;
+}
+
 export function validateSwiftSource(source: string, file: string): SwiftValidationResult {
   const diagnostics: Diagnostic[] = [];
   const stripped = stripCommentsAndStrings(source);
@@ -81,6 +86,22 @@ export function validateSwiftSource(source: string, file: string): SwiftValidati
   checkOpaqueViewReturnsNeedExplicitReturn(source, stripped, file, diagnostics);
 
   return { file, diagnostics };
+}
+
+export function validateSwiftSources(
+  inputs: SwiftValidationInput[]
+): SwiftValidationResult[] {
+  const results = inputs.map((input) => validateSwiftSource(input.source, input.file));
+  if (inputs.length < 2) return results;
+
+  const diagnosticsByFile = new Map(
+    results.map((result) => [result.file, result.diagnostics])
+  );
+  for (const diagnostic of checkSameTargetMissingMembers(inputs)) {
+    const diagnostics = diagnosticsByFile.get(diagnostic.file ?? "");
+    if (diagnostics) diagnostics.push(diagnostic);
+  }
+  return results;
 }
 
 const ACCESSIBILITY_CONTAINER_NAMES = [
@@ -327,6 +348,154 @@ function checkOpaqueViewReturnsNeedExplicitReturn(
     );
   }
 }
+
+function checkSameTargetMissingMembers(inputs: SwiftValidationInput[]): Diagnostic[] {
+  const typeMembers = collectTypeMemberIndex(inputs);
+  if (typeMembers.size === 0) return [];
+
+  const diagnostics: Diagnostic[] = [];
+  const reported = new Set<string>();
+
+  for (const input of inputs) {
+    const stripped = stripCommentsAndStrings(input.source);
+    const bindings = collectTypedBindings(stripped, typeMembers);
+    if (bindings.size === 0) continue;
+
+    const memberAccess = /\b([a-z][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)\b/g;
+    let match: RegExpExecArray | null;
+    while ((match = memberAccess.exec(stripped)) !== null) {
+      const objectName = match[1]!;
+      const memberName = match[2]!;
+      const typeName = bindings.get(objectName);
+      if (!typeName) continue;
+      if (KNOWN_CROSS_FILE_MEMBER_NAMES.has(memberName)) continue;
+
+      const members = typeMembers.get(typeName);
+      if (!members || members.has(memberName)) continue;
+
+      const key = `${input.file}:${objectName}:${typeName}:${memberName}:${match.index}`;
+      if (reported.has(key)) continue;
+      reported.add(key);
+
+      diagnostics.push(
+        makeDiagnostic(
+          "AX768",
+          input.file,
+          1 + countNewlinesUpTo(input.source, match.index),
+          {
+            message: `Changed Swift files reference '${objectName}.${memberName}', but '${typeName}' in this validation set does not declare '${memberName}'`,
+            suggestion:
+              "Use a member that exists on the declaring type, include the extension file that defines it, or rerun Xcode if this member is provided by generated code outside the validation set.",
+          }
+        )
+      );
+    }
+  }
+
+  return diagnostics;
+}
+
+function collectTypeMemberIndex(
+  inputs: SwiftValidationInput[]
+): Map<string, Set<string>> {
+  const index = new Map<string, Set<string>>();
+  for (const input of inputs) {
+    const stripped = stripCommentsAndStrings(input.source);
+    const declarations = findTypeDeclarations(stripped, input.source);
+    for (const declaration of declarations) {
+      const typeName = baseSwiftTypeName(declaration.name);
+      if (!typeName) continue;
+      const members = index.get(typeName) ?? new Set<string>();
+      const body = stripped.slice(declaration.bodyStart, declaration.bodyEnd);
+
+      for (const member of collectDeclaredMemberNames(body)) members.add(member);
+      index.set(typeName, members);
+    }
+  }
+  return index;
+}
+
+function collectDeclaredMemberNames(typeBody: string): Set<string> {
+  const members = new Set<string>();
+  const patterns = [
+    /\b(?:static\s+|class\s+)?(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\b/g,
+    /\b(?:static\s+|class\s+)?func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g,
+  ];
+
+  for (const pattern of patterns) {
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(typeBody)) !== null) {
+      members.add(match[1]!);
+    }
+  }
+
+  const casePattern =
+    /\bcase\s+([A-Za-z_][A-Za-z0-9_]*(?:\s*,\s*[A-Za-z_][A-Za-z0-9_]*)*)/g;
+  let caseMatch: RegExpExecArray | null;
+  while ((caseMatch = casePattern.exec(typeBody)) !== null) {
+    for (const name of caseMatch[1]!.split(",")) {
+      const trimmed = name.trim();
+      if (trimmed) members.add(trimmed);
+    }
+  }
+
+  return members;
+}
+
+function collectTypedBindings(
+  stripped: string,
+  typeMembers: Map<string, Set<string>>
+): Map<string, string> {
+  const bindings = new Map<string, string>();
+  const bindingPattern =
+    /\b(?:let|var)\s+([a-z][A-Za-z0-9_]*)\s*(?::\s*([A-Z][A-Za-z0-9_.]*(?:<[^=\n>]+>)?\??))?\s*(?:=\s*([A-Z][A-Za-z0-9_.]*)\s*\()?/g;
+  let match: RegExpExecArray | null;
+  while ((match = bindingPattern.exec(stripped)) !== null) {
+    const name = match[1]!;
+    const typeName = baseSwiftTypeName(match[2] ?? match[3] ?? "");
+    if (typeName && typeMembers.has(typeName)) bindings.set(name, typeName);
+  }
+
+  const functionPattern = /\bfunc\s+[A-Za-z_][A-Za-z0-9_]*\s*\(([^)]*)\)/g;
+  let functionMatch: RegExpExecArray | null;
+  while ((functionMatch = functionPattern.exec(stripped)) !== null) {
+    for (const rawParam of functionMatch[1]!.split(",")) {
+      const paramMatch = rawParam.match(
+        /\b(?:[A-Za-z_][A-Za-z0-9_]*\s+)?([a-z][A-Za-z0-9_]*)\s*:\s*([A-Z][A-Za-z0-9_.]*(?:<[^>]+>)?\??)/
+      );
+      if (!paramMatch) continue;
+      const typeName = baseSwiftTypeName(paramMatch[2] ?? "");
+      if (typeName && typeMembers.has(typeName)) bindings.set(paramMatch[1]!, typeName);
+    }
+  }
+
+  return bindings;
+}
+
+function baseSwiftTypeName(raw: string): string | undefined {
+  const cleaned = raw
+    .replace(/\?.*$/, "")
+    .replace(/<.*$/, "")
+    .replace(/^\[/, "")
+    .replace(/\]$/, "")
+    .split(".")
+    .at(-1)
+    ?.trim();
+  return cleaned && /^[A-Z][A-Za-z0-9_]*$/.test(cleaned) ? cleaned : undefined;
+}
+
+const KNOWN_CROSS_FILE_MEMBER_NAMES = new Set([
+  "allCases",
+  "count",
+  "debugDescription",
+  "description",
+  "hashValue",
+  "id",
+  "isEmpty",
+  "localizedDescription",
+  "rawValue",
+  "self",
+]);
 
 function hasViewBuilderAttribute(stripped: string, declarationIndex: number): boolean {
   const prefix = stripped.slice(Math.max(0, declarationIndex - 180), declarationIndex);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -252,6 +252,38 @@ export interface IRApp {
   sourceFile: string;
 }
 
+// ─── Public Page IR Types ────────────────────────────────────────────────
+
+export type IRPublicPageFieldValue = string | number | boolean;
+
+export interface IRPublicPageModule {
+  /** Stable module id inside the page manifest, e.g. `emailCapture`. */
+  id: string;
+  /** Human-facing title rendered by the host surface. */
+  title: string;
+  /** Safe host-rendered module kind, e.g. `emailCapture`, `qrInstall`, `mcpServer`. */
+  kind?: string;
+  /** Repeated `permission:` fields are lifted here for scanner/gate use. */
+  permissions: string[];
+  /** Remaining manifest fields for the host renderer. */
+  fields: Record<string, IRPublicPageFieldValue | IRPublicPageFieldValue[]>;
+}
+
+/**
+ * A safe custom public project/profile page. The compiler lowers `.axint`
+ * `page` declarations into this manifest IR so host apps can render modules
+ * without accepting arbitrary scripts, tracking pixels, or unsandboxed code.
+ */
+export interface IRPublicPage {
+  name: string;
+  title?: string;
+  tagline?: string;
+  theme?: string;
+  fields: Record<string, IRPublicPageFieldValue | IRPublicPageFieldValue[]>;
+  modules: IRPublicPageModule[];
+  sourceFile: string;
+}
+
 // ─── Live Activity IR Types ─────────────────────────────────────────────────
 
 /** A single field on a Live Activity's ContentState (the part that updates). */

--- a/src/run/project-runner.ts
+++ b/src/run/project-runner.ts
@@ -23,7 +23,7 @@ import {
   type AxintAgentAdviceReport,
 } from "../project/local-agent.js";
 import { startAxintSession } from "../project/session.js";
-import { validateSwiftSource } from "../core/swift-validator.js";
+import { validateSwiftSources } from "../core/swift-validator.js";
 import type { Diagnostic } from "../core/types.js";
 import {
   renderWorkflowCheckReport,
@@ -105,6 +105,16 @@ export interface AxintRunXcodeTestFailure {
   source: "xcodebuild-output" | "xcresult";
 }
 
+export interface AxintRunRunnerIssue {
+  kind: "ui-automation-infrastructure" | "hosted-test-runner-timeout";
+  severity: "blocked";
+  message: string;
+  evidence: string;
+  likelyCause: string;
+  remediation: string;
+  command?: string;
+}
+
 export interface AxintRunStep {
   name: string;
   state: AxintRunStepState;
@@ -152,6 +162,7 @@ export interface AxintRunReport {
     buildSettings?: AxintRunCommandResult;
   };
   xcodeTestFailures: AxintRunXcodeTestFailure[];
+  runnerHealth: AxintRunRunnerIssue[];
   steps: AxintRunStep[];
   artifacts: {
     json?: string;
@@ -218,12 +229,14 @@ export async function runAxintProject(
     },
   ];
 
-  for (const file of swiftFiles) {
-    const source = readFileSync(file, "utf-8");
-    validationDiagnostics.push(
-      ...validateSwiftSource(source, relativeOrAbsolute(cwd, file)).diagnostics
-    );
-  }
+  validationDiagnostics.push(
+    ...validateSwiftSources(
+      swiftFiles.map((file) => ({
+        file: relativeOrAbsolute(cwd, file),
+        source: readFileSync(file, "utf-8"),
+      }))
+    ).flatMap((result) => result.diagnostics)
+  );
 
   steps.push({
     name: "Swift validation",
@@ -343,6 +356,8 @@ export async function runAxintProject(
   }
 
   const xcodeTestFailures = collectXcodeTestFailures(commands.test);
+  const runnerHealth = detectXcodeRunnerIssues(commands.test, plan, xcodeTestFailures);
+  reconcileXcodeTestStepWithRunnerHealth(steps, runnerHealth);
   const xcodeFailureEvidence = formatXcodeTestFailuresForEvidence(xcodeTestFailures);
   const xcodeEvidence = buildXcodeEvidence(commands, plan, xcodeTestFailures);
   const focusedBehavior = buildFocusedTestBehavior(
@@ -421,6 +436,7 @@ export async function runAxintProject(
     },
     cloudChecks,
     xcodeTestFailures,
+    runnerHealth,
     commands,
     steps: steps.map((step) =>
       step.durationMs === undefined && step.name === "Axint session"
@@ -432,7 +448,14 @@ export async function runAxintProject(
       projectContextMarkdown: projectContext.markdownPath,
       feedbackSignals,
     },
-    nextSteps: buildNextSteps(status, steps, workflow, cloudChecks, xcodeTestFailures),
+    nextSteps: buildNextSteps(
+      status,
+      steps,
+      workflow,
+      cloudChecks,
+      xcodeTestFailures,
+      runnerHealth
+    ),
     repairPrompt: buildRunRepairPrompt({
       status,
       workflow,
@@ -440,6 +463,7 @@ export async function runAxintProject(
       cloudChecks,
       commands,
       xcodeTestFailures,
+      runnerHealth,
       agent: agentProfile,
     }),
   };
@@ -470,6 +494,7 @@ export async function runAxintProject(
       workflow,
       cloudChecks,
       xcodeTestFailures,
+      runnerHealth,
       agentAdvice
     ),
   };
@@ -480,6 +505,7 @@ export async function runAxintProject(
     cloudChecks,
     commands,
     xcodeTestFailures,
+    runnerHealth,
     agent: agentProfile,
     agentAdvice,
   });
@@ -572,6 +598,11 @@ export function renderAxintRunReport(
     ...(report.xcodeTestFailures.length > 0
       ? report.xcodeTestFailures.slice(0, 8).map(renderXcodeTestFailureLine)
       : ["- None."]),
+    "",
+    "## Xcode Runner Health",
+    ...(report.runnerHealth.length > 0
+      ? report.runnerHealth.slice(0, 6).map(renderRunnerHealthLine)
+      : ["- No runner-health issues detected."]),
     "",
     "## Cloud Checks",
     ...(report.cloudChecks.length > 0
@@ -1077,6 +1108,16 @@ function stepFromCommand(name: string, result: AxintRunCommandResult): AxintRunS
   };
 }
 
+function reconcileXcodeTestStepWithRunnerHealth(
+  steps: AxintRunStep[],
+  runnerHealth: AxintRunRunnerIssue[]
+) {
+  if (runnerHealth.length === 0) return;
+  const step = steps.find((item) => item.name === "Xcode test");
+  if (!step) return;
+  step.detail = runnerHealth[0]!.message;
+}
+
 function commandPassed(result?: AxintRunCommandResult): boolean {
   return Boolean(
     result &&
@@ -1163,11 +1204,14 @@ function buildFocusedTestBehavior(
   const selectors = plan.onlyTesting.join(", ");
   if (result.exitCode !== 0 || result.timedOut) {
     const firstFailure = failures[0];
+    const runnerIssues = detectXcodeRunnerIssues(result, plan, failures);
     return {
       expectedBehavior: `Focused test selector(s) should pass: ${selectors}.`,
       actualBehavior: firstFailure
         ? `Focused test selector(s) did not pass through axint run --only-testing: ${selectors}. First failure: ${formatXcodeFailureOneLine(firstFailure)}.`
-        : `Focused test selector(s) did not pass through axint run --only-testing: ${selectors}.`,
+        : runnerIssues[0]
+          ? `Focused test selector(s) compiled but did not execute assertions through axint run --only-testing: ${selectors}. ${runnerIssues[0].message}`
+          : `Focused test selector(s) did not pass through axint run --only-testing: ${selectors}.`,
     };
   }
   return {
@@ -1260,6 +1304,79 @@ function extractXcodeTestFailuresFromText(text: string): AxintRunXcodeTestFailur
   }
 
   return failures;
+}
+
+function detectXcodeRunnerIssues(
+  result?: AxintRunCommandResult,
+  plan?: XcodePlan,
+  failures: AxintRunXcodeTestFailure[] = []
+): AxintRunRunnerIssue[] {
+  if (!result || result.dryRun || (result.exitCode === 0 && !result.timedOut)) {
+    return [];
+  }
+  const output = [result.stdout, result.stderr, readCommandLogTail(result.logPath)]
+    .filter(Boolean)
+    .join("\n");
+  const normalized = stripAnsi(output).replace(/\s+/g, " ").trim();
+  const issues: AxintRunRunnerIssue[] = [];
+  const command = [result.command, ...result.args].map(shellQuote).join(" ");
+
+  if (
+    /\btimed out while enabling automation mode\b/i.test(normalized) ||
+    /\btest runner failed to initialize for ui testing\b/i.test(normalized) ||
+    /\bfailed to initialize.*ui testing\b/i.test(normalized)
+  ) {
+    issues.push({
+      kind: "ui-automation-infrastructure",
+      severity: "blocked",
+      message:
+        "Xcode UI automation did not start; XCTest never reached a trustworthy app assertion.",
+      evidence: firstMatchingLine(output, [
+        /timed out while enabling automation mode/i,
+        /test runner failed to initialize for ui testing/i,
+        /failed to initialize.*ui testing/i,
+      ]),
+      likelyCause:
+        "The simulator/app runner or accessibility automation channel is stuck before the UI test can exercise the app.",
+      remediation:
+        "Kill stale app/test-runner processes, retry once, and report the UI proof as blocked by XCTest infrastructure if the same startup error repeats.",
+      command,
+    });
+  }
+
+  const selectorProvided = Boolean(plan?.onlyTesting.length);
+  const macHosted = !plan?.destination || /macos/i.test(plan.destination);
+  const assertionOutput =
+    failures.length > 0 ||
+    /\bxct(?:assert|fail|waiter)|failed assertion|test case\b.*\bfailed\b/i.test(output);
+  if (
+    result.timedOut &&
+    selectorProvided &&
+    macHosted &&
+    !assertionOutput &&
+    !issues.some((issue) => issue.kind === "ui-automation-infrastructure")
+  ) {
+    issues.push({
+      kind: "hosted-test-runner-timeout",
+      severity: "blocked",
+      message:
+        "Focused selector compiled, but the hosted macOS test runner timed out before any assertion output.",
+      evidence:
+        firstMatchingLine(output, [
+          /command timed out/i,
+          /timed out/i,
+          /debugserver/i,
+          /\/[^ ]+\.app\//i,
+        ]) || `Command timed out after ${Math.round(result.durationMs / 1000)}s.`,
+      likelyCause:
+        "A stale hosted app, debugserver, or xcodebuild runner is holding the test process before the selected suite can start.",
+      remediation:
+        "Kill stale host app/debugserver/xcodebuild processes, keep the same --only-testing selector, and retry before changing product code.",
+      command,
+    });
+  }
+
+  return issues;
 }
 
 function parseSwiftFailureLine(
@@ -1648,6 +1765,18 @@ function renderXcodeTestFailureLine(failure: AxintRunXcodeTestFailure): string {
   return `- ${formatXcodeFailureOneLine(failure)}${detail ? `\n  - ${detail}` : ""}`;
 }
 
+function renderRunnerHealthLine(issue: AxintRunRunnerIssue): string {
+  return [
+    `- ${issue.kind}: ${issue.message}`,
+    `  - likely cause: ${issue.likelyCause}`,
+    `  - next move: ${issue.remediation}`,
+    issue.evidence ? `  - evidence: ${issue.evidence}` : undefined,
+    issue.command ? `  - command: \`${issue.command}\`` : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
 function formatXcodeFailureOneLine(failure: AxintRunXcodeTestFailure): string {
   const name = failure.testName ?? failure.suiteName ?? "Unknown Xcode test";
   const location = failure.file
@@ -1672,8 +1801,24 @@ function commandEvidence(
   ]
     .filter(Boolean)
     .join("\n");
-  const output = trimCommandEvidence([result.stdout, result.stderr].join("\n"));
+  const output = trimCommandEvidence(
+    [result.stdout, result.stderr, readCommandLogTail(result.logPath)]
+      .filter(Boolean)
+      .join("\n")
+  );
   return [header, metadata, output].filter(Boolean).join("\n");
+}
+
+function firstMatchingLine(value: string, patterns: RegExp[]): string {
+  const lines = stripAnsi(value)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  for (const pattern of patterns) {
+    const line = lines.find((candidate) => pattern.test(candidate));
+    if (line) return line;
+  }
+  return "";
 }
 
 function focusedTestOutput(
@@ -1832,6 +1977,7 @@ function buildNextSteps(
   workflow: WorkflowCheckReport,
   cloudChecks: CloudCheckReport[],
   xcodeTestFailures: AxintRunXcodeTestFailure[] = [],
+  runnerHealth: AxintRunRunnerIssue[] = [],
   agentAdvice?: AxintAgentAdviceReport
 ): string[] {
   if (status === "pass") {
@@ -1866,12 +2012,26 @@ function buildNextSteps(
       }: ${failure.message}${failure.repairHint ? ` ${failure.repairHint}` : ""}`
     );
   }
+  for (const issue of runnerHealth.slice(0, 3)) {
+    next.add(
+      `${issue.message} ${issue.remediation}${
+        issue.command ? ` Retry: ${issue.command}` : ""
+      }`
+    );
+  }
   for (const item of workflow.required) next.add(item);
   for (const check of cloudChecks) {
     for (const item of check.nextSteps) next.add(item);
   }
   for (const step of steps) {
     if (step.state === "fail" && step.command) {
+      if (
+        runnerHealth.length > 0 &&
+        step.name === "Xcode test" &&
+        runnerHealth.some((issue) => issue.command === step.command)
+      ) {
+        continue;
+      }
       next.add(`Fix the failing step, then rerun: ${step.command}`);
     }
   }
@@ -1888,6 +2048,7 @@ function buildRunRepairPrompt(input: {
   cloudChecks: CloudCheckReport[];
   commands: AxintRunReport["commands"];
   xcodeTestFailures?: AxintRunXcodeTestFailure[];
+  runnerHealth?: AxintRunRunnerIssue[];
   agent?: AxintAgentToolProfile;
   agentAdvice?: AxintAgentAdviceReport;
 }) {
@@ -1977,6 +2138,13 @@ function buildRunRepairPrompt(input: {
       : [
           "- None extracted. If Xcode failed, inspect the command log or .xcresult artifact.",
         ]),
+    "",
+    "Xcode runner health:",
+    ...(input.runnerHealth && input.runnerHealth.length > 0
+      ? input.runnerHealth.slice(0, 6).map((issue) => {
+          return `- ${issue.kind}: ${issue.message} Likely cause: ${issue.likelyCause} Next move: ${issue.remediation}`;
+        })
+      : ["- No runner-health issue classified."]),
   ];
 
   if (input.agentAdvice) {

--- a/tests/cli/status.test.ts
+++ b/tests/cli/status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { renderCliStatus } from "../../src/cli/status.js";
+import { renderCliStatus, renderMcpRecoveryPacket } from "../../src/cli/status.js";
 
 describe("axint status", () => {
   it("prints local version and same-thread reload guidance", () => {
@@ -18,5 +18,21 @@ describe("axint status", () => {
     expect(output).toContain("Expected local package version: 9.9.9");
     expect(output).toContain("axint.upgrade");
     expect(output).toContain("axint.cloud.check");
+  });
+
+  it("prints a same-thread MCP recovery packet with CLI fallbacks", () => {
+    const output = renderMcpRecoveryPacket("9.9.9", {
+      dir: "/tmp/My Project",
+      agent: "codex",
+      sessionToken: "axsess_test",
+    });
+
+    expect(output).toContain("Axint MCP Recovery Packet");
+    expect(output).toContain("Transport closed");
+    expect(output).toContain("@axint/compiler@9.9.9");
+    expect(output).toContain("axint workflow check");
+    expect(output).toContain("--session-token axsess_test");
+    expect(output).toContain("axint run --cwd");
+    expect(output).toContain("continue through the CLI fallback");
   });
 });

--- a/tests/cloud/check.test.ts
+++ b/tests/cloud/check.test.ts
@@ -306,6 +306,40 @@ struct ProjectRoomContentView: View {
     );
   });
 
+  it("does not treat build-only evidence as UI proof when the behavior says proof is pending", () => {
+    const report = runCloudCheck({
+      fileName: "HomeFeedView.swift",
+      platform: "macOS",
+      source: `
+import SwiftUI
+
+struct HomeFeedView: View {
+    var body: some View {
+        ScrollView {
+            Button("Post") {}
+                .accessibilityIdentifier("home-post")
+        }
+    }
+}
+`,
+      expectedBehavior:
+        "The Home feed post control should stay visible and hittable after the composer repair.",
+      actualBehavior:
+        "The source patch is in place. Focused UI proof is pending and will run next.",
+      xcodeBuildLog: "** BUILD SUCCEEDED **",
+    });
+
+    expect(report.status).toBe("needs_review");
+    expect(report.gate.decision).toBe("evidence_required");
+    expect(report.gate.canClaimFixed).toBe(false);
+    expect(report.coverage).toContainEqual(
+      expect.objectContaining({
+        label: "Xcode build, UI tests, and runtime behavior",
+        state: "needs_runtime",
+      })
+    );
+  });
+
   it("trusts passing focused Xcode proof when behavior prose uses different wording", () => {
     const report = runCloudCheck({
       fileName: "DiscoverTabView.swift",
@@ -578,6 +612,54 @@ struct InviteModel {
     expect(report.gate.canClaimFixed).toBe(false);
     expect(report.diagnostics.map((d) => d.code)).toContain("AXCLOUD-XCTEST-FAILURE");
     expect(report.repairPrompt).toContain("failing assertion");
+  });
+
+  it("classifies Xcode UI automation startup failure separately from app assertions", () => {
+    const report = runCloudCheck({
+      fileName: "OnboardingControlsView.swift",
+      source: `
+import SwiftUI
+
+struct OnboardingControlsView: View {
+    var body: some View { Button("Continue") {} }
+}
+`,
+      xcodeBuildLog: [
+        "Focused Xcode test proof failed.",
+        "The test runner failed to initialize for UI testing.",
+        "Timed out while enabling automation mode.",
+        "** TEST FAILED **",
+      ].join("\n"),
+    });
+
+    expect(report.status).toBe("fail");
+    expect(report.diagnostics.map((d) => d.code)).toContain(
+      "AXCLOUD-XCTEST-AUTOMATION-INFRASTRUCTURE"
+    );
+    expect(report.repairPrompt).toContain("XCTest infrastructure");
+  });
+
+  it("classifies focused runner timeouts before assertions as runner health", () => {
+    const report = runCloudCheck({
+      fileName: "P3FrontendArchitectureTests.swift",
+      source: `
+import SwiftUI
+
+struct CommandPaletteShell: View {
+    var body: some View { Text("Palette") }
+}
+`,
+      xcodeBuildLog: [
+        "Focused Xcode test proof failed.",
+        "Selectors: -only-testing:SwarmTests/P3FrontendArchitectureTests",
+        "[axint] Command timed out after 240s; sending SIGTERM to child process group.",
+        "** TEST FAILED **",
+      ].join("\n"),
+    });
+
+    expect(report.status).toBe("fail");
+    expect(report.diagnostics.map((d) => d.code)).toContain("AXCLOUD-XCTEST-RUNNER-HANG");
+    expect(report.repairPrompt).toContain("runner health");
   });
 
   it("routes document-only artifacts away from Apple compiler diagnostics", () => {

--- a/tests/core/axint-dsl/lowering.test.ts
+++ b/tests/core/axint-dsl/lowering.test.ts
@@ -60,6 +60,64 @@ describe("axint-dsl lowering — happy path", () => {
     expect(intent.donateOnPerform).toBe(false);
   });
 
+  it("lowers custom public pages into safe module manifests", () => {
+    const { pages, intents, entities, diagnostics } = lowerSource(`
+      page AxintLander {
+        title: "Axint"
+        tagline: "Compiler-native project pages"
+        theme: "black-cream"
+
+        module emailCapture "Join the build" {
+          kind: emailCapture
+          permission: collectEmail
+          permission: outboundLink
+          privacy: "Used only for Axint updates."
+        }
+
+        module shareCard "Launch card" {
+          kind: shareCard
+          output: "1200x630 PNG"
+          source: uploadedArtwork
+        }
+      }
+    `);
+
+    expect(diagnostics).toHaveLength(0);
+    expect(intents).toHaveLength(0);
+    expect(entities).toHaveLength(0);
+    expect(pages).toHaveLength(1);
+    expect(pages[0]).toMatchObject({
+      name: "AxintLander",
+      title: "Axint",
+      tagline: "Compiler-native project pages",
+      theme: "black-cream",
+      modules: [
+        {
+          id: "emailCapture",
+          title: "Join the build",
+          kind: "emailCapture",
+          permissions: ["collectEmail", "outboundLink"],
+          fields: {
+            kind: "emailCapture",
+            permission: ["collectEmail", "outboundLink"],
+            privacy: "Used only for Axint updates.",
+          },
+        },
+        {
+          id: "shareCard",
+          title: "Launch card",
+          kind: "shareCard",
+          permissions: [],
+          fields: {
+            kind: "shareCard",
+            output: "1200x630 PNG",
+            source: "uploadedArtwork",
+          },
+        },
+      ],
+    });
+  });
+
   it("lowers params with primitive and optional types", () => {
     const { intents, diagnostics } = lowerSource(`
       intent SendMessage {

--- a/tests/core/axint-dsl/parser.test.ts
+++ b/tests/core/axint-dsl/parser.test.ts
@@ -4,6 +4,7 @@ import type {
   EntityDecl,
   EnumDecl,
   IntentDecl,
+  PageDecl,
   ParamDecl,
   SummarySwitch,
   SummaryWhen,
@@ -115,6 +116,46 @@ describe("axint-dsl parser — happy path", () => {
     expect((nav!.summary as SummaryWhen).param.name).toBe("destination");
     expect(setMode!.summary?.kind).toBe("SummarySwitch");
     expect((setMode!.summary as SummarySwitch).param.name).toBe("mode");
+  });
+
+  it("parses a custom public page with safe modules", () => {
+    const file = parseOk(`
+      page AxintLander {
+        title: "Axint"
+        tagline: "Compiler-native project pages"
+        theme: "black-cream"
+
+        module emailCapture "Join the build" {
+          kind: emailCapture
+          permission: collectEmail
+          privacy: "Used only for Axint updates."
+        }
+
+        module shareCard "Launch card" {
+          kind: shareCard
+          output: "1200x630 PNG"
+          source: uploadedArtwork
+        }
+      }
+    `);
+
+    const page = file.declarations[0] as PageDecl;
+    expect(page.kind).toBe("PageDecl");
+    expect(page.name.name).toBe("AxintLander");
+    expect(page.fields.map((field) => field.name.name)).toEqual([
+      "title",
+      "tagline",
+      "theme",
+    ]);
+    expect(page.modules.map((module) => module.id.name)).toEqual([
+      "emailCapture",
+      "shareCard",
+    ]);
+    expect(page.modules[0]!.fields.map((field) => field.name.name)).toEqual([
+      "kind",
+      "permission",
+      "privacy",
+    ]);
   });
 });
 

--- a/tests/core/axint-dsl/printer.test.ts
+++ b/tests/core/axint-dsl/printer.test.ts
@@ -68,6 +68,7 @@ function canonicalize(value: unknown): unknown {
 interface LowerSnapshot {
   readonly intents: unknown;
   readonly entities: unknown;
+  readonly pages: unknown;
   readonly diagnostics: readonly DiagnosticSummary[];
 }
 
@@ -83,6 +84,7 @@ function loweredSnapshot(source: string): LowerSnapshot {
   return {
     intents: canonicalize(lowered.intents),
     entities: canonicalize(lowered.entities),
+    pages: canonicalize(lowered.pages),
     diagnostics: [...parsed.diagnostics, ...lowered.diagnostics].map(summarize),
   };
 }
@@ -576,6 +578,27 @@ intent A {
 intent B {
   title: "B"
   description: "b"
+}
+`,
+  },
+  {
+    name: "custom public page",
+    source: `page AxintLander {
+  title: "Axint"
+  tagline: "Compiler-native project pages"
+  theme: "black-cream"
+
+  module emailCapture "Join the build" {
+    kind: emailCapture
+    permission: collectEmail
+    privacy: "Used only for Axint updates."
+  }
+
+  module shareCard "Launch card" {
+    kind: shareCard
+    output: "1200x630 PNG"
+    source: uploadedArtwork
+  }
 }
 `,
   },

--- a/tests/core/swift-validator.test.ts
+++ b/tests/core/swift-validator.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { validateSwiftSource } from "../../src/core/swift-validator.js";
+import {
+  validateSwiftSource,
+  validateSwiftSources,
+} from "../../src/core/swift-validator.js";
 
 function validate(source: string) {
   return validateSwiftSource(source, "test.swift");
@@ -211,6 +214,39 @@ describe("swift validator — SwiftUI compiler parity", () => {
 
     const diagnostic = validate(source).diagnostics.find((d) => d.code === "AX739");
     expect(diagnostic?.message).toContain("isAxintProject");
+  });
+
+  it("flags changed model/view files with a direct missing member access", () => {
+    const model = `
+      struct ShareCardDesignProfile {
+          let style: ShareCardStyle
+      }
+
+      struct ShareCardStyle {
+          let detail: String
+      }
+    `;
+    const view = `
+      import SwiftUI
+
+      struct LaunchCenterView: View {
+          let profile: ShareCardDesignProfile
+
+          var body: some View {
+              Text(profile.detail)
+          }
+      }
+    `;
+
+    const diagnostics = validateSwiftSources([
+      { file: "ShareCardDesignProfile.swift", source: model },
+      { file: "LaunchCenterView.swift", source: view },
+    ]).flatMap((result) => result.diagnostics);
+
+    const diagnostic = diagnostics.find((d) => d.code === "AX768");
+    expect(diagnostic?.file).toBe("LaunchCenterView.swift");
+    expect(diagnostic?.message).toContain("profile.detail");
+    expect(diagnostic?.message).toContain("ShareCardDesignProfile");
   });
 });
 

--- a/tests/run/project-runner.test.ts
+++ b/tests/run/project-runner.test.ts
@@ -448,6 +448,98 @@ describe("runAxintProject", () => {
     }
   });
 
+  it("classifies UI automation startup failures as runner infrastructure", async () => {
+    const dir = makeFakeXcodeProject();
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const xcodebuild = join(binDir, "xcodebuild");
+    writeFileSync(
+      xcodebuild,
+      [
+        "#!/bin/sh",
+        'if echo " $* " | grep -q " test "; then',
+        '  echo "The test runner failed to initialize for UI testing."',
+        '  echo "Timed out while enabling automation mode."',
+        '  echo "** TEST FAILED **"',
+        "  exit 65",
+        "else",
+        '  echo "** BUILD SUCCEEDED **"',
+        "  exit 0",
+        "fi",
+        "",
+      ].join("\n")
+    );
+    chmodSync(xcodebuild, 0o755);
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    try {
+      const report = await runAxintProject({
+        cwd: dir,
+        writeReport: false,
+        onlyTesting: ["SwarmUITests/SwarmUITests/testOnboardingControls"],
+      });
+      const rendered = renderAxintRunReport(report);
+      const cloudCodes = report.cloudChecks.flatMap((check) =>
+        check.diagnostics.map((diagnostic) => diagnostic.code)
+      );
+
+      expect(report.runnerHealth).toContainEqual(
+        expect.objectContaining({ kind: "ui-automation-infrastructure" })
+      );
+      expect(report.nextSteps.join("\n")).toContain("Xcode UI automation did not start");
+      expect(rendered).toContain("## Xcode Runner Health");
+      expect(rendered).toContain("ui-automation-infrastructure");
+      expect(cloudCodes).toContain("AXCLOUD-XCTEST-AUTOMATION-INFRASTRUCTURE");
+    } finally {
+      process.env.PATH = previousPath;
+    }
+  });
+
+  it("does not tell agents to add a focused test when only-testing timed out before assertions", async () => {
+    const dir = makeFakeXcodeProject();
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const xcodebuild = join(binDir, "xcodebuild");
+    writeFileSync(
+      xcodebuild,
+      [
+        "#!/bin/sh",
+        'if echo " $* " | grep -q " test "; then',
+        "  sleep 2",
+        "  exit 1",
+        "else",
+        '  echo "** BUILD SUCCEEDED **"',
+        "  exit 0",
+        "fi",
+        "",
+      ].join("\n")
+    );
+    chmodSync(xcodebuild, 0o755);
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    try {
+      const report = await runAxintProject({
+        cwd: dir,
+        writeReport: false,
+        timeoutSeconds: 1,
+        onlyTesting: ["SwarmTests/P3FrontendArchitectureTests"],
+      });
+      const nextSteps = report.nextSteps.join("\n");
+      const prompt = report.repairPrompt;
+
+      expect(report.runnerHealth).toContainEqual(
+        expect.objectContaining({ kind: "hosted-test-runner-timeout" })
+      );
+      expect(nextSteps).toContain("Focused selector compiled");
+      expect(nextSteps).not.toContain("Add or update a focused unit/UI test");
+      expect(prompt).toContain("hosted-test-runner-timeout");
+    } finally {
+      process.env.PATH = previousPath;
+    }
+  });
+
   it("reports nothing to cancel when the latest run has already finished", async () => {
     const dir = makeFakeXcodeProject();
     const report = await runAxintProject({

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.14";
+const VERSION = "0.4.15";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary

Release Axint 0.4.15 with runner-recovery dogfooding fixes, same-target Swift member validation, Cloud Check pending-proof hardening, MCP recovery guidance, and safe public-page DSL manifest support.

## What changed

- Adds `axint mcp recover` for same-thread CLI fallback when MCP transport closes.
- Adds Xcode runner-health classification for UI automation startup failures and hosted macOS focused test hangs.
- Adds `AX768` same-target Swift missing-member validation.
- Downgrades Cloud Check when UI/runtime proof is explicitly pending.
- Adds `.axint` public `page` / `module` manifest parsing, lowering, printing, grammar docs, and tests.
- Bumps all canonical version surfaces to `0.4.15` and refreshes README/metrics/release notes.

## Validation

- `npm run versions:check`
- `npm run metrics:check`
- `npm run docs:check`
- `npm run release:check`
- `npm run boundary:check`
- `npm run typecheck`
- `npm run typecheck:examples`
- `npm run lint`
- `npm audit --audit-level=moderate`
- `npm test` — 76 files, 1093 tests
- `npm run prepublishOnly`
- Python: `ruff check .`, `mypy axint`, `pyright`, `pytest -v`, `python3 -m build`
- Tag release workflow `v0.4.15` passed and published npm + PyPI.

## Release status

- Tag: `v0.4.15`
- Release workflow: passed
- npm: `@axint/compiler@0.4.15` published
- PyPI: `axint==0.4.15` published
