### PR TITLE
Add source-free feedback flywheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,12 +230,21 @@ axint repair "comment box is visible but cannot be tapped" \
   --agent codex
 
 axint feedback latest --format markdown
+axint feedback status
 ```
 
 `axint repair` writes `.axint/repair/latest.*` and a privacy-safe
 `.axint/feedback/latest.json` packet. The feedback packet includes project shape,
 diagnostic codes, issue class, redacted evidence, and likely Axint product owner,
 but not source code.
+
+Axint also queues source-free feedback automatically when Cloud Check, Run, or
+Repair finds an Axint learning signal. The default endpoint is
+`https://registry.axint.ai/api/v1/feedback`; packets declare
+`source_not_included`, never include source by default, and can be turned off with
+`axint feedback opt-out`, `AXINT_FEEDBACK=off`, or `AXINT_DISABLE_FEEDBACK=1`.
+Use `axint feedback list` on a maintainer inbox to cluster imported edge cases
+into the next Axint fixes.
 
 The same senior repair read is shared by `axint.suggest`, `axint.feature`,
 `axint.cloud.check`, and `axint.repair`. If a prompt describes a broken existing
@@ -385,7 +394,8 @@ MCP tools and built-in prompts:
 | `axint.fix-packet` | Read the latest AI-ready repair packet from a local compile or watch run |
 | `axint.cloud.check` | Run an agent-callable Cloud Check report against Swift or TypeScript source |
 | `axint.repair` | Plan a project-aware Apple repair loop for existing app bugs, with likely files, root causes, host-aware patch guidance, proof commands, and feedback packet |
-| `axint.feedback.create` | Create or read a privacy-safe, source-free feedback packet users can inspect before sending to Axint Cloud |
+| `axint.feedback.create` | Create or read a privacy-safe, source-free feedback packet |
+| `axint feedback status / opt-out / opt-in / sync / list` | Manage automatic source-free feedback, opt out, retry queued packets, and cluster imported feedback into Axint fix queues |
 | `axint.agent.install` | Install the local multi-agent project brain so Codex, Claude, Cursor, Xcode, and humans share one `.axint` truth layer |
 | `axint.agent.advice` | Return host-specific next moves from project context, active claims, latest proof, and latest repair artifacts |
 | `axint.agent.claim` | Claim files before an agent edits them so other agents avoid conflicting patches |

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.15 · 33 MCP tools + 5 prompts · 189 diagnostic codes · 1204 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.15 · 33 MCP tools + 5 prompts · 189 diagnostic codes · 1213 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/metrics.json
+++ b/metrics.json
@@ -83,7 +83,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1090,
+    "typescript": 1099,
     "python": 114
   },
   "registryPackages": 14,

--- a/src/cli/feedback.ts
+++ b/src/cli/feedback.ts
@@ -5,6 +5,20 @@ import {
   runAxintRepair,
 } from "../repair/project-repair.js";
 import {
+  exportAxintFeedback,
+  importAxintFeedback,
+  listAxintFeedbackInbox,
+  renderFeedbackExportReport,
+  renderFeedbackImportReport,
+  renderFeedbackInboxReport,
+  type AxintFeedbackFormat,
+} from "../feedback/inbox.js";
+import {
+  resolveAutoFeedbackPolicy,
+  syncAutomaticFeedback,
+  writeAutoFeedbackPolicy,
+} from "../feedback/auto.js";
+import {
   normalizeAxintAgent,
   type AxintAgentProfileName,
 } from "../project/agent-profile.js";
@@ -102,9 +116,246 @@ export function registerFeedback(program: Command) {
         );
       }
     );
+
+  feedback
+    .command("export")
+    .description(
+      "Export source-free Axint feedback into a shareable bundle for a maintainer"
+    )
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--out <file>", "Output JSON bundle path")
+    .option("--project <label>", "Human-readable project label")
+    .option("--contact <text>", "Optional contact handle or email")
+    .option("--all", "Include all local feedback packets instead of only latest")
+    .option("--markdown", "Shortcut for --format markdown")
+    .option(
+      "--format <format>",
+      "Output format: json or markdown",
+      parseFormat,
+      "markdown"
+    )
+    .action(
+      (options: {
+        dir: string;
+        out?: string;
+        project?: string;
+        contact?: string;
+        all?: boolean;
+        markdown?: boolean;
+        format: AxintFeedbackFormat;
+      }) => {
+        const report = exportAxintFeedback({
+          cwd: options.dir,
+          out: options.out,
+          projectLabel: options.project,
+          contact: options.contact,
+          latestOnly: !options.all,
+        });
+        console.log(
+          renderFeedbackExportReport(
+            report,
+            options.markdown ? "markdown" : options.format
+          )
+        );
+      }
+    );
+
+  feedback
+    .command("status")
+    .description("Show automatic source-free feedback policy and opt-out controls")
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--markdown", "Shortcut for --format markdown")
+    .option(
+      "--format <format>",
+      "Output format: json or markdown",
+      parseFormat,
+      "markdown"
+    )
+    .action(
+      (options: { dir: string; markdown?: boolean; format: AxintFeedbackFormat }) => {
+        const policy = resolveAutoFeedbackPolicy(options.dir);
+        const format = options.markdown ? "markdown" : options.format;
+        if (format === "json") {
+          console.log(`${JSON.stringify(policy, null, 2)}\n`);
+          return;
+        }
+        console.log(
+          [
+            "# Axint Automatic Feedback",
+            "",
+            `- Mode: ${policy.mode}`,
+            `- Endpoint: ${policy.endpoint}`,
+            `- Reason: ${policy.reason}`,
+            "- Redaction: source_not_included",
+            "- Source sharing: never_by_default",
+            "",
+            "Opt out any time with `axint feedback opt-out` or `AXINT_FEEDBACK=off`.",
+          ].join("\n")
+        );
+      }
+    );
+
+  feedback
+    .command("opt-out")
+    .description("Turn off automatic source-free feedback for this project")
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--markdown", "Shortcut for --format markdown")
+    .option(
+      "--format <format>",
+      "Output format: json or markdown",
+      parseFormat,
+      "markdown"
+    )
+    .action(
+      (options: { dir: string; markdown?: boolean; format: AxintFeedbackFormat }) => {
+        const policy = writeAutoFeedbackPolicy(options.dir, "off");
+        if ((options.markdown ? "markdown" : options.format) === "json") {
+          console.log(`${JSON.stringify(policy, null, 2)}\n`);
+          return;
+        }
+        console.log("Axint automatic source-free feedback is off for this project.");
+      }
+    );
+
+  feedback
+    .command("opt-in")
+    .description("Turn automatic source-free feedback back on for this project")
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--local-only", "Queue packets locally but do not submit them")
+    .option("--markdown", "Shortcut for --format markdown")
+    .option(
+      "--format <format>",
+      "Output format: json or markdown",
+      parseFormat,
+      "markdown"
+    )
+    .action(
+      (options: {
+        dir: string;
+        localOnly?: boolean;
+        markdown?: boolean;
+        format: AxintFeedbackFormat;
+      }) => {
+        const policy = writeAutoFeedbackPolicy(
+          options.dir,
+          options.localOnly ? "local_only" : "on"
+        );
+        if ((options.markdown ? "markdown" : options.format) === "json") {
+          console.log(`${JSON.stringify(policy, null, 2)}\n`);
+          return;
+        }
+        console.log(
+          `Axint automatic source-free feedback is ${policy.mode} for this project.`
+        );
+      }
+    );
+
+  feedback
+    .command("sync")
+    .description("Retry queued automatic feedback packets")
+    .option("--dir <dir>", "Project directory", ".")
+    .option("--endpoint <url>", "Override feedback endpoint")
+    .option("--markdown", "Shortcut for --format markdown")
+    .option(
+      "--format <format>",
+      "Output format: json or markdown",
+      parseFormat,
+      "markdown"
+    )
+    .action(
+      async (options: {
+        dir: string;
+        endpoint?: string;
+        markdown?: boolean;
+        format: AxintFeedbackFormat;
+      }) => {
+        const report = await syncAutomaticFeedback({
+          cwd: options.dir,
+          endpoint: options.endpoint,
+        });
+        if ((options.markdown ? "markdown" : options.format) === "json") {
+          console.log(`${JSON.stringify(report, null, 2)}\n`);
+          return;
+        }
+        console.log(
+          [
+            "# Axint Feedback Sync",
+            "",
+            `- Attempted: ${report.attempted}`,
+            `- Sent: ${report.sent}`,
+            `- Failed: ${report.failed}`,
+            `- Mode: ${report.policy.mode}`,
+            `- Endpoint: ${report.policy.endpoint}`,
+          ].join("\n")
+        );
+      }
+    );
+
+  feedback
+    .command("import")
+    .description("Import source-free feedback bundles into the local Axint inbox")
+    .argument("<files...>", "Feedback bundle or packet JSON files")
+    .option("--dir <dir>", "Inbox project directory", ".")
+    .option("--project <label>", "Override project label for imported packets")
+    .option("--contact <text>", "Optional contact handle or email")
+    .option("--markdown", "Shortcut for --format markdown")
+    .option(
+      "--format <format>",
+      "Output format: json or markdown",
+      parseFormat,
+      "markdown"
+    )
+    .action(
+      (
+        files: string[],
+        options: {
+          dir: string;
+          project?: string;
+          contact?: string;
+          markdown?: boolean;
+          format: AxintFeedbackFormat;
+        }
+      ) => {
+        const report = importAxintFeedback(files, {
+          cwd: options.dir,
+          projectLabel: options.project,
+          contact: options.contact,
+        });
+        console.log(
+          renderFeedbackImportReport(
+            report,
+            options.markdown ? "markdown" : options.format
+          )
+        );
+      }
+    );
+
+  feedback
+    .command("list")
+    .alias("inbox")
+    .description("List imported feedback packets and repeated Axint fix clusters")
+    .option("--dir <dir>", "Inbox project directory", ".")
+    .option("--markdown", "Shortcut for --format markdown")
+    .option(
+      "--format <format>",
+      "Output format: json or markdown",
+      parseFormat,
+      "markdown"
+    )
+    .action(
+      (options: { dir: string; markdown?: boolean; format: AxintFeedbackFormat }) => {
+        const report = listAxintFeedbackInbox({ cwd: options.dir });
+        console.log(
+          renderFeedbackInboxReport(
+            report,
+            options.markdown ? "markdown" : options.format
+          )
+        );
+      }
+    );
 }
 
-function parseFormat(value: string): "json" | "markdown" {
+function parseFormat(value: string): AxintFeedbackFormat {
   if (value === "json" || value === "markdown") return value;
   throw new Error(`invalid feedback format: ${value}`);
 }

--- a/src/cli/suggest.ts
+++ b/src/cli/suggest.ts
@@ -131,6 +131,7 @@ function renderSuggestReport(
       `- Surfaces: ${suggestion.surfaces.join(", ")}`,
       `- Complexity: ${suggestion.complexity}`,
       suggestion.confidence ? `- Confidence: ${suggestion.confidence}` : null,
+      suggestion.modeTrace ? `- Mode trace: ${suggestion.modeTrace}` : null,
       suggestion.rationale ? `- Rationale: ${suggestion.rationale}` : null,
       suggestion.impact ? `- Impact: ${suggestion.impact}` : null,
       suggestion.loop ? `- Loop: ${suggestion.loop}` : null,

--- a/src/cloud/check.ts
+++ b/src/cloud/check.ts
@@ -1049,6 +1049,18 @@ function diagnosticsFromBuildLog(buildLog: string, file: string): Diagnostic[] {
     });
   }
 
+  if (/\bfailed to terminate\s+[a-z0-9_.-]+:\d+\b/.test(text)) {
+    diagnostics.push({
+      code: "AXCLOUD-XCTEST-STALE-APP",
+      severity: "warning",
+      file,
+      message:
+        "Xcode UI setup could not terminate a stale app process before the test reached the app behavior under review.",
+      suggestion:
+        "Kill the stale app PID named in the log, clean up stale debugserver/test-runner processes if needed, then rerun the same focused selector before changing product code.",
+    });
+  }
+
   if (
     /\btimed out while enabling automation mode\b/.test(text) ||
     /\btest runner failed to initialize for ui testing\b/.test(text) ||
@@ -1173,6 +1185,20 @@ function diagnosticsFromTestFailure(
 ): Diagnostic[] {
   const text = normalizeTextForEvidence(testFailure);
   const diagnostics: Diagnostic[] = [];
+
+  if (/\bfailed to terminate\s+[a-z0-9_.-]+:\d+\b/.test(text)) {
+    return [
+      {
+        code: "AXCLOUD-XCTEST-STALE-APP",
+        severity: "warning",
+        file,
+        message:
+          "XCTest setup could not terminate a stale app process, so this evidence is runner-health blocked rather than a product assertion failure.",
+        suggestion:
+          "Kill the stale app PID named in the log, clean up stale XCTest/debugserver processes if needed, and rerun the same focused selector before changing app code.",
+      },
+    ];
+  }
 
   if (
     /\bxct(?:assert|fail|waiter)[a-z]*\s+failed\b|\btest case\b.*\bfailed\b|\bfailing test\b|\bis not equal to\b|\bfailed assertion\b/.test(

--- a/src/cloud/feedback-store.ts
+++ b/src/cloud/feedback-store.ts
@@ -1,10 +1,15 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import {
+  queueAutomaticFeedback,
+  type AxintAutoFeedbackQueueResult,
+} from "../feedback/auto.js";
 import type { CloudLearningSignal } from "./check.js";
 
 export interface StoredCloudFeedback {
   path: string;
   signal: CloudLearningSignal;
+  autoFeedback?: AxintAutoFeedbackQueueResult;
 }
 
 export function writeCloudFeedbackSignal(
@@ -15,5 +20,9 @@ export function writeCloudFeedbackSignal(
   mkdirSync(root, { recursive: true });
   const path = resolve(root, `${signal.fingerprint}.json`);
   writeFileSync(path, `${JSON.stringify(signal, null, 2)}\n`, "utf-8");
-  return { path, signal };
+  const autoFeedback = queueAutomaticFeedback(signal, {
+    cwd: options.cwd,
+    packetType: "cloud",
+  });
+  return { path, signal, autoFeedback };
 }

--- a/src/core/swift-validator.ts
+++ b/src/core/swift-validator.ts
@@ -359,6 +359,7 @@ function checkSameTargetMissingMembers(inputs: SwiftValidationInput[]): Diagnost
   for (const input of inputs) {
     const stripped = stripCommentsAndStrings(input.source);
     const bindings = collectTypedBindings(stripped, typeMembers);
+    const untypedClosureParameters = collectUntypedClosureParameters(stripped);
     if (bindings.size === 0) continue;
 
     const memberAccess = /\b([a-z][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)\b/g;
@@ -366,6 +367,7 @@ function checkSameTargetMissingMembers(inputs: SwiftValidationInput[]): Diagnost
     while ((match = memberAccess.exec(stripped)) !== null) {
       const objectName = match[1]!;
       const memberName = match[2]!;
+      if (untypedClosureParameters.has(objectName)) continue;
       const typeName = bindings.get(objectName);
       if (!typeName) continue;
       if (KNOWN_CROSS_FILE_MEMBER_NAMES.has(memberName)) continue;
@@ -470,6 +472,16 @@ function collectTypedBindings(
   }
 
   return bindings;
+}
+
+function collectUntypedClosureParameters(stripped: string): Set<string> {
+  const parameters = new Set<string>();
+  const closurePattern = /\{\s*([a-z][A-Za-z0-9_]*)\s+in\b/g;
+  let match: RegExpExecArray | null;
+  while ((match = closurePattern.exec(stripped)) !== null) {
+    parameters.add(match[1]!);
+  }
+  return parameters;
 }
 
 function baseSwiftTypeName(raw: string): string | undefined {

--- a/src/feedback/auto.ts
+++ b/src/feedback/auto.ts
@@ -1,0 +1,277 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import type { CloudLearningSignal } from "../cloud/check.js";
+import type { AxintRepairFeedbackPacket } from "../repair/project-repair.js";
+
+export type AxintAutoFeedbackMode = "on" | "off" | "local_only";
+export type AxintAutoFeedbackPacketType = "cloud" | "repair";
+
+export interface AxintAutoFeedbackPolicy {
+  mode: AxintAutoFeedbackMode;
+  endpoint: string;
+  reason: string;
+  sourceSharing: "never_by_default";
+  redaction: "source_not_included";
+}
+
+export interface AxintAutoFeedbackEnvelope {
+  schema: "https://axint.ai/schemas/auto-feedback.v1.json";
+  id: string;
+  createdAt: string;
+  packetType: AxintAutoFeedbackPacketType;
+  compilerVersion?: string;
+  privacy: {
+    redaction: "source_not_included";
+    sourceSharing: "never_by_default";
+    optOut: "AXINT_FEEDBACK=off or axint feedback opt-out";
+  };
+  packet: AxintRepairFeedbackPacket | CloudLearningSignal;
+}
+
+export interface AxintAutoFeedbackQueueResult {
+  policy: AxintAutoFeedbackPolicy;
+  queued: boolean;
+  queuePath?: string;
+  submitted: "queued" | "disabled" | "local_only" | "attempted";
+}
+
+export const DEFAULT_AUTO_FEEDBACK_ENDPOINT = "https://registry.axint.ai/api/v1/feedback";
+
+export function resolveAutoFeedbackPolicy(cwd = process.cwd()): AxintAutoFeedbackPolicy {
+  const envMode = normalizeMode(
+    process.env.AXINT_FEEDBACK ?? process.env.AXINT_TELEMETRY
+  );
+  if (isOptOutEnv()) {
+    return policy("off", "opted out by environment");
+  }
+  if (envMode) {
+    return policy(envMode, `configured by environment`);
+  }
+
+  const localPolicy = readLocalPolicy(cwd);
+  if (localPolicy) return localPolicy;
+
+  return policy("on", "default source-free diagnostics feedback");
+}
+
+export function writeAutoFeedbackPolicy(
+  cwd: string,
+  mode: AxintAutoFeedbackMode
+): AxintAutoFeedbackPolicy {
+  const root = resolve(cwd, ".axint/feedback");
+  mkdirSync(root, { recursive: true });
+  const current = policy(mode, "configured by local project policy");
+  writeFileSync(
+    join(root, "policy.json"),
+    `${JSON.stringify(
+      {
+        mode,
+        endpoint: current.endpoint,
+        privacy: {
+          redaction: current.redaction,
+          sourceSharing: current.sourceSharing,
+        },
+      },
+      null,
+      2
+    )}\n`,
+    "utf-8"
+  );
+  return current;
+}
+
+export function queueAutomaticFeedback(
+  packet: AxintRepairFeedbackPacket | CloudLearningSignal,
+  options: { cwd?: string; packetType: AxintAutoFeedbackPacketType } = {
+    packetType: "cloud",
+  }
+): AxintAutoFeedbackQueueResult {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const currentPolicy = resolveAutoFeedbackPolicy(cwd);
+  if (currentPolicy.mode === "off") {
+    return {
+      policy: currentPolicy,
+      queued: false,
+      submitted: "disabled",
+    };
+  }
+
+  const envelope = buildAutoFeedbackEnvelope(packet, options.packetType);
+  const outboxDir = resolve(cwd, ".axint/feedback/outbox");
+  mkdirSync(outboxDir, { recursive: true });
+  const queuePath = join(outboxDir, `${envelope.id}.json`);
+  writeFileSync(queuePath, `${JSON.stringify(envelope, null, 2)}\n`, "utf-8");
+
+  if (currentPolicy.mode === "local_only" || isTestRuntime()) {
+    return {
+      policy: currentPolicy,
+      queued: true,
+      queuePath,
+      submitted: currentPolicy.mode === "local_only" ? "local_only" : "queued",
+    };
+  }
+
+  void submitFeedbackEnvelope(queuePath, currentPolicy).catch(() => {
+    // Feedback must never break the user's build loop.
+  });
+
+  return {
+    policy: currentPolicy,
+    queued: true,
+    queuePath,
+    submitted: "attempted",
+  };
+}
+
+export async function syncAutomaticFeedback(
+  options: { cwd?: string; endpoint?: string } = {}
+): Promise<{
+  policy: AxintAutoFeedbackPolicy;
+  attempted: number;
+  sent: number;
+  failed: number;
+}> {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const currentPolicy = {
+    ...resolveAutoFeedbackPolicy(cwd),
+    endpoint: options.endpoint ?? resolveAutoFeedbackPolicy(cwd).endpoint,
+  };
+  if (currentPolicy.mode === "off") {
+    return { policy: currentPolicy, attempted: 0, sent: 0, failed: 0 };
+  }
+  const outboxDir = resolve(cwd, ".axint/feedback/outbox");
+  if (!existsSync(outboxDir)) {
+    return { policy: currentPolicy, attempted: 0, sent: 0, failed: 0 };
+  }
+  const files = readdirSync(outboxDir).filter(
+    (file) => file.endsWith(".json") && !file.endsWith(".sent.json")
+  );
+  let sent = 0;
+  let failed = 0;
+  for (const file of files) {
+    const ok = await submitFeedbackEnvelope(join(outboxDir, file), currentPolicy);
+    if (ok) sent += 1;
+    else failed += 1;
+  }
+  return { policy: currentPolicy, attempted: files.length, sent, failed };
+}
+
+function buildAutoFeedbackEnvelope(
+  packet: AxintRepairFeedbackPacket | CloudLearningSignal,
+  packetType: AxintAutoFeedbackPacketType
+): AxintAutoFeedbackEnvelope {
+  const createdAt = new Date().toISOString();
+  const stable = "fingerprint" in packet ? packet.fingerprint : packet.id;
+  return {
+    schema: "https://axint.ai/schemas/auto-feedback.v1.json",
+    id: `auto-feedback-${hashString([packetType, stable, createdAt].join(":"))}`,
+    createdAt,
+    packetType,
+    compilerVersion: packet.compilerVersion,
+    privacy: {
+      redaction: "source_not_included",
+      sourceSharing: "never_by_default",
+      optOut: "AXINT_FEEDBACK=off or axint feedback opt-out",
+    },
+    packet,
+  };
+}
+
+async function submitFeedbackEnvelope(
+  path: string,
+  currentPolicy: AxintAutoFeedbackPolicy
+): Promise<boolean> {
+  if (currentPolicy.mode !== "on") return false;
+  let envelope: AxintAutoFeedbackEnvelope;
+  try {
+    envelope = JSON.parse(readFileSync(path, "utf-8")) as AxintAutoFeedbackEnvelope;
+  } catch {
+    return false;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 1500);
+  try {
+    const response = await fetch(currentPolicy.endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": `axint-feedback/${envelope.compilerVersion ?? "unknown"}`,
+      },
+      body: JSON.stringify(envelope),
+      signal: controller.signal,
+    });
+    if (!response.ok) return false;
+    renameSync(path, path.replace(/\.json$/, ".sent.json"));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function readLocalPolicy(cwd: string): AxintAutoFeedbackPolicy | undefined {
+  const path = resolve(cwd, ".axint/feedback/policy.json");
+  if (!existsSync(path)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as {
+      mode?: string;
+      endpoint?: string;
+    };
+    const mode = normalizeMode(parsed.mode);
+    if (!mode) return undefined;
+    return policy(mode, "configured by local project policy", parsed.endpoint);
+  } catch {
+    return undefined;
+  }
+}
+
+function policy(
+  mode: AxintAutoFeedbackMode,
+  reason: string,
+  endpoint = process.env.AXINT_FEEDBACK_ENDPOINT ?? DEFAULT_AUTO_FEEDBACK_ENDPOINT
+): AxintAutoFeedbackPolicy {
+  return {
+    mode,
+    endpoint,
+    reason,
+    sourceSharing: "never_by_default",
+    redaction: "source_not_included",
+  };
+}
+
+function normalizeMode(value?: string): AxintAutoFeedbackMode | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (["0", "false", "no", "off", "disabled"].includes(normalized)) return "off";
+  if (["local", "local_only", "queue"].includes(normalized)) return "local_only";
+  if (["1", "true", "yes", "on", "enabled"].includes(normalized)) return "on";
+  return undefined;
+}
+
+function isOptOutEnv(): boolean {
+  return ["1", "true", "yes", "on"].includes(
+    (process.env.AXINT_DISABLE_FEEDBACK ?? "").trim().toLowerCase()
+  );
+}
+
+function isTestRuntime(): boolean {
+  return Boolean(
+    process.env.VITEST ||
+    process.env.NODE_ENV === "test" ||
+    process.argv.some((arg) => /vitest|tsx/.test(arg))
+  );
+}
+
+function hashString(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}

--- a/src/feedback/inbox.ts
+++ b/src/feedback/inbox.ts
@@ -1,0 +1,608 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
+import { basename, dirname, join, resolve } from "node:path";
+import type { CloudLearningSignal } from "../cloud/check.js";
+import type { AxintRepairFeedbackPacket } from "../repair/project-repair.js";
+
+export type AxintFeedbackFormat = "json" | "markdown";
+
+export type AxintFeedbackPacket =
+  | { kind: "repair"; packet: AxintRepairFeedbackPacket }
+  | { kind: "cloud"; packet: CloudLearningSignal };
+
+export interface AxintFeedbackBundle {
+  schema: "https://axint.ai/schemas/feedback-bundle.v1.json";
+  id: string;
+  createdAt: string;
+  compilerVersion?: string;
+  projectLabel?: string;
+  contact?: string;
+  privacy: {
+    redaction: "source_not_included";
+    sourceSharing: "never_by_default";
+    userCanInspectBeforeSending: true;
+    transport: "manual_export" | "manual_import";
+  };
+  packets: Array<AxintRepairFeedbackPacket | CloudLearningSignal>;
+}
+
+export interface AxintFeedbackInboxItem {
+  id: string;
+  packetType: "repair" | "cloud";
+  importedAt: string;
+  projectLabel?: string;
+  contact?: string;
+  sourceFile: string;
+  compilerVersion?: string;
+  priority: string;
+  issueClass: string;
+  status?: string;
+  confidence?: string;
+  diagnostics: string[];
+  signals: string[];
+  suggestedOwner?: string;
+  suggestedAction?: string;
+  privacy: "source_not_included";
+  warnings: string[];
+}
+
+export interface AxintFeedbackCluster {
+  key: string;
+  count: number;
+  priority: string;
+  issueClass: string;
+  diagnostics: string[];
+  signals: string[];
+  suggestedOwner?: string;
+  suggestedAction?: string;
+  packetIds: string[];
+  projects: string[];
+}
+
+export interface AxintFeedbackExportReport {
+  cwd: string;
+  outPath: string;
+  bundle: AxintFeedbackBundle;
+  packetCount: number;
+  warnings: string[];
+}
+
+export interface AxintFeedbackImportReport {
+  cwd: string;
+  inboxDir: string;
+  imported: AxintFeedbackInboxItem[];
+  skipped: Array<{ file: string; reason: string }>;
+  warnings: string[];
+}
+
+export interface AxintFeedbackInboxReport {
+  cwd: string;
+  inboxDir: string;
+  items: AxintFeedbackInboxItem[];
+  clusters: AxintFeedbackCluster[];
+  nextMoves: string[];
+  privacy: {
+    redaction: "source_not_included";
+    sourceSharing: "never_by_default";
+  };
+}
+
+type ExportOptions = {
+  cwd?: string;
+  out?: string;
+  projectLabel?: string;
+  contact?: string;
+  latestOnly?: boolean;
+};
+
+type ImportOptions = {
+  cwd?: string;
+  projectLabel?: string;
+  contact?: string;
+};
+
+type ListOptions = {
+  cwd?: string;
+};
+
+export function exportAxintFeedback(
+  options: ExportOptions = {}
+): AxintFeedbackExportReport {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const latestPackets = options.latestOnly ? readLatestFeedbackPacket(cwd) : [];
+  const packets =
+    options.latestOnly && latestPackets.length > 0
+      ? latestPackets
+      : readLocalFeedbackPackets(cwd);
+  const createdAt = new Date().toISOString();
+  const warnings: string[] = [];
+
+  if (packets.length === 0) {
+    warnings.push(
+      "No local feedback packets found. Run `axint run`, `axint repair`, or `axint feedback create` first."
+    );
+  }
+
+  const packetPayloads = packets.map((entry) => entry.packet);
+  for (const packet of packetPayloads) {
+    warnings.push(...privacyWarningsForPacket(packet));
+  }
+
+  const bundleId = `feedback-bundle-${hashString(
+    [cwd, createdAt, packetPayloads.map(packetStableId).join("|")].join(":")
+  )}`;
+  const bundle: AxintFeedbackBundle = {
+    schema: "https://axint.ai/schemas/feedback-bundle.v1.json",
+    id: bundleId,
+    createdAt,
+    compilerVersion: firstCompilerVersion(packetPayloads),
+    projectLabel: options.projectLabel,
+    contact: options.contact,
+    privacy: {
+      redaction: "source_not_included",
+      sourceSharing: "never_by_default",
+      userCanInspectBeforeSending: true,
+      transport: "manual_export",
+    },
+    packets: packetPayloads,
+  };
+
+  const outPath = resolve(
+    cwd,
+    options.out ?? join(".axint/feedback/outbox", `${bundle.id}.json`)
+  );
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, `${JSON.stringify(bundle, null, 2)}\n`, "utf-8");
+
+  return { cwd, outPath, bundle, packetCount: packetPayloads.length, warnings };
+}
+
+export function importAxintFeedback(
+  files: string[],
+  options: ImportOptions = {}
+): AxintFeedbackImportReport {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const inboxDir = resolve(cwd, ".axint/feedback/inbox");
+  mkdirSync(inboxDir, { recursive: true });
+  const imported: AxintFeedbackInboxItem[] = [];
+  const skipped: Array<{ file: string; reason: string }> = [];
+  const warnings: string[] = [];
+
+  for (const file of files) {
+    const abs = resolve(file);
+    if (!existsSync(abs)) {
+      skipped.push({ file, reason: "file_not_found" });
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(abs, "utf-8"));
+    } catch {
+      skipped.push({ file, reason: "invalid_json" });
+      continue;
+    }
+
+    const packets = expandFeedbackPayload(parsed);
+    if (packets.length === 0) {
+      skipped.push({ file, reason: "no_source_free_feedback_packets" });
+      continue;
+    }
+
+    for (const entry of packets) {
+      const packetWarnings = privacyWarningsForPacket(entry.packet);
+      warnings.push(...packetWarnings.map((warning) => `${basename(file)}: ${warning}`));
+      const item = itemFromPacket(entry, {
+        importedAt: new Date().toISOString(),
+        projectLabel: options.projectLabel ?? bundleProjectLabel(parsed),
+        contact: options.contact ?? bundleContact(parsed),
+        sourceFile: abs,
+        warnings: packetWarnings,
+      });
+      const target = join(inboxDir, `${item.id}.json`);
+      writeFileSync(
+        target,
+        `${JSON.stringify({ ...item, packet: entry.packet }, null, 2)}\n`,
+        "utf-8"
+      );
+      imported.push(item);
+    }
+
+    const archivePath = join(inboxDir, "_imports", basename(abs));
+    mkdirSync(resolve(archivePath, ".."), { recursive: true });
+    copyFileSync(abs, archivePath);
+  }
+
+  return { cwd, inboxDir, imported, skipped, warnings };
+}
+
+export function listAxintFeedbackInbox(
+  options: ListOptions = {}
+): AxintFeedbackInboxReport {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const inboxDir = resolve(cwd, ".axint/feedback/inbox");
+  const items = readInboxItems(inboxDir);
+  const clusters = clusterInboxItems(items);
+  const nextMoves = clusters.slice(0, 8).map((cluster) => {
+    const diagnostics = cluster.diagnostics.length
+      ? ` (${cluster.diagnostics.slice(0, 4).join(", ")})`
+      : "";
+    const owner = cluster.suggestedOwner ? ` for ${cluster.suggestedOwner}` : "";
+    return `${cluster.priority.toUpperCase()} · ${cluster.count} packet${cluster.count === 1 ? "" : "s"} · ${cluster.issueClass}${diagnostics}${owner}: ${cluster.suggestedAction ?? "Cluster repeated packets into a new Axint diagnostic, repair heuristic, or proof rule."}`;
+  });
+
+  return {
+    cwd,
+    inboxDir,
+    items,
+    clusters,
+    nextMoves,
+    privacy: {
+      redaction: "source_not_included",
+      sourceSharing: "never_by_default",
+    },
+  };
+}
+
+export function renderFeedbackExportReport(
+  report: AxintFeedbackExportReport,
+  format: AxintFeedbackFormat
+): string {
+  if (format === "json") return `${JSON.stringify(report, null, 2)}\n`;
+  return [
+    "# Axint Feedback Export",
+    "",
+    `- Packets: ${report.packetCount}`,
+    `- Bundle: ${report.outPath}`,
+    "- Privacy: source not included; source sharing is never enabled by default",
+    ...(report.bundle.projectLabel
+      ? [`- Project label: ${report.bundle.projectLabel}`]
+      : []),
+    ...(report.warnings.length
+      ? ["", "## Warnings", ...report.warnings.map((w) => `- ${w}`)]
+      : []),
+    "",
+    "Send this JSON bundle to the Axint maintainer, or import it into an Axint feedback inbox.",
+  ].join("\n");
+}
+
+export function renderFeedbackImportReport(
+  report: AxintFeedbackImportReport,
+  format: AxintFeedbackFormat
+): string {
+  if (format === "json") return `${JSON.stringify(report, null, 2)}\n`;
+  return [
+    "# Axint Feedback Import",
+    "",
+    `- Imported: ${report.imported.length}`,
+    `- Skipped: ${report.skipped.length}`,
+    `- Inbox: ${report.inboxDir}`,
+    "- Privacy: imported packets are source-free",
+    "",
+    ...(report.imported.length
+      ? [
+          "## Imported Packets",
+          ...report.imported.map(
+            (item) =>
+              `- ${item.priority.toUpperCase()} · ${item.issueClass} · ${item.id}${item.projectLabel ? ` · ${item.projectLabel}` : ""}`
+          ),
+        ]
+      : ["No packets imported."]),
+    ...(report.skipped.length
+      ? [
+          "",
+          "## Skipped",
+          ...report.skipped.map((item) => `- ${item.file}: ${item.reason}`),
+        ]
+      : []),
+    ...(report.warnings.length
+      ? ["", "## Privacy Warnings", ...report.warnings.map((warning) => `- ${warning}`)]
+      : []),
+  ].join("\n");
+}
+
+export function renderFeedbackInboxReport(
+  report: AxintFeedbackInboxReport,
+  format: AxintFeedbackFormat
+): string {
+  if (format === "json") return `${JSON.stringify(report, null, 2)}\n`;
+  return [
+    "# Axint Feedback Inbox",
+    "",
+    `- Packets: ${report.items.length}`,
+    `- Clusters: ${report.clusters.length}`,
+    `- Inbox: ${report.inboxDir}`,
+    "- Privacy: source not included; source sharing is never enabled by default",
+    "",
+    "## Next Axint Fixes",
+    ...(report.nextMoves.length
+      ? report.nextMoves.map((move) => `- ${move}`)
+      : ["- No imported feedback yet."]),
+    "",
+    "## Clusters",
+    ...(report.clusters.length
+      ? report.clusters.map(
+          (cluster) =>
+            `- ${cluster.priority.toUpperCase()} · ${cluster.count}x · ${cluster.issueClass} · ${cluster.diagnostics.join(", ") || "no diagnostics"}`
+        )
+      : ["- No clusters yet."]),
+    "",
+    "## Recent Packets",
+    ...(report.items.length
+      ? report.items.slice(0, 20).map((item) => {
+          const project = item.projectLabel ? ` · ${item.projectLabel}` : "";
+          const diagnostics = item.diagnostics.length
+            ? ` · ${item.diagnostics.join(", ")}`
+            : "";
+          return `- ${item.priority.toUpperCase()} · ${item.issueClass}${diagnostics}${project} · ${item.id}`;
+        })
+      : ["- No packets yet."]),
+  ].join("\n");
+}
+
+function readLatestFeedbackPacket(cwd: string): AxintFeedbackPacket[] {
+  const latest = resolve(cwd, ".axint/feedback/latest.json");
+  if (!existsSync(latest)) return [];
+  try {
+    return expandFeedbackPayload(JSON.parse(readFileSync(latest, "utf-8"))).slice(0, 1);
+  } catch {
+    return [];
+  }
+}
+
+function readLocalFeedbackPackets(cwd: string): AxintFeedbackPacket[] {
+  const dir = resolve(cwd, ".axint/feedback");
+  if (!existsSync(dir)) return [];
+  const packets: AxintFeedbackPacket[] = [];
+  const seen = new Set<string>();
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith(".json")) continue;
+    const path = join(dir, file);
+    try {
+      for (const packet of expandFeedbackPayload(
+        JSON.parse(readFileSync(path, "utf-8"))
+      )) {
+        const id = packetStableId(packet.packet);
+        if (seen.has(id)) continue;
+        seen.add(id);
+        packets.push(packet);
+      }
+    } catch {
+      // Ignore corrupt local scratch packets; import/list reports are stricter.
+    }
+  }
+  return packets;
+}
+
+function expandFeedbackPayload(payload: unknown): AxintFeedbackPacket[] {
+  if (!payload || typeof payload !== "object") return [];
+  const record = payload as Record<string, unknown>;
+  if (record.schema === "https://axint.ai/schemas/feedback-bundle.v1.json") {
+    const packets = Array.isArray(record.packets) ? record.packets : [];
+    return packets.flatMap(expandFeedbackPayload);
+  }
+  if (isRepairFeedbackPacket(record)) {
+    return [{ kind: "repair", packet: record as unknown as AxintRepairFeedbackPacket }];
+  }
+  if (isCloudLearningSignal(record)) {
+    return [{ kind: "cloud", packet: record as unknown as CloudLearningSignal }];
+  }
+  if (record.packet && typeof record.packet === "object") {
+    return expandFeedbackPayload(record.packet);
+  }
+  return [];
+}
+
+function readInboxItems(inboxDir: string): AxintFeedbackInboxItem[] {
+  if (!existsSync(inboxDir)) return [];
+  const items: AxintFeedbackInboxItem[] = [];
+  for (const file of readdirSync(inboxDir)) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(join(inboxDir, file), "utf-8"));
+      if (isInboxItem(parsed)) items.push(parsed);
+    } catch {
+      // Ignore corrupt inbox scratch files in list mode.
+    }
+  }
+  return items.sort((a, b) => b.importedAt.localeCompare(a.importedAt));
+}
+
+function clusterInboxItems(items: AxintFeedbackInboxItem[]): AxintFeedbackCluster[] {
+  const clusters = new Map<string, AxintFeedbackCluster>();
+  for (const item of items) {
+    const key = [
+      item.issueClass,
+      item.diagnostics.slice(0, 4).join(","),
+      item.signals.slice(0, 3).join(","),
+    ].join(":");
+    const existing = clusters.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.packetIds.push(item.id);
+      existing.projects = uniqueStrings(
+        [...existing.projects, item.projectLabel].filter(Boolean) as string[]
+      );
+      existing.diagnostics = uniqueStrings([
+        ...existing.diagnostics,
+        ...item.diagnostics,
+      ]);
+      existing.signals = uniqueStrings([...existing.signals, ...item.signals]);
+      existing.priority = highestPriority(existing.priority, item.priority);
+      continue;
+    }
+    clusters.set(key, {
+      key,
+      count: 1,
+      priority: item.priority,
+      issueClass: item.issueClass,
+      diagnostics: item.diagnostics,
+      signals: item.signals,
+      suggestedOwner: item.suggestedOwner,
+      suggestedAction: item.suggestedAction,
+      packetIds: [item.id],
+      projects: item.projectLabel ? [item.projectLabel] : [],
+    });
+  }
+  return [...clusters.values()].sort((a, b) => {
+    const priority = priorityRank(b.priority) - priorityRank(a.priority);
+    if (priority !== 0) return priority;
+    return b.count - a.count;
+  });
+}
+
+function itemFromPacket(
+  entry: AxintFeedbackPacket,
+  meta: {
+    importedAt: string;
+    projectLabel?: string;
+    contact?: string;
+    sourceFile: string;
+    warnings: string[];
+  }
+): AxintFeedbackInboxItem {
+  if (entry.kind === "repair") {
+    const packet = entry.packet;
+    return {
+      id: packetStableId(packet),
+      packetType: "repair",
+      importedAt: meta.importedAt,
+      projectLabel: meta.projectLabel,
+      contact: meta.contact,
+      sourceFile: meta.sourceFile,
+      compilerVersion: packet.compilerVersion,
+      priority: packet.classification.priority,
+      issueClass: packet.classification.issueClass,
+      status: packet.classification.status,
+      confidence: packet.classification.confidence,
+      diagnostics: packet.diagnostics.map((diagnostic) => diagnostic.code),
+      signals: packet.signals,
+      suggestedOwner: packet.suggestedAxintOwner,
+      suggestedAction: packet.suggestedProductAction,
+      privacy: "source_not_included",
+      warnings: meta.warnings,
+    };
+  }
+  const packet = entry.packet;
+  return {
+    id: packetStableId(packet),
+    packetType: "cloud",
+    importedAt: meta.importedAt,
+    projectLabel: meta.projectLabel,
+    contact: meta.contact,
+    sourceFile: meta.sourceFile,
+    compilerVersion: packet.compilerVersion,
+    priority: packet.priority,
+    issueClass: packet.kind,
+    status: packet.status,
+    confidence: undefined,
+    diagnostics: packet.diagnosticCodes,
+    signals: packet.signals,
+    suggestedOwner: packet.suggestedOwner,
+    suggestedAction: packet.suggestedAction,
+    privacy: "source_not_included",
+    warnings: meta.warnings,
+  };
+}
+
+function isRepairFeedbackPacket(value: Record<string, unknown>): boolean {
+  return (
+    value.schema === "https://axint.ai/schemas/repair-feedback.v1.json" &&
+    typeof value.id === "string" &&
+    typeof value.privacy === "object" &&
+    (value.privacy as Record<string, unknown>).redaction === "source_not_included"
+  );
+}
+
+function isCloudLearningSignal(value: Record<string, unknown>): boolean {
+  return (
+    typeof value.fingerprint === "string" &&
+    value.redaction === "source_not_included" &&
+    Array.isArray(value.diagnosticCodes) &&
+    typeof value.suggestedAction === "string"
+  );
+}
+
+function isInboxItem(value: unknown): value is AxintFeedbackInboxItem {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    typeof (value as AxintFeedbackInboxItem).id === "string" &&
+    typeof (value as AxintFeedbackInboxItem).issueClass === "string" &&
+    (value as AxintFeedbackInboxItem).privacy === "source_not_included"
+  );
+}
+
+function packetStableId(packet: AxintRepairFeedbackPacket | CloudLearningSignal): string {
+  if ("fingerprint" in packet) return packet.fingerprint;
+  return packet.id;
+}
+
+function firstCompilerVersion(
+  packets: Array<AxintRepairFeedbackPacket | CloudLearningSignal>
+): string | undefined {
+  return packets.find((packet) => packet.compilerVersion)?.compilerVersion;
+}
+
+function privacyWarningsForPacket(
+  packet: AxintRepairFeedbackPacket | CloudLearningSignal
+): string[] {
+  const warnings: string[] = [];
+  const text = JSON.stringify(packet);
+  if (!text.includes("source_not_included")) {
+    warnings.push("packet does not declare source_not_included redaction");
+  }
+  if (/\bimport\s+(SwiftUI|AppIntents|Foundation)\b/.test(text)) {
+    warnings.push(
+      "packet appears to contain raw Swift import text; inspect before sharing"
+    );
+  }
+  if (/\bstruct\s+\w+\s*:\s*(View|AppIntent)\b/.test(text)) {
+    warnings.push(
+      "packet appears to contain raw Swift declaration text; inspect before sharing"
+    );
+  }
+  return uniqueStrings(warnings);
+}
+
+function bundleProjectLabel(payload: unknown): string | undefined {
+  return typeof payload === "object" && payload
+    ? stringValue((payload as Record<string, unknown>).projectLabel)
+    : undefined;
+}
+
+function bundleContact(payload: unknown): string | undefined {
+  return typeof payload === "object" && payload
+    ? stringValue((payload as Record<string, unknown>).contact)
+    : undefined;
+}
+
+function highestPriority(a: string, b: string): string {
+  return priorityRank(b) > priorityRank(a) ? b : a;
+}
+
+function priorityRank(value: string): number {
+  if (value === "p0") return 4;
+  if (value === "p1") return 3;
+  if (value === "p2") return 2;
+  if (value === "p3") return 1;
+  return 0;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function hashString(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}

--- a/src/mcp/suggest.ts
+++ b/src/mcp/suggest.ts
@@ -37,6 +37,7 @@ export interface FeatureSuggestion {
   impact?: string;
   loop?: string;
   nextStep?: string;
+  modeTrace?: string;
 }
 
 interface DomainFeatureSet {
@@ -909,6 +910,14 @@ export function suggestFeatures(input: SuggestInput): FeatureSuggestion[] {
   const text = normalizeText(input.appDescription);
   const excludedText = normalizeText((input.exclude ?? []).join(" "));
   const explicitDomain = normalizeDomain(input.domain);
+  const freshProductMode = detectFreshProductMode(input, text);
+
+  if (freshProductMode?.kind === "public-page") {
+    return publicLanderSuggestions(input, text, limit, freshProductMode.trace);
+  }
+  if (freshProductMode?.kind === "brand-polish") {
+    return brandPolishSuggestions(input, text, limit, freshProductMode.trace);
+  }
 
   if (looksLikeExistingProductRepair(input, text)) {
     return existingProductRepairSuggestions(input, text, limit);
@@ -995,6 +1004,287 @@ export async function suggestFeaturesSmart(
   const localSuggestions = suggestFeatures(input);
   const pro = await requestProSuggestions(input, localSuggestions);
   return pro.status === "used" ? pro.suggestions : localSuggestions;
+}
+
+type FreshProductMode =
+  | {
+      kind: "public-page";
+      trace: string;
+    }
+  | {
+      kind: "brand-polish";
+      trace: string;
+    }
+  | undefined;
+
+function detectFreshProductMode(
+  input: SuggestInput,
+  normalizedAppDescription: string
+): FreshProductMode {
+  const goalsText = normalizeText((input.goals ?? []).join(" "));
+  const constraintsText = normalizeText((input.constraints ?? []).join(" "));
+  const combined = [normalizedAppDescription, goalsText, constraintsText]
+    .filter(Boolean)
+    .join(" ");
+
+  const publicPageCues = [
+    ".axint",
+    "custom lander",
+    "custom startup landing page",
+    "landing page",
+    "startup landing",
+    "public lander",
+    "public page",
+    "public project page",
+    "profile page",
+    "project profile",
+    "project page",
+    "premium public project page",
+    "page manifest",
+    "module manifest",
+    "brand",
+    "brand asset",
+    "programmable module",
+    "programmable modules",
+    "shareable launch card",
+    "share card",
+    "share cards",
+    "custom share card",
+    "customize share card",
+    "customize share cards",
+    "install qr",
+    "qr block",
+    "qr blocks",
+    "email capture",
+    "safe customization",
+  ].filter((cue) => hasKeyword(combined, cue));
+
+  const buildIntent = [
+    "add",
+    "become",
+    "build",
+    "create",
+    "design",
+    "generate",
+    "make",
+    "ship",
+    "turn into",
+    "upgrade into",
+  ].some((cue) => hasKeyword(combined, cue));
+
+  const staleContextHint = [
+    "older repair",
+    "previous repair",
+    "repair notes",
+    "stale",
+    "old context",
+    "previous context",
+  ].some((cue) => hasKeyword(combined, cue));
+
+  if (publicPageCues.length >= 2 && (buildIntent || staleContextHint)) {
+    const cueList = publicPageCues.slice(0, 5).join(", ");
+    return {
+      kind: "public-page",
+      trace: `Current prompt won because it contains fresh public-page cues (${cueList}); repair words are treated as constraints unless the user asks to fix a broken existing screen.`,
+    };
+  }
+
+  const brandCues = [
+    "official mark",
+    "symbol mark",
+    "wordmark",
+    "brand accuracy",
+    "brand asset",
+    "wrong brand",
+    "wrong logo",
+    "wrong symbol",
+    "hand-drawn symbol",
+    "profile identity",
+    "brand kit",
+    "axint.ai",
+  ].filter((cue) => hasKeyword(combined, cue));
+
+  const brandIntent = [
+    "needs",
+    "replace",
+    "use",
+    "keep",
+    "remove",
+    "preserve",
+    "make premium",
+    "repair",
+    "polish",
+  ].some((cue) => hasKeyword(combined, cue));
+
+  if (brandCues.length >= 2 && brandIntent) {
+    const cueList = brandCues.slice(0, 5).join(", ");
+    return {
+      kind: "brand-polish",
+      trace: `Current prompt won because it contains brand/provenance cues (${cueList}); Axint is treating this as existing-product brand polish, not fresh feature brainstorming.`,
+    };
+  }
+
+  return undefined;
+}
+
+function publicLanderSuggestions(
+  input: SuggestInput,
+  normalizedAppDescription: string,
+  limit: number,
+  modeTrace: string
+): FeatureSuggestion[] {
+  const labels = semanticLabels(normalizedAppDescription, 5);
+  const projectLabel =
+    labels.find((label) => /axint|project|profile|public|lander/i.test(label)) ??
+    "Project";
+  const platform = input.platform ? `${input.platform} ` : "";
+  const rationale = `Mode trace: ${modeTrace} Axint is planning a new customer-facing lander/module surface instead of re-entering stale SwiftUI repair mode.`;
+
+  const suggestions: FeatureSuggestion[] = [
+    {
+      name: `${projectLabel} Public Lander Manifest`,
+      description:
+        "Define the public page as a safe .axint module contract so humans and agents can configure hero, proof, install, share, and capture blocks without editing raw SwiftUI first.",
+      surfaces: ["view", "component", "store"],
+      complexity: "medium",
+      featurePrompt: `Create a ${platform}.axint page manifest for a custom public lander with programmable modules, proof blocks, install QR blocks, email capture, safe customization, share card metadata, and preserved UI test identifiers. If the project has existing public-page files, inspect and patch ProjectShowcaseView, ShareComposerView, brand assets, and public-page customization before generating new surfaces.`,
+      domain: "public-page",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact:
+        "Turns a vague public profile request into a structured page contract agents can extend safely.",
+      loop: "Manifest -> validate modules -> render page -> prove identifiers",
+      nextStep:
+        "Generate or update the .axint page first, then compile/render the SwiftUI surface against that manifest.",
+      modeTrace,
+    },
+    {
+      name: "Share Card and Install Blocks",
+      description:
+        "Create reusable launch blocks for social preview cards, QR install flows, copyable install commands, and email capture moments.",
+      surfaces: ["component", "view"],
+      complexity: "medium",
+      featurePrompt: `Create reusable ${platform}public-page modules for share cards, install QR, copyable install command, email capture, creator/project metadata, and analytics-safe call-to-action events.`,
+      domain: "public-page",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact: "Makes each project page distributable instead of merely decorative.",
+      loop: "Preview -> share -> install -> capture",
+      nextStep:
+        "Keep each block addressable with stable accessibility identifiers and manifest keys.",
+      modeTrace,
+    },
+    {
+      name: "Safe Customization Rules",
+      description:
+        "Add guardrails that let users customize copy, layout modules, theme tokens, and share assets while blocking unsafe links or broken module combinations.",
+      surfaces: ["store", "component"],
+      complexity: "medium",
+      featurePrompt: `Create safe customization rules for a .axint public page: allowed modules, required fields, link validation, theme token bounds, share image metadata, and fallback copy for missing blocks.`,
+      domain: "public-page",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact:
+        "Lets agents personalize public pages without creating malformed or unsafe output.",
+      loop: "Customize -> validate -> preview -> publish",
+      nextStep:
+        "Run validation before rendering and return actionable diagnostics for missing modules.",
+      modeTrace,
+    },
+    {
+      name: "Public Page Proof Harness",
+      description:
+        "Add focused proof for the public page: required modules render, install/share actions are hittable, and preserved identifiers remain stable across customization.",
+      surfaces: ["view"],
+      complexity: "low",
+      featurePrompt: `Add focused ${platform}tests for the custom public lander: hero renders, share card metadata exists, install QR block is visible, email capture is reachable, and preserved UI test identifiers remain stable.`,
+      domain: "public-page",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact: "Keeps the new lander work from regressing into static mockup territory.",
+      loop: "Render -> interact -> verify identifiers -> Cloud Check",
+      nextStep:
+        "Run `axint run` with the changed manifest, rendering files, and focused page tests.",
+      modeTrace,
+    },
+  ];
+
+  return suggestions.slice(0, limit);
+}
+
+function brandPolishSuggestions(
+  input: SuggestInput,
+  normalizedAppDescription: string,
+  limit: number,
+  modeTrace: string
+): FeatureSuggestion[] {
+  const labels = semanticLabels(normalizedAppDescription, 4);
+  const brandLabel =
+    labels.find((label) => /axint|brand|mark|symbol|profile/i.test(label)) ?? "Brand";
+  const platform = input.platform ? `${input.platform} ` : "";
+  const rationale = `Mode trace: ${modeTrace} Axint is planning a surgical brand/provenance pass for existing product surfaces instead of generic feature ideas.`;
+
+  const suggestions: FeatureSuggestion[] = [
+    {
+      name: `${brandLabel} Asset Provenance Map`,
+      description:
+        "Find the official mark, compare it against current local assets, and decide exactly which surfaces use the symbol, wordmark, or cover art.",
+      surfaces: ["component", "view"],
+      complexity: "low",
+      featurePrompt: `Audit asset provenance for the ${platform}project before editing UI: identify the official Axint symbol mark source, current local asset filenames, wrong or hand-drawn variants, wordmark-only surfaces, and the exact SwiftUI files that render each asset. Return file targets, replacement plan, and visual proof steps.`,
+      domain: "brand-polish",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact:
+        "Prevents agents from swapping logos by vibes and gives brand changes a proof trail.",
+      loop: "Source asset -> map usage -> patch smallest surfaces -> visual proof",
+      nextStep:
+        "Inspect assets and the existing brand kit before generating or replacing any image.",
+      modeTrace,
+    },
+    {
+      name: "Existing Surface Brand Wiring",
+      description:
+        "Patch the current SwiftUI surfaces and brand-kit tokens in place instead of creating a new marketing screen.",
+      surfaces: ["view", "store", "component"],
+      complexity: "medium",
+      featurePrompt: `Repair existing ${platform}brand wiring in place: inspect BrandKit, ProjectShowcaseView, profile/project surfaces, cover art, and any share-card composer before changing the official mark. Preserve working routes and accessibility identifiers, remove the wrong brand asset, and keep wordmark usage where appropriate.`,
+      domain: "brand-polish",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact:
+        "Keeps premium polish tied to the real app instead of drifting into a disconnected redesign.",
+      loop: "Inspect -> patch assets/tokens -> validate Swift -> focused UI proof",
+      nextStep:
+        "Use `axint validate-swift` on the touched SwiftUI files, then run a focused visual or UI proof.",
+      modeTrace,
+    },
+    {
+      name: "Brand Visual Proof Pass",
+      description:
+        "Add proof that the correct asset appears on the right surfaces and the old/wrong mark no longer appears.",
+      surfaces: ["view"],
+      complexity: "low",
+      featurePrompt: `Add visual proof for the ${platform}brand repair: verify the official Axint symbol appears on intended project surfaces, the wordmark cover remains where appropriate, the wrong hand-drawn symbol is absent, and share-card previews use the correct brand assets. Include screenshot or focused UI-test evidence in Cloud Check.`,
+      domain: "brand-polish",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact: "Turns subjective polish into verifiable product quality.",
+      loop: "Render -> compare -> screenshot/test -> Cloud Check evidence",
+      nextStep:
+        "Attach the screenshot path, UI-test log, or preview proof to Cloud Check after the patch.",
+      modeTrace,
+    },
+  ];
+
+  return suggestions.slice(0, limit);
 }
 
 function keywordScore(text: string, keywords: string[]): number {

--- a/src/repair/project-repair.ts
+++ b/src/repair/project-repair.ts
@@ -17,6 +17,7 @@ import {
   formatAppleRepairRead,
   type AppleRepairIntelligence,
 } from "./intelligence.js";
+import { queueAutomaticFeedback } from "../feedback/auto.js";
 import {
   readProjectContextIndex,
   writeProjectContextIndex,
@@ -934,6 +935,10 @@ function writeRepairFeedback(report: AxintRepairReport): void {
     `${JSON.stringify(report.feedbackPacket, null, 2)}\n`,
     "utf-8"
   );
+  queueAutomaticFeedback(report.feedbackPacket, {
+    cwd: report.cwd,
+    packetType: "repair",
+  });
 }
 
 function compactRepairReport(report: AxintRepairReport): AxintRepairReport {

--- a/src/run/project-runner.ts
+++ b/src/run/project-runner.ts
@@ -106,7 +106,10 @@ export interface AxintRunXcodeTestFailure {
 }
 
 export interface AxintRunRunnerIssue {
-  kind: "ui-automation-infrastructure" | "hosted-test-runner-timeout";
+  kind:
+    | "ui-automation-infrastructure"
+    | "hosted-test-runner-timeout"
+    | "stale-app-termination";
   severity: "blocked";
   message: string;
   evidence: string;
@@ -184,6 +187,11 @@ interface XcodePlan {
   derivedDataPath?: string;
   testPlan?: string;
   onlyTesting: string[];
+}
+
+interface ProofReconciliation {
+  xcodeBuildPassed: boolean;
+  focusedXcodeTestsPassed: boolean;
 }
 
 export async function runAxintProject(
@@ -387,6 +395,13 @@ export async function runAxintProject(
       refreshedWithEvidence: true,
     });
   }
+  const proofReconciliation = buildProofReconciliation(commands, plan);
+  reconcileSwiftValidationStepWithXcodeProof(
+    steps,
+    validationDiagnostics,
+    proofReconciliation
+  );
+  reconcileCloudCheckStepWithFocusedProof(steps, cloudChecks, proofReconciliation);
 
   const workflow = runWorkflowCheck({
     cwd,
@@ -405,13 +420,19 @@ export async function runAxintProject(
     modifiedFiles: swiftFiles.map((file) => relativeOrAbsolute(cwd, file)),
   });
 
-  const status = summarizeStatus(steps, workflow, validationDiagnostics, cloudChecks);
+  const status = summarizeStatus(
+    steps,
+    workflow,
+    validationDiagnostics,
+    cloudChecks,
+    proofReconciliation
+  );
   const feedbackSignals = writeRunFeedbackSignals(cwd, cloudChecks);
   let report: AxintRunReport = {
     id: runId,
     kind: input.kind ?? "local",
     status,
-    gate: gateForStatus(status, steps),
+    gate: gateForStatus(status, steps, proofReconciliation),
     cwd,
     projectName,
     platform,
@@ -1115,6 +1136,7 @@ function reconcileXcodeTestStepWithRunnerHealth(
   if (runnerHealth.length === 0) return;
   const step = steps.find((item) => item.name === "Xcode test");
   if (!step) return;
+  step.state = "warn";
   step.detail = runnerHealth[0]!.message;
 }
 
@@ -1126,6 +1148,76 @@ function commandPassed(result?: AxintRunCommandResult): boolean {
     !result.timedOut &&
     !result.cancelled
   );
+}
+
+function buildProofReconciliation(
+  commands: AxintRunReport["commands"],
+  plan?: XcodePlan
+): ProofReconciliation {
+  return {
+    xcodeBuildPassed: commandPassed(commands.build),
+    focusedXcodeTestsPassed: Boolean(
+      plan?.onlyTesting.length && commandPassed(commands.test)
+    ),
+  };
+}
+
+function validationDiagnosticReconciledByXcode(
+  diagnostic: Diagnostic,
+  proof: ProofReconciliation
+): boolean {
+  return (
+    proof.xcodeBuildPassed &&
+    diagnostic.severity === "warning" &&
+    diagnostic.code === "AX768"
+  );
+}
+
+function cloudCheckReconciledByFocusedProof(
+  check: CloudCheckReport,
+  proof: ProofReconciliation
+): boolean {
+  if (!proof.xcodeBuildPassed || !proof.focusedXcodeTestsPassed) return false;
+  if (check.status !== "needs_review") return false;
+  const reviewDiagnostics = check.diagnostics.filter((d) => d.severity !== "info");
+  return (
+    reviewDiagnostics.length > 0 &&
+    reviewDiagnostics.every((d) => d.code === "AXCLOUD-UI-ACCESSIBILITY-ID")
+  );
+}
+
+function reconcileSwiftValidationStepWithXcodeProof(
+  steps: AxintRunStep[],
+  diagnostics: Diagnostic[],
+  proof: ProofReconciliation
+) {
+  if (!proof.xcodeBuildPassed) return;
+  const warnings = diagnostics.filter((d) => d.severity === "warning");
+  if (warnings.length === 0) return;
+  if (!warnings.every((d) => validationDiagnosticReconciledByXcode(d, proof))) {
+    return;
+  }
+  const step = steps.find((item) => item.name === "Swift validation");
+  if (!step || step.state !== "warn") return;
+  step.state = "pass";
+  step.detail = `${step.detail} Xcode build passed, so Axint downgraded ${warnings.length} partial-context AX768 warning${warnings.length === 1 ? "" : "s"} from the final gate.`;
+}
+
+function reconcileCloudCheckStepWithFocusedProof(
+  steps: AxintRunStep[],
+  cloudChecks: CloudCheckReport[],
+  proof: ProofReconciliation
+) {
+  if (!proof.focusedXcodeTestsPassed) return;
+  const reviewChecks = cloudChecks.filter((check) => check.status === "needs_review");
+  if (reviewChecks.length === 0) return;
+  if (!reviewChecks.every((check) => cloudCheckReconciledByFocusedProof(check, proof))) {
+    return;
+  }
+  const step = steps.find((item) => item.name === "Cloud Check");
+  if (!step || step.state !== "warn") return;
+  step.state = "pass";
+  step.detail = `${step.detail} Passing focused Xcode proof reconciled generic accessibility warnings for the final gate.`;
 }
 
 function updateCloudCheckStep(
@@ -1340,6 +1432,24 @@ function detectXcodeRunnerIssues(
         "The simulator/app runner or accessibility automation channel is stuck before the UI test can exercise the app.",
       remediation:
         "Kill stale app/test-runner processes, retry once, and report the UI proof as blocked by XCTest infrastructure if the same startup error repeats.",
+      command,
+    });
+  }
+
+  const staleTermination = normalized.match(
+    /\bfailed to terminate\s+([A-Za-z0-9_.-]+):(\d+)\b/i
+  );
+  if (staleTermination) {
+    const bundleId = staleTermination[1] ?? "the app";
+    const pid = staleTermination[2];
+    issues.push({
+      kind: "stale-app-termination",
+      severity: "blocked",
+      message:
+        "Xcode UI setup could not terminate a stale app process, so the test did not reach trustworthy app behavior.",
+      evidence: firstMatchingLine(output, [/failed to terminate\s+[A-Za-z0-9_.-]+:\d+/i]),
+      likelyCause: `${bundleId}${pid ? ` pid ${pid}` : ""} was still running or stuck when XCTest tried to reset UI state.`,
+      remediation: `Kill the stale app process${pid ? ` with kill ${pid}` : ""}, clean up stale XCTest/debugserver processes if needed, then rerun the same --only-testing selector before changing product code.`,
       command,
     });
   }
@@ -1929,20 +2039,28 @@ function summarizeStatus(
   steps: AxintRunStep[],
   workflow: WorkflowCheckReport,
   diagnostics: Diagnostic[],
-  cloudChecks: CloudCheckReport[]
+  cloudChecks: CloudCheckReport[],
+  proof: ProofReconciliation
 ): AxintRunReport["status"] {
+  const blockingDiagnostics = diagnostics.filter(
+    (diagnostic) => !validationDiagnosticReconciledByXcode(diagnostic, proof)
+  );
+  const blockingCloudChecks = cloudChecks.filter(
+    (check) => !cloudCheckReconciledByFocusedProof(check, proof)
+  );
+
   if (
     steps.some((step) => step.state === "fail") ||
     workflow.status === "needs_action" ||
-    diagnostics.some((diagnostic) => diagnostic.severity === "error") ||
-    cloudChecks.some((check) => check.status === "fail")
+    blockingDiagnostics.some((diagnostic) => diagnostic.severity === "error") ||
+    blockingCloudChecks.some((check) => check.status === "fail")
   ) {
     return "fail";
   }
   if (
     steps.some((step) => step.state === "warn" || step.state === "skipped") ||
-    diagnostics.some((diagnostic) => diagnostic.severity === "warning") ||
-    cloudChecks.some((check) => check.status === "needs_review")
+    blockingDiagnostics.some((diagnostic) => diagnostic.severity === "warning") ||
+    blockingCloudChecks.some((check) => check.status === "needs_review")
   ) {
     return "needs_review";
   }
@@ -1951,12 +2069,15 @@ function summarizeStatus(
 
 function gateForStatus(
   status: AxintRunReport["status"],
-  steps: AxintRunStep[]
+  steps: AxintRunStep[],
+  proof: ProofReconciliation
 ): AxintRunReport["gate"] {
   if (status === "pass") {
     return {
       decision: "ready_to_ship",
-      reason: "Axint gates, build/test commands, and supplied runtime evidence passed.",
+      reason: proof.focusedXcodeTestsPassed
+        ? "Axint gates, build/test commands, and focused Xcode proof passed."
+        : "Axint gates, build/test commands, and supplied runtime evidence passed.",
     };
   }
   if (steps.some((step) => step.state === "fail")) {

--- a/tests/cloud/check.test.ts
+++ b/tests/cloud/check.test.ts
@@ -639,6 +639,27 @@ struct OnboardingControlsView: View {
     expect(report.repairPrompt).toContain("XCTest infrastructure");
   });
 
+  it("classifies stale app termination as runner health instead of XCTest failure", () => {
+    const report = runCloudCheck({
+      fileName: "DiscoverView.swift",
+      source: `
+import SwiftUI
+
+struct DiscoverView: View {
+    var body: some View { Text("Discover") }
+}
+`,
+      testFailure:
+        "SwarmUITests.swift:62: error: Failed to terminate co.agenticempire.Swarm:9770",
+    });
+    const codes = report.diagnostics.map((diagnostic) => diagnostic.code);
+
+    expect(report.status).toBe("needs_review");
+    expect(codes).toContain("AXCLOUD-XCTEST-STALE-APP");
+    expect(codes).not.toContain("AXCLOUD-XCTEST-FAILURE");
+    expect(report.repairPrompt).toContain("stale app PID");
+  });
+
   it("classifies focused runner timeouts before assertions as runner health", () => {
     const report = runCloudCheck({
       fileName: "P3FrontendArchitectureTests.swift",

--- a/tests/core/swift-validator.test.ts
+++ b/tests/core/swift-validator.test.ts
@@ -248,6 +248,45 @@ describe("swift validator — SwiftUI compiler parity", () => {
     expect(diagnostic?.message).toContain("profile.detail");
     expect(diagnostic?.message).toContain("ShareCardDesignProfile");
   });
+
+  it("does not bind untyped closure loop variables to stale nearby model names", () => {
+    const source = `
+      import SwiftUI
+
+      enum PublicPageModuleKind: CaseIterable, Identifiable {
+          case proof
+          var id: String { "proof" }
+          var symbol: String { "checkmark.seal" }
+          var label: String { "Proof" }
+      }
+
+      struct PublicPageModule {
+          let kind: PublicPageModuleKind
+      }
+
+      struct CreatorTemplate {
+          let recommendedModules: [PublicPageModuleKind]
+      }
+
+      struct ProjectShowcaseView: View {
+          let template: CreatorTemplate
+
+          var body: some View {
+              let module: PublicPageModule = PublicPageModule(kind: .proof)
+              _ = module.kind
+              ForEach(template.recommendedModules) { module in
+                  Label(module.label, systemImage: module.symbol)
+              }
+          }
+      }
+    `;
+
+    const diagnostics = validateSwiftSources([
+      { file: "PublicPageCustomization.swift", source },
+    ]).flatMap((result) => result.diagnostics);
+
+    expect(diagnostics.filter((d) => d.code === "AX768")).toEqual([]);
+  });
 });
 
 // ─── New rules: AX704 AppIntent title ─────────────────────────────

--- a/tests/feedback/inbox.test.ts
+++ b/tests/feedback/inbox.test.ts
@@ -1,0 +1,85 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCloudCheck } from "../../src/cloud/check.js";
+import { writeCloudFeedbackSignal } from "../../src/cloud/feedback-store.js";
+import {
+  resolveAutoFeedbackPolicy,
+  writeAutoFeedbackPolicy,
+} from "../../src/feedback/auto.js";
+import {
+  exportAxintFeedback,
+  importAxintFeedback,
+  listAxintFeedbackInbox,
+  renderFeedbackInboxReport,
+} from "../../src/feedback/inbox.js";
+
+describe("Axint feedback inbox", () => {
+  it("queues source-free Cloud feedback automatically while preserving opt-out", () => {
+    const root = mkdtempSync(join(tmpdir(), "axint-auto-feedback-"));
+    try {
+      const report = runCloudCheck({
+        fileName: "BrokenIntent.swift",
+        source: `
+import AppIntents
+
+struct BrokenIntent: AppIntent {
+    static let title: LocalizedStringResource = "Broken"
+}
+`,
+      });
+      expect(report.learningSignal).toBeTruthy();
+      const stored = writeCloudFeedbackSignal(report.learningSignal!, { cwd: root });
+
+      expect(stored.autoFeedback?.policy.redaction).toBe("source_not_included");
+      expect(stored.autoFeedback?.queued).toBe(true);
+      expect(stored.autoFeedback?.queuePath).toBeTruthy();
+      expect(existsSync(stored.autoFeedback!.queuePath!)).toBe(true);
+      expect(resolveAutoFeedbackPolicy(root).mode).toBe("on");
+
+      writeAutoFeedbackPolicy(root, "off");
+      const second = writeCloudFeedbackSignal(report.learningSignal!, { cwd: root });
+      expect(second.autoFeedback?.submitted).toBe("disabled");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("exports, imports, and clusters source-free feedback from another project", () => {
+    const friend = mkdtempSync(join(tmpdir(), "axint-friend-feedback-"));
+    const maintainer = mkdtempSync(join(tmpdir(), "axint-maintainer-feedback-"));
+    try {
+      const report = runCloudCheck({
+        fileName: "BrokenIntent.swift",
+        source: `
+import AppIntents
+
+struct BrokenIntent: AppIntent {
+    static let title: LocalizedStringResource = "Broken"
+}
+`,
+      });
+      writeCloudFeedbackSignal(report.learningSignal!, { cwd: friend });
+      const exported = exportAxintFeedback({
+        cwd: friend,
+        projectLabel: "Friend Workout App",
+      });
+      expect(exported.packetCount).toBe(1);
+
+      const imported = importAxintFeedback([exported.outPath], { cwd: maintainer });
+      expect(imported.imported).toHaveLength(1);
+
+      const inbox = listAxintFeedbackInbox({ cwd: maintainer });
+      expect(inbox.items[0]?.projectLabel).toBe("Friend Workout App");
+      expect(inbox.clusters[0]?.diagnostics).toContain("AX704");
+      expect(renderFeedbackInboxReport(inbox, "markdown")).toContain("Next Axint Fixes");
+      expect(
+        readdirSync(join(maintainer, ".axint/feedback/inbox")).length
+      ).toBeGreaterThan(0);
+    } finally {
+      rmSync(friend, { recursive: true, force: true });
+      rmSync(maintainer, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/mcp/suggest.test.ts
+++ b/tests/mcp/suggest.test.ts
@@ -20,4 +20,57 @@ describe("axint.suggest", () => {
     );
     expect(suggestions[0]?.featurePrompt).not.toContain("Create a new");
   });
+
+  it("lets fresh public-lander prompts override stale repair context", () => {
+    const suggestions = suggestFeatures({
+      appDescription:
+        "Build the Axint project profile into a custom .axint-powered public lander with programmable modules, share cards, install QR blocks, email capture, safe customization, preserved UI test identifiers, and older repair notes about accessibility, Capture, and reduced motion.",
+      platform: "macOS",
+      limit: 4,
+    });
+
+    expect(suggestions[0]?.domain).toBe("public-page");
+    expect(suggestions[0]?.name).toContain("Public Lander");
+    expect(suggestions[0]?.featurePrompt).toContain(".axint page manifest");
+    expect(suggestions[0]?.featurePrompt).toContain("share card");
+    expect(suggestions[0]?.rationale).toContain("Mode trace");
+    expect(suggestions.map((suggestion) => suggestion.domain)).not.toContain("repair");
+  });
+
+  it("treats premium landing-page and share-card prompts as product design work", () => {
+    const suggestions = suggestFeatures({
+      appDescription:
+        "SWARM macOS SwiftUI: make the Axint public project page a premium custom startup landing page, customize share cards, preserve accessibility IDs, and remove orange from Nima's profile identity.",
+      platform: "macOS",
+      domain: "developer-tools",
+      goals: ["premium public project page", "shareable launch card"],
+      stage: "mvp",
+      limit: 3,
+    });
+
+    expect(suggestions[0]?.domain).toBe("public-page");
+    expect(suggestions[0]?.featurePrompt).toContain("ProjectShowcaseView");
+    expect(suggestions[0]?.featurePrompt).toContain("ShareComposerView");
+    expect(suggestions[0]?.rationale).toContain("Mode trace");
+    expect(suggestions.map((suggestion) => suggestion.domain)).not.toContain("repair");
+  });
+
+  it("routes brand-asset repair prompts to provenance and visual proof", () => {
+    const suggestions = suggestFeatures({
+      appDescription:
+        "SWARM macOS project network app needs the official Axint symbol mark from axint.ai on Axint project surfaces while keeping the wordmark cover where appropriate",
+      platform: "macOS",
+      goals: ["brand accuracy", "premium project page"],
+      constraints: ["do not use the wrong hand-drawn symbol"],
+      limit: 3,
+    });
+
+    expect(suggestions[0]?.domain).toBe("brand-polish");
+    expect(suggestions[0]?.featurePrompt).toContain("asset provenance");
+    expect(suggestions[0]?.featurePrompt).toContain("visual proof");
+    expect(suggestions[0]?.rationale).toContain("Mode trace");
+    expect(suggestions.map((suggestion) => suggestion.domain)).not.toContain(
+      "collaboration"
+    );
+  });
 });

--- a/tests/run/project-runner.test.ts
+++ b/tests/run/project-runner.test.ts
@@ -296,6 +296,98 @@ describe("runAxintProject", () => {
     }
   });
 
+  it("lets passing Xcode build and focused UI proof reconcile partial-context AX768 warnings", async () => {
+    const dir = makeFakeXcodeProject();
+    mkdirSync(join(dir, "Swarm", "Views"), { recursive: true });
+    mkdirSync(join(dir, "Swarm", "Models"), { recursive: true });
+    mkdirSync(join(dir, "SwarmUITests"), { recursive: true });
+    writeFileSync(
+      join(dir, "Swarm", "Models", "ShareCardDesignProfile.swift"),
+      [
+        "import Foundation",
+        "struct ShareCardDesignProfile {",
+        "  let style: ShareCardStyle",
+        "}",
+        "struct ShareCardStyle {",
+        "  let detail: String",
+        "}",
+        "",
+      ].join("\n")
+    );
+    writeFileSync(
+      join(dir, "Swarm", "Views", "ProjectShowcaseView.swift"),
+      [
+        "import SwiftUI",
+        "",
+        "struct ProjectShowcaseView: View {",
+        "  let profile: ShareCardDesignProfile",
+        "  var body: some View {",
+        "    Text(profile.detail)",
+        '      .accessibilityIdentifier("project-showcase-detail")',
+        "  }",
+        "}",
+        "",
+      ].join("\n")
+    );
+    writeFileSync(
+      join(dir, "SwarmUITests", "SwarmUITests.swift"),
+      "import XCTest\nfinal class SwarmUITests: XCTestCase {}\n"
+    );
+
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const xcodebuild = join(binDir, "xcodebuild");
+    writeFileSync(
+      xcodebuild,
+      [
+        "#!/bin/sh",
+        'if echo " $* " | grep -q " test "; then',
+        "  echo \"Test Suite 'SwarmUITests' started.\"",
+        "  echo \"Test Case '-[SwarmUITests testShareComposerOpensFromProjectProfileAndHome]' passed (0.72 seconds).\"",
+        '  echo "** TEST SUCCEEDED **"',
+        '  echo "Executed 1 test, with 0 failures"',
+        "else",
+        '  echo "** BUILD SUCCEEDED **"',
+        "fi",
+        "exit 0",
+        "",
+      ].join("\n")
+    );
+    chmodSync(xcodebuild, 0o755);
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    try {
+      const report = await runAxintProject({
+        cwd: dir,
+        writeReport: false,
+        modifiedFiles: [
+          "Swarm/Models/ShareCardDesignProfile.swift",
+          "Swarm/Views/ProjectShowcaseView.swift",
+        ],
+        onlyTesting: [
+          "SwarmUITests/SwarmUITests/testShareComposerOpensFromProjectProfileAndHome",
+        ],
+        expectedBehavior:
+          "The project showcase detail is visible and the share composer opens from the project profile and home.",
+        actualBehavior:
+          "Focused UITest transcript attached for the current share-card proof.",
+      });
+
+      expect(report.swiftValidation.diagnostics.map((d) => d.code)).toContain("AX768");
+      expect(report.commands.build?.exitCode).toBe(0);
+      expect(report.commands.test?.exitCode).toBe(0);
+      expect(report.steps.find((step) => step.name === "Swift validation")?.state).toBe(
+        "pass"
+      );
+      expect(report.status).toBe("pass");
+      expect(report.gate.decision).toBe("ready_to_ship");
+      expect(report.gate.reason).toContain("focused Xcode proof");
+    } finally {
+      process.env.PATH = previousPath;
+    }
+  });
+
   it("extracts failing Xcode test details into the run report and Cloud Check", async () => {
     const dir = makeFakeXcodeProject();
     const binDir = join(dir, "bin");
@@ -491,6 +583,59 @@ describe("runAxintProject", () => {
       expect(rendered).toContain("## Xcode Runner Health");
       expect(rendered).toContain("ui-automation-infrastructure");
       expect(cloudCodes).toContain("AXCLOUD-XCTEST-AUTOMATION-INFRASTRUCTURE");
+    } finally {
+      process.env.PATH = previousPath;
+    }
+  });
+
+  it("classifies failed app termination during UI setup as runner health", async () => {
+    const dir = makeFakeXcodeProject();
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const xcodebuild = join(binDir, "xcodebuild");
+    writeFileSync(
+      xcodebuild,
+      [
+        "#!/bin/sh",
+        'if echo " $* " | grep -q " test "; then',
+        "  echo \"Test Suite 'SwarmUITests' started.\"",
+        '  echo "SwarmUITests.swift:62: error: Failed to terminate co.agenticempire.Swarm:9770"',
+        '  echo "** TEST FAILED **"',
+        "  exit 65",
+        "else",
+        '  echo "** BUILD SUCCEEDED **"',
+        "  exit 0",
+        "fi",
+        "",
+      ].join("\n")
+    );
+    chmodSync(xcodebuild, 0o755);
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    try {
+      const report = await runAxintProject({
+        cwd: dir,
+        writeReport: false,
+        onlyTesting: [
+          "SwarmUITests/SwarmUITests/testDiscoverPrimaryCardsAndAgentActionsAreClickable",
+        ],
+      });
+      const cloudCodes = report.cloudChecks.flatMap((check) =>
+        check.diagnostics.map((diagnostic) => diagnostic.code)
+      );
+
+      expect(report.runnerHealth).toContainEqual(
+        expect.objectContaining({
+          kind: "stale-app-termination",
+          evidence: expect.stringContaining("Failed to terminate"),
+        })
+      );
+      expect(report.steps.find((step) => step.name === "Xcode test")?.state).toBe("warn");
+      expect(report.nextSteps.join("\n")).toContain("stale app process");
+      expect(report.nextSteps.join("\n")).toContain("kill 9770");
+      expect(cloudCodes).toContain("AXCLOUD-XCTEST-STALE-APP");
+      expect(cloudCodes).not.toContain("AXCLOUD-XCTEST-FAILURE");
     } finally {
       process.env.PATH = previousPath;
     }


### PR DESCRIPTION
## Summary
- add automatic source-free feedback queue, sync, opt-in/opt-out, and maintainer inbox commands
- wire Cloud Check and repair feedback into source-free automatic packets
- harden suggest/run/validator dogfooding fixes and refresh metrics

## Verification
- npm test
- npm run typecheck
- npm run lint
- npm run build
- npm run metrics:emit && npm run metrics:check
- npm run versions:check
- npm run docs:check
- npm run boundary:check && npm run release:check