### PR TITLE
Reduce agent token overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.15 · 33 MCP tools + 5 prompts · 189 diagnostic codes · 1213 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.16 · 33 MCP tools + 5 prompts · 189 diagnostic codes · 1217 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -318,6 +318,10 @@ For a repeatable first-use demo, inspect `examples/wow/composer-blocker`. It mod
 Long runs also write `.axint/run/jobs/<id>.json` and `.axint/run/latest-active.json`. If a client disconnects, an MCP transport times out, or an agent needs to rejoin a build in the same thread, use `axint run status` to see active process IDs and `axint run cancel` to stop the child process group without restarting the whole chat.
 
 Rendered `axint run --format json` is compact by default: it keeps verdict, evidence, diagnostics, artifact paths, feedback packet paths, and next actions visible while omitting full Swift source and trimming long command output. Use `--include-source` only when the active agent explicitly needs inline Swift/code output in the response.
+
+Agent-token safety is also built into the default run loop. `axint run` keeps full command logs on disk under `.axint/run/logs`, while the agent-facing report keeps compact tails and artifact paths. If you omit `--changed`, Axint validates the project but Cloud Checks only the highest-risk Swift files instead of pushing every source file into the next agent turn. Pass `--changed <files>` when you want a focused full proof loop.
+
+The MCP tool listing is compact by default for the same reason: agents receive tool names, schemas, enums, and short summaries instead of the full prose-heavy manifest. Set `AXINT_MCP_MANIFEST_MODE=full` or `AXINT_MCP_FULL_MANIFEST=1` only when debugging tool documentation.
 
 Use `--dry-run` to prove the harness and planned `xcodebuild` commands before letting a local or BYO Mac runner execute the job.
 

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.15",
+  "version": "0.4.16",
   "mcpTools": 33,
   "mcpToolNames": [
     "axint.status",
@@ -83,7 +83,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1099,
+    "typescript": 1103,
     "python": 114
   },
   "registryPackages": 14,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.15"
+__version__ = "0.4.16"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.15"
+version = "0.4.16"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "transport": {
         "type": "stdio"
       }
@@ -28,7 +28,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "transport": {
         "type": "stdio"
       }

--- a/src/cli/cloud.ts
+++ b/src/cli/cloud.ts
@@ -59,9 +59,9 @@ export function registerCloud(program: Command) {
       "Target platform hint: iOS, macOS, watchOS, visionOS, all",
       parseCloudPlatform
     )
-    .option("--build-log <text>", "Inline Xcode build log or error snippet")
+    .option("--build-log <text>", "Inline short Xcode build error/proof snippet")
     .option("--build-log-file <file>", "Read Xcode build log evidence from a file")
-    .option("--test-failure <text>", "Inline unit/UI test failure output")
+    .option("--test-failure <text>", "Inline short unit/UI test failure excerpt")
     .option(
       "--test-failure-file <file>",
       "Read unit/UI test failure evidence from a file"

--- a/src/cloud/check.ts
+++ b/src/cloud/check.ts
@@ -158,6 +158,10 @@ export interface CloudLearningSignal {
   createdAt: string;
 }
 
+const DEFAULT_CLOUD_PROMPT_RENDER_CHARS = 1_600;
+const DEFAULT_CLOUD_JSON_PROMPT_CHARS = 3_000;
+const DEFAULT_CLOUD_EVIDENCE_SUMMARY_CHARS = 800;
+
 export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
   const { source, fileName } = readCloudCheckSource(input);
   const compilerVersion = packageVersion();
@@ -574,7 +578,18 @@ export function renderCloudCheckReport(
     );
   }
 
-  lines.push("", "## Agent Repair Prompt", "```text", report.repairPrompt, "```");
+  const compactPrompt = trimMiddle(
+    report.repairPrompt,
+    positiveEnvInt("AXINT_CLOUD_PROMPT_RENDER_CHARS", DEFAULT_CLOUD_PROMPT_RENDER_CHARS),
+    "agent repair prompt"
+  );
+  lines.push("", "## Agent Repair Prompt", "```text", compactPrompt, "```");
+  if (compactPrompt !== report.repairPrompt) {
+    lines.push(
+      "",
+      "_Prompt compacted for agent-token safety. Use `--format prompt` only when you need the full continuation block inline._"
+    );
+  }
   return lines.join("\n");
 }
 
@@ -898,10 +913,32 @@ function compactCloudCheckReport(report: CloudCheckReport): Omit<
     sourceLines: number;
     outputLines: number;
   };
+  outputRedaction: {
+    mode: "compact";
+    reason: string;
+    fullPromptFormat: "--format prompt";
+  };
 } {
   const { swiftCode, ...rest } = report;
+  const promptBudget = positiveEnvInt(
+    "AXINT_CLOUD_JSON_PROMPT_CHARS",
+    DEFAULT_CLOUD_JSON_PROMPT_CHARS
+  );
   return {
     ...rest,
+    evidence: {
+      ...report.evidence,
+      summary: report.evidence.summary.map((item) =>
+        trimMiddle(item, DEFAULT_CLOUD_EVIDENCE_SUMMARY_CHARS, "evidence")
+      ),
+    },
+    repairPrompt: trimMiddle(report.repairPrompt, promptBudget, "repair prompt"),
+    outputRedaction: {
+      mode: "compact" as const,
+      reason:
+        "Rendered Cloud Check JSON keeps verdict, diagnostics, evidence summary, and next steps compact for agent conversations.",
+      fullPromptFormat: "--format prompt" as const,
+    },
     ...(swiftCode
       ? {
           sourceRedaction: {
@@ -2605,7 +2642,25 @@ function summarizeEvidenceValue(label: string, value: string): string {
     .join(" | ")
     .replace(/\s+/g, " ")
     .trim()
-    .slice(0, 1500);
+    .slice(0, DEFAULT_CLOUD_EVIDENCE_SUMMARY_CHARS);
+}
+
+function trimMiddle(value: string, maxChars: number, label: string): string {
+  if (value.length <= maxChars) return value;
+  const marker = `\n\n[... axint compacted ${value.length - maxChars} chars from ${label}; use the dedicated full-output format or inspect artifacts if needed ...]\n\n`;
+  if (marker.length >= maxChars) return value.slice(0, maxChars);
+  const headChars = Math.max(200, Math.floor((maxChars - marker.length) * 0.45));
+  const tailChars = Math.max(200, maxChars - marker.length - headChars);
+  return `${value.slice(0, headChars).trimEnd()}${marker}${value
+    .slice(-tailChars)
+    .trimStart()}`;
+}
+
+function positiveEnvInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
 }
 
 function unique<T>(values: T[]): T[] {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,3 +1,7 @@
 export { createAxintServer, startMCPServer } from "./server.js";
-export { TOOL_MANIFEST } from "./manifest.js";
+export {
+  TOOL_MANIFEST,
+  compactToolManifest,
+  getRuntimeToolManifest,
+} from "./manifest.js";
 export { PROMPT_MANIFEST, getPromptMessages } from "./prompts.js";

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -1065,7 +1065,7 @@ export const TOOL_MANIFEST = [
         source: {
           type: "string",
           description:
-            "Inline Swift or Axint TypeScript source to check. Use this when the agent already has the code in memory.",
+            "Inline Swift or Axint TypeScript source to check. Prefer sourcePath when possible; inline source should be reserved for short snippets already in the agent context.",
         },
         sourcePath: {
           type: "string",
@@ -1107,12 +1107,12 @@ export const TOOL_MANIFEST = [
         xcodeBuildLog: {
           type: "string",
           description:
-            "Optional Xcode build output. Cloud Check will classify recognized compile, availability, duplicate symbol, and conformance failures into actionable diagnostics.",
+            "Optional short Xcode build excerpt. Pass only the failing lines or focused proof summary; full logs should stay in .axint artifacts or local files.",
         },
         testFailure: {
           type: "string",
           description:
-            "Optional failing unit/UI-test output. Use this when static checks pass but Xcode tests still fail; Cloud Check will look for element lookup, accessibility identifier, timeout, and runtime evidence patterns.",
+            "Optional short failing unit/UI-test excerpt. Use this when static checks pass but Xcode tests still fail; include the assertion, selector, file/line, and not the full transcript.",
         },
         runtimeFailure: {
           type: "string",
@@ -1594,7 +1594,7 @@ export const TOOL_MANIFEST = [
           type: "array",
           items: { type: "string" },
           description:
-            "Changed Swift files to validate and Cloud Check. If omitted, Axint scans project Swift files.",
+            "Changed Swift files to validate and Cloud Check. Pass this whenever possible; if omitted, Axint validates the project but Cloud Checks only a compact highest-risk subset.",
         },
         skipBuild: {
           type: "boolean",
@@ -2131,3 +2131,94 @@ export const TOOL_MANIFEST = [
     },
   },
 ] as const;
+
+type RuntimeManifestEnv = {
+  AXINT_MCP_FULL_MANIFEST?: string;
+  AXINT_MCP_MANIFEST_MODE?: string;
+  AXINT_MCP_TOOL_DESCRIPTION_CHARS?: string;
+  AXINT_MCP_SCHEMA_DESCRIPTION_CHARS?: string;
+  AXINT_MCP_NESTED_DESCRIPTION_CHARS?: string;
+};
+
+type CompactManifestOptions = {
+  toolDescriptionChars: number;
+  schemaDescriptionChars: number;
+  nestedDescriptionChars: number;
+};
+
+const DEFAULT_RUNTIME_TOOL_DESCRIPTION_CHARS = 140;
+const DEFAULT_RUNTIME_SCHEMA_DESCRIPTION_CHARS = 0;
+const DEFAULT_RUNTIME_NESTED_DESCRIPTION_CHARS = 0;
+
+export function getRuntimeToolManifest(env: RuntimeManifestEnv = {}) {
+  const mode = env.AXINT_MCP_MANIFEST_MODE?.trim().toLowerCase();
+  if (env.AXINT_MCP_FULL_MANIFEST === "1" || mode === "full" || mode === "verbose") {
+    return TOOL_MANIFEST;
+  }
+
+  return compactToolManifest({
+    toolDescriptionChars: positiveEnvInt(
+      env.AXINT_MCP_TOOL_DESCRIPTION_CHARS,
+      DEFAULT_RUNTIME_TOOL_DESCRIPTION_CHARS
+    ),
+    schemaDescriptionChars: positiveEnvInt(
+      env.AXINT_MCP_SCHEMA_DESCRIPTION_CHARS,
+      DEFAULT_RUNTIME_SCHEMA_DESCRIPTION_CHARS
+    ),
+    nestedDescriptionChars: positiveEnvInt(
+      env.AXINT_MCP_NESTED_DESCRIPTION_CHARS,
+      DEFAULT_RUNTIME_NESTED_DESCRIPTION_CHARS
+    ),
+  });
+}
+
+export function compactToolManifest(options: CompactManifestOptions) {
+  return TOOL_MANIFEST.map((tool) => ({
+    ...tool,
+    description: compactDescription(tool.description, options.toolDescriptionChars),
+    inputSchema: compactSchemaValue(tool.inputSchema, options, 0),
+  })) as unknown as typeof TOOL_MANIFEST;
+}
+
+function compactSchemaValue(
+  value: unknown,
+  options: CompactManifestOptions,
+  depth: number
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => compactSchemaValue(item, options, depth + 1));
+  }
+
+  if (!value || typeof value !== "object") return value;
+
+  const compacted: Record<string, unknown> = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (key === "description" && typeof nestedValue === "string") {
+      const limit =
+        depth <= 2 ? options.schemaDescriptionChars : options.nestedDescriptionChars;
+      if (limit <= 0) continue;
+      compacted[key] = compactDescription(nestedValue, limit);
+      continue;
+    }
+
+    compacted[key] = compactSchemaValue(nestedValue, options, depth + 1);
+  }
+
+  return compacted;
+}
+
+function compactDescription(value: string, maxChars: number): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxChars) return normalized;
+
+  const safeLimit = Math.max(32, maxChars);
+  const wordBoundary = normalized.lastIndexOf(" ", safeLimit - 4);
+  const end = wordBoundary > 32 ? wordBoundary : safeLimit - 3;
+  return `${normalized.slice(0, end).trim()}...`;
+}
+
+function positiveEnvInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -58,7 +58,7 @@ import { suggestFeaturesSmart, type SuggestInput } from "./suggest.js";
 import { TEMPLATES, getTemplate } from "../templates/index.js";
 import { validateSwiftSource } from "../core/swift-validator.js";
 import { fixSwiftSourceMultipass } from "../core/swift-fixer.js";
-import { TOOL_MANIFEST } from "./manifest.js";
+import { TOOL_MANIFEST, getRuntimeToolManifest } from "./manifest.js";
 import { PROMPT_MANIFEST, getPromptMessages } from "./prompts.js";
 import { handleCompileFromSchema, type SchemaCompileArgs } from "./schema-compile.js";
 import {
@@ -1240,7 +1240,7 @@ export function createAxintServer(): Server {
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: TOOL_MANIFEST,
+    tools: getRuntimeToolManifest(process.env),
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {

--- a/src/run/project-runner.ts
+++ b/src/run/project-runner.ts
@@ -76,6 +76,11 @@ export interface AxintRunInput {
   writeReport?: boolean;
 }
 
+const DEFAULT_CLOUD_SWEEP_LIMIT = 8;
+const DEFAULT_COMMAND_CAPTURE_CHARS = 64 * 1024;
+const DEFAULT_COMMAND_EVIDENCE_CHARS = 4 * 1024;
+const DEFAULT_COMMAND_RENDER_TAIL_CHARS = 600;
+
 export interface AxintRunCommandResult {
   command: string;
   args: string[];
@@ -259,7 +264,14 @@ export async function runAxintProject(
         : `Validated ${swiftFiles.length} Swift file${swiftFiles.length === 1 ? "" : "s"}.`,
   });
 
-  const cloudTargets = swiftFiles.length > 0 ? swiftFiles : [];
+  const cloudTargets = selectCloudCheckTargets({
+    cwd,
+    swiftFiles,
+    modifiedFiles: input.modifiedFiles,
+    projectContext: projectContext.index,
+  });
+  const cloudTargetsWereLimited =
+    swiftFiles.length > cloudTargets.length && !input.modifiedFiles?.length;
   for (const file of cloudTargets) {
     cloudChecks.push(
       runCloudCheck({
@@ -286,7 +298,9 @@ export async function runAxintProject(
     detail:
       cloudChecks.length === 0
         ? "No source file was available for Cloud Check."
-        : `Ran ${cloudChecks.length} Cloud Check report${cloudChecks.length === 1 ? "" : "s"}.`,
+        : cloudTargetsWereLimited
+          ? `Ran ${cloudChecks.length} compact Cloud Check report${cloudChecks.length === 1 ? "" : "s"} from the highest-risk project files. Pass --changed for a focused full sweep.`
+          : `Ran ${cloudChecks.length} Cloud Check report${cloudChecks.length === 1 ? "" : "s"}.`,
   });
 
   const commands: AxintRunReport["commands"] = {};
@@ -1014,6 +1028,28 @@ function resolveSwiftFiles(cwd: string, files?: string[]): string[] {
     );
   }
   return findSwiftFiles(cwd).slice(0, 80);
+}
+
+function selectCloudCheckTargets(input: {
+  cwd: string;
+  swiftFiles: string[];
+  modifiedFiles?: string[];
+  projectContext: { topInteractionRiskFiles?: Array<{ path: string }> };
+}): string[] {
+  if (input.modifiedFiles?.length) return input.swiftFiles;
+  if (input.swiftFiles.length <= DEFAULT_CLOUD_SWEEP_LIMIT) return input.swiftFiles;
+
+  const byPath = new Map(
+    input.swiftFiles.map((file) => [relativeOrAbsolute(input.cwd, file), file])
+  );
+  const ranked = (input.projectContext.topInteractionRiskFiles ?? [])
+    .map((file) => byPath.get(file.path))
+    .filter((file): file is string => Boolean(file));
+  const selected = unique([...ranked, ...input.swiftFiles]).slice(
+    0,
+    DEFAULT_CLOUD_SWEEP_LIMIT
+  );
+  return selected;
 }
 
 function findSwiftFiles(dir: string): string[] {
@@ -1970,7 +2006,7 @@ function runtimeFailureFromCommand(result?: AxintRunCommandResult): string | und
   );
 }
 
-function trimCommandEvidence(value: string, maxChars = 12000): string {
+function trimCommandEvidence(value: string, maxChars = commandEvidenceBudget()): string {
   const text = value.trim();
   if (text.length <= maxChars) return text;
   const head = text.slice(0, 1600).trimEnd();
@@ -1978,7 +2014,11 @@ function trimCommandEvidence(value: string, maxChars = 12000): string {
   return `${head}\n\n[... axint trimmed long command evidence ...]\n\n${tail}`;
 }
 
-function appendCommandOutput(current: string, next: string, maxChars = 8 * 1024 * 1024) {
+function appendCommandOutput(
+  current: string,
+  next: string,
+  maxChars = commandCaptureBudget()
+) {
   const combined = `${current}${next}`;
   if (combined.length <= maxChars) return combined;
   const tail = combined.slice(-(maxChars - 80));
@@ -2292,8 +2332,12 @@ function buildRunRepairPrompt(input: {
       `${label} command failed:`,
       `- Command: ${[result.command, ...result.args].map(shellQuote).join(" ")}`,
       `- Exit: ${result.exitCode ?? result.signal ?? "unknown"}`,
-      result.stderr ? `- stderr: ${result.stderr.slice(0, 4000)}` : "",
-      result.stdout ? `- stdout: ${result.stdout.slice(-4000)}` : ""
+      result.stderr
+        ? `- stderr: ${tailText(result.stderr, DEFAULT_COMMAND_RENDER_TAIL_CHARS)}`
+        : "",
+      result.stdout
+        ? `- stdout: ${tailText(result.stdout, DEFAULT_COMMAND_RENDER_TAIL_CHARS)}`
+        : ""
     );
   }
 
@@ -2309,8 +2353,9 @@ function writeRunArtifacts(report: AxintRunReport) {
   mkdirSync(dir, { recursive: true });
   const jsonPath = join(dir, "latest.json");
   const markdownPath = join(dir, "latest.md");
+  const compactReport = compactRunReport(report, {});
   const serializable = {
-    ...report,
+    ...compactReport,
     artifacts: {
       json: jsonPath,
       markdown: markdownPath,
@@ -2320,7 +2365,7 @@ function writeRunArtifacts(report: AxintRunReport) {
     },
   };
   writeFileSync(jsonPath, `${JSON.stringify(serializable, null, 2)}\n`, "utf-8");
-  writeFileSync(markdownPath, renderAxintRunReport(serializable), "utf-8");
+  writeFileSync(markdownPath, renderAxintRunReport(report), "utf-8");
   return {
     json: jsonPath,
     markdown: markdownPath,
@@ -2403,8 +2448,8 @@ function compactRunCommand(
   if (!result) return undefined;
   const { stdout, stderr, ...rest } = result;
   const compact: CompactRunCommandResult = { ...rest };
-  if (stdout) compact.stdoutTail = tailText(stdout, 1200);
-  if (stderr) compact.stderrTail = tailText(stderr, 1200);
+  if (stdout) compact.stdoutTail = tailText(stdout, DEFAULT_COMMAND_RENDER_TAIL_CHARS);
+  if (stderr) compact.stderrTail = tailText(stderr, DEFAULT_COMMAND_RENDER_TAIL_CHARS);
   if (stdout || stderr) {
     compact.outputRedaction = {
       ...(stdout ? { stdout: "trimmed_from_axint_run_json" as const } : {}),
@@ -2447,6 +2492,21 @@ function compactCloudCheckForRun(report: CloudCheckReport): Omit<
 function tailText(value: string, maxChars: number): string {
   if (value.length <= maxChars) return value;
   return `[... ${value.length - maxChars} chars trimmed ...]\n${value.slice(-maxChars)}`;
+}
+
+function commandCaptureBudget(): number {
+  return positiveEnvInt("AXINT_COMMAND_CAPTURE_CHARS", DEFAULT_COMMAND_CAPTURE_CHARS);
+}
+
+function commandEvidenceBudget(): number {
+  return positiveEnvInt("AXINT_COMMAND_EVIDENCE_CHARS", DEFAULT_COMMAND_EVIDENCE_CHARS);
+}
+
+function positiveEnvInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
 }
 
 function relativeOrAbsolute(cwd: string, path: string) {

--- a/tests/cloud/check.test.ts
+++ b/tests/cloud/check.test.ts
@@ -133,6 +133,7 @@ struct ContentView: View {
     expect(payload.fileName).toBe("ContentView.swift");
     expect(payload.swiftCode).toBeUndefined();
     expect(payload.sourceRedaction.swiftCode).toBe("omitted_from_rendered_json");
+    expect(payload.outputRedaction.mode).toBe("compact");
     expect(payload.confidence.level).toBe("medium");
     expect(payload.coverage).toContainEqual(
       expect.objectContaining({
@@ -147,6 +148,40 @@ struct ContentView: View {
       })
     );
     expect(payload.repairPrompt).toContain("This is not a runtime pass");
+  });
+
+  it("keeps JSON and markdown reports compact for agent contexts", () => {
+    const longBuildLog = Array.from(
+      { length: 300 },
+      (_, index) =>
+        `CompileSwift normal arm64 File${index}.swift warning: long generated output line ${index}`
+    ).join("\n");
+    const report = runCloudCheck({
+      fileName: "ContentView.swift",
+      source: `
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View { Text("Hello") }
+}
+`,
+      xcodeBuildLog: longBuildLog,
+      expectedBehavior: "The focused UI proof should pass.",
+      actualBehavior: "The focused UI proof has not run yet.",
+    });
+
+    const payload = JSON.parse(renderCloudCheckReport(report, "json")) as {
+      evidence: { summary: string[] };
+      repairPrompt: string;
+      outputRedaction?: { mode: string; fullPromptFormat: string };
+    };
+    const markdown = renderCloudCheckReport(report, "markdown");
+
+    expect(payload.evidence.summary.join("\n").length).toBeLessThan(1400);
+    expect(payload.repairPrompt.length).toBeLessThanOrEqual(3000);
+    expect(payload.outputRedaction?.mode).toBe("compact");
+    expect(payload.outputRedaction?.fullPromptFormat).toBe("--format prompt");
+    expect(markdown.length).toBeLessThan(9000);
   });
 
   it("turns supplied UI-test evidence into actionable Cloud diagnostics", () => {

--- a/tests/mcp/http-transport.test.ts
+++ b/tests/mcp/http-transport.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import worker from "../../workers/mcp-http/src/worker.js";
-import { TOOL_MANIFEST } from "../../src/mcp/manifest.js";
+import { TOOL_MANIFEST, getRuntimeToolManifest } from "../../src/mcp/manifest.js";
 import { PROMPT_MANIFEST } from "../../src/mcp/prompts.js";
 
 const packageVersion = JSON.parse(
@@ -78,15 +78,20 @@ describe("axint HTTP MCP transport", () => {
     });
   });
 
-  it("lists the full MCP tool manifest", async () => {
+  it("lists the compact MCP tool manifest by default", async () => {
     const response = await request({ jsonrpc: "2.0", id: 1, method: "tools/list" });
     const payload = await response.json();
+    const compactManifest = getRuntimeToolManifest();
 
     expect(response.status).toBe(200);
     expect(payload.result.tools).toHaveLength(TOOL_MANIFEST.length);
     expect(payload.result.tools.map((tool: { name: string }) => tool.name)).toEqual(
       TOOL_MANIFEST.map((tool) => tool.name)
     );
+    expect(JSON.stringify(payload.result.tools).length).toBeLessThan(
+      JSON.stringify(TOOL_MANIFEST).length
+    );
+    expect(payload.result.tools).toEqual(compactManifest);
   });
 
   it("reports the running remote MCP server version through axint.status", async () => {

--- a/tests/mcp/index.test.ts
+++ b/tests/mcp/index.test.ts
@@ -6,6 +6,7 @@ describe("axint/mcp import surface", () => {
 
     expect(typeof mod.createAxintServer).toBe("function");
     expect(typeof mod.startMCPServer).toBe("function");
+    expect(typeof mod.getRuntimeToolManifest).toBe("function");
     expect(Array.isArray(mod.TOOL_MANIFEST)).toBe(true);
     expect(Array.isArray(mod.PROMPT_MANIFEST)).toBe(true);
     expect(mod.TOOL_MANIFEST.length).toBeGreaterThan(0);
@@ -24,5 +25,20 @@ describe("axint/mcp import surface", () => {
     expect(prompt.messages[0].content.text).toContain("axint.context.memory");
     expect(prompt.messages[0].content.text).toContain("axint.context.docs");
     expect(prompt.messages[0].content.text).toContain("axint.status");
+  });
+
+  it("keeps runtime tool listings compact unless verbose mode is requested", async () => {
+    const mod = await import("../../src/mcp/index.js");
+    const compact = mod.getRuntimeToolManifest();
+    const full = mod.getRuntimeToolManifest({ AXINT_MCP_MANIFEST_MODE: "full" });
+
+    expect(compact).toHaveLength(mod.TOOL_MANIFEST.length);
+    expect(compact.map((tool: { name: string }) => tool.name)).toEqual(
+      mod.TOOL_MANIFEST.map((tool: { name: string }) => tool.name)
+    );
+    expect(full).toBe(mod.TOOL_MANIFEST);
+    expect(JSON.stringify(compact).length).toBeLessThan(
+      JSON.stringify(mod.TOOL_MANIFEST).length * 0.75
+    );
   });
 });

--- a/tests/run/project-runner.test.ts
+++ b/tests/run/project-runner.test.ts
@@ -176,6 +176,85 @@ describe("runAxintProject", () => {
     }
   });
 
+  it("writes compact latest artifacts and caps captured command output", async () => {
+    const dir = makeFakeXcodeProject();
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const xcodebuild = join(binDir, "xcodebuild");
+    writeFileSync(
+      xcodebuild,
+      [
+        "#!/bin/sh",
+        "printf '%12000s\\n' x",
+        "echo '** TEST SUCCEEDED **'",
+        "exit 0",
+        "",
+      ].join("\n")
+    );
+    chmodSync(xcodebuild, 0o755);
+
+    const previousPath = process.env.PATH;
+    const previousCapture = process.env.AXINT_COMMAND_CAPTURE_CHARS;
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    process.env.AXINT_COMMAND_CAPTURE_CHARS = "2000";
+    try {
+      const report = await runAxintProject({
+        cwd: dir,
+        writeReport: true,
+      });
+      const latest = JSON.parse(readFileSync(report.artifacts.json!, "utf-8")) as {
+        cloudChecks: Array<{ swiftCode?: string; sourceRedaction?: unknown }>;
+        commands: { build?: { stdout?: string; stdoutTail?: string } };
+        outputRedaction?: { mode: string };
+      };
+
+      expect(report.commands.build?.stdout.length).toBeLessThanOrEqual(2000);
+      expect(latest.cloudChecks[0]?.swiftCode).toBeUndefined();
+      expect(latest.cloudChecks[0]?.sourceRedaction).toBeDefined();
+      expect(latest.commands.build?.stdout).toBeUndefined();
+      expect(latest.commands.build?.stdoutTail?.length).toBeLessThanOrEqual(700);
+      expect(latest.outputRedaction?.mode).toBe("compact");
+    } finally {
+      process.env.PATH = previousPath;
+      if (previousCapture === undefined) {
+        delete process.env.AXINT_COMMAND_CAPTURE_CHARS;
+      } else {
+        process.env.AXINT_COMMAND_CAPTURE_CHARS = previousCapture;
+      }
+    }
+  });
+
+  it("limits broad Cloud Check sweeps when changed files are omitted", async () => {
+    const dir = makeFakeXcodeProject();
+    for (let index = 0; index < 12; index += 1) {
+      writeFileSync(
+        join(dir, `ExtraView${index}.swift`),
+        [
+          "import SwiftUI",
+          "",
+          `struct ExtraView${index}: View {`,
+          "  var body: some View {",
+          `    Text("Extra ${index}")`,
+          "  }",
+          "}",
+          "",
+        ].join("\n")
+      );
+    }
+
+    const report = await runAxintProject({
+      cwd: dir,
+      dryRun: true,
+      writeReport: false,
+    });
+    const cloudStep = report.steps.find((step) => step.name === "Cloud Check");
+
+    expect(report.swiftValidation.filesChecked).toBe(13);
+    expect(report.cloudChecks).toHaveLength(8);
+    expect(cloudStep?.detail).toContain("compact Cloud Check");
+    expect(cloudStep?.detail).toContain("Pass --changed");
+  });
+
   it("plans focused Xcode UI tests with only-testing selectors", async () => {
     const dir = makeFakeXcodeProject();
     const report = await runAxintProject({

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -49,7 +49,7 @@ import type { SuggestInput } from "../../../src/mcp/suggest.js";
 import { TEMPLATES, getTemplate } from "../../../src/templates/index.js";
 import { validateSwiftSource } from "../../../src/core/swift-validator.js";
 import { fixSwiftSourceMultipass } from "../../../src/core/swift-fixer.js";
-import { TOOL_MANIFEST } from "../../../src/mcp/manifest.js";
+import { TOOL_MANIFEST, getRuntimeToolManifest } from "../../../src/mcp/manifest.js";
 import { PROMPT_MANIFEST, getPromptMessages } from "../../../src/mcp/prompts.js";
 import type {
   IRIntent,
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.15";
+const VERSION = "0.4.16";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 
@@ -124,6 +124,11 @@ const GLAMA_SERVER_MARKER = {
 type Env = {
   ALLOWED_ORIGINS?: string;
   MAX_BODY_BYTES?: string;
+  AXINT_MCP_FULL_MANIFEST?: string;
+  AXINT_MCP_MANIFEST_MODE?: string;
+  AXINT_MCP_TOOL_DESCRIPTION_CHARS?: string;
+  AXINT_MCP_SCHEMA_DESCRIPTION_CHARS?: string;
+  AXINT_MCP_NESTED_DESCRIPTION_CHARS?: string;
 };
 
 function resolveAllowedOrigin(origin: string | null, env: Env): string | null {
@@ -850,7 +855,7 @@ export default {
     }
 
     if (method === "tools/list") {
-      return jsonrpc(id, { tools: TOOL_MANIFEST }, cors);
+      return jsonrpc(id, { tools: getRuntimeToolManifest(env) }, cors);
     }
 
     if (method === "tools/call") {


### PR DESCRIPTION
## Summary
- reduce default agent token overhead in Axint run and Cloud Check artifacts
- return compact MCP tool manifests by default while keeping full manifests opt-in
- bump Axint to v0.4.16 and sync package, Python, extension, server, and worker version surfaces

## Validation
- npm run typecheck
- npm run metrics:emit && npm run metrics:check && npm run docs:check
- npm run build && npm test
- python3 -m pytest
- root npm run truth:check
