### PR TITLE
Release Axint 0.4.19 actor isolation, conformance propagation, registry search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,11 +63,12 @@ python/**/__pycache__/
 *.tgz
 
 # Hosted separately — not part of the compiler repo
-registry/
-site/
-launch/
-docs/launch/
-.github-org-profile/
+# Anchored to repo root so we don't accidentally exclude src/registry/, etc.
+/registry/
+/site/
+/launch/
+/docs/launch/
+/.github-org-profile/
 profile/
 .github-org-temp/
 .scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+## [0.4.19] — 2026-05-03
+
+### Added
+
+- **`AX847` type-erased SwiftUI protocol method missing** — bundled table of methods that exist on a sub-protocol but not on the type-erased name. Catches the dogfooding `AnyShape.strokeBorder` pattern (strokeBorder lives on InsettableShape; AnyShape only conforms to Shape). Suggests the closest valid replacement (e.g. `.stroke` for `.strokeBorder` on AnyShape).
+- **`AX846` @ViewBuilder requires View return type** — flags any `@ViewBuilder` annotation on a property/function whose return type isn't `some View` / `View`. Catches the dogfooding `@ViewBuilder some Shape` pattern that produces `_ConditionalContent` (View only) but is asked to satisfy a Shape constraint.
+- **`AX845` @MainActor static method in init default-value** — for any `@MainActor` class/struct with init parameter defaults that call `TypeName.staticMethod()` or `Self.staticMethod()`, fires when the static method isn't `nonisolated`. Default-value expressions evaluate at the caller's isolation context (often non-isolated), and Swift 6 rejects the actor crossing. Single-keyword fix the diagnostic suggests directly.
+- **`AX844` synthesized conformance propagation** — for any struct that explicitly declares `Hashable`, `Equatable`, `Codable`, `Decodable`, or `Encodable`, walks stored properties via project-context index and confirms each property's type also conforms. Catches the `LiveTeammate { let builder: BuilderProfile }` pattern where the property type lives in another file and doesn't conform. Includes a project-wide extension scan so `extension X: Hashable {}` declarations elsewhere are honored.
+- **`AX843` state-machine orphan** — for each enum declared in the input set, finds case-write sites (`= .foo`) and case-read sites (`switch`/`case .foo:`/`is .foo`/`==`/`if case`) across the project. Cases with writes but zero reads emit `info`-severity. Catches the `Navigator.rightPane = .voiceInbox` pattern where the writer survived a refactor but the consumer view was dropped.
+- **`axint.registry.search` MCP tool** — natural-language query against the local Axint Registry. Returns ranked hits with name, version, description, surface areas, install command. Token-overlap scoring with field weighting (name + tags + siri-phrases ranked higher than description). Filters by `kind` (app-intent, view, widget, ...) and `platform` (iOS/macOS/...). Use BEFORE `axint.feature` / `axint.compile` so agents can install existing packages instead of regenerating Swift.
+- **`AXINT_REGISTRY_PATH`** env var — points the registry tooling at any axint-registry checkout. Defaults to the sibling `../axint-registry/` for normal workspace setups.
+
+### Changed
+
+- **`registryPackages` metric is now auto-counted** from the sibling `axint-registry/first-party/` directory instead of a hardcoded constant. The previous value (14) was stale; the real count from the registry is now what shows up in `metrics.json` and on every public surface. Honestly smaller, but real.
+
 ## [0.4.18] — 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.18 · 33 MCP tools + 5 prompts · 198 diagnostic codes · 1257 tests · 14 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.19 · 34 MCP tools + 5 prompts · 203 diagnostic codes · 1278 tests · 5 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -390,6 +390,7 @@ MCP tools and built-in prompts:
 | `axint.context.docs` | Return the project-local Axint docs context so agents can reload docs after compaction |
 | `axint.suggest` | Suggest app-specific Apple-native features, reusable components, and shared stores from a product description |
 | `axint suggest` | CLI fallback for the same suggestion pass when MCP transport is stale, closed, or unavailable |
+| `axint.registry.search` | Search the Axint Registry for already-published packages that match a natural-language query — call this before `axint.feature` so agents install existing packages instead of regenerating Swift the community has shipped |
 | `axint.workflow.check` | Check whether an agent rehydrated Axint after compaction, has an active session token, and used suggest, feature, swift.validate, cloud.check, and Xcode proof before moving on |
 | `axint workflow check` | CLI fallback for the same workflow gate when MCP is stale, closed, or unavailable |
 | `axint.scaffold` | Generate a starter TypeScript intent from a description |

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.4.18",
-  "mcpTools": 33,
+  "version": "0.4.19",
+  "mcpTools": 34,
   "mcpToolNames": [
     "axint.status",
     "axint.upgrade",
@@ -14,6 +14,7 @@
     "axint.context.memory",
     "axint.context.docs",
     "axint.suggest",
+    "axint.registry.search",
     "axint.workflow.check",
     "axint.scaffold",
     "axint.compile",
@@ -45,7 +46,7 @@
     "axint.create-intent"
   ],
   "bundledTemplates": 26,
-  "diagnostics": 198,
+  "diagnostics": 203,
   "xcodeFixRules": 33,
   "xcodeFixRuleCodes": [
     "AX701",
@@ -83,9 +84,9 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1143,
+    "typescript": 1164,
     "python": 114
   },
-  "registryPackages": 14,
+  "registryPackages": 5,
   "distributionSurfaces": 4
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.18"
+__version__ = "0.4.19"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.18"
+version = "0.4.19"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/release-0.4.18.sh
+++ b/release-0.4.18.sh
@@ -76,7 +76,7 @@ else
   green "committed"
 fi
 
-bold "Pushing to origin/$FEATURE…"
+bold "Pushing to origin/${FEATURE}"
 git push -u origin "$FEATURE"
 green "pushed"
 

--- a/release-0.4.19.sh
+++ b/release-0.4.19.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# release-0.4.19.sh — finalizes the 0.4.19 release.
+#
+# Run this ONCE from your Mac terminal:
+#   cd ~/agenticempire/axint && bash release-0.4.19.sh
+#
+# What's in this release:
+#   1. AX843 — state-machine orphan (enum case written but never read)
+#   2. AX844 — synthesized Hashable/Equatable/Codable propagation
+#   3. AX845 — @MainActor static method in init default-value
+#   4. AX846 — @ViewBuilder requires View return type (catches @ViewBuilder some Shape)
+#   5. AX847 — type-erased SwiftUI protocol method missing (catches AnyShape.strokeBorder)
+#   6. axint.registry.search MCP tool — agent-lookup loop entry point
+#   7. registryPackages metric is auto-counted (was hardcoded 14)
+#   + bump-consumer-versions-and-sync.sh fixes (auto-detect + npm install)
+#
+# After PR merges:
+#   npm run build && npm publish --access public
+#   git tag v0.4.19 && git push origin v0.4.19
+#   bash ~/SWARM/install-axint-mcp.sh   # already pinned to 0.4.19
+
+set -euo pipefail
+
+bold() { printf "\033[1m%s\033[0m\n" "$1"; }
+green() { printf "\033[32m✓\033[0m %s\n" "$1"; }
+red() { printf "\033[31m✗\033[0m %s\n" "$1" >&2; }
+yellow() { printf "\033[33m→\033[0m %s\n" "$1"; }
+
+cd "$(dirname "$0")"
+
+bold "axint 0.4.19 release"
+echo
+
+if [ -f .git/index.lock ]; then
+  rm -f .git/index.lock
+  green "cleared stale .git/index.lock"
+fi
+
+CURRENT="$(git branch --show-current)"
+FEATURE="v0419-coverage-rules"
+
+if [ "$CURRENT" != "$FEATURE" ]; then
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    git stash push -u -m "auto-stash for 0.4.19 release script" >/dev/null
+    STASHED=1
+  fi
+  git fetch origin --quiet
+  git checkout main
+  git pull --ff-only origin main
+  if git rev-parse --verify "$FEATURE" >/dev/null 2>&1; then
+    git checkout "$FEATURE"
+  else
+    git checkout -b "$FEATURE"
+  fi
+  if [ "${STASHED:-0}" = "1" ]; then
+    git stash pop >/dev/null 2>&1 || yellow "stash pop conflict — resolve manually"
+  fi
+  green "on branch ${FEATURE}"
+else
+  green "already on ${FEATURE}"
+fi
+
+bold "Running gates"
+npm run versions:check >/dev/null && green "versions:check"
+npm run metrics:check >/dev/null && green "metrics:check"
+npm run docs:check >/dev/null && green "docs:check"
+npm run lint >/dev/null && green "lint"
+npm run typecheck >/dev/null && green "typecheck"
+npx vitest run --reporter=dot >/dev/null && green "vitest"
+
+bold "Committing"
+git add -A
+if git diff --cached --quiet; then
+  yellow "No staged changes — release commit may already exist."
+else
+  git commit -m "Release Axint 0.4.19 actor isolation, conformance propagation, registry search"
+  green "committed"
+fi
+
+bold "Pushing to origin/${FEATURE}"
+git push -u origin "${FEATURE}"
+green "pushed"
+
+if command -v gh >/dev/null 2>&1; then
+  bold "Opening PR"
+  if gh pr view "$FEATURE" >/dev/null 2>&1; then
+    yellow "PR already exists for ${FEATURE}"
+  else
+    gh pr create \
+      --title "Release Axint 0.4.19 actor isolation, conformance propagation, registry search" \
+      --body "$(cat <<'EOF'
+Five new validator rules from the SWARM dogfooding log, one new MCP tool, and infrastructure fixes.
+
+New rules:
+
+- AX847 catches methods called on type-erased SwiftUI protocols that don't exist on the erased surface. Bundled table — currently AnyShape.strokeBorder (lives on InsettableShape, not Shape) and AnyShape.inset. Suggests the closest valid replacement (`.stroke` for `.strokeBorder`).
+- AX846 catches @ViewBuilder annotations on properties/funcs whose return type isn't some View. Catches the @ViewBuilder some Shape pattern that produces _ConditionalContent (View only) but is asked to satisfy a Shape constraint.
+- AX845 catches @MainActor classes with init parameter defaults that call same-type static methods. Default-value expressions evaluate at the caller's isolation context (often non-isolated), and Swift 6 rejects the actor crossing. Single-keyword fix the diagnostic suggests directly (mark the static method nonisolated).
+- AX844 catches structs declaring synthesized Hashable/Equatable/Codable when a stored property's type doesn't conform. Walks project-context to verify cross-file conformance, including extensions. Catches the SkillEndorsementBucket / LiveTeammate pattern from this sprint.
+- AX843 catches enum cases written somewhere but never read by a switch/pattern anywhere reachable. Catches the Navigator.rightPane = .voiceInbox pattern where the writer survived a refactor but the consumer view was dropped.
+
+New tool:
+
+- axint.registry.search — natural-language query against the local Axint Registry. Returns ranked hits with install commands. Use BEFORE axint.feature so agents install existing packages instead of regenerating Swift the community has already shipped. Token-overlap scoring with field weighting; honors AXINT_REGISTRY_PATH for non-default checkouts.
+
+Infrastructure:
+
+- registryPackages metric is now auto-counted from the sibling axint-registry/first-party/ directory. The previous hardcoded 14 was stale; the real count from the registry now flows through metrics.json and every public surface.
+- bump-consumer-versions-and-sync.sh now auto-detects OLD/NEW versions from axint/package.json and uses npm install --save-exact for docs.axint.ai's lockfile (avoids the EINTEGRITY trap from the 0.4.17/0.4.18 deploys).
+
+21 new tests (1278 total). Diagnostics 198 to 203. Lint, typecheck, versions:check, metrics:check, docs:check all clean.
+EOF
+)"
+    green "PR opened"
+  fi
+fi
+
+echo
+bold "Done. After PR merges:"
+echo "  npm run build && npm publish --access public"
+echo "  git tag v0.4.19 && git push origin v0.4.19"
+echo "  bash ~/SWARM/install-axint-mcp.sh   # already pinned to 0.4.19"

--- a/scripts/metrics.mjs
+++ b/scripts/metrics.mjs
@@ -40,9 +40,17 @@ export function computeMetrics({ countTests = true } = {}) {
 // Counts published packages in the sibling axint-registry repo. Looks for
 // per-package directories (each one is a published package). Honors an
 // explicit AXINT_REGISTRY_PATH env var so CI can point at any checkout.
-// Falls back to a sensible default of 0 + a stderr warning if the registry
-// repo isn't reachable — better than silently shipping a stale hardcoded
-// number forever.
+//
+// Fallback chain when the registry isn't on disk (CI runners that don't
+// have the private axint-registry repo cloned):
+//   1. Read the previously-committed value from metrics.json. This makes
+//      drift detection still work — `metrics:emit` updates the count on
+//      the dev machine that has the registry; CI trusts what got committed.
+//   2. Default to 0 + a stderr warning if no metrics.json exists yet.
+//
+// Net effect: dev machines compute the real count, CI preserves it.
+// `metrics:check` only fires when the dev machine forgot to re-emit after
+// the registry actually changed.
 function countRegistryPackages() {
   const candidates = [
     process.env.AXINT_REGISTRY_PATH,
@@ -62,9 +70,22 @@ function countRegistryPackages() {
     return count;
   }
 
-  // Registry not on disk — surface honestly rather than lying with 14.
+  // Registry not on disk (typical for CI). Trust the committed value so
+  // we don't fail check just because CI can't see the private repo.
+  try {
+    const metricsPath = resolve(ROOT, "metrics.json");
+    if (existsSync(metricsPath)) {
+      const committed = JSON.parse(readFileSync(metricsPath, "utf-8"));
+      if (typeof committed.registryPackages === "number") {
+        return committed.registryPackages;
+      }
+    }
+  } catch {
+    // Fall through to 0 + warning.
+  }
+
   console.warn(
-    "metrics: axint-registry not found at any known path; registryPackages = 0. Set AXINT_REGISTRY_PATH to override."
+    "metrics: axint-registry not found and no committed value in metrics.json; registryPackages = 0. Set AXINT_REGISTRY_PATH to override."
   );
   return 0;
 }

--- a/scripts/metrics.mjs
+++ b/scripts/metrics.mjs
@@ -3,7 +3,7 @@
 // compares it against the committed snapshot so CI catches drift.
 
 import { execFileSync } from "node:child_process";
-import { readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -29,11 +29,44 @@ export function computeMetrics({ countTests = true } = {}) {
           python: runPytestCount(),
         }
       : { typescript: 0, python: 0 },
-    // Kept as explicit constants — both depend on repos outside the compiler tree.
-    // Update these when the corresponding surface ships a new package.
-    registryPackages: 14,
+    registryPackages: countRegistryPackages(),
+    // Distribution surfaces still hand-tracked — they're abstract enough
+    // (axint.ai, docs.axint.ai, registry.axint.ai, MCP registry) that
+    // counting from the filesystem doesn't make sense.
     distributionSurfaces: 4,
   };
+}
+
+// Counts published packages in the sibling axint-registry repo. Looks for
+// per-package directories (each one is a published package). Honors an
+// explicit AXINT_REGISTRY_PATH env var so CI can point at any checkout.
+// Falls back to a sensible default of 0 + a stderr warning if the registry
+// repo isn't reachable — better than silently shipping a stale hardcoded
+// number forever.
+function countRegistryPackages() {
+  const candidates = [
+    process.env.AXINT_REGISTRY_PATH,
+    resolve(ROOT, "..", "axint-registry"),
+    resolve(ROOT, "..", "..", "axint-registry"),
+  ].filter(Boolean);
+
+  for (const root of candidates) {
+    const firstParty = resolve(root, "first-party");
+    if (!existsSync(firstParty)) continue;
+    let count = 0;
+    for (const name of readdirSync(firstParty)) {
+      if (name.startsWith(".") || name === "README.md") continue;
+      const stat = statSync(resolve(firstParty, name));
+      if (stat.isDirectory()) count++;
+    }
+    return count;
+  }
+
+  // Registry not on disk — surface honestly rather than lying with 14.
+  console.warn(
+    "metrics: axint-registry not found at any known path; registryPackages = 0. Set AXINT_REGISTRY_PATH to override."
+  );
+  return 0;
 }
 
 function extractTopLevelNames(relPath, symbol) {

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.18",
+      "version": "0.4.19",
       "transport": {
         "type": "stdio"
       }
@@ -28,14 +28,14 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.18",
+      "version": "0.4.19",
       "transport": {
         "type": "stdio"
       }
     }
   ],
   "capabilities": {
-    "tools": 33,
+    "tools": 34,
     "prompts": 5
   }
 }

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -799,6 +799,41 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticInfo> = {
       "SwiftUI View struct is declared but has zero call sites in the project — likely dead code",
     category: "swiftui-reachability",
   },
+  AX843: {
+    code: "AX843",
+    severity: "info",
+    message:
+      "Enum case is assigned somewhere in the project but no switch/pattern reads it — likely dead state branch",
+    category: "swift-state-machine",
+  },
+  AX844: {
+    code: "AX844",
+    severity: "error",
+    message:
+      "Synthesized Hashable/Equatable/Codable cannot be derived because a stored property's type does not conform",
+    category: "swift-cross-file",
+  },
+  AX845: {
+    code: "AX845",
+    severity: "error",
+    message:
+      "@MainActor static member referenced from a non-isolated init default-value expression — Swift 6 rejects the actor crossing",
+    category: "swift-concurrency",
+  },
+  AX846: {
+    code: "AX846",
+    severity: "error",
+    message:
+      "@ViewBuilder requires a View-shaped return type — _ConditionalContent only conforms to View, never to Shape, Layout, or other protocols",
+    category: "swiftui-viewbuilder",
+  },
+  AX847: {
+    code: "AX847",
+    severity: "error",
+    message:
+      "Method called on a type-erased SwiftUI protocol (AnyShape, AnyView, ...) that does not exist on the erased protocol surface",
+    category: "swiftui-type-erasure",
+  },
   AX714: {
     code: "AX714",
     severity: "error",

--- a/src/core/swift-validator.ts
+++ b/src/core/swift-validator.ts
@@ -25,6 +25,7 @@ import {
   escapeRegex,
   findMatchingBrace,
   findTypeDeclarations,
+  hasAttribute,
   hasConformance,
   makeDiagnostic,
   stripCommentsAndStrings,
@@ -105,6 +106,9 @@ export function validateSwiftSource(source: string, file: string): SwiftValidati
   checkDenseViewWithoutAffordance(source, stripped, file, diagnostics);
   checkUndefinedBooleanIdentifiers(source, stripped, file, diagnostics);
   checkUndefinedStringInterpolationIdentifiers(source, stripped, file, diagnostics);
+  checkMainActorStaticInDefaultValue(source, stripped, file, diagnostics);
+  checkViewBuilderReturnType(source, stripped, file, diagnostics);
+  checkTypeErasedProtocolMethods(source, stripped, file, diagnostics);
 
   return { file, diagnostics };
 }
@@ -142,6 +146,18 @@ export function validateSwiftSources(
 
       const projectMember = checkProjectIndexMemberAccess(inputs, projectFiles);
       for (const diagnostic of projectMember) {
+        const diagnostics = diagnosticsByFile.get(diagnostic.file ?? "");
+        if (diagnostics) diagnostics.push(diagnostic);
+      }
+
+      const conformance = checkSynthesizedConformancePropagation(inputs, projectFiles);
+      for (const diagnostic of conformance) {
+        const diagnostics = diagnosticsByFile.get(diagnostic.file ?? "");
+        if (diagnostics) diagnostics.push(diagnostic);
+      }
+
+      const stateOrphans = checkStateMachineOrphans(inputs, projectFiles);
+      for (const diagnostic of stateOrphans) {
         const diagnostics = diagnosticsByFile.get(diagnostic.file ?? "");
         if (diagnostics) diagnostics.push(diagnostic);
       }
@@ -2860,4 +2876,689 @@ function collectImportedModules(stripped: string): Set<string> {
     modules.add(root);
   }
   return modules;
+}
+
+// ─── Rule: AX844 — Synthesized conformance can't propagate across files ─
+//
+// Catches the dogfooding pattern where a struct declares Hashable/Equatable/
+// Codable but a stored property's type — defined in another file — doesn't
+// conform. Swift's compiler walks the stored-property type graph at conf-
+// ormance derivation time and rejects the synthesis. axint's other rules
+// don't do that walk; this one does, using the project-context index.
+//
+// Heuristic boundaries: only fires when (a) we have project context, (b) the
+// property's type is in the project index (so we know its declared
+// conformances), (c) the type doesn't itself declare the protocol, and (d)
+// the type isn't a known-conforming primitive (Int, String, Bool, etc).
+
+const SYNTHESIZABLE_PROTOCOLS = [
+  "Hashable",
+  "Equatable",
+  "Codable",
+  "Decodable",
+  "Encodable",
+] as const;
+type SynthProtocol = (typeof SYNTHESIZABLE_PROTOCOLS)[number];
+
+// Standard library types every Swift programmer takes for granted as
+// conforming to the synthesizable protocols. Not exhaustive but covers the
+// common ones used as stored-property types.
+const PRIMITIVE_CONFORMING: Record<SynthProtocol, ReadonlySet<string>> = {
+  Hashable: new Set([
+    "Int",
+    "Int8",
+    "Int16",
+    "Int32",
+    "Int64",
+    "UInt",
+    "UInt8",
+    "UInt16",
+    "UInt32",
+    "UInt64",
+    "Float",
+    "Float32",
+    "Float64",
+    "Double",
+    "CGFloat",
+    "Bool",
+    "String",
+    "Substring",
+    "Character",
+    "Date",
+    "URL",
+    "UUID",
+    "Data",
+    "TimeInterval",
+    "Decimal",
+  ]),
+  Equatable: new Set([
+    "Int",
+    "Int8",
+    "Int16",
+    "Int32",
+    "Int64",
+    "UInt",
+    "UInt8",
+    "UInt16",
+    "UInt32",
+    "UInt64",
+    "Float",
+    "Float32",
+    "Float64",
+    "Double",
+    "CGFloat",
+    "Bool",
+    "String",
+    "Substring",
+    "Character",
+    "Date",
+    "URL",
+    "UUID",
+    "Data",
+    "TimeInterval",
+    "Decimal",
+  ]),
+  Codable: new Set([
+    "Int",
+    "Int8",
+    "Int16",
+    "Int32",
+    "Int64",
+    "UInt",
+    "UInt8",
+    "UInt16",
+    "UInt32",
+    "UInt64",
+    "Float",
+    "Float32",
+    "Float64",
+    "Double",
+    "CGFloat",
+    "Bool",
+    "String",
+    "Date",
+    "URL",
+    "UUID",
+    "Data",
+    "TimeInterval",
+    "Decimal",
+  ]),
+  Decodable: new Set([
+    "Int",
+    "Int8",
+    "Int16",
+    "Int32",
+    "Int64",
+    "UInt",
+    "UInt8",
+    "UInt16",
+    "UInt32",
+    "UInt64",
+    "Float",
+    "Float32",
+    "Float64",
+    "Double",
+    "CGFloat",
+    "Bool",
+    "String",
+    "Date",
+    "URL",
+    "UUID",
+    "Data",
+    "TimeInterval",
+    "Decimal",
+  ]),
+  Encodable: new Set([
+    "Int",
+    "Int8",
+    "Int16",
+    "Int32",
+    "Int64",
+    "UInt",
+    "UInt8",
+    "UInt16",
+    "UInt32",
+    "UInt64",
+    "Float",
+    "Float32",
+    "Float64",
+    "Double",
+    "CGFloat",
+    "Bool",
+    "String",
+    "Date",
+    "URL",
+    "UUID",
+    "Data",
+    "TimeInterval",
+    "Decimal",
+  ]),
+};
+
+interface ConformanceIndexEntry {
+  // The conformances this type declares directly via `: A, B, C` syntax,
+  // plus conformances added via `extension TypeName: A {}` declarations
+  // anywhere in the project.
+  conformances: Set<string>;
+}
+
+function checkSynthesizedConformancePropagation(
+  inputs: SwiftValidationInput[],
+  projectFiles: Map<string, string>
+): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  const inputPaths = new Set(inputs.map((i) => resolve(i.file)));
+
+  // Build a project-wide map of type → declared conformances (incl. extensions).
+  const conformanceIndex = collectConformanceIndex(projectFiles);
+
+  for (const input of inputs) {
+    if (!inputPaths.has(resolve(input.file))) continue;
+    const stripped = stripCommentsAndStrings(input.source);
+    const decls = findTypeDeclarations(stripped, input.source);
+
+    for (const decl of decls) {
+      // Only structs synthesize Hashable/Equatable/Codable for free
+      // (classes need explicit implementations, enums w/o associated values
+      // get them automatically anyway).
+      if (decl.kind !== "struct") continue;
+
+      const declaredProtocols: SynthProtocol[] = [];
+      for (const proto of SYNTHESIZABLE_PROTOCOLS) {
+        if (hasConformance(decl, proto)) declaredProtocols.push(proto);
+      }
+      if (declaredProtocols.length === 0) continue;
+
+      const body = stripped.slice(decl.bodyStart, decl.bodyEnd);
+      const properties = collectStoredPropertyTypes(body);
+      if (properties.length === 0) continue;
+
+      for (const prop of properties) {
+        const elementType = unwrapCollectionType(prop.typeText);
+        const baseName = baseSwiftTypeName(elementType);
+        if (!baseName) continue;
+
+        for (const proto of declaredProtocols) {
+          if (PRIMITIVE_CONFORMING[proto].has(baseName)) continue;
+          const entry = conformanceIndex.get(baseName);
+          // Type isn't in our index — could be a system type we don't know
+          // about. Don't fire (would produce false positives on Apple SDK
+          // types like `BindingType` etc.).
+          if (!entry) continue;
+          if (entry.conformances.has(proto)) continue;
+
+          const propLine =
+            1 + countNewlinesUpTo(input.source, decl.bodyStart + prop.offsetInBody);
+
+          diagnostics.push(
+            makeDiagnostic("AX844", input.file, propLine, {
+              message: `Synthesized '${proto}' for '${decl.name}' will fail: stored property '${prop.name}' has type '${prop.typeText}' and '${baseName}' does not declare '${proto}' conformance.`,
+              suggestion: `Either remove '${proto}' from '${decl.name}', or extend '${baseName}: ${proto}' in its defining file, or change '${prop.name}' to a ${proto}-conforming type. The Swift compiler will reject this on the next build.`,
+            })
+          );
+        }
+      }
+    }
+  }
+
+  return diagnostics;
+}
+
+function collectConformanceIndex(
+  projectFiles: Map<string, string>
+): Map<string, ConformanceIndexEntry> {
+  const index = new Map<string, ConformanceIndexEntry>();
+
+  for (const [, source] of projectFiles) {
+    const stripped = stripCommentsAndStrings(source);
+    const decls = findTypeDeclarations(stripped, source);
+
+    for (const decl of decls) {
+      const baseName = baseSwiftTypeName(decl.name);
+      if (!baseName) continue;
+      const entry = index.get(baseName) ?? { conformances: new Set<string>() };
+
+      // Direct conformances from `struct X: A, B, C {`. The decl's own
+      // attributes/conformances are tracked elsewhere; we re-extract here
+      // from the declaration source to avoid coupling assumptions.
+      const beforeBody = source.slice(0, decl.bodyStart);
+      const headerMatch = beforeBody.match(
+        /\b(?:struct|class|enum|actor|protocol)\s+[A-Za-z_][A-Za-z0-9_]*\s*(?:<[^>]*>)?\s*:\s*([^{]+)\{\s*$/
+      );
+      if (headerMatch) {
+        for (const conformance of headerMatch[1]!.split(",")) {
+          const name = baseSwiftTypeName(conformance.trim());
+          if (name) entry.conformances.add(name);
+        }
+      }
+
+      index.set(baseName, entry);
+    }
+
+    // Also pick up `extension TypeName: A, B {}` style.
+    const extPattern =
+      /\bextension\s+([A-Za-z_][A-Za-z0-9_.]*)\s*(?:<[^>]*>)?\s*:\s*([^{]+)\{/g;
+    let extMatch: RegExpExecArray | null;
+    while ((extMatch = extPattern.exec(stripped)) !== null) {
+      const baseName = baseSwiftTypeName(extMatch[1]!);
+      if (!baseName) continue;
+      const entry = index.get(baseName) ?? { conformances: new Set<string>() };
+      for (const conformance of extMatch[2]!.split(",")) {
+        const name = baseSwiftTypeName(conformance.trim());
+        if (name) entry.conformances.add(name);
+      }
+      index.set(baseName, entry);
+    }
+  }
+
+  return index;
+}
+
+interface StoredPropertyInfo {
+  name: string;
+  typeText: string;
+  offsetInBody: number;
+}
+
+function collectStoredPropertyTypes(body: string): StoredPropertyInfo[] {
+  const properties: StoredPropertyInfo[] = [];
+  // Match `let foo: Type` or `var foo: Type = …` patterns. Type capture
+  // starts with `[`, `(`, or a letter so we cover array/dict sugar like
+  // `[Foo]` and tuple types like `(String, Int)` in addition to bare names.
+  // Skips computed properties via the `(?=\s*(?:=|$|\{|\n))` lookahead.
+  const pattern =
+    /(?:@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?\s+)?(?:public|internal|private|fileprivate|open|static|class)?\s*(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([[(A-Za-z_][A-Za-z0-9_.<>?![\](), :\s]*?)(?=\s*(?:=|\{|\n|$))/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(body)) !== null) {
+    const name = match[1]!;
+    const typeText = (match[2] ?? "").trim().replace(/\s+/g, " ");
+    if (!typeText) continue;
+    if (typeText.endsWith("{") || /\bget\b/.test(typeText)) continue;
+    properties.push({ name, typeText, offsetInBody: match.index });
+  }
+  return properties;
+}
+
+function unwrapCollectionType(typeText: string): string {
+  let t = typeText.trim();
+  // Strip optional sugar.
+  while (t.endsWith("?") || t.endsWith("!")) t = t.slice(0, -1).trim();
+  // Array sugar: [Foo] -> Foo
+  const arrayMatch = t.match(/^\[\s*(.+)\s*\]$/);
+  if (arrayMatch) return unwrapCollectionType(arrayMatch[1]!);
+  // Dictionary sugar: [K: V] -> we care about V (the more interesting type)
+  const dictMatch = t.match(/^\[\s*[^:]+\s*:\s*(.+)\s*\]$/);
+  if (dictMatch) return unwrapCollectionType(dictMatch[1]!);
+  // Generic collections: Set<Foo>, Array<Foo>, Optional<Foo>
+  const genMatch = t.match(/^(?:Set|Array|Optional|Dictionary)<\s*([^,>]+)/);
+  if (genMatch) return unwrapCollectionType(genMatch[1]!);
+  return t;
+}
+
+// ─── Rule: AX843 — State-machine orphan ─────────────────────────────────
+//
+// Catches the dogfooding pattern where an enum case is assigned somewhere
+// (e.g. `Navigator.rightPane = .voiceInbox`) but no `switch` or pattern
+// match anywhere reads it. The case is dead state — the writer thinks
+// it's wiring something up; the reader was never built or got dropped in
+// a refactor (the SocialShellView voice-inbox case).
+//
+// Conservative scope to keep noise down:
+//   - Only fires when project context is loaded (we need the full read
+//     surface, not just what's in the input set).
+//   - Only fires for enums declared in the input set (otherwise we'd
+//     warn on every system enum case the agent uses).
+//   - "Read" means: appears in `case .X:`, `case .X(let …):`, `is .X`,
+//     or `== .X` patterns.
+//   - Severity is `info` because false positives are possible (cases
+//     might be read via reflection, JSON decoding, etc.).
+
+function checkStateMachineOrphans(
+  inputs: SwiftValidationInput[],
+  projectFiles: Map<string, string>
+): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  const inputPaths = new Set(inputs.map((i) => resolve(i.file)));
+
+  // For each enum declared in the input set, collect its cases.
+  for (const input of inputs) {
+    if (!inputPaths.has(resolve(input.file))) continue;
+    const stripped = stripCommentsAndStrings(input.source);
+    const decls = findTypeDeclarations(stripped, input.source);
+
+    for (const decl of decls) {
+      if (decl.kind !== "enum") continue;
+      const body = stripped.slice(decl.bodyStart, decl.bodyEnd);
+      const cases = collectEnumCases(body);
+      if (cases.length === 0) continue;
+
+      for (const enumCase of cases) {
+        const writeCount = countCaseWrites(projectFiles, decl.name, enumCase.name);
+        if (writeCount === 0) continue; // never written, so not an "orphan"
+
+        const readCount = countCaseReads(projectFiles, enumCase.name, decl.name);
+        if (readCount > 0) continue;
+
+        const offsetInSource = decl.bodyStart + enumCase.offsetInBody;
+        diagnostics.push(
+          makeDiagnostic(
+            "AX843",
+            input.file,
+            1 + countNewlinesUpTo(input.source, offsetInSource),
+            {
+              message: `Enum case '${decl.name}.${enumCase.name}' is assigned ${writeCount} time(s) in the project but no switch/pattern reads it.`,
+              suggestion: `Either add a consumer (a 'switch ${enumCase.name === "default" ? "value" : "value"}' or 'case .${enumCase.name}:' branch) somewhere reachable from the live root, or remove the case if the feature was dropped. Common cause: a refactor replaced the consumer view but kept the writer.`,
+            }
+          )
+        );
+      }
+    }
+  }
+
+  return diagnostics;
+}
+
+function collectEnumCases(body: string): Array<{ name: string; offsetInBody: number }> {
+  const cases: Array<{ name: string; offsetInBody: number }> = [];
+  // `case foo`, `case foo, bar`, `case foo(String)` — capture each name.
+  const pattern = /\bcase\s+([A-Za-z_][A-Za-z0-9_]*(?:\s*,\s*[A-Za-z_][A-Za-z0-9_]*)*)/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(body)) !== null) {
+    const startOffset = match.index + match[0].indexOf(match[1]!);
+    let cursor = startOffset;
+    for (const raw of match[1]!.split(",")) {
+      const name = raw.trim();
+      if (name) {
+        const offset = body.indexOf(name, cursor);
+        cases.push({ name, offsetInBody: offset >= 0 ? offset : cursor });
+        cursor = offset + name.length;
+      }
+    }
+  }
+  return cases;
+}
+
+function countCaseWrites(
+  projectFiles: Map<string, string>,
+  enumName: string,
+  caseName: string
+): number {
+  // Writes look like `Foo.bar = ...`, `someExpr = .bar`, `someExpr = Foo.bar`.
+  // We're conservative: only count `= .caseName` and `= EnumName.caseName`.
+  let count = 0;
+  const directRe = new RegExp(`=\\s*\\.${escapeRegex(caseName)}\\b`, "g");
+  const qualifiedRe = new RegExp(
+    `=\\s*${escapeRegex(enumName)}\\.${escapeRegex(caseName)}\\b`,
+    "g"
+  );
+  for (const [, source] of projectFiles) {
+    const stripped = stripCommentsAndStrings(source);
+    count += (stripped.match(directRe) ?? []).length;
+    count += (stripped.match(qualifiedRe) ?? []).length;
+  }
+  return count;
+}
+
+function countCaseReads(
+  projectFiles: Map<string, string>,
+  caseName: string,
+  enumName: string
+): number {
+  // Reads: `case .caseName`, `is .caseName`, `== .caseName`, `case let .caseName`,
+  // `case EnumName.caseName`. We don't try to scope to switches over the right
+  // enum — too brittle. We just count any of these patterns; if zero, no read.
+  let count = 0;
+  const patterns = [
+    new RegExp(`\\bcase\\s+(?:let\\s+|var\\s+)?\\.${escapeRegex(caseName)}\\b`, "g"),
+    new RegExp(
+      `\\bcase\\s+(?:let\\s+|var\\s+)?${escapeRegex(enumName)}\\.${escapeRegex(caseName)}\\b`,
+      "g"
+    ),
+    new RegExp(`\\bis\\s+\\.${escapeRegex(caseName)}\\b`, "g"),
+    new RegExp(`==\\s*\\.${escapeRegex(caseName)}\\b`, "g"),
+    new RegExp(`==\\s*${escapeRegex(enumName)}\\.${escapeRegex(caseName)}\\b`, "g"),
+    // if case .caseName = expr  syntax
+    new RegExp(
+      `\\bif\\s+case\\s+(?:let\\s+|var\\s+)?\\.${escapeRegex(caseName)}\\b`,
+      "g"
+    ),
+  ];
+  for (const [, source] of projectFiles) {
+    const stripped = stripCommentsAndStrings(source);
+    for (const pattern of patterns) {
+      count += (stripped.match(pattern) ?? []).length;
+    }
+  }
+  return count;
+}
+
+// ─── Rule: AX845 — @MainActor static method in init default-value ──────
+//
+// Catches the dogfooding pattern where a `@MainActor` class/struct has an
+// init parameter whose default value calls one of the same type's static
+// methods (e.g. `init(base: URL = MyStore.defaultBase())`). Default-value
+// expressions evaluate at the call-site's isolation context — which is
+// often non-isolated (SwiftUI environment injection, parallel construction).
+// Swift 6 rejects the actor crossing.
+//
+// Fix the agent should propose: mark the static helper `nonisolated` if it
+// doesn't actually touch MainActor state. Single-keyword fix.
+//
+// Conservative scope: only fires on `static func` references (not `static
+// let` constants, which are evaluated once at type initialization). Single-
+// file analysis — no project context needed.
+
+function checkMainActorStaticInDefaultValue(
+  source: string,
+  stripped: string,
+  file: string,
+  diagnostics: Diagnostic[]
+) {
+  const decls = findTypeDeclarations(stripped, source);
+  for (const decl of decls) {
+    if (decl.kind !== "class" && decl.kind !== "struct") continue;
+    if (!hasAttribute(decl, "@MainActor")) continue;
+
+    const body = stripped.slice(decl.bodyStart, decl.bodyEnd);
+
+    // Collect the type's static methods that aren't explicitly nonisolated.
+    const isolatedStatics = collectIsolatedStaticMethods(body);
+    if (isolatedStatics.size === 0) continue;
+
+    // Find every init declaration's parameter list and inspect default values.
+    const initPattern = /\binit\s*\(([^)]*)\)/g;
+    let initMatch: RegExpExecArray | null;
+    while ((initMatch = initPattern.exec(body)) !== null) {
+      const paramsText = initMatch[1] ?? "";
+      const initStartInBody = initMatch.index;
+
+      // Walk each top-level parameter, looking for `= TypeName.staticMember(`.
+      for (const rawParam of splitTopLevelArgs(paramsText)) {
+        const eqIdx = findTopLevelEquals(rawParam);
+        if (eqIdx === -1) continue;
+        const defaultExpr = rawParam.slice(eqIdx + 1).trim();
+
+        // Match `TypeName.foo(` and `Self.foo(` patterns.
+        const callPattern = new RegExp(
+          `\\b(?:${escapeRegex(decl.name)}|Self)\\.([A-Za-z_][A-Za-z0-9_]*)\\s*\\(`,
+          "g"
+        );
+        let callMatch: RegExpExecArray | null;
+        while ((callMatch = callPattern.exec(defaultExpr)) !== null) {
+          const memberName = callMatch[1]!;
+          if (!isolatedStatics.has(memberName)) continue;
+
+          const offsetInSource = decl.bodyStart + initStartInBody;
+          diagnostics.push(
+            makeDiagnostic("AX845", file, 1 + countNewlinesUpTo(source, offsetInSource), {
+              message: `@MainActor type '${decl.name}' has an init parameter default that calls static method '${memberName}()' — Swift 6 rejects this because default-value expressions evaluate at the caller's isolation context, which may not be MainActor.`,
+              suggestion: `Mark '${memberName}()' as 'nonisolated' (preferred — it's a one-keyword fix if the method doesn't touch MainActor state). Alternatively, move the default into the body of init or remove the default and require callers to provide the value explicitly.`,
+            })
+          );
+        }
+      }
+    }
+  }
+}
+
+function collectIsolatedStaticMethods(typeBody: string): Set<string> {
+  const isolated = new Set<string>();
+  // Match `static func X(...)` declarations. Capture the name. Then check
+  // back ~100 chars to see if `nonisolated` precedes it on the same line
+  // or attribute block.
+  const pattern = /\bstatic\s+func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(typeBody)) !== null) {
+    const name = match[1]!;
+    const before = typeBody.slice(Math.max(0, match.index - 120), match.index);
+    if (/\bnonisolated\b\s*$/.test(before)) continue;
+    if (/\bnonisolated\b[^{};]*$/m.test(before)) continue;
+    isolated.add(name);
+  }
+  return isolated;
+}
+
+function findTopLevelEquals(text: string): number {
+  let depth = 0;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === "(" || c === "[" || c === "<") depth++;
+    else if (c === ")" || c === "]" || c === ">") depth--;
+    else if (c === "=" && depth === 0 && text[i + 1] !== "=" && text[i - 1] !== "=") {
+      return i;
+    }
+  }
+  return -1;
+}
+
+// ─── Rule: AX846 — @ViewBuilder requires a View return type ────────────
+//
+// Catches the dogfooding pattern where `@ViewBuilder` annotates a property
+// or function whose return type isn't `some View` / `View`. The result-
+// builder transform produces `_ConditionalContent<A, B>` for if/else, and
+// `_ConditionalContent` only conforms to `View` — never to `Shape`,
+// `Layout`, `ToolbarContent`, etc. So `@ViewBuilder some Shape` is
+// unsatisfiable and Xcode rejects it.
+//
+// Single-file analysis, no project context required. Fires per declaration.
+
+const VIEWBUILDER_LIKE_RETURN_TYPES = new Set([
+  "View",
+  "AnyView",
+  "EmptyView",
+  "TupleView",
+  "Group",
+  // Other result builders Apple ships — not exhaustive, but covers the
+  // ones a developer would plausibly @ViewBuilder against by mistake.
+]);
+
+function checkViewBuilderReturnType(
+  source: string,
+  stripped: string,
+  file: string,
+  diagnostics: Diagnostic[]
+) {
+  // Match `@ViewBuilder ... var name : ReturnType {` and similar for func.
+  // We capture the return type so we can validate it.
+  const propertyPattern =
+    /@ViewBuilder\b[^{};]*?\b(?:var|let)\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(some\s+[A-Za-z_][A-Za-z0-9_.]*|[A-Za-z_][A-Za-z0-9_.<>?[\]]*)\s*\{/g;
+  const funcPattern =
+    /@ViewBuilder\b[^{};]*?\bfunc\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:<[^>]*>)?\s*\([^)]*\)\s*->\s*(some\s+[A-Za-z_][A-Za-z0-9_.]*|[A-Za-z_][A-Za-z0-9_.<>?[\]]*)/g;
+
+  for (const pattern of [propertyPattern, funcPattern]) {
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(stripped)) !== null) {
+      const name = match[1]!;
+      const returnTypeRaw = match[2]!.trim();
+      const baseName = baseSwiftTypeName(returnTypeRaw.replace(/^some\s+/, ""));
+      if (!baseName) continue;
+      if (VIEWBUILDER_LIKE_RETURN_TYPES.has(baseName)) continue;
+
+      // Special case: if the return type is something obviously View-shaped
+      // by suffix convention (ends in "View"), skip — the dev knows what
+      // they're doing. e.g. `some MyCustomView`.
+      if (baseName.endsWith("View")) continue;
+
+      diagnostics.push(
+        makeDiagnostic("AX846", file, 1 + countNewlinesUpTo(source, match.index), {
+          message: `@ViewBuilder on '${name}' returns '${returnTypeRaw}' but @ViewBuilder produces View-shaped content (_ConditionalContent / TupleView / EmptyView). '${baseName}' is not a View protocol — Xcode will reject this.`,
+          suggestion:
+            baseName === "Shape"
+              ? "Drop @ViewBuilder and return AnyShape directly: write `private var name: AnyShape { if cond { return AnyShape(Circle()) } else { return AnyShape(...) } }`. AnyShape is the canonical type-erased Shape and preserves Shape methods like strokeBorder."
+              : `Drop @ViewBuilder and return Any${baseName} (if available) explicitly with branches that wrap each result. @ViewBuilder is exclusively for View-returning helpers.`,
+        })
+      );
+    }
+  }
+}
+
+// ─── Rule: AX847 — type-erased SwiftUI protocol method missing ─────────
+//
+// Catches the dogfooding pattern where a developer type-erases to AnyShape
+// (or AnyView / AnyTransition) and then calls a method that lives on a
+// sub-protocol the erasure dropped. The canonical example: AnyShape only
+// conforms to Shape, but `.strokeBorder` is on InsettableShape — so
+// `anyShape.strokeBorder(...)` fails compile.
+//
+// Bundled table of "type-erased name -> methods that DON'T exist on the
+// erased surface". Walks property declarations, let/var bindings, and
+// computed properties for variables typed as one of these erased names,
+// then scans for forbidden method calls on them.
+
+const TYPE_ERASURE_LOST_METHODS: Record<string, Record<string, string>> = {
+  AnyShape: {
+    strokeBorder:
+      "Use .stroke instead. strokeBorder lives on InsettableShape; AnyShape only conforms to Shape. The visual difference (half-pixel inset) is invisible at lineWidths <= 1pt. For perfect inset rendering, write a custom AnyInsettableShape wrapper.",
+    inset:
+      "AnyShape erases the InsettableShape conformance. Either keep the original concrete type (Circle / RoundedRectangle), or write a custom AnyInsettableShape wrapper.",
+  },
+  // Future: AnyView, AnyTransition, AnyLayout — add as incidents surface.
+};
+
+function checkTypeErasedProtocolMethods(
+  source: string,
+  stripped: string,
+  file: string,
+  diagnostics: Diagnostic[]
+) {
+  // Find every binding/property typed as a known type-erased protocol.
+  // Covers `let x: AnyShape`, `var x: AnyShape`, `private var x: AnyShape`,
+  // and computed properties `var x: AnyShape { ... }`.
+  const erasedBindings = new Map<string, string>();
+  const erasedNames = Object.keys(TYPE_ERASURE_LOST_METHODS);
+  const namePattern = erasedNames.map(escapeRegex).join("|");
+  const declRegex = new RegExp(
+    `\\b(?:let|var)\\s+([a-z_][A-Za-z0-9_]*)\\s*:\\s*(${namePattern})\\b`,
+    "g"
+  );
+  let declMatch: RegExpExecArray | null;
+  while ((declMatch = declRegex.exec(stripped)) !== null) {
+    erasedBindings.set(declMatch[1]!, declMatch[2]!);
+  }
+
+  if (erasedBindings.size === 0) return;
+
+  const reported = new Set<string>();
+  for (const [varName, erasedType] of erasedBindings) {
+    const lostMethods = TYPE_ERASURE_LOST_METHODS[erasedType]!;
+    for (const [methodName, advice] of Object.entries(lostMethods)) {
+      const callRegex = new RegExp(
+        `\\b${escapeRegex(varName)}\\.${escapeRegex(methodName)}\\s*\\(`,
+        "g"
+      );
+      let callMatch: RegExpExecArray | null;
+      while ((callMatch = callRegex.exec(stripped)) !== null) {
+        const key = `${varName}:${methodName}:${callMatch.index}`;
+        if (reported.has(key)) continue;
+        reported.add(key);
+
+        diagnostics.push(
+          makeDiagnostic("AX847", file, 1 + countNewlinesUpTo(source, callMatch.index), {
+            message: `'${varName}' is typed as '${erasedType}' but '.${methodName}(' lives on a sub-protocol that ${erasedType} does not conform to. Xcode will reject this with "Value of type '${erasedType}' has no member '${methodName}'".`,
+            suggestion: advice,
+          })
+        );
+      }
+    }
+  }
 }

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -693,6 +693,59 @@ export const TOOL_MANIFEST = [
     },
   },
   {
+    name: "axint.registry.search",
+    description:
+      "Search the Axint Registry for already-published packages that match a " +
+      "natural-language query. Use this BEFORE calling axint.feature or " +
+      "axint.compile so the agent can install an existing package instead " +
+      "of regenerating Swift the community has already shipped. Returns " +
+      "ranked hits with name, version, description, surface areas, and the " +
+      "install command. Local mode walks the sibling axint-registry " +
+      "checkout (configurable via AXINT_REGISTRY_PATH).",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        query: {
+          type: "string",
+          description:
+            "Free-form description of what the agent is about to build. " +
+            "E.g., 'log a workout', 'capture a voice note', 'show timer'. " +
+            "Tokenized and matched against package name, tags, surface areas, " +
+            "siri phrases, and description.",
+        },
+        kind: {
+          type: "string",
+          description:
+            "Optional surface filter. One of: app-intent, view, widget, " +
+            "store, app, component. Loose match; 'intent' matches 'app-intent'.",
+        },
+        platform: {
+          type: "string",
+          description:
+            "Optional platform filter. One of: iOS, macOS, watchOS, tvOS, " +
+            "visionOS. Filters by the manifest's min-platform version field.",
+        },
+        limit: {
+          type: "number",
+          description: "Hard cap on returned hits. Defaults to 10.",
+        },
+        minScore: {
+          type: "number",
+          description:
+            "Minimum normalized match score (0..1) below which results are " +
+            "dropped. Defaults to 0.1.",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
     name: "axint.workflow.check",
     description:
       "Read-only agent workflow gate. Requires the current Axint session token " +

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -55,6 +55,7 @@ import { formatSwift } from "../core/format.js";
 import { scaffoldIntent } from "./scaffold.js";
 import { generateFeature, type FeatureInput, type Surface } from "./feature.js";
 import { suggestFeaturesSmart, type SuggestInput } from "./suggest.js";
+import { searchRegistry, type RegistrySearchOptions } from "../registry/search.js";
 import { TEMPLATES, getTemplate } from "../templates/index.js";
 import { validateSwiftSource } from "../core/swift-validator.js";
 import { fixSwiftSourceMultipass } from "../core/swift-fixer.js";
@@ -736,6 +737,44 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
       suggestions.length > 0
         ? `Suggested Apple-native features:\n${domainSummary}\n\n${output}\n\nUse axint.feature with any prompt above to generate the full feature package.`
         : "No specific suggestions for this app description. Try providing more detail about the app's purpose."
+    );
+  }
+
+  if (name === "axint.registry.search") {
+    const a = args as RegistrySearchOptions;
+    if (!a.query) {
+      return errorText("Error: 'query' is required for axint.registry.search");
+    }
+    const hits = searchRegistry(a);
+    if (hits.length === 0) {
+      return diagnosticsText(
+        `No matching packages in the Axint Registry for query: "${a.query}".\n` +
+          `Either the package isn't published yet (consider publishing yours), ` +
+          `or the registry isn't reachable (set AXINT_REGISTRY_PATH if you have a checkout). ` +
+          `Proceed with axint.feature / axint.compile to generate fresh.`
+      );
+    }
+    const lines = hits.map((hit, i) => {
+      const ns = hit.namespace ? `${hit.namespace}/` : "";
+      const tags = hit.tags.length ? ` | tags: ${hit.tags.slice(0, 5).join(", ")}` : "";
+      const surfaces = hit.surfaceAreas.length
+        ? ` | surfaces: ${hit.surfaceAreas.join(", ")}`
+        : "";
+      const matchedOn = hit.matchedOn.length
+        ? ` (matched on: ${hit.matchedOn.join(", ")})`
+        : "";
+      return (
+        `${i + 1}. ${ns}${hit.name}@${hit.version}  [score ${hit.score.toFixed(2)}${matchedOn}]\n` +
+        `   ${hit.description}${surfaces}${tags}\n` +
+        `   Install: ${hit.installCommand}`
+      );
+    });
+    return diagnosticsText(
+      `Found ${hits.length} matching package${hits.length === 1 ? "" : "s"} ` +
+        `in the Axint Registry. Prefer installing one of these instead of ` +
+        `regenerating Swift the community has already shipped:\n\n${lines.join(
+          "\n\n"
+        )}\n\nIf none of these match, proceed with axint.feature / axint.compile.`
     );
   }
 

--- a/src/registry/search.ts
+++ b/src/registry/search.ts
@@ -1,0 +1,243 @@
+/**
+ * Axint Registry — local search.
+ *
+ * Walks the sibling `axint-registry/first-party/` directory (or a path
+ * supplied via AXINT_REGISTRY_PATH), reads each package's manifest.json,
+ * and ranks matches against a free-form query.
+ *
+ * The agent-lookup loop (added in 0.4.19) calls this from `axint.suggest`
+ * and the new `axint.registry.search` MCP tool. The point: before an agent
+ * generates fresh Swift for a feature, it queries the registry to see if
+ * a known-good package already exists. If yes, install instead of regenerate.
+ *
+ * Search is intentionally simple — scoring is token-overlap with light
+ * field weighting. No tantivy, no Lucene; the registry is small enough
+ * (low hundreds of packages even at scale) that a full scan is < 5ms.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+export interface RegistryManifest {
+  schema_version?: string;
+  name: string;
+  namespace?: string;
+  version: string;
+  description?: string;
+  license?: string;
+  primary_language?: string;
+  languages?: string[];
+  compiler_version?: string;
+  surface_areas?: string[];
+  tags?: string[];
+  siri_phrases?: string[];
+  min_ios_version?: string;
+  min_macos_version?: string;
+  author?: { github_login?: string };
+}
+
+export interface RegistrySearchHit {
+  name: string;
+  namespace?: string;
+  version: string;
+  description: string;
+  score: number;
+  /** What field(s) drove the score, surfaced for explainability. */
+  matchedOn: string[];
+  surfaceAreas: string[];
+  tags: string[];
+  installCommand: string;
+  /** Filesystem path to the package directory (for tooling that wants to read source). */
+  path: string;
+}
+
+export interface RegistrySearchOptions {
+  query: string;
+  /** Filter by surface area (e.g. "app-intent", "view", "widget"). */
+  kind?: string;
+  /** Filter by minimum platform support (e.g. "iOS", "macOS"). */
+  platform?: string;
+  /** Hard cap on returned hits. Defaults to 10. */
+  limit?: number;
+  /** Minimum score below which results are dropped. Defaults to 0.1. */
+  minScore?: number;
+  /** Override for the registry root. Falls back to AXINT_REGISTRY_PATH or sibling. */
+  registryPath?: string;
+}
+
+const SKIP_FIRSTPARTY_ENTRIES = new Set([".DS_Store", "README.md", ".git"]);
+
+export function locateRegistryRoot(override?: string): string | null {
+  const candidates = [
+    override,
+    process.env.AXINT_REGISTRY_PATH,
+    // When running from the axint repo's checkout.
+    resolve(process.cwd(), "..", "axint-registry"),
+    resolve(process.cwd(), "..", "..", "axint-registry"),
+  ].filter((p): p is string => Boolean(p));
+
+  for (const candidate of candidates) {
+    if (existsSync(resolve(candidate, "first-party"))) return candidate;
+  }
+  return null;
+}
+
+export function loadRegistryManifests(
+  registryPath: string
+): Array<{ manifest: RegistryManifest; path: string }> {
+  const firstParty = resolve(registryPath, "first-party");
+  if (!existsSync(firstParty)) return [];
+
+  const out: Array<{ manifest: RegistryManifest; path: string }> = [];
+  for (const name of readdirSync(firstParty)) {
+    if (SKIP_FIRSTPARTY_ENTRIES.has(name)) continue;
+    const dir = resolve(firstParty, name);
+    let stat;
+    try {
+      stat = statSync(dir);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+
+    const manifestPath = resolve(dir, "manifest.json");
+    if (!existsSync(manifestPath)) continue;
+    try {
+      const raw = readFileSync(manifestPath, "utf-8");
+      const manifest = JSON.parse(raw) as RegistryManifest;
+      if (!manifest.name || !manifest.version) continue;
+      out.push({ manifest, path: dir });
+    } catch {
+      // Skip unreadable / malformed manifests rather than failing the whole search.
+      continue;
+    }
+  }
+  return out;
+}
+
+/**
+ * Tokenize a string for matching: lowercase, split on non-alphanum,
+ * drop short tokens. Used for both the query and every searchable field.
+ */
+function tokenize(text: string): Set<string> {
+  if (!text) return new Set();
+  const tokens = text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 2);
+  return new Set(tokens);
+}
+
+/**
+ * Field weights — tags and name are stronger signals than description.
+ * Siri phrases are useful because they're literally what a user might say.
+ */
+const FIELD_WEIGHTS: Record<string, number> = {
+  name: 3.0,
+  namespace: 1.0,
+  description: 1.0,
+  tags: 2.5,
+  surface_areas: 2.0,
+  siri_phrases: 2.0,
+};
+
+interface ScoreBreakdown {
+  score: number;
+  matchedOn: string[];
+}
+
+function scoreManifest(
+  manifest: RegistryManifest,
+  queryTokens: Set<string>
+): ScoreBreakdown {
+  if (queryTokens.size === 0) return { score: 0, matchedOn: [] };
+
+  const fieldTokens: Record<string, Set<string>> = {
+    name: tokenize(manifest.name),
+    namespace: tokenize(manifest.namespace ?? ""),
+    description: tokenize(manifest.description ?? ""),
+    tags: tokenize((manifest.tags ?? []).join(" ")),
+    surface_areas: tokenize((manifest.surface_areas ?? []).join(" ")),
+    siri_phrases: tokenize((manifest.siri_phrases ?? []).join(" ")),
+  };
+
+  let score = 0;
+  const matchedFields = new Set<string>();
+  for (const [field, weight] of Object.entries(FIELD_WEIGHTS)) {
+    const fieldSet = fieldTokens[field];
+    if (!fieldSet || fieldSet.size === 0) continue;
+    let fieldHits = 0;
+    for (const token of queryTokens) {
+      if (fieldSet.has(token)) fieldHits++;
+    }
+    if (fieldHits > 0) {
+      score += (fieldHits / queryTokens.size) * weight;
+      matchedFields.add(field);
+    }
+  }
+
+  // Normalize so the maximum reachable score sits near 1.0 — easier for
+  // callers to apply minScore thresholds without understanding the weights.
+  const maxPossible = Object.values(FIELD_WEIGHTS).reduce((a, b) => a + b, 0);
+  const normalized = score / maxPossible;
+  return { score: normalized, matchedOn: [...matchedFields] };
+}
+
+function platformMatches(manifest: RegistryManifest, requested: string): boolean {
+  const want = requested.toLowerCase();
+  if (want === "ios") return Boolean(manifest.min_ios_version);
+  if (want === "macos") return Boolean(manifest.min_macos_version);
+  if (want === "watchos" || want === "tvos" || want === "visionos") {
+    // No explicit min-version field for these yet; assume "yes" until the
+    // manifest schema grows them so we don't drop legitimate matches.
+    return true;
+  }
+  return true;
+}
+
+function kindMatches(manifest: RegistryManifest, kind: string): boolean {
+  const surfaces = (manifest.surface_areas ?? []).map((s) => s.toLowerCase());
+  if (surfaces.length === 0) return true;
+  const want = kind.toLowerCase();
+  // Allow loose matches: "intent" matches "app-intent", "view" matches "swiftui-view".
+  return surfaces.some((s) => s === want || s.includes(want) || want.includes(s));
+}
+
+export function searchRegistry(options: RegistrySearchOptions): RegistrySearchHit[] {
+  const { query, kind, platform, limit = 10, minScore = 0.1 } = options;
+  const root = locateRegistryRoot(options.registryPath);
+  if (!root) return [];
+
+  const manifests = loadRegistryManifests(root);
+  if (manifests.length === 0) return [];
+
+  const queryTokens = tokenize(query);
+  if (queryTokens.size === 0) return [];
+
+  const hits: RegistrySearchHit[] = [];
+  for (const { manifest, path } of manifests) {
+    if (kind && !kindMatches(manifest, kind)) continue;
+    if (platform && !platformMatches(manifest, platform)) continue;
+
+    const { score, matchedOn } = scoreManifest(manifest, queryTokens);
+    if (score < minScore) continue;
+
+    const ns = manifest.namespace ?? "";
+    const fullName = ns ? `${ns}/${manifest.name}` : manifest.name;
+    hits.push({
+      name: manifest.name,
+      namespace: manifest.namespace,
+      version: manifest.version,
+      description: manifest.description ?? "",
+      score,
+      matchedOn,
+      surfaceAreas: manifest.surface_areas ?? [],
+      tags: manifest.tags ?? [],
+      installCommand: `axint install ${fullName}@${manifest.version}`,
+      path,
+    });
+  }
+
+  hits.sort((a, b) => b.score - a.score);
+  return hits.slice(0, limit);
+}

--- a/tests/core/swift-validator-0419-rules.test.ts
+++ b/tests/core/swift-validator-0419-rules.test.ts
@@ -1,0 +1,520 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { validateSwiftSources } from "../../src/core/swift-validator.js";
+
+// ─── AX844 — synthesized conformance propagation ─────────────────────
+
+describe("AX844 — synthesized Hashable/Equatable/Codable conformance", () => {
+  let tmpRoot: string;
+
+  beforeAll(() => {
+    tmpRoot = join(tmpdir(), `axint-ax844-${Date.now()}`);
+    mkdirSync(join(tmpRoot, "Models"), { recursive: true });
+    // BuilderProfile is Sendable, Identifiable, Codable — NOT Hashable.
+    writeFileSync(
+      join(tmpRoot, "Models", "SocialModels.swift"),
+      `import Foundation
+
+struct BuilderProfile: Sendable, Identifiable, Codable {
+    let id: UUID
+    let name: String
+}
+`
+    );
+  });
+
+  afterAll(() => {
+    if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("fires on the dogfooding Hashable propagation case", () => {
+    const inputPath = join(tmpRoot, "Stores", "SocialStore.swift");
+    mkdirSync(join(tmpRoot, "Stores"), { recursive: true });
+    const inputSource = `import Foundation
+
+struct LiveTeammate: Identifiable, Hashable, Sendable {
+    let builder: BuilderProfile
+    let lastActiveAt: Date
+    var id: UUID { builder.id }
+}
+`;
+    writeFileSync(inputPath, inputSource);
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    const ax844 = results[0]!.diagnostics.filter((d) => d.code === "AX844");
+    expect(ax844.length).toBeGreaterThanOrEqual(1);
+    const hashableHit = ax844.find((d) => d.message.includes("Hashable"));
+    expect(hashableHit).toBeDefined();
+    expect(hashableHit!.message).toContain("LiveTeammate");
+    expect(hashableHit!.message).toContain("BuilderProfile");
+  });
+
+  it("fires when a stored array element type doesn't conform", () => {
+    const inputPath = join(tmpRoot, "Stores", "Bucket.swift");
+    const inputSource = `import Foundation
+
+struct SkillEndorsementBucket: Hashable, Sendable, Identifiable {
+    let skill: String
+    let count: Int
+    let endorsers: [BuilderProfile]
+    var id: String { skill }
+}
+`;
+    writeFileSync(inputPath, inputSource);
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    const ax844 = results[0]!.diagnostics.filter((d) => d.code === "AX844");
+    expect(ax844.length).toBeGreaterThanOrEqual(1);
+    expect(ax844[0]!.message).toContain("BuilderProfile");
+  });
+
+  it("does not fire on primitive types like String / Int / Date", () => {
+    const inputPath = join(tmpRoot, "Stores", "Pure.swift");
+    const inputSource = `import Foundation
+
+struct PureBucket: Hashable, Codable {
+    let name: String
+    let count: Int
+    let when: Date
+    let amount: Double
+}
+`;
+    writeFileSync(inputPath, inputSource);
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    expect(results[0]!.diagnostics.filter((d) => d.code === "AX844").length).toBe(0);
+  });
+
+  it("does not fire when the property type extends to declare the protocol elsewhere", () => {
+    // Add an extension that declares Hashable on BuilderProfile.
+    writeFileSync(
+      join(tmpRoot, "Models", "BuilderProfile+Hashable.swift"),
+      `import Foundation
+
+extension BuilderProfile: Hashable {
+    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+    static func == (lhs: BuilderProfile, rhs: BuilderProfile) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+`
+    );
+
+    const inputPath = join(tmpRoot, "Stores", "OK.swift");
+    const inputSource = `import Foundation
+
+struct OK: Hashable {
+    let builder: BuilderProfile
+}
+`;
+    writeFileSync(inputPath, inputSource);
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    expect(results[0]!.diagnostics.filter((d) => d.code === "AX844").length).toBe(0);
+
+    // Cleanup the extension so other tests aren't affected.
+    rmSync(join(tmpRoot, "Models", "BuilderProfile+Hashable.swift"));
+  });
+});
+
+// ─── AX843 — state-machine orphan ─────────────────────────────────────
+
+describe("AX843 — enum case written but never read", () => {
+  let tmpRoot: string;
+
+  beforeAll(() => {
+    tmpRoot = join(tmpdir(), `axint-ax843-${Date.now()}`);
+    mkdirSync(join(tmpRoot, "Stores"), { recursive: true });
+    mkdirSync(join(tmpRoot, "Views"), { recursive: true });
+  });
+
+  afterAll(() => {
+    if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("fires on the dogfooding voiceInbox case (writer exists, no reader)", () => {
+    // Writer file: assigns .voiceInbox in two places.
+    writeFileSync(
+      join(tmpRoot, "Stores", "Navigator.swift"),
+      `import SwiftUI
+
+@Observable
+final class Navigator {
+    var rightPane: RightPane = .none
+    var rightPaneVisible: Bool = false
+
+    func toggleVoiceInbox() {
+        rightPane = .voiceInbox
+        rightPaneVisible.toggle()
+    }
+}
+`
+    );
+
+    // Live root: writes the enum case but never switches on it.
+    writeFileSync(
+      join(tmpRoot, "Views", "SocialShellView.swift"),
+      `import SwiftUI
+
+struct SocialShellView: View {
+    @State var nav = Navigator()
+    var body: some View {
+        Button("Toggle") {
+            nav.rightPane = .voiceInbox
+        }
+    }
+}
+`
+    );
+
+    // Enum declaration in the input set.
+    const inputPath = join(tmpRoot, "Stores", "RightPane.swift");
+    const inputSource = `import Foundation
+
+enum RightPane {
+    case none
+    case voiceInbox
+    case settings
+}
+`;
+    writeFileSync(inputPath, inputSource);
+
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    const ax843 = results[0]!.diagnostics.filter((d) => d.code === "AX843");
+    expect(ax843.length).toBeGreaterThanOrEqual(1);
+    expect(ax843.some((d) => d.message.includes("voiceInbox"))).toBe(true);
+  });
+
+  it("does not fire when a switch reads the case", () => {
+    writeFileSync(
+      join(tmpRoot, "Views", "ConsumerView.swift"),
+      `import SwiftUI
+
+struct ConsumerView: View {
+    let pane: RightPane
+    var body: some View {
+        switch pane {
+        case .voiceInbox: Text("voice")
+        case .none: Text("none")
+        case .settings: Text("settings")
+        }
+    }
+}
+`
+    );
+
+    const inputPath = join(tmpRoot, "Stores", "RightPane2.swift");
+    const inputSource = `import Foundation
+
+enum RightPane {
+    case none
+    case voiceInbox
+    case settings
+}
+`;
+    writeFileSync(inputPath, inputSource);
+
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    expect(results[0]!.diagnostics.filter((d) => d.code === "AX843").length).toBe(0);
+  });
+});
+
+// ─── AX845 — @MainActor static in init default value ────────────────
+
+describe("AX845 — @MainActor static method in init default-value expression", () => {
+  it("fires on the dogfooding GitHubEventsStore pattern", () => {
+    const source = `import Foundation
+
+@Observable @MainActor
+final class GitHubEventsStore {
+    private let storageBase: URL
+
+    init(storageBase: URL = GitHubEventsStore.defaultStorageBase()) {
+        self.storageBase = storageBase
+    }
+
+    private static func defaultStorageBase() -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    }
+}
+`;
+    const [result] = validateSwiftSources([{ file: "GitHubEventsStore.swift", source }]);
+    const ax845 = result.diagnostics.filter((d) => d.code === "AX845");
+    expect(ax845.length).toBe(1);
+    expect(ax845[0]!.message).toContain("GitHubEventsStore");
+    expect(ax845[0]!.message).toContain("defaultStorageBase");
+    expect(ax845[0]!.suggestion).toContain("nonisolated");
+  });
+
+  it("does not fire when the static method is marked nonisolated", () => {
+    const source = `import Foundation
+
+@MainActor
+final class Store {
+    private let base: URL
+    init(base: URL = Store.defaultBase()) { self.base = base }
+    nonisolated private static func defaultBase() -> URL {
+        FileManager.default.temporaryDirectory
+    }
+}
+`;
+    const [result] = validateSwiftSources([{ file: "Store.swift", source }]);
+    expect(result.diagnostics.filter((d) => d.code === "AX845").length).toBe(0);
+  });
+
+  it("does not fire when the class is not @MainActor", () => {
+    const source = `import Foundation
+
+final class PlainStore {
+    private let base: URL
+    init(base: URL = PlainStore.defaultBase()) { self.base = base }
+    private static func defaultBase() -> URL {
+        FileManager.default.temporaryDirectory
+    }
+}
+`;
+    const [result] = validateSwiftSources([{ file: "PlainStore.swift", source }]);
+    expect(result.diagnostics.filter((d) => d.code === "AX845").length).toBe(0);
+  });
+
+  it("fires on Self.foo() reference inside the same @MainActor type", () => {
+    const source = `import Foundation
+
+@MainActor
+struct Config {
+    let name: String
+    init(name: String = Self.defaultName()) { self.name = name }
+    private static func defaultName() -> String { "default" }
+}
+`;
+    const [result] = validateSwiftSources([{ file: "Config.swift", source }]);
+    const ax845 = result.diagnostics.filter((d) => d.code === "AX845");
+    expect(ax845.length).toBe(1);
+    expect(ax845[0]!.message).toContain("defaultName");
+  });
+});
+
+// ─── AX846 — @ViewBuilder with non-View return type ─────────────────
+
+describe("AX846 — @ViewBuilder requires View return type", () => {
+  it("fires on the dogfooding @ViewBuilder some Shape pattern", () => {
+    const source = `import SwiftUI
+
+struct MonogramTile: View {
+    let isCircle: Bool
+    let cornerRadius: CGFloat
+
+    @ViewBuilder
+    private var shape: some Shape {
+        if isCircle {
+            Circle()
+        } else {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        }
+    }
+
+    var body: some View { Color.clear }
+}
+`;
+    const [result] = validateSwiftSources([{ file: "MonogramTile.swift", source }]);
+    const ax846 = result.diagnostics.filter((d) => d.code === "AX846");
+    expect(ax846.length).toBe(1);
+    expect(ax846[0]!.message).toContain("Shape");
+    expect(ax846[0]!.suggestion).toContain("AnyShape");
+  });
+
+  it("does not fire on @ViewBuilder some View (the canonical valid case)", () => {
+    const source = `import SwiftUI
+
+struct V: View {
+    @ViewBuilder
+    private var inner: some View {
+        if true { Text("a") } else { Text("b") }
+    }
+    var body: some View { inner }
+}
+`;
+    const [result] = validateSwiftSources([{ file: "V.swift", source }]);
+    expect(result.diagnostics.filter((d) => d.code === "AX846").length).toBe(0);
+  });
+
+  it("does not fire on @ViewBuilder func returning some View", () => {
+    const source = `import SwiftUI
+
+struct V: View {
+    @ViewBuilder
+    private func chip(label: String) -> some View {
+        Text(label)
+    }
+    var body: some View { chip(label: "hi") }
+}
+`;
+    const [result] = validateSwiftSources([{ file: "V.swift", source }]);
+    expect(result.diagnostics.filter((d) => d.code === "AX846").length).toBe(0);
+  });
+});
+
+// ─── AX847 — type-erased SwiftUI protocol method missing ─────────────
+
+describe("AX847 — type-erased AnyShape methods that don't exist on Shape", () => {
+  it("fires on the dogfooding AnyShape.strokeBorder pattern", () => {
+    const source = `import SwiftUI
+
+struct MonogramTile: View {
+    let isCircle: Bool
+    private var shape: AnyShape {
+        if isCircle { return AnyShape(Circle()) }
+        return AnyShape(Rectangle())
+    }
+    var body: some View {
+        Color.clear
+            .overlay(shape.strokeBorder(.gray, lineWidth: 1))
+    }
+}
+`;
+    const [result] = validateSwiftSources([{ file: "MonogramTile.swift", source }]);
+    const ax847 = result.diagnostics.filter((d) => d.code === "AX847");
+    expect(ax847.length).toBeGreaterThanOrEqual(1);
+    expect(ax847[0]!.message).toContain("AnyShape");
+    expect(ax847[0]!.message).toContain("strokeBorder");
+    expect(ax847[0]!.suggestion).toContain(".stroke");
+  });
+
+  it("does not fire when .stroke is used (the correct method)", () => {
+    const source = `import SwiftUI
+
+struct V: View {
+    private var shape: AnyShape { AnyShape(Circle()) }
+    var body: some View {
+        Color.clear.overlay(shape.stroke(.gray, lineWidth: 1))
+    }
+}
+`;
+    const [result] = validateSwiftSources([{ file: "V.swift", source }]);
+    expect(result.diagnostics.filter((d) => d.code === "AX847").length).toBe(0);
+  });
+
+  it("does not fire on a concrete shape type that does conform to InsettableShape", () => {
+    const source = `import SwiftUI
+
+struct V: View {
+    var body: some View {
+        Color.clear.overlay(Circle().strokeBorder(.gray, lineWidth: 1))
+    }
+}
+`;
+    const [result] = validateSwiftSources([{ file: "V.swift", source }]);
+    expect(result.diagnostics.filter((d) => d.code === "AX847").length).toBe(0);
+  });
+});
+
+// ─── Registry search ─────────────────────────────────────────────────
+
+describe("axint registry search", () => {
+  let tmpRegistry: string;
+
+  beforeAll(() => {
+    tmpRegistry = join(tmpdir(), `axint-registry-${Date.now()}`);
+    mkdirSync(join(tmpRegistry, "first-party", "timer"), { recursive: true });
+    mkdirSync(join(tmpRegistry, "first-party", "weather-widget"), { recursive: true });
+    mkdirSync(join(tmpRegistry, "first-party", "note-capture"), { recursive: true });
+
+    writeFileSync(
+      join(tmpRegistry, "first-party", "timer", "manifest.json"),
+      JSON.stringify({
+        schema_version: "1.0",
+        name: "timer",
+        namespace: "@axint",
+        version: "1.0.0",
+        description: "Start, stop, or cancel a named timer via Siri or Shortcuts",
+        primary_language: "typescript",
+        surface_areas: ["app-intent", "productivity"],
+        tags: ["timer", "siri", "shortcuts", "productivity"],
+        siri_phrases: ["Start a 10 minute pasta timer"],
+        min_ios_version: "17.0",
+      })
+    );
+
+    writeFileSync(
+      join(tmpRegistry, "first-party", "weather-widget", "manifest.json"),
+      JSON.stringify({
+        name: "weather-widget",
+        namespace: "@axint",
+        version: "1.0.0",
+        description: "A WidgetKit widget showing the current weather",
+        surface_areas: ["widget"],
+        tags: ["weather", "widget"],
+      })
+    );
+
+    writeFileSync(
+      join(tmpRegistry, "first-party", "note-capture", "manifest.json"),
+      JSON.stringify({
+        name: "note-capture",
+        namespace: "@axint",
+        version: "1.0.0",
+        description: "Capture a quick note from anywhere",
+        surface_areas: ["app-intent"],
+        tags: ["notes", "capture", "quick"],
+      })
+    );
+  });
+
+  afterAll(() => {
+    if (tmpRegistry) rmSync(tmpRegistry, { recursive: true, force: true });
+  });
+
+  it("finds the timer package for 'start a timer'", async () => {
+    const { searchRegistry } = await import("../../src/registry/search.js");
+    const hits = searchRegistry({ query: "start a timer", registryPath: tmpRegistry });
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+    expect(hits[0]!.name).toBe("timer");
+    expect(hits[0]!.installCommand).toContain("@axint/timer@1.0.0");
+  });
+
+  it("filters by surface area when kind is provided", async () => {
+    const { searchRegistry } = await import("../../src/registry/search.js");
+    const hits = searchRegistry({
+      query: "weather",
+      kind: "widget",
+      registryPath: tmpRegistry,
+    });
+    expect(hits.length).toBe(1);
+    expect(hits[0]!.name).toBe("weather-widget");
+  });
+
+  it("returns empty when no manifest matches", async () => {
+    const { searchRegistry } = await import("../../src/registry/search.js");
+    const hits = searchRegistry({
+      query: "nonexistent zzzzz",
+      registryPath: tmpRegistry,
+    });
+    expect(hits.length).toBe(0);
+  });
+
+  it("returns empty when registry is missing entirely", async () => {
+    const { searchRegistry } = await import("../../src/registry/search.js");
+    const hits = searchRegistry({
+      query: "anything",
+      registryPath: "/tmp/does-not-exist-zzz",
+    });
+    expect(hits.length).toBe(0);
+  });
+
+  it("ranks tags / siri-phrase matches above bare description matches", async () => {
+    const { searchRegistry } = await import("../../src/registry/search.js");
+    const hits = searchRegistry({ query: "siri timer", registryPath: tmpRegistry });
+    expect(hits[0]!.name).toBe("timer");
+    expect(hits[0]!.matchedOn).toContain("tags");
+  });
+});

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.18";
+const VERSION = "0.4.19";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
Five new validator rules from the SWARM dogfooding log, one new MCP tool, and infrastructure fixes.

New rules:

- AX847 catches methods called on type-erased SwiftUI protocols that don't exist on the erased surface. Bundled table — currently AnyShape.strokeBorder (lives on InsettableShape, not Shape) and AnyShape.inset. Suggests the closest valid replacement (`.stroke` for `.strokeBorder`).
- AX846 catches @ViewBuilder annotations on properties/funcs whose return type isn't some View. Catches the @ViewBuilder some Shape pattern that produces _ConditionalContent (View only) but is asked to satisfy a Shape constraint.
- AX845 catches @MainActor classes with init parameter defaults that call same-type static methods. Default-value expressions evaluate at the caller's isolation context (often non-isolated), and Swift 6 rejects the actor crossing. Single-keyword fix the diagnostic suggests directly (mark the static method nonisolated).
- AX844 catches structs declaring synthesized Hashable/Equatable/Codable when a stored property's type doesn't conform. Walks project-context to verify cross-file conformance, including extensions. Catches the SkillEndorsementBucket / LiveTeammate pattern from this sprint.
- AX843 catches enum cases written somewhere but never read by a switch/pattern anywhere reachable. Catches the Navigator.rightPane = .voiceInbox pattern where the writer survived a refactor but the consumer view was dropped.

New tool:

- axint.registry.search — natural-language query against the local Axint Registry. Returns ranked hits with install commands. Use BEFORE axint.feature so agents install existing packages instead of regenerating Swift the community has already shipped. Token-overlap scoring with field weighting; honors AXINT_REGISTRY_PATH for non-default checkouts.

Infrastructure:

- registryPackages metric is now auto-counted from the sibling axint-registry/first-party/ directory. The previous hardcoded 14 was stale; the real count from the registry now flows through metrics.json and every public surface.
- bump-consumer-versions-and-sync.sh now auto-detects OLD/NEW versions from axint/package.json and uses npm install --save-exact for docs.axint.ai's lockfile (avoids the EINTEGRITY trap from the 0.4.17/0.4.18 deploys).

21 new tests (1278 total). Diagnostics 198 to 203. Lint, typecheck, versions:check, metrics:check, docs:check all clean.