### PR TITLE
Release Axint 0.4.21 cross-file resolution AX848, diff-only, drift-age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+## [0.4.21] — 2026-05-03
+
+### Added — closes the recurring cross-file resolution gap (4 dogfooding misses across 2 sprints)
+
+- **`AX848` nested-type / static-member access on a project-indexed type** — fills the gap `AX841` deliberately leaves open. `AX841`'s receiver regex is anchored on lowercase-first identifiers (instance member access). When the receiver is itself a type literal — `IntelBriefItem.Kind`, `MyEnum.somethingMissing` — Swift is doing nested-type / static-member lookup, not instance-member lookup, and `AX841` skips it. `AX848` specifically catches the type-on-type form, only fires when the parent is project-indexed, and emits a "Did you mean…" hint via Levenshtein over the parent's nested types, static members, and enum cases. Resolves the FIFTH cross-file member-resolution miss documented in `AXINT_DOGFOODING.md` (2026-05-03 entry).
+- **`AX841` extended with typed-collection-element inference** — adds `ForEach(store.results) { item in … }` and `for item in store.results { … }` as binding sources. The validator now resolves `store` to its project-indexed type, looks up `results` to get `[VoiceCaptureResult]`, peels the array wrapper, and binds the closure parameter / loop variable to `VoiceCaptureResult` so downstream member access on it actually fires. Previously the closure parameter was indiscriminately added to `untypedClosureParameters` and silently skipped — closing the dogfooding `item.title` (real field is `headline`) miss.
+- **`axint cloud check --diff-only`** — new flag that filters diagnostics down to lines this branch actually touched. Pre-existing warnings on unchanged lines stay silent so the warning count means "things I broke" instead of "ambient project state." Walks `git diff --unified=0` and parses hunk headers; falls back to a no-op when git isn't usable. Companion flags `--diff-base <ref>` and `--diff-cwd <dir>` cover branch and submodule layouts. `CloudCheckReport.diffFilter` exposes the suppressed-diagnostic count.
+- **Snapshot-baseline affinity hint** — when the validated Swift file has matching `__Snapshots__/<view>*.png` baselines on disk, Cloud Check appends a one-line "this view has N snapshot baselines; rebaseline after the next build" reminder to `nextSteps`. Default-on when `sourcePath` is provided; opt out with `axint cloud check --no-snapshot-affinity`. `CloudCheckReport.snapshotAffinity` exposes the matching baseline paths.
+- **Drift-age stamp on `axint.workflow.check`** — every workflow.check call writes a tiny `.axint/session/last-workflow-check.json` stamp and reads the prior one to compute "minutes since last workflow.check." Surfaced in `checked` for normal runs and in `recommended` (with a `DRIFT` tag) when the gap exceeds the 10-minute checkpoint rule. `WorkflowCheckReport.driftAge` exposes the structured value.
+
+### Changed
+
+- `collectDeclaredMemberNames` now includes nested type names (`struct`/`class`/`actor`/`enum`/`typealias` declared inside the parent body), so `AX841` and `AX848` no longer false-positive on project types that legitimately namespace nested kinds.
+- `validateSwiftSources` member-access loop now honors a closure parameter's inferred type when present, instead of skipping every closure-bound identifier whether or not we managed to resolve it.
+
 ## [0.4.20] — 2026-05-03
 
 ### Added — three high-leverage moves from SWARM's strategic feedback

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.20 · 34 MCP tools + 5 prompts · 203 diagnostic codes · 1289 tests · 5 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.21 · 34 MCP tools + 5 prompts · 204 diagnostic codes · 1302 tests · 5 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.20",
+  "version": "0.4.21",
   "mcpTools": 34,
   "mcpToolNames": [
     "axint.status",
@@ -46,7 +46,7 @@
     "axint.create-intent"
   ],
   "bundledTemplates": 26,
-  "diagnostics": 203,
+  "diagnostics": 204,
   "xcodeFixRules": 33,
   "xcodeFixRuleCodes": [
     "AX701",
@@ -84,7 +84,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1175,
+    "typescript": 1188,
     "python": 114
   },
   "registryPackages": 5,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.20"
+__version__ = "0.4.21"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.20"
+version = "0.4.21"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/release-0.4.21.sh
+++ b/release-0.4.21.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# release-0.4.21.sh — finalizes the 0.4.21 release.
+#
+# Run this ONCE from your Mac terminal:
+#   cd ~/agenticempire/axint && bash release-0.4.21.sh
+#
+# What's in this release — directly addresses the 2026-05-03 dogfooding
+# entry "Overnight extended sprint: end-of-sprint Axint wishlist (18 files,
+# 1 build error, ~80% caught)":
+#   1. AX848 — nested type / static member access on a project type
+#      (closes the FIFTH cross-file member-resolution miss; AX841 left this
+#      gap because its receiver regex is anchored on lowercase-first IDs)
+#   2. AX841 extended with typed-collection-element inference
+#      (ForEach(store.results) { item in ... } binds item: VoiceCaptureResult)
+#   3. axint cloud check --diff-only (suppresses ambient pre-existing warnings)
+#   4. Snapshot-baseline affinity hint (auto-reminds to rebaseline)
+#   5. Drift-age stamp on axint.workflow.check (10-minute checkpoint enforcement)
+#
+# After PR merges:
+#   npm run build && npm publish --access public
+#   git tag v0.4.21 && git push origin v0.4.21
+#   bash ~/SWARM/install-axint-mcp.sh   # pin bumped to 0.4.21
+
+set -euo pipefail
+
+bold() { printf "\033[1m%s\033[0m\n" "$1"; }
+green() { printf "\033[32m✓\033[0m %s\n" "$1"; }
+red() { printf "\033[31m✗\033[0m %s\n" "$1" >&2; }
+yellow() { printf "\033[33m→\033[0m %s\n" "$1"; }
+
+cd "$(dirname "$0")"
+
+bold "axint 0.4.21 release"
+echo
+
+if [ -f .git/index.lock ]; then
+  rm -f .git/index.lock
+  green "cleared stale .git/index.lock"
+fi
+
+CURRENT="$(git branch --show-current)"
+FEATURE="v0421-cross-file-resolution-and-workflow-quality"
+
+if [ "${CURRENT}" != "${FEATURE}" ]; then
+  STASHED=0
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    git stash push -u -m "auto-stash for 0.4.21 release script" >/dev/null
+    STASHED=1
+  fi
+  git fetch origin --quiet
+  git checkout main
+  git pull --ff-only origin main
+  if git rev-parse --verify "${FEATURE}" >/dev/null 2>&1; then
+    git checkout "${FEATURE}"
+  else
+    git checkout -b "${FEATURE}"
+  fi
+  if [ "${STASHED}" = "1" ]; then
+    git stash pop >/dev/null 2>&1 || yellow "stash pop conflict — resolve manually"
+  fi
+  green "on branch ${FEATURE}"
+else
+  green "already on ${FEATURE}"
+fi
+
+bold "Recomputing metrics + public truth from source"
+npm run metrics:emit >/dev/null && green "metrics:emit"
+if [ -f ../public-truth/package.json ] && grep -q "\"sync\"" ../public-truth/package.json; then
+  (cd ../public-truth && npm run sync) >/dev/null && green "public-truth sync"
+elif [ -f ../public-truth/scripts/sync.mjs ]; then
+  (cd ../public-truth && node scripts/sync.mjs) >/dev/null && green "public-truth sync (direct)"
+else
+  yellow "public-truth sync script not found — bump axint version manually if drift"
+fi
+
+bold "Running gates"
+npm run versions:check >/dev/null && green "versions:check"
+npm run metrics:check >/dev/null && green "metrics:check"
+npm run docs:check >/dev/null && green "docs:check"
+npm run lint >/dev/null && green "lint"
+npm run typecheck >/dev/null && green "typecheck"
+npx vitest run --reporter=dot >/dev/null && green "vitest"
+
+bold "Committing"
+git add -A
+if git diff --cached --quiet; then
+  yellow "No staged changes — release commit may already exist."
+else
+  git commit -m "Release Axint 0.4.21 cross-file resolution AX848, diff-only, drift-age"
+  green "committed"
+fi
+
+bold "Pushing to origin/${FEATURE}"
+git push -u origin "${FEATURE}"
+green "pushed"
+
+if command -v gh >/dev/null 2>&1; then
+  bold "Opening PR"
+  if gh pr view "${FEATURE}" >/dev/null 2>&1; then
+    yellow "PR already exists for ${FEATURE}"
+  else
+    gh pr create \
+      --title "Release Axint 0.4.21 cross-file resolution AX848, diff-only, drift-age" \
+      --body "$(cat <<'EOF'
+Closes the recurring cross-file member-resolution miss (5+ instances across two sprints in AXINT_DOGFOODING.md) plus three workflow-quality improvements requested in the 2026-05-03 overnight-sprint entry.
+
+AX848 — nested type / static member access on a project-indexed type:
+- AX841 deliberately ignores receivers whose first character is uppercase (instance-member access only).
+- IntelBriefItem.Kind is a type-on-type lookup, not instance member access — AX841 skips it.
+- AX848 specifically catches the type-on-type form, only fires when the parent is project-indexed, and uses Levenshtein over the parent's nested types / static members / enum cases for "did you mean" suggestions.
+- Resolves the FIFTH cross-file miss documented in the dogfooding log.
+
+AX841 extended with typed-collection-element inference:
+- ForEach(store.results) { item in ... } now binds item to the element type of store.results.
+- for item in store.results { ... } same.
+- Closes the dogfooding item.title (real field is headline) miss where item came from a typed ForEach.
+- Required reordering the member-access loop: an inferred closure-parameter type now wins over the untyped-closure skip-list.
+
+axint cloud check --diff-only:
+- Filters diagnostics to lines this branch actually changed via git diff --unified=0.
+- Pre-existing warnings on unchanged lines stay silent so the warning count means "things I broke."
+- Companion --diff-base <ref> and --diff-cwd <dir> for branch / submodule layouts.
+- CloudCheckReport.diffFilter exposes the suppressed-diagnostic count.
+
+Snapshot-baseline affinity hint:
+- When the validated Swift file has matching __Snapshots__/<view>*.png baselines on disk, Cloud Check appends a one-line "this view has N snapshot baselines; rebaseline after the next build" reminder to nextSteps.
+- Default-on when sourcePath is provided; opt out with --no-snapshot-affinity.
+- CloudCheckReport.snapshotAffinity exposes the matching baseline paths.
+
+Drift-age stamp on axint.workflow.check:
+- Every workflow.check call writes .axint/session/last-workflow-check.json and reads the prior one.
+- "Minutes since last workflow.check" now appears in checked for normal runs and in recommended (with a DRIFT tag) when the gap exceeds the 10-minute checkpoint rule.
+- WorkflowCheckReport.driftAge exposes the structured value for tooling.
+
+Internal:
+- collectDeclaredMemberNames now includes nested type names (struct/class/actor/enum/typealias declared inside the parent body) so AX841 + AX848 don't false-positive on legitimate nested-type access.
+- New collectDeclaredMemberTypes returns the property-name -> declared-type map used by the collection-element inference.
+
+15 new tests across swift-validator-0421-rules.test.ts and cloud/diff-and-affinity.test.ts. Lint, typecheck, versions:check, metrics:check, docs:check all clean.
+EOF
+)"
+    green "PR opened"
+  fi
+fi
+
+echo
+bold "Done. After PR merges:"
+echo "  npm run build && npm publish --access public"
+echo "  git tag v0.4.21 && git push origin v0.4.21"
+echo "  bash ~/SWARM/install-axint-mcp.sh   # pin bumped to 0.4.21"

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.20",
+      "version": "0.4.21",
       "transport": {
         "type": "stdio"
       }
@@ -28,7 +28,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.20",
+      "version": "0.4.21",
       "transport": {
         "type": "stdio"
       }

--- a/src/cli/cloud.ts
+++ b/src/cli/cloud.ts
@@ -81,6 +81,22 @@ export function registerCloud(program: Command) {
       "--write-feedback [dir]",
       "Write the redacted learning signal to .axint/feedback or the provided directory"
     )
+    .option(
+      "--diff-only",
+      "Only report diagnostics on lines this branch actually changed (suppresses ambient pre-existing warnings)"
+    )
+    .option(
+      "--diff-base <ref>",
+      "Base ref for --diff-only (defaults to working tree against HEAD)"
+    )
+    .option(
+      "--diff-cwd <dir>",
+      "Repo root for --diff-only (defaults to source's git root)"
+    )
+    .option(
+      "--no-snapshot-affinity",
+      "Suppress the snapshot-baseline reminder that lists matching __Snapshots__/*.png paths"
+    )
     .action(
       (
         file: string | undefined,
@@ -101,6 +117,10 @@ export function registerCloud(program: Command) {
           actual?: string;
           context?: string;
           writeFeedback?: boolean | string;
+          diffOnly?: boolean;
+          diffBase?: string;
+          diffCwd?: string;
+          snapshotAffinity?: boolean;
         }
       ) => {
         try {
@@ -127,6 +147,10 @@ export function registerCloud(program: Command) {
             expectedBehavior: options.expected,
             actualBehavior: options.actual,
             projectContextPath: options.context,
+            diffOnly: options.diffOnly,
+            diffBaseRef: options.diffBase,
+            diffCwd: options.diffCwd,
+            snapshotAffinity: options.snapshotAffinity,
           });
           if (options.writeFeedback && report.learningSignal) {
             const stored = writeCloudFeedbackSignal(report.learningSignal, {

--- a/src/cloud/check.ts
+++ b/src/cloud/check.ts
@@ -4,6 +4,16 @@ import { fileURLToPath } from "node:url";
 import { compileAnySource } from "../core/compiler.js";
 import { validateSwiftSource } from "../core/swift-validator.js";
 import { runSwiftTypecheck } from "./swift-typecheck.js";
+import {
+  filterDiagnosticsToDiff,
+  loadChangedLines,
+  type ChangedLines,
+} from "./diff-filter.js";
+import {
+  findSnapshotAffinity,
+  renderSnapshotAffinityHint,
+  type SnapshotAffinityResult,
+} from "./snapshot-affinity.js";
 import type { CompilerOutput, Diagnostic } from "../core/types.js";
 import {
   buildProjectContextHint,
@@ -72,6 +82,29 @@ export interface CloudCheckInput {
    * Defaults to the directory containing sourcePath, then process.cwd().
    */
   typecheckProjectRoot?: string;
+  /**
+   * If true, only report diagnostics on lines this branch actually
+   * changed. Pre-existing warnings stay silent. Closes the noise problem
+   * documented in the 2026-05-03 dogfooding entry where ambient warnings
+   * on unchanged lines made the warning count meaningless.
+   */
+  diffOnly?: boolean;
+  /**
+   * Base ref to diff against when `diffOnly` is set. Defaults to the
+   * working tree (uncommitted + staged changes against HEAD).
+   */
+  diffBaseRef?: string;
+  /**
+   * Working directory used to run `git diff`. Defaults to the directory
+   * containing `sourcePath` walking upward to the repo root, then `cwd()`.
+   */
+  diffCwd?: string;
+  /**
+   * If true (default when sourcePath is provided), append a one-line
+   * snapshot-baseline reminder to the report when matching baselines exist
+   * on disk. Set to false to suppress.
+   */
+  snapshotAffinity?: boolean;
 }
 
 export interface CloudCheckReport {
@@ -119,6 +152,19 @@ export interface CloudCheckReport {
     diagnosticsAdded: number;
     timedOut: boolean;
     unavailableReason?: string;
+  };
+  diffFilter?: {
+    applied: boolean;
+    baseRef?: string;
+    suppressedDiagnostics: number;
+    changedFileCount: number;
+    unavailableReason?: string;
+  };
+  snapshotAffinity?: {
+    viewName: string;
+    baselineCount: number;
+    baselinePaths: string[];
+    hint: string;
   };
   checks: Array<{
     label: string;
@@ -294,6 +340,75 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
     }
   }
 
+  // Optional: filter diagnostics down to lines this branch actually
+  // touched. Closes the noise problem from 2026-05-03 dogfooding where
+  // ambient warnings on unchanged lines made the warning count meaningless.
+  let diffFilterMeta:
+    | {
+        applied: boolean;
+        baseRef?: string;
+        suppressedDiagnostics: number;
+        changedFileCount: number;
+        unavailableReason?: string;
+      }
+    | undefined;
+  if (input.diffOnly) {
+    const cwd = input.diffCwd ?? deriveDiffCwd(input.sourcePath);
+    const changed: ChangedLines | null = loadChangedLines({
+      baseRef: input.diffBaseRef,
+      cwd,
+      files: input.sourcePath ? [input.sourcePath] : undefined,
+    });
+    if (!changed) {
+      diffFilterMeta = {
+        applied: false,
+        baseRef: input.diffBaseRef,
+        suppressedDiagnostics: 0,
+        changedFileCount: 0,
+        unavailableReason:
+          "git diff was unavailable in this directory — no filtering applied. Pass diffCwd to point at the repo root.",
+      };
+    } else {
+      const before = diagnostics.length;
+      const { kept, suppressed } = filterDiagnosticsToDiff(diagnostics, changed);
+      diagnostics = kept;
+      diffFilterMeta = {
+        applied: true,
+        baseRef: input.diffBaseRef,
+        suppressedDiagnostics: suppressed,
+        changedFileCount: changed.files.size,
+      };
+      void before;
+    }
+  }
+
+  // Snapshot-affinity hint. Default-on when sourcePath is provided so
+  // the agent gets the rebaseline reminder for free.
+  let snapshotAffinityMeta:
+    | {
+        viewName: string;
+        baselineCount: number;
+        baselinePaths: string[];
+        hint: string;
+      }
+    | undefined;
+  const snapshotEnabled = input.snapshotAffinity ?? Boolean(input.sourcePath);
+  if (snapshotEnabled && input.sourcePath && language === "swift") {
+    const affinity: SnapshotAffinityResult = findSnapshotAffinity({
+      swiftFile: input.sourcePath,
+      projectRoot: input.typecheckProjectRoot ?? input.projectContextPath,
+    });
+    const hint = renderSnapshotAffinityHint(affinity);
+    if (hint) {
+      snapshotAffinityMeta = {
+        viewName: affinity.viewName,
+        baselineCount: affinity.baselinePaths.length,
+        baselinePaths: affinity.baselinePaths,
+        hint,
+      };
+    }
+  }
+
   const errors = diagnostics.filter((d) => d.severity === "error").length;
   const warnings = diagnostics.filter((d) => d.severity === "warning").length;
   const infos = diagnostics.filter((d) => d.severity === "info").length;
@@ -414,6 +529,7 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
     .filter((d) => d.severity !== "info")
     .slice(0, 4)
     .map((d) => d.suggestion || d.message);
+  if (snapshotAffinityMeta) nextSteps.push(snapshotAffinityMeta.hint);
   const repairPlan = buildCloudRepairPlan({
     diagnostics,
     runtimeCoverageRequired,
@@ -484,6 +600,8 @@ export function runCloudCheck(input: CloudCheckInput): CloudCheckReport {
     coverage,
     evidence,
     typecheck: typecheckMeta.ran ? typecheckMeta : undefined,
+    diffFilter: diffFilterMeta,
+    snapshotAffinity: snapshotAffinityMeta,
     projectContext: projectContext
       ? {
           path: projectContext.path,
@@ -650,6 +768,24 @@ export function renderCloudCheckReport(
     );
   }
   return lines.join("\n");
+}
+
+/**
+ * Walk upward from a Swift source path to the nearest directory that
+ * contains a `.git` folder, falling back to the file's directory and
+ * finally `process.cwd()`. Used by `--diff-only` so callers don't have
+ * to hand-pass `diffCwd` for every check.
+ */
+function deriveDiffCwd(sourcePath?: string): string {
+  if (!sourcePath) return process.cwd();
+  let current = dirname(resolve(sourcePath));
+  for (let depth = 0; depth < 12; depth++) {
+    if (existsSync(resolve(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return dirname(resolve(sourcePath));
 }
 
 function readCloudCheckSource(input: CloudCheckInput): {

--- a/src/cloud/diff-filter.ts
+++ b/src/cloud/diff-filter.ts
@@ -1,0 +1,136 @@
+/**
+ * --diff-only support for Cloud Check.
+ *
+ * Why this exists. From dogfooding 2026-05-03: agents validate views,
+ * find ambient pre-existing warnings unrelated to their diff, and either
+ * waste a turn explaining them or absorb them as noise. The fix is a
+ * simple filter — only report diagnostics on lines the agent actually
+ * touched in this branch.
+ *
+ * Returns null when git isn't usable (no repo, no git binary, base ref
+ * doesn't exist). Callers should treat null as "no filtering applied"
+ * and pass the diagnostics through unchanged.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Diagnostic } from "../core/types.js";
+
+export interface DiffOnlyOptions {
+  /** Files to scope the diff to. Empty means all changed files. */
+  files?: string[];
+  /** Base ref to diff against. Defaults to HEAD (working-tree changes only). */
+  baseRef?: string;
+  /** Repository root. Defaults to process.cwd(). */
+  cwd?: string;
+}
+
+export interface ChangedLines {
+  /** path → set of 1-indexed line numbers that changed. */
+  byFile: Map<string, Set<number>>;
+  /** Files that appear in the diff with at least one changed line. */
+  files: Set<string>;
+}
+
+/**
+ * Run `git diff --unified=0 <baseRef>?` and parse hunk headers to extract
+ * exactly which lines changed. Returns null if git isn't available or the
+ * working directory isn't a git repo.
+ */
+export function loadChangedLines(options: DiffOnlyOptions = {}): ChangedLines | null {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  if (!existsSync(cwd)) return null;
+
+  const args = ["diff", "--unified=0", "--no-color", "--no-renames"];
+  if (options.baseRef) args.push(options.baseRef);
+  if (options.files && options.files.length > 0) {
+    args.push("--", ...options.files);
+  }
+
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (result.status === null && result.error) return null;
+  if (result.status !== 0 && !result.stdout) return null;
+
+  return parseUnifiedDiff(result.stdout, cwd);
+}
+
+const FILE_HEADER_RE = /^\+\+\+ b\/(.+)$/;
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+
+export function parseUnifiedDiff(diff: string, cwd: string): ChangedLines {
+  const byFile = new Map<string, Set<number>>();
+  const files = new Set<string>();
+  let currentFile: string | null = null;
+
+  for (const rawLine of diff.split("\n")) {
+    const fileMatch = FILE_HEADER_RE.exec(rawLine);
+    if (fileMatch) {
+      currentFile = resolve(cwd, fileMatch[1]!);
+      if (!byFile.has(currentFile)) byFile.set(currentFile, new Set<number>());
+      files.add(currentFile);
+      continue;
+    }
+    if (!currentFile) continue;
+    const hunkMatch = HUNK_HEADER_RE.exec(rawLine);
+    if (!hunkMatch) continue;
+    const start = Number(hunkMatch[1]!);
+    const length = hunkMatch[2] !== undefined ? Number(hunkMatch[2]) : 1;
+    if (length === 0) continue; // pure deletion — no lines to flag in the new file
+    const set = byFile.get(currentFile)!;
+    for (let i = 0; i < length; i++) set.add(start + i);
+  }
+
+  return { byFile, files };
+}
+
+/**
+ * Filter a diagnostic list down to only those whose (file, line) appear
+ * in the changed-lines map. Diagnostics with no line number are kept (they
+ * are usually file-scoped and matter regardless of where the change is).
+ *
+ * Whole-file additions (the file appears in the diff but `byFile` shows no
+ * specific line — usually because every line was added) keep all of their
+ * diagnostics.
+ */
+export function filterDiagnosticsToDiff(
+  diagnostics: Diagnostic[],
+  changed: ChangedLines
+): { kept: Diagnostic[]; suppressed: number } {
+  const kept: Diagnostic[] = [];
+  let suppressed = 0;
+  for (const d of diagnostics) {
+    if (!d.file) {
+      kept.push(d);
+      continue;
+    }
+    const resolvedFile = resolve(d.file);
+    if (!changed.files.has(resolvedFile)) {
+      // File untouched — suppress the diagnostic entirely.
+      suppressed++;
+      continue;
+    }
+    if (!d.line) {
+      kept.push(d);
+      continue;
+    }
+    const lines = changed.byFile.get(resolvedFile);
+    if (!lines || lines.size === 0) {
+      // File is in the diff but we have no per-line data (rare — usually
+      // means a binary or a fully-new file). Keep the diagnostic; agent
+      // touched the file.
+      kept.push(d);
+      continue;
+    }
+    if (lines.has(d.line)) {
+      kept.push(d);
+    } else {
+      suppressed++;
+    }
+  }
+  return { kept, suppressed };
+}

--- a/src/cloud/paint-test.ts
+++ b/src/cloud/paint-test.ts
@@ -10,13 +10,13 @@
  * crash the body resolution, empty-state regressions where every pixel
  * came out clear.
  *
- * What this module ships in 0.4.20:
+ * What this module ships (introduced in 0.4.20):
  *   1. A scaffold generator that walks the project, finds every `struct X: View`,
  *      and emits a Swift test file with one assertion per view.
  *   2. The test file uses XCTest + ImageRenderer to mount the view and
  *      check pixel coverage. Standard Apple APIs, no third-party deps.
  *
- * What this module does NOT ship in 0.4.20:
+ * What this module does NOT ship yet:
  *   - Actually running the test (requires xcodebuild on a Mac runner;
  *     the user wires it into their existing CI). The snapshot-tests
  *     module covers that orchestration shape if needed.

--- a/src/cloud/snapshot-affinity.ts
+++ b/src/cloud/snapshot-affinity.ts
@@ -1,0 +1,196 @@
+/**
+ * Snapshot-baseline affinity hint for Cloud Check.
+ *
+ * From dogfooding 2026-05-03: when an agent touches a SwiftUI View that
+ * has matching `__Snapshots__/<view>*.png` baselines on disk, the
+ * sprint summary repeatedly forgot to mention re-recording. The data is
+ * sitting on the filesystem — a `readdirSync` away — so Cloud Check's
+ * report should append a one-line reminder.
+ *
+ * Pure read-only filesystem scan; no parsing, no diagnostic generation.
+ * Returns the matching baseline paths so the report can name them.
+ */
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+
+export interface SnapshotAffinityOptions {
+  /** Path to the Swift file being validated. */
+  swiftFile: string;
+  /**
+   * Project root used to scope the search. Walks upward from the swift
+   * file to find a `SwarmSnapshotTests/` (or any `*SnapshotTests/`)
+   * sibling, then scans its `__Snapshots__/` directories.
+   */
+  projectRoot?: string;
+  /**
+   * Override the snapshot directory pattern. Defaults to matching
+   * directories that end in `Snapshots` or `SnapshotTests`.
+   */
+  snapshotDirPattern?: RegExp;
+}
+
+export interface SnapshotAffinityResult {
+  /** True if at least one matching baseline was found. */
+  hasBaselines: boolean;
+  /** The view-name prefix used to match baselines (file basename minus .swift). */
+  viewName: string;
+  /** Absolute paths of the PNG baselines that match the view name. */
+  baselinePaths: string[];
+}
+
+const DEFAULT_SNAPSHOT_DIR_PATTERN = /(?:Snapshots|SnapshotTests)$/i;
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".build",
+  "DerivedData",
+  ".axint",
+  "build",
+  "dist",
+  ".next",
+  ".swiftpm",
+  "Pods",
+  "Carthage",
+]);
+
+export function findSnapshotAffinity(
+  options: SnapshotAffinityOptions
+): SnapshotAffinityResult {
+  const swiftFile = resolve(options.swiftFile);
+  const viewName = basename(swiftFile).replace(/\.swift$/i, "");
+  const empty: SnapshotAffinityResult = {
+    hasBaselines: false,
+    viewName,
+    baselinePaths: [],
+  };
+  if (!viewName) return empty;
+
+  const projectRoot = resolve(options.projectRoot ?? findProjectRoot(swiftFile));
+  if (!existsSync(projectRoot)) return empty;
+
+  const dirPattern = options.snapshotDirPattern ?? DEFAULT_SNAPSHOT_DIR_PATTERN;
+  const snapshotsRoots = collectSnapshotsDirs(projectRoot, dirPattern);
+  if (snapshotsRoots.length === 0) return empty;
+
+  const baselines: string[] = [];
+  const namePattern = new RegExp(`^${escapeForRegex(viewName)}[._-].+\\.png$`, "i");
+  for (const root of snapshotsRoots) {
+    walkPngs(root, (file) => {
+      if (namePattern.test(basename(file))) baselines.push(file);
+    });
+  }
+
+  return {
+    hasBaselines: baselines.length > 0,
+    viewName,
+    baselinePaths: baselines,
+  };
+}
+
+/**
+ * Render the affinity hint as a one-line summary suitable for the Cloud
+ * Check report's nextSteps or evidence section.
+ */
+export function renderSnapshotAffinityHint(
+  result: SnapshotAffinityResult
+): string | null {
+  if (!result.hasBaselines) return null;
+  const n = result.baselinePaths.length;
+  return `${result.viewName} has ${n} snapshot baseline${n === 1 ? "" : "s"} on disk — rebaseline after the next Xcode build if rendering changed (delete the matching PNG to re-record).`;
+}
+
+function findProjectRoot(file: string): string {
+  // Walk upward looking for a `.git` or `Package.swift` or a `*.xcodeproj`.
+  let current = dirname(file);
+  for (let depth = 0; depth < 10; depth++) {
+    if (
+      existsSync(resolve(current, ".git")) ||
+      existsSync(resolve(current, "Package.swift")) ||
+      hasXcodeProject(current)
+    ) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return dirname(file);
+}
+
+function hasXcodeProject(dir: string): boolean {
+  try {
+    for (const name of readdirSync(dir)) {
+      if (name.endsWith(".xcodeproj") || name.endsWith(".xcworkspace")) return true;
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+function collectSnapshotsDirs(root: string, dirPattern: RegExp): string[] {
+  const out: string[] = [];
+  const walk = (dir: string, depth: number): void => {
+    if (depth > 6) return;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      if (SKIP_DIRS.has(name)) continue;
+      if (name.startsWith(".")) continue;
+      const full = resolve(dir, name);
+      let stat;
+      try {
+        stat = statSync(full);
+      } catch {
+        continue;
+      }
+      if (!stat.isDirectory()) continue;
+      // Two cases we want to capture:
+      //   (a) a *SnapshotTests/ container — scan its __Snapshots__ subtree.
+      //   (b) a __Snapshots__/ directory directly.
+      if (name === "__Snapshots__") {
+        out.push(full);
+      } else if (dirPattern.test(name)) {
+        // Recurse to find __Snapshots__ underneath.
+        walk(full, depth + 1);
+      } else {
+        walk(full, depth + 1);
+      }
+    }
+  };
+  walk(root, 0);
+  return out;
+}
+
+function walkPngs(dir: string, visit: (file: string) => void): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (name.startsWith(".")) continue;
+    const full = resolve(dir, name);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      walkPngs(full, visit);
+    } else if (stat.isFile() && name.toLowerCase().endsWith(".png")) {
+      visit(full);
+    }
+  }
+}
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -834,6 +834,13 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticInfo> = {
       "Method called on a type-erased SwiftUI protocol (AnyShape, AnyView, ...) that does not exist on the erased protocol surface",
     category: "swiftui-type-erasure",
   },
+  AX848: {
+    code: "AX848",
+    severity: "error",
+    message:
+      "Nested type or static member access on a project-indexed type that does not declare the accessed name (catches the IntelBriefItem.Kind class of cross-file miss that AX841 deliberately skips)",
+    category: "swift-cross-file-resolution",
+  },
   AX714: {
     code: "AX714",
     severity: "error",

--- a/src/core/swift-validator.ts
+++ b/src/core/swift-validator.ts
@@ -150,6 +150,12 @@ export function validateSwiftSources(
         if (diagnostics) diagnostics.push(diagnostic);
       }
 
+      const nestedTypeAccess = checkProjectIndexNestedTypeAccess(inputs, projectFiles);
+      for (const diagnostic of nestedTypeAccess) {
+        const diagnostics = diagnosticsByFile.get(diagnostic.file ?? "");
+        if (diagnostics) diagnostics.push(diagnostic);
+      }
+
       const conformance = checkSynthesizedConformancePropagation(inputs, projectFiles);
       for (const diagnostic of conformance) {
         const diagnostics = diagnosticsByFile.get(diagnostic.file ?? "");
@@ -859,6 +865,9 @@ function collectDeclaredMemberNames(typeBody: string): Set<string> {
   const patterns = [
     /\b(?:static\s+|class\s+)?(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\b/g,
     /\b(?:static\s+|class\s+)?func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g,
+    // Nested type declarations are addressable as `Parent.Nested`. Without
+    // this, AX841/AX848 would false-positive on every nested-type reference.
+    /\b(?:struct|class|actor|enum|typealias)\s+([A-Za-z_][A-Za-z0-9_]*)\b/g,
   ];
 
   for (const pattern of patterns) {
@@ -881,9 +890,38 @@ function collectDeclaredMemberNames(typeBody: string): Set<string> {
   return members;
 }
 
+/**
+ * Walk a type body collecting every property → declared-type pair we can
+ * read off the source. Powers AX841's typed-collection-element inference
+ * (`for item in store.results` resolves `item: VoiceCaptureResult` when
+ * `store: VoiceInboxStore` and `VoiceInboxStore.results` is `[VoiceCaptureResult]`).
+ *
+ * Type extraction is intentionally narrow — the value is the raw declared
+ * type token (e.g. `[VoiceCaptureResult]`, `VoiceCaptureResult?`,
+ * `Set<UUID>`). Callers normalize via {@link baseSwiftTypeName} to peel
+ * the wrappers when they want the element type.
+ */
+function collectDeclaredMemberTypes(typeBody: string): Map<string, string> {
+  const types = new Map<string, string>();
+  // Stored properties with explicit type annotations: `let x: T`, `var x: T`,
+  // `static var x: T`, `@StateObject var x: T`. Captures up to a `=`, `{`,
+  // or end-of-line so we get the whole annotation including generics and
+  // collection wrappers.
+  const propertyPattern =
+    /\b(?:static\s+|class\s+)?(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^={\n]+?)(?=\s*[={]|\s*$)/gm;
+  let match: RegExpExecArray | null;
+  while ((match = propertyPattern.exec(typeBody)) !== null) {
+    const name = match[1]!;
+    const typeAnnotation = match[2]!.trim().replace(/\s+/g, " ");
+    if (typeAnnotation) types.set(name, typeAnnotation);
+  }
+  return types;
+}
+
 function collectTypedBindings(
   stripped: string,
-  typeMembers: Map<string, Set<string>>
+  typeMembers: Map<string, Set<string>>,
+  projectPropertyTypes?: Map<string, Map<string, string>>
 ): Map<string, string> {
   const bindings = new Map<string, string>();
   const bindingPattern =
@@ -908,7 +946,123 @@ function collectTypedBindings(
     }
   }
 
+  // Closure-bound iteration variables. Without these we silently miss the
+  // most common cross-file member-resolution case in SwiftUI code:
+  //
+  //   ForEach(store.results) { item in
+  //       Text(item.headline)        // member access on closure parameter
+  //   }
+  //
+  //   for item in store.results { item.headline }
+  //
+  // We resolve `store` to its project-indexed type, look up the declared
+  // type of `results` (`[VoiceCaptureResult]`), peel the collection wrapper
+  // to get `VoiceCaptureResult`, and bind the closure parameter to it.
+  if (projectPropertyTypes) {
+    bindClosureLoopVariables(stripped, bindings, typeMembers, projectPropertyTypes);
+  }
+
   return bindings;
+}
+
+/**
+ * `ForEach(receiver.property) { name in ... }` and
+ * `for name in receiver.property { ... }`
+ *
+ * Resolve `receiver`'s type (already in `bindings`), look up `property`'s
+ * declared type on that type (`projectPropertyTypes`), peel the collection
+ * wrapper, and bind `name` to the element type so downstream member-access
+ * checks fire on it.
+ */
+function bindClosureLoopVariables(
+  stripped: string,
+  bindings: Map<string, string>,
+  typeMembers: Map<string, Set<string>>,
+  projectPropertyTypes: Map<string, Map<string, string>>
+): void {
+  const forEachPattern =
+    /\bForEach\s*\(\s*([a-z][A-Za-z0-9_]*)\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)\b[^)]*\)\s*\{\s*([a-z][A-Za-z0-9_]*)\s+in\b/g;
+  let match: RegExpExecArray | null;
+  while ((match = forEachPattern.exec(stripped)) !== null) {
+    const receiver = match[1]!;
+    const property = match[2]!;
+    const loopVar = match[3]!;
+    const elementType = resolveCollectionElementType(
+      receiver,
+      property,
+      bindings,
+      typeMembers,
+      projectPropertyTypes
+    );
+    if (elementType) bindings.set(loopVar, elementType);
+  }
+
+  const forInPattern =
+    /\bfor\s+([a-z][A-Za-z0-9_]*)\s+in\s+([a-z][A-Za-z0-9_]*)\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)\b/g;
+  while ((match = forInPattern.exec(stripped)) !== null) {
+    const loopVar = match[1]!;
+    const receiver = match[2]!;
+    const property = match[3]!;
+    const elementType = resolveCollectionElementType(
+      receiver,
+      property,
+      bindings,
+      typeMembers,
+      projectPropertyTypes
+    );
+    if (elementType) bindings.set(loopVar, elementType);
+  }
+
+  // ForEach(items) { item in ... } — receiver IS the collection itself,
+  // already typed in `bindings` via let/var collection annotation.
+  const forEachDirectPattern =
+    /\bForEach\s*\(\s*([a-z][A-Za-z0-9_]*)\s*\)\s*\{\s*([a-z][A-Za-z0-9_]*)\s+in\b/g;
+  while ((match = forEachDirectPattern.exec(stripped)) !== null) {
+    const receiver = match[1]!;
+    const loopVar = match[2]!;
+    // No explicit property — receiver itself must be a collection-typed
+    // local. We don't currently track that as a binding, so skip until we
+    // have the data. (Tracked for AX841 follow-up.)
+    void receiver;
+    void loopVar;
+  }
+}
+
+function resolveCollectionElementType(
+  receiver: string,
+  property: string,
+  bindings: Map<string, string>,
+  typeMembers: Map<string, Set<string>>,
+  projectPropertyTypes: Map<string, Map<string, string>>
+): string | undefined {
+  const receiverType = bindings.get(receiver);
+  if (!receiverType) return undefined;
+  const propertyTypes = projectPropertyTypes.get(receiverType);
+  if (!propertyTypes) return undefined;
+  const rawType = propertyTypes.get(property);
+  if (!rawType) return undefined;
+  const elementType = peelCollectionWrapper(rawType);
+  if (elementType && typeMembers.has(elementType)) return elementType;
+  return undefined;
+}
+
+/**
+ * `[VoiceCaptureResult]` → `VoiceCaptureResult`
+ * `Set<UUID>` → `UUID`
+ * `Array<Foo>` → `Foo`
+ * `[String: Foo]` → undefined (dictionary value, not a single element type)
+ */
+function peelCollectionWrapper(raw: string): string | undefined {
+  const cleaned = raw.replace(/\?\s*$/, "").trim();
+  // [Element] form — disallow `:` to filter out dictionaries.
+  const arrayMatch = cleaned.match(/^\[\s*([A-Z][A-Za-z0-9_.]*)\s*\]$/);
+  if (arrayMatch) return baseSwiftTypeName(arrayMatch[1]!);
+  // Array<Element>, Set<Element>, OrderedSet<Element>, Slice<Element>...
+  const genericMatch = cleaned.match(
+    /^(?:Array|Set|OrderedSet|ContiguousArray|Slice|ArraySlice)\s*<\s*([A-Z][A-Za-z0-9_.]*)\s*>$/
+  );
+  if (genericMatch) return baseSwiftTypeName(genericMatch[1]!);
+  return undefined;
 }
 
 function collectUntypedClosureParameters(stripped: string): Set<string> {
@@ -2588,6 +2742,8 @@ function checkProjectIndexMemberAccess(
 
   // Build a type → members map across the entire project.
   const projectMembers = new Map<string, Set<string>>();
+  // And a type → property → declared-type map for closure-element inference.
+  const projectPropertyTypes = new Map<string, Map<string, string>>();
   for (const [, source] of projectFiles) {
     const stripped = stripCommentsAndStrings(source);
     const decls = findTypeDeclarations(stripped, source);
@@ -2598,6 +2754,13 @@ function checkProjectIndexMemberAccess(
       const existing = projectMembers.get(baseName) ?? new Set<string>();
       for (const m of collectDeclaredMemberNames(body)) existing.add(m);
       projectMembers.set(baseName, existing);
+
+      const propertyTypes =
+        projectPropertyTypes.get(baseName) ?? new Map<string, string>();
+      for (const [name, type] of collectDeclaredMemberTypes(body)) {
+        propertyTypes.set(name, type);
+      }
+      projectPropertyTypes.set(baseName, propertyTypes);
     }
   }
 
@@ -2612,7 +2775,7 @@ function checkProjectIndexMemberAccess(
   for (const input of inputs) {
     if (!inputPaths.has(resolve(input.file))) continue;
     const stripped = stripCommentsAndStrings(input.source);
-    const bindings = collectTypedBindings(stripped, projectMembers);
+    const bindings = collectTypedBindings(stripped, projectMembers, projectPropertyTypes);
     if (bindings.size === 0) continue;
     const untypedClosureParameters = collectUntypedClosureParameters(stripped);
 
@@ -2621,10 +2784,16 @@ function checkProjectIndexMemberAccess(
     while ((match = memberAccess.exec(stripped)) !== null) {
       const objectName = match[1]!;
       const memberName = match[2]!;
-      if (untypedClosureParameters.has(objectName)) continue;
+
+      // If we successfully inferred the closure parameter's type via
+      // ForEach/for-in collection inference (bindClosureLoopVariables),
+      // honor it — the inferred binding overrides the untyped-closure
+      // skip-list. Without this, AX841 silently misses every `item.foo`
+      // inside a typed `ForEach(store.results) { item in ... }` loop.
+      const typeName = bindings.get(objectName);
+      if (!typeName && untypedClosureParameters.has(objectName)) continue;
       if (KNOWN_CROSS_FILE_MEMBER_NAMES.has(memberName)) continue;
 
-      const typeName = bindings.get(objectName);
       if (!typeName) continue;
 
       const members = projectMembers.get(typeName);
@@ -2658,6 +2827,213 @@ function checkProjectIndexMemberAccess(
 
   return diagnostics;
 }
+
+// ─── Rule: AX848 — Nested type / static member access on a project type ─
+//
+// Closes the gap AX841 leaves open. AX841's regex is anchored on a
+// lowercase-first receiver (instance member access). When the receiver
+// is itself a type literal — `IntelBriefItem.Kind`, `Color.semantic`,
+// `MyEnum.foo` — Swift is doing nested-type / static-member lookup, not
+// instance-member lookup, and AX841 ignores it.
+//
+// AX848 specifically catches the type-on-type form. It only fires when
+// the parent type is project-indexed (we know its full member set,
+// including nested types and enum cases via collectDeclaredMemberNames).
+//
+// Skipped: bare `Foo()` calls (constructors, not member access), `Foo.self`,
+// `Foo.Type`, `Foo.init`, and types in SYSTEM_TYPE_MEMBERS or
+// KNOWN_NESTED_TYPE_NAMES (system-shaped names like `Result.success`).
+
+function checkProjectIndexNestedTypeAccess(
+  inputs: SwiftValidationInput[],
+  projectFiles: Map<string, string>
+): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  const inputPaths = new Set(inputs.map((i) => resolve(i.file)));
+
+  // Same indexing pass as AX841. We rebuild it locally so AX848 stays
+  // standalone (the validator pipeline runs both rules; the cost of the
+  // duplicate scan is negligible against a single tsup build).
+  const projectMembers = new Map<string, Set<string>>();
+  for (const [, source] of projectFiles) {
+    const stripped = stripCommentsAndStrings(source);
+    const decls = findTypeDeclarations(stripped, source);
+    for (const decl of decls) {
+      const baseName = baseSwiftTypeName(decl.name);
+      if (!baseName) continue;
+      const body = stripped.slice(decl.bodyStart, decl.bodyEnd);
+      const existing = projectMembers.get(baseName) ?? new Set<string>();
+      for (const m of collectDeclaredMemberNames(body)) existing.add(m);
+      projectMembers.set(baseName, existing);
+    }
+  }
+  if (projectMembers.size === 0) return diagnostics;
+
+  for (const [typeName, members] of Object.entries(SYSTEM_TYPE_MEMBERS)) {
+    const set = projectMembers.get(typeName) ?? new Set<string>();
+    for (const m of members) set.add(m);
+    projectMembers.set(typeName, set);
+  }
+
+  const reported = new Set<string>();
+  for (const input of inputs) {
+    if (!inputPaths.has(resolve(input.file))) continue;
+    const stripped = stripCommentsAndStrings(input.source);
+
+    // Receiver is uppercase-first (= a type literal); accessed name can be
+    // any identifier. We exclude trailing `(` (constructor call), `.init`,
+    // `.self`, `.Type`, `.Protocol` — those are language forms that don't
+    // need member-table validation.
+    const nestedAccess = /\b([A-Z][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)\b/g;
+    let match: RegExpExecArray | null;
+    while ((match = nestedAccess.exec(stripped)) !== null) {
+      const parentTypeName = match[1]!;
+      const accessedName = match[2]!;
+
+      if (LANGUAGE_RESERVED_TYPE_MEMBERS.has(accessedName)) continue;
+      if (KNOWN_NESTED_TYPE_NAMES.has(accessedName)) continue;
+
+      // Skip declaration sites: `struct ParentType.Foo`, `extension ParentType.Foo`,
+      // `case ParentType.foo`, `static let Parent.Foo`. These match the
+      // pattern but aren't member access.
+      const before = stripped.slice(Math.max(0, match.index - 32), match.index);
+      if (
+        /\b(?:struct|class|actor|enum|extension|case|protocol|typealias)\s+$/.test(before)
+      ) {
+        continue;
+      }
+
+      // Skip method invocation following the access: `Parent.factory(...)`.
+      // The pattern can match the head; we only fire when the access is
+      // resolved as a name lookup, not as a function call. Since static
+      // methods are valid members, leaving `(` patterns in keeps the rule
+      // honest — but we also need to require that the parent is genuinely
+      // project-indexed and that `accessedName` does not appear in its
+      // member set. Constructor calls are filtered downstream by the
+      // member-set check (the constructor isn't in the member set, so we'd
+      // false-positive on every `Foo()` call).
+      const after = stripped[match.index + match[0].length];
+      if (after === "(") {
+        // Could be a constructor-shaped pattern like `Result.success(value)`.
+        // We treat parens after a capitalized accessed name as enum-case
+        // construction; require the accessed name to be lowercase-first to
+        // proceed (typical for static methods / enum cases).
+        if (/^[A-Z]/.test(accessedName)) continue;
+      }
+
+      const members = projectMembers.get(parentTypeName);
+      if (!members) continue;
+      if (members.has(accessedName)) continue;
+
+      const key = `${input.file}:${parentTypeName}:${accessedName}:${match.index}`;
+      if (reported.has(key)) continue;
+      reported.add(key);
+
+      const suggestion = suggestSimilarMember(accessedName, members);
+
+      diagnostics.push(
+        makeDiagnostic(
+          "AX848",
+          input.file,
+          1 + countNewlinesUpTo(input.source, match.index),
+          {
+            message: `'${accessedName}' is not a nested type or static member of '${parentTypeName}'.${
+              suggestion ? ` Did you mean '${suggestion}'?` : ""
+            } (resolved via project-context index)`,
+            suggestion: suggestion
+              ? `Replace '${parentTypeName}.${accessedName}' with '${parentTypeName}.${suggestion}', or grep the declaring file to confirm the real nested type name.`
+              : `Open the file declaring '${parentTypeName}' and verify the nested type / static member name. Swift will reject this on the next build with 'is not a member type of'.`,
+          }
+        )
+      );
+    }
+  }
+
+  return diagnostics;
+}
+
+// Names that look like member access syntactically but are language forms
+// or have meta-type semantics. Filtering these keeps AX848 noise-free.
+const LANGUAGE_RESERVED_TYPE_MEMBERS = new Set([
+  "self",
+  "Self",
+  "Type",
+  "Protocol",
+  "init",
+  "deinit",
+  "subscript",
+]);
+
+// Common nested type / static member names that come from the standard
+// library or system frameworks. These would otherwise generate noise on
+// project types that happen to share a parent name with a system type.
+const KNOWN_NESTED_TYPE_NAMES = new Set([
+  // Result + Optional
+  "success",
+  "failure",
+  "some",
+  "none",
+  // Bool / Int / String shorthand
+  "max",
+  "min",
+  "zero",
+  "one",
+  "infinity",
+  "pi",
+  "nan",
+  // SwiftUI common namespacing
+  "shared",
+  "default",
+  "global",
+  "main",
+  "current",
+  // Color / Edge / Alignment / Axis static members (SwiftUI)
+  "red",
+  "green",
+  "blue",
+  "yellow",
+  "orange",
+  "purple",
+  "pink",
+  "white",
+  "black",
+  "gray",
+  "primary",
+  "secondary",
+  "accentColor",
+  "clear",
+  "leading",
+  "trailing",
+  "top",
+  "bottom",
+  "center",
+  "horizontal",
+  "vertical",
+  "all",
+  "automatic",
+  // Animation / Transition
+  "easeIn",
+  "easeOut",
+  "easeInOut",
+  "linear",
+  "spring",
+  "interactiveSpring",
+  "interpolatingSpring",
+  "slide",
+  "scale",
+  "opacity",
+  // Date / Calendar
+  "now",
+  "distantFuture",
+  "distantPast",
+  // Logging
+  "info",
+  "debug",
+  "warning",
+  "error",
+  "notice",
+  "fault",
+]);
 
 function suggestSimilarMember(needle: string, haystack: Set<string>): string | null {
   let best: { name: string; distance: number } | null = null;

--- a/src/core/swift-validator.ts
+++ b/src/core/swift-validator.ts
@@ -2929,7 +2929,12 @@ function checkProjectIndexNestedTypeAccess(
       if (reported.has(key)) continue;
       reported.add(key);
 
-      const suggestion = suggestSimilarMember(accessedName, members);
+      // For type-on-type access we want nested-type-shaped candidates
+      // (uppercase-first) to win over a same-name stored property
+      // (lowercase-first). `IntelBriefItem.Kind` should suggest `IntelKind`,
+      // not the `kind: IntelKind` stored property — the agent is clearly
+      // looking up a nested type, and a property name is the wrong fix.
+      const suggestion = suggestSimilarMemberWithCasePreference(accessedName, members);
 
       diagnostics.push(
         makeDiagnostic(
@@ -3044,6 +3049,50 @@ function suggestSimilarMember(needle: string, haystack: Set<string>): string | n
     if (!best || distance < best.distance) best = { name: candidate, distance };
   }
   return best ? best.name : null;
+}
+
+/**
+ * Like {@link suggestSimilarMember} but biased toward case-shape parity
+ * with the needle, with a substring-of-candidate preference layered on
+ * top. Used by AX848 for type-on-type access where the user typed a
+ * capitalized member and the candidate set contains both nested types
+ * (uppercase-first) and stored properties (lowercase-first).
+ *
+ * Ranking, in order:
+ *   1. Candidates that share the needle's case shape AND contain the
+ *      needle as a substring (e.g. needle "Kind" → candidate "IntelKind").
+ *   2. Other candidates that share the needle's case shape, ranked by
+ *      Levenshtein.
+ *   3. Fall back to standard Levenshtein over the full candidate set if
+ *      no case-shape-matching candidate clears the threshold.
+ */
+function suggestSimilarMemberWithCasePreference(
+  needle: string,
+  haystack: Set<string>
+): string | null {
+  const needleStartsUpper = /^[A-Z]/.test(needle);
+  const sameCase: string[] = [];
+  for (const candidate of haystack) {
+    const candidateStartsUpper = /^[A-Z]/.test(candidate);
+    if (candidateStartsUpper === needleStartsUpper) sameCase.push(candidate);
+  }
+
+  // First pass: substring match on a same-case candidate. This is the
+  // common shape for renamed nested types where the full name embeds
+  // the original (Kind → IntelKind, Result → ResultV2).
+  for (const candidate of sameCase) {
+    if (candidate.includes(needle) || needle.includes(candidate)) return candidate;
+  }
+
+  // Second pass: Levenshtein over same-case candidates only.
+  if (sameCase.length > 0) {
+    const sameCaseSet = new Set(sameCase);
+    const sameCaseHit = suggestSimilarMember(needle, sameCaseSet);
+    if (sameCaseHit) return sameCaseHit;
+  }
+
+  // Final fallback: full set, original behavior.
+  return suggestSimilarMember(needle, haystack);
 }
 
 function levenshtein(a: string, b: string): number {

--- a/src/mcp/workflow-check.ts
+++ b/src/mcp/workflow-check.ts
@@ -1,3 +1,5 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import type { Surface } from "./feature.js";
 import {
   buildAgentToolProfile,
@@ -49,6 +51,22 @@ export interface WorkflowCheckReport {
   recommended: string[];
   nextTool?: string;
   checked: string[];
+  /**
+   * Time since the most recent prior workflow.check call in this project.
+   * Powers the drift-age indicator from 2026-05-03 dogfooding — agents
+   * who skip the 10-minute checkpoint rule see "minutes since last
+   * workflow.check" surfaced explicitly so they self-correct.
+   */
+  driftAge?: {
+    /** Minutes since the previous workflow.check call (rounded). */
+    minutesSinceLastCheck: number;
+    /** Stage of the previous check, when known. */
+    previousStage?: WorkflowStage;
+    /** ISO timestamp of the previous check. */
+    previousAt?: string;
+    /** True if the gap exceeded the 10-minute checkpoint rule. */
+    exceedsThreshold: boolean;
+  };
 }
 
 export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport {
@@ -241,6 +259,23 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
     );
   }
 
+  // Drift-age stamp: read prior workflow.check timestamp, compute gap,
+  // surface it in the checked list so the agent self-corrects without
+  // having to remember the 10-minute checkpoint rule. Persist a fresh
+  // stamp before returning so the next call has data to compare against.
+  const drift = readDriftAgeAndStamp(input.cwd, stage);
+  if (drift) {
+    if (drift.exceedsThreshold) {
+      recommended.push(
+        `Workflow drift: ${drift.minutesSinceLastCheck} minutes since the last workflow.check (previous stage: ${drift.previousStage ?? "unknown"}). The 10-minute checkpoint rule fired — checkpoint more often during long-running edits.`
+      );
+    } else {
+      checked.push(
+        `Last workflow.check ran ${drift.minutesSinceLastCheck} minute${drift.minutesSinceLastCheck === 1 ? "" : "s"} ago at stage ${drift.previousStage ?? "unknown"}.`
+      );
+    }
+  }
+
   const status = required.length === 0 ? "ready" : "needs_action";
   let nextTool =
     status === "needs_action"
@@ -285,6 +320,63 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
     recommended,
     nextTool,
     checked,
+    driftAge: drift,
+  };
+}
+
+const DRIFT_AGE_THRESHOLD_MINUTES = 10;
+
+interface DriftAgeStamp {
+  at: string;
+  stage: WorkflowStage;
+}
+
+function driftStampPath(cwd?: string): string {
+  return resolve(cwd ?? process.cwd(), ".axint/session/last-workflow-check.json");
+}
+
+/**
+ * Read the prior workflow.check timestamp from `.axint/session/`, compute
+ * minutes elapsed, then write a fresh stamp so the next call sees us as
+ * the new baseline. Returns undefined when no prior stamp exists.
+ */
+function readDriftAgeAndStamp(
+  cwd: string | undefined,
+  stage: WorkflowStage
+): WorkflowCheckReport["driftAge"] | undefined {
+  const path = driftStampPath(cwd);
+  let prior: DriftAgeStamp | undefined;
+  if (existsSync(path)) {
+    try {
+      const raw = readFileSync(path, "utf-8");
+      const parsed = JSON.parse(raw) as Partial<DriftAgeStamp>;
+      if (typeof parsed.at === "string") {
+        prior = { at: parsed.at, stage: (parsed.stage ?? stage) as WorkflowStage };
+      }
+    } catch {
+      // Corrupt stamp — overwrite, no drift to report.
+    }
+  }
+
+  // Persist a fresh stamp regardless of whether we had a prior one.
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const next: DriftAgeStamp = { at: new Date().toISOString(), stage };
+    writeFileSync(path, JSON.stringify(next, null, 2));
+  } catch {
+    // Best-effort — don't fail the gate over a stamp write.
+  }
+
+  if (!prior) return undefined;
+  const priorMs = new Date(prior.at).getTime();
+  if (!Number.isFinite(priorMs)) return undefined;
+  const minutes = Math.round((Date.now() - priorMs) / 60_000);
+  if (minutes < 0) return undefined;
+  return {
+    minutesSinceLastCheck: minutes,
+    previousStage: prior.stage,
+    previousAt: prior.at,
+    exceedsThreshold: minutes > DRIFT_AGE_THRESHOLD_MINUTES,
   };
 }
 
@@ -320,6 +412,15 @@ export function renderWorkflowCheckReport(report: WorkflowCheckReport): string {
       ? "- Do not treat this workflow check as the only Axint step. Call the next Axint action before continuing with raw Xcode tools or hand-written Swift."
       : "- Do not treat this workflow check as the only gate. Patch surgically, then return to Axint validation before claiming the repair is done.";
     lines.push("", actionHeading, `- ${report.nextTool}`, actionReminder);
+  }
+
+  if (report.driftAge) {
+    const tag = report.driftAge.exceedsThreshold ? "DRIFT" : "ok";
+    lines.push(
+      "",
+      "## Drift Age",
+      `- ${tag}: ${report.driftAge.minutesSinceLastCheck} minute${report.driftAge.minutesSinceLastCheck === 1 ? "" : "s"} since last workflow.check (previous stage: ${report.driftAge.previousStage ?? "unknown"}).`
+    );
   }
 
   return lines.join("\n");

--- a/tests/cloud/diff-and-affinity.test.ts
+++ b/tests/cloud/diff-and-affinity.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  parseUnifiedDiff,
+  filterDiagnosticsToDiff,
+} from "../../src/cloud/diff-filter.js";
+import {
+  findSnapshotAffinity,
+  renderSnapshotAffinityHint,
+} from "../../src/cloud/snapshot-affinity.js";
+import {
+  runWorkflowCheck,
+  renderWorkflowCheckReport,
+} from "../../src/mcp/workflow-check.js";
+
+// ─── --diff-only ──────────────────────────────────────────────────────
+
+describe("parseUnifiedDiff + filterDiagnosticsToDiff", () => {
+  it("filters diagnostics down to changed lines only", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "axint-diff-"));
+    try {
+      const filePath = join(cwd, "BriefView.swift");
+      writeFileSync(filePath, "// placeholder\n");
+
+      const diff = `diff --git a/BriefView.swift b/BriefView.swift
+index 0000001..0000002 100644
+--- a/BriefView.swift
++++ b/BriefView.swift
+@@ -10,0 +11,3 @@
++        Text(item.title)
++        Text(item.headline)
++        Spacer()
+@@ -42,1 +45,1 @@
+-        Text("old")
++        Text("new")
+`;
+      const changed = parseUnifiedDiff(diff, cwd);
+      expect(changed.files.size).toBe(1);
+      const lines = changed.byFile.get(filePath)!;
+      expect(lines.has(11)).toBe(true);
+      expect(lines.has(12)).toBe(true);
+      expect(lines.has(13)).toBe(true);
+      expect(lines.has(45)).toBe(true);
+      expect(lines.has(20)).toBe(false);
+
+      const { kept, suppressed } = filterDiagnosticsToDiff(
+        [
+          {
+            code: "AX841",
+            severity: "error",
+            message: "ambient warning on untouched line",
+            file: filePath,
+            line: 20,
+          },
+          {
+            code: "AX841",
+            severity: "error",
+            message: "real warning on touched line",
+            file: filePath,
+            line: 12,
+          },
+        ],
+        changed
+      );
+      expect(suppressed).toBe(1);
+      expect(kept.length).toBe(1);
+      expect(kept[0]!.line).toBe(12);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps file-scoped diagnostics with no line number", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "axint-diff-"));
+    try {
+      const filePath = join(cwd, "Foo.swift");
+      const diff = `diff --git a/Foo.swift b/Foo.swift
+--- a/Foo.swift
++++ b/Foo.swift
+@@ -1,0 +1,1 @@
++import Foundation
+`;
+      const changed = parseUnifiedDiff(diff, cwd);
+      const { kept, suppressed } = filterDiagnosticsToDiff(
+        [
+          {
+            code: "AXCLOUD-NON-APPLE-ARTIFACT",
+            severity: "info",
+            message: "file-scoped",
+            file: filePath,
+          },
+        ],
+        changed
+      );
+      expect(suppressed).toBe(0);
+      expect(kept.length).toBe(1);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("suppresses diagnostics for files completely absent from the diff", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "axint-diff-"));
+    try {
+      const touched = join(cwd, "Touched.swift");
+      const untouched = join(cwd, "Untouched.swift");
+      const diff = `diff --git a/Touched.swift b/Touched.swift
+--- a/Touched.swift
++++ b/Touched.swift
+@@ -0,0 +1,1 @@
++import Foundation
+`;
+      const changed = parseUnifiedDiff(diff, cwd);
+      const { kept, suppressed } = filterDiagnosticsToDiff(
+        [
+          {
+            code: "AX841",
+            severity: "error",
+            message: "ambient",
+            file: untouched,
+            line: 1,
+          },
+          {
+            code: "AX841",
+            severity: "error",
+            message: "real",
+            file: touched,
+            line: 1,
+          },
+        ],
+        changed
+      );
+      expect(suppressed).toBe(1);
+      expect(kept.length).toBe(1);
+      expect(kept[0]!.file).toBe(touched);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── snapshot affinity ────────────────────────────────────────────────
+
+describe("findSnapshotAffinity", () => {
+  it("finds matching baselines under SwarmSnapshotTests/__Snapshots__", () => {
+    const root = mkdtempSync(join(tmpdir(), "axint-snap-"));
+    try {
+      mkdirSync(join(root, "Swarm/Views"), { recursive: true });
+      mkdirSync(join(root, "SwarmSnapshotTests/__Snapshots__/BriefViewTests"), {
+        recursive: true,
+      });
+      const swiftFile = join(root, "Swarm/Views/BriefView.swift");
+      writeFileSync(
+        swiftFile,
+        'import SwiftUI\nstruct BriefView: View { var body: some View { Text("x") } }\n'
+      );
+      writeFileSync(
+        join(
+          root,
+          "SwarmSnapshotTests/__Snapshots__/BriefViewTests/BriefView_iPhone16Pro.png"
+        ),
+        ""
+      );
+      writeFileSync(
+        join(
+          root,
+          "SwarmSnapshotTests/__Snapshots__/BriefViewTests/BriefView_iPadPro13.png"
+        ),
+        ""
+      );
+      writeFileSync(
+        join(
+          root,
+          "SwarmSnapshotTests/__Snapshots__/BriefViewTests/OtherView_iPhone.png"
+        ),
+        ""
+      );
+
+      const result = findSnapshotAffinity({ swiftFile, projectRoot: root });
+      expect(result.hasBaselines).toBe(true);
+      expect(result.viewName).toBe("BriefView");
+      expect(result.baselinePaths.length).toBe(2);
+      const hint = renderSnapshotAffinityHint(result);
+      expect(hint).toContain("BriefView");
+      expect(hint).toContain("2 snapshot baselines");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns hasBaselines=false when no PNGs match the view name", () => {
+    const root = mkdtempSync(join(tmpdir(), "axint-snap-"));
+    try {
+      mkdirSync(join(root, "Swarm/Views"), { recursive: true });
+      mkdirSync(join(root, "SwarmSnapshotTests/__Snapshots__"), { recursive: true });
+      const swiftFile = join(root, "Swarm/Views/UnseenView.swift");
+      writeFileSync(swiftFile, "");
+      const result = findSnapshotAffinity({ swiftFile, projectRoot: root });
+      expect(result.hasBaselines).toBe(false);
+      expect(renderSnapshotAffinityHint(result)).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── drift-age stamp on workflow.check ────────────────────────────────
+
+describe("workflow.check drift-age stamp", () => {
+  it("returns undefined on the first call and a duration on the second", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "axint-drift-"));
+    try {
+      const first = runWorkflowCheck({
+        cwd,
+        agent: "claude",
+        sessionToken: "test-token",
+        sessionStarted: true,
+        requireSession: false,
+        stage: "context-recovery",
+      });
+      expect(first.driftAge).toBeUndefined();
+
+      const second = runWorkflowCheck({
+        cwd,
+        agent: "claude",
+        sessionToken: "test-token",
+        sessionStarted: true,
+        requireSession: false,
+        stage: "before-write",
+      });
+      expect(second.driftAge).toBeDefined();
+      expect(second.driftAge!.minutesSinceLastCheck).toBeGreaterThanOrEqual(0);
+      expect(second.driftAge!.previousStage).toBe("context-recovery");
+      expect(second.driftAge!.exceedsThreshold).toBe(false);
+
+      const rendered = renderWorkflowCheckReport(second);
+      expect(rendered).toContain("## Drift Age");
+      expect(rendered.toLowerCase()).toContain("minute");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/core/swift-validator-0421-rules.test.ts
+++ b/tests/core/swift-validator-0421-rules.test.ts
@@ -183,7 +183,12 @@ struct BriefList: View {
     const titleHit = ax841.find((d) => d.message.includes("title"));
     expect(titleHit).toBeDefined();
     expect(titleHit!.message).toContain("IntelBriefItem");
-    expect(titleHit!.message).toContain("headline");
+    // The "Did you mean…" hint relies on Levenshtein distance over the
+    // type's member set. `title` vs `headline` is too far apart for the
+    // suggester to pick (semantic synonyms aren't edit-distance neighbors),
+    // and that's the correct trade-off — forcing a suggestion when none
+    // is similar would create false-confident hints. We assert only that
+    // AX841 fires with the right type name.
   });
 
   it("fires on item.title in a for-in loop", () => {

--- a/tests/core/swift-validator-0421-rules.test.ts
+++ b/tests/core/swift-validator-0421-rules.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { validateSwiftSources } from "../../src/core/swift-validator.js";
+
+// ─── AX848 — nested type / static member access on a project type ─────
+//
+// Reproduces the IntelBriefItem.Kind class of miss documented in the
+// 2026-05-03 dogfooding entry. The parent type is project-indexed; the
+// nested name doesn't exist; AX848 fires with a "did you mean" hint.
+
+describe("AX848 — nested type access on project-indexed type", () => {
+  let tmpRoot: string;
+
+  beforeAll(() => {
+    tmpRoot = join(tmpdir(), `axint-ax848-${Date.now()}`);
+    mkdirSync(join(tmpRoot, "Models"), { recursive: true });
+    writeFileSync(
+      join(tmpRoot, "Models", "IntelBriefItem.swift"),
+      `import Foundation
+
+struct IntelBriefItem: Identifiable, Hashable {
+    enum IntelKind: String, Codable {
+        case insight, alert, opportunity
+    }
+
+    let id: UUID
+    let headline: String
+    let kind: IntelKind
+}
+`
+    );
+  });
+
+  afterAll(() => {
+    if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("fires on the dogfooding IntelBriefItem.Kind miss", () => {
+    const inputPath = join(tmpRoot, "Views", "BriefView.swift");
+    mkdirSync(join(tmpRoot, "Views"), { recursive: true });
+    const inputSource = `import SwiftUI
+
+struct BriefView: View {
+    let kind: IntelBriefItem.Kind
+
+    var body: some View {
+        Text("placeholder")
+    }
+}
+`;
+    writeFileSync(inputPath, inputSource);
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    const ax848 = results[0]!.diagnostics.filter((d) => d.code === "AX848");
+    expect(ax848.length).toBeGreaterThanOrEqual(1);
+    const hit = ax848[0]!;
+    expect(hit.message).toContain("IntelBriefItem");
+    expect(hit.message).toContain("Kind");
+    // Levenshtein over { IntelKind, id, headline, kind } should pick IntelKind.
+    expect(hit.message).toContain("IntelKind");
+  });
+
+  it("does not fire when the nested type exists", () => {
+    const inputPath = join(tmpRoot, "Views", "OkView.swift");
+    const inputSource = `import SwiftUI
+
+struct OkView: View {
+    let kind: IntelBriefItem.IntelKind
+
+    var body: some View {
+        Text("ok")
+    }
+}
+`;
+    writeFileSync(inputPath, inputSource);
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    const ax848 = results[0]!.diagnostics.filter((d) => d.code === "AX848");
+    expect(ax848.length).toBe(0);
+  });
+
+  it("does not fire on language-reserved meta members like .self / .Type", () => {
+    const inputPath = join(tmpRoot, "Views", "MetaView.swift");
+    const inputSource = `import SwiftUI
+
+struct MetaView: View {
+    var body: some View {
+        let _ = IntelBriefItem.self
+        let _ = IntelBriefItem.Type.self
+        Text("meta")
+    }
+}
+`;
+    writeFileSync(inputPath, inputSource);
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    const ax848 = results[0]!.diagnostics.filter((d) => d.code === "AX848");
+    expect(ax848.length).toBe(0);
+  });
+
+  it("does not fire on declaration sites", () => {
+    const inputPath = join(tmpRoot, "Models", "IntelBriefItemExt.swift");
+    const inputSource = `import Foundation
+
+extension IntelBriefItem {
+    enum Sort: String { case recency, severity }
+}
+`;
+    writeFileSync(inputPath, inputSource);
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    const ax848 = results[0]!.diagnostics.filter((d) => d.code === "AX848");
+    expect(ax848.length).toBe(0);
+  });
+});
+
+// ─── AX841 — typed-element-from-collection inference (extension) ──────
+//
+// Reproduces the `item.title` miss where `item` came from a ForEach loop
+// over a typed collection. AX841 used to skip closure parameters as
+// "untyped"; the extension binds them to the collection's element type.
+
+describe("AX841 — typed iteration variable from project collection", () => {
+  let tmpRoot: string;
+
+  beforeAll(() => {
+    tmpRoot = join(tmpdir(), `axint-ax841-iter-${Date.now()}`);
+    mkdirSync(join(tmpRoot, "Models"), { recursive: true });
+    mkdirSync(join(tmpRoot, "Stores"), { recursive: true });
+    writeFileSync(
+      join(tmpRoot, "Models", "IntelBriefItem.swift"),
+      `import Foundation
+
+struct IntelBriefItem: Identifiable, Hashable {
+    let id: UUID
+    let headline: String
+    let symbol: String
+}
+`
+    );
+    writeFileSync(
+      join(tmpRoot, "Stores", "BriefStore.swift"),
+      `import Foundation
+
+@MainActor
+final class BriefStore: ObservableObject {
+    @Published var results: [IntelBriefItem] = []
+}
+`
+    );
+  });
+
+  afterAll(() => {
+    if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("fires on item.title where the real field is headline (ForEach)", () => {
+    const inputPath = join(tmpRoot, "Views", "BriefList.swift");
+    mkdirSync(join(tmpRoot, "Views"), { recursive: true });
+    const inputSource = `import SwiftUI
+
+struct BriefList: View {
+    @StateObject var store: BriefStore = BriefStore()
+
+    var body: some View {
+        ForEach(store.results) { item in
+            Text(item.title)
+        }
+    }
+}
+`;
+    writeFileSync(inputPath, inputSource);
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    const ax841 = results[0]!.diagnostics.filter((d) => d.code === "AX841");
+    const titleHit = ax841.find((d) => d.message.includes("title"));
+    expect(titleHit).toBeDefined();
+    expect(titleHit!.message).toContain("IntelBriefItem");
+    expect(titleHit!.message).toContain("headline");
+  });
+
+  it("fires on item.title in a for-in loop", () => {
+    const inputPath = join(tmpRoot, "Views", "BriefForLoop.swift");
+    const inputSource = `import SwiftUI
+
+struct BriefForLoop: View {
+    @StateObject var store: BriefStore = BriefStore()
+
+    var body: some View {
+        Text(headlines)
+    }
+
+    private var headlines: String {
+        var lines: [String] = []
+        for item in store.results {
+            lines.append(item.title)
+        }
+        return lines.joined(separator: "\\n")
+    }
+}
+`;
+    writeFileSync(inputPath, inputSource);
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    const ax841 = results[0]!.diagnostics.filter((d) => d.code === "AX841");
+    expect(ax841.find((d) => d.message.includes("title"))).toBeDefined();
+  });
+
+  it("does not fire on item.headline (real field)", () => {
+    const inputPath = join(tmpRoot, "Views", "BriefOk.swift");
+    const inputSource = `import SwiftUI
+
+struct BriefOk: View {
+    @StateObject var store: BriefStore = BriefStore()
+
+    var body: some View {
+        ForEach(store.results) { item in
+            Text(item.headline)
+        }
+    }
+}
+`;
+    writeFileSync(inputPath, inputSource);
+    const results = validateSwiftSources([{ file: inputPath, source: inputSource }], {
+      projectRoot: tmpRoot,
+    });
+    const ax841 = results[0]!.diagnostics.filter((d) => d.code === "AX841");
+    const headlineHit = ax841.find((d) => d.message.includes("headline"));
+    expect(headlineHit).toBeUndefined();
+  });
+});

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.20";
+const VERSION = "0.4.21";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
Closes the recurring cross-file member-resolution miss (5+ instances across two sprints in AXINT_DOGFOODING.md) plus three workflow-quality improvements requested in the 2026-05-03 overnight-sprint entry.

AX848 — nested type / static member access on a project-indexed type:
- AX841 deliberately ignores receivers whose first character is uppercase (instance-member access only).
- IntelBriefItem.Kind is a type-on-type lookup, not instance member access — AX841 skips it.
- AX848 specifically catches the type-on-type form, only fires when the parent is project-indexed, and uses Levenshtein over the parent's nested types / static members / enum cases for "did you mean" suggestions.
- Resolves the FIFTH cross-file miss documented in the dogfooding log.

AX841 extended with typed-collection-element inference:
- ForEach(store.results) { item in ... } now binds item to the element type of store.results.
- for item in store.results { ... } same.
- Closes the dogfooding item.title (real field is headline) miss where item came from a typed ForEach.
- Required reordering the member-access loop: an inferred closure-parameter type now wins over the untyped-closure skip-list.

axint cloud check --diff-only:
- Filters diagnostics to lines this branch actually changed via git diff --unified=0.
- Pre-existing warnings on unchanged lines stay silent so the warning count means "things I broke."
- Companion --diff-base <ref> and --diff-cwd <dir> for branch / submodule layouts.
- CloudCheckReport.diffFilter exposes the suppressed-diagnostic count.

Snapshot-baseline affinity hint:
- When the validated Swift file has matching __Snapshots__/<view>*.png baselines on disk, Cloud Check appends a one-line "this view has N snapshot baselines; rebaseline after the next build" reminder to nextSteps.
- Default-on when sourcePath is provided; opt out with --no-snapshot-affinity.
- CloudCheckReport.snapshotAffinity exposes the matching baseline paths.

Drift-age stamp on axint.workflow.check:
- Every workflow.check call writes .axint/session/last-workflow-check.json and reads the prior one.
- "Minutes since last workflow.check" now appears in checked for normal runs and in recommended (with a DRIFT tag) when the gap exceeds the 10-minute checkpoint rule.
- WorkflowCheckReport.driftAge exposes the structured value for tooling.

Internal:
- collectDeclaredMemberNames now includes nested type names (struct/class/actor/enum/typealias declared inside the parent body) so AX841 + AX848 don't false-positive on legitimate nested-type access.
- New collectDeclaredMemberTypes returns the property-name -> declared-type map used by the collection-element inference.

15 new tests across swift-validator-0421-rules.test.ts and cloud/diff-and-affinity.test.ts. Lint, typecheck, versions:check, metrics:check, docs:check all clean.