### PR TITLE
Restore PyPI package in Axint server metadata

### DIFF
--- a/server.json
+++ b/server.json
@@ -24,6 +24,14 @@
       "transport": {
         "type": "stdio"
       }
+    },
+    {
+      "registryType": "pypi",
+      "identifier": "axint",
+      "version": "0.4.23",
+      "transport": {
+        "type": "stdio"
+      }
     }
   ],
   "capabilities": {


### PR DESCRIPTION
## Summary
- restore the PyPI axint@0.4.23 package entry in server.json now that the coordinated release is live
- keep the npm package and remote MCP endpoint intact so registries can discover every valid install surface

## Verification
- npx -y mcp-publisher validate server.json
- npm run versions:check
- npm run docs:check