### PR TITLE
Sync Registry package count

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.23 · 34 MCP tools + 5 prompts · 204 diagnostic codes · 1305 tests · 29 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.23 · 34 MCP tools + 5 prompts · 204 diagnostic codes · 1305 tests · 39 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/metrics.json
+++ b/metrics.json
@@ -87,6 +87,6 @@
     "typescript": 1191,
     "python": 114
   },
-  "registryPackages": 29,
+  "registryPackages": 39,
   "distributionSurfaces": 4
 }


### PR DESCRIPTION
Updates public proof metrics and the README proof line after the Registry reached 39 live packages with demo coverage.