### PR TITLE
Fix MCP Marketplace security scan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.23",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.9.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "commander": "^14.0.3",
         "typescript": "^6.0.3"
       },
@@ -3211,9 +3211,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -111,8 +111,11 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "commander": "^14.0.3",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "ip-address": "^10.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- raise the declared MCP TypeScript SDK dependency floor to the current 1.29.0 line
- add a targeted npm override for ip-address 10.2.0 so the transitive express-rate-limit advisory is cleared
- refresh package-lock so marketplace and npm scanners see the clean dependency graph

## Validation
- npm audit --omit=dev
- npm run typecheck
- npm test -- tests/mcp/server.test.ts tests/core/scaffold.test.ts
- npm run build
- npm run metrics:check
- npm pack --dry-run