### PR TITLE
Release Axint 0.4.24 project version sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+## [0.4.24] — 2026-05-06
+
+### Added
+
+- **Project-pack version sync** — `axint project sync-version` plus the `axint.project.syncVersion` MCP tool update Axint-owned project hints after an upgrade, including `.axint/project.json`, `AGENTS.md`, `CLAUDE.md`, `.axint/AXINT_MEMORY.md`, `.axint/AXINT_REHYDRATE.md`, `.axint/AXINT_DOCS_CONTEXT.md`, and `.axint/README.md`.
+
+### Fixed
+
+- **Same-thread upgrade drift** — project packs no longer keep telling agents to expect an older Axint version after `axint upgrade --apply`; users can run one command to refresh the local truth without overwriting unrelated notes.
+- **MCP Marketplace security scan** — updated the MCP SDK dependency path and pinned the transitive `ip-address` resolution so package scanners no longer report the old ReDoS / DNS rebinding vulnerability chain.
+
 ## [0.4.23] — 2026-05-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.23 · 34 MCP tools + 5 prompts · 204 diagnostic codes · 1305 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.24 · 35 MCP tools + 5 prompts · 204 diagnostic codes · 1306 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -423,6 +423,7 @@ MCP tools and built-in prompts:
 | `axint.feature` | Generate an editable feature package: intents, views, widgets, components, app shells, stores, tests, and support fragments |
 | `axint.project.pack` | Generate `.mcp.json`, `AGENTS.md`, `CLAUDE.md`, `.axint` rehydration/memory/docs/project files, and the session-first workflow for first-try agent setup |
 | `axint.project.index` | Scan the local Apple project and write a compact `.axint/context` pack so Cloud Check can reason over changed files and nearby SwiftUI surfaces |
+| `axint.project.syncVersion` | Refresh Axint-owned project-pack version hints after an upgrade so local agent truth does not point at an older package |
 | `axint.context.memory` | Return the compact Axint operating memory for new chats and context-compaction recovery |
 | `axint.context.docs` | Return the project-local Axint docs context so agents can reload docs after compaction |
 | `axint.suggest` | Suggest app-specific Apple-native features, reusable components, and shared stores from a product description |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## 2026-05-06 — Project-pack version sync and MCP Marketplace hardening
+
+This release tightens the upgrade story. When Axint updates inside a long-running
+agent workflow, the package version, MCP server version, and local project-pack
+truth need to agree.
+
+### Added
+
+- `axint project sync-version`
+  - Updates Axint-owned project version hints after an upgrade.
+  - Refreshes `.axint/project.json`, `AGENTS.md`, `CLAUDE.md`, and the Axint-owned `.axint` memory/rehydration/docs files.
+  - Leaves unrelated user-authored notes alone unless they match a known Axint version marker.
+  - Supports `--dry-run`, `--version`, `--dir`, and `--format json`.
+- `axint.project.syncVersion`
+  - MCP equivalent for agents that need to refresh stale project-pack truth without leaving the active thread.
+
+### Fixed
+
+- MCP Marketplace package scanners now see the patched MCP SDK path and the safe `ip-address` resolution.
+- Same-thread upgrades no longer leave the local project pack telling agents to expect the previous Axint version.
+
 ## 2026-05-05 — Create Axint App Day Agent launchpad
 
 This release wave turns first use into something developers can demo, screenshot,

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.4.23",
-  "mcpTools": 34,
+  "version": "0.4.24",
+  "mcpTools": 35,
   "mcpToolNames": [
     "axint.status",
     "axint.upgrade",
@@ -11,6 +11,7 @@
     "axint.feature",
     "axint.project.pack",
     "axint.project.index",
+    "axint.project.syncVersion",
     "axint.context.memory",
     "axint.context.docs",
     "axint.suggest",
@@ -84,7 +85,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1191,
+    "typescript": 1192,
     "python": 114
   },
   "registryPackages": 58,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.23",
+      "version": "0.4.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.23"
+__version__ = "0.4.24"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.23"
+version = "0.4.24"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -2,14 +2,14 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.agenticempire/axint",
   "title": "Axint",
-  "description": "Apple-native AI agent execution: 34 MCP tools, 5 prompts, compile, validate, repair, and prove.",
+  "description": "Apple-native AI agent execution: 35 MCP tools, 5 prompts, compile, validate, repair, and prove.",
   "repository": {
     "url": "https://github.com/agenticempire/axint",
     "source": "github"
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.23",
+      "version": "0.4.24",
       "transport": {
         "type": "stdio"
       }
@@ -28,14 +28,14 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.23",
+      "version": "0.4.24",
       "transport": {
         "type": "stdio"
       }
     }
   ],
   "capabilities": {
-    "tools": 34,
+    "tools": 35,
     "prompts": 5
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,6 +33,7 @@
  *   axint doctor                  Audit version truth, MCP wiring, and project start files
  *   axint project init            Write Axint project-start files for agent workflows
  *   axint project index           Index the local Apple project into .axint/context
+ *   axint project sync-version    Refresh Axint-owned project-pack version hints after an upgrade
  *   axint session start           Start an enforced Axint agent session and refresh context
  *   axint workflow check          Run workflow gates from CLI when MCP is unavailable
  *   axint run                     Run Axint's enforced Apple build/test/runtime loop
@@ -154,6 +155,7 @@ program
   .description(
     "The open-source compiler that transforms AI agent definitions into native Apple App Intents."
   )
+  .enablePositionalOptions()
   .version(VERSION)
   .addHelpText(
     "after",

--- a/src/cli/project.ts
+++ b/src/cli/project.ts
@@ -12,6 +12,11 @@ import {
   writeProjectContextIndex,
   type ProjectContextIndexFormat,
 } from "../project/context-index.js";
+import {
+  renderProjectVersionSync,
+  syncProjectVersion,
+  type ProjectVersionSyncFormat,
+} from "../project/version-sync.js";
 
 export function registerProject(program: Command, version: string) {
   const project = program
@@ -101,6 +106,36 @@ export function registerProject(program: Command, version: string) {
         console.log(renderProjectContextIndex(result.index, options.format));
       }
     );
+
+  project
+    .command("sync-version")
+    .description(
+      "Update Axint-owned project-pack version hints after upgrading the package"
+    )
+    .option("--dir <dir>", "Project directory to update", ".")
+    .option("--version <version>", "Axint version to write. Defaults to this CLI version")
+    .option("--dry-run", "Print what would change without writing files")
+    .option(
+      "--format <format>",
+      "Output format: markdown or json",
+      parseVersionSyncFormat,
+      "markdown" as ProjectVersionSyncFormat
+    )
+    .action(
+      (options: {
+        dir: string;
+        version?: string;
+        dryRun?: boolean;
+        format: ProjectVersionSyncFormat;
+      }) => {
+        const result = syncProjectVersion({
+          targetDir: options.dir,
+          version: options.version ?? version,
+          dryRun: options.dryRun ?? false,
+        });
+        console.log(renderProjectVersionSync(result, options.format));
+      }
+    );
 }
 
 function parseAgent(value: string): ProjectAgent {
@@ -122,4 +157,9 @@ function parseFormat(value: string): ProjectStartPackFormat {
 function parseContextIndexFormat(value: string): ProjectContextIndexFormat {
   if (value === "markdown" || value === "json") return value;
   throw new Error(`invalid context index format: ${value}`);
+}
+
+function parseVersionSyncFormat(value: string): ProjectVersionSyncFormat {
+  if (value === "markdown" || value === "json") return value;
+  throw new Error(`invalid project version sync format: ${value}`);
 }

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -544,6 +544,44 @@ export const TOOL_MANIFEST = [
     },
   },
   {
+    name: "axint.project.syncVersion",
+    description:
+      "Update Axint-owned project-pack version hints after an upgrade. " +
+      "Use this after axint.upgrade or npm/pip upgrades so .axint/project.json, " +
+      "AGENTS.md, CLAUDE.md, and Axint rehydration docs stop pointing agents at an older package version.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        targetDir: {
+          type: "string",
+          description:
+            "Project directory to update. Defaults to the current working directory.",
+        },
+        version: {
+          type: "string",
+          description:
+            "Axint version to write. Defaults to the running MCP server version.",
+        },
+        dryRun: {
+          type: "boolean",
+          description:
+            "When true, reports the files that would change without writing them.",
+        },
+        format: {
+          type: "string",
+          enum: ["markdown", "json"],
+          description: "Output format. Defaults to markdown.",
+        },
+      },
+    },
+  },
+  {
     name: "axint.context.memory",
     description:
       "Return the compact Axint operating memory that agents should reload " +

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -36,6 +36,7 @@
  *   - axint.upgrade:          Check/apply Axint upgrades with same-thread recovery
  *   - axint.project.pack:     Generate first-try project-start files
  *   - axint.project.index:    Index the local Apple project into .axint/context
+ *   - axint.project.syncVersion: Sync stale project-pack version hints
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -115,6 +116,11 @@ import {
   writeProjectContextIndex,
   type ProjectContextIndexFormat,
 } from "../project/context-index.js";
+import {
+  renderProjectVersionSync,
+  syncProjectVersion,
+  type ProjectVersionSyncFormat,
+} from "../project/version-sync.js";
 import { buildAxintDocsContext } from "../project/docs-context.js";
 import { buildAxintOperatingMemory } from "../project/operating-memory.js";
 import {
@@ -227,6 +233,12 @@ type ProjectContextArgs = {
   includeGit?: boolean;
   dryRun?: boolean;
   format?: ProjectContextIndexFormat;
+};
+type ProjectVersionSyncArgs = {
+  targetDir?: string;
+  version?: string;
+  dryRun?: boolean;
+  format?: ProjectVersionSyncFormat;
 };
 
 // Read version from package.json so it stays in sync.
@@ -835,6 +847,18 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
         },
       ],
     };
+  }
+
+  if (name === "axint.project.syncVersion") {
+    const payload = (args ?? {}) as ProjectVersionSyncArgs;
+    const result = syncProjectVersion({
+      targetDir: payload.targetDir,
+      version: payload.version ?? pkg.version,
+      dryRun: payload.dryRun ?? false,
+    });
+    return diagnosticsText(
+      renderProjectVersionSync(result, payload.format ?? "markdown")
+    );
   }
 
   if (name === "axint.context.memory") {

--- a/src/project/docs-context.ts
+++ b/src/project/docs-context.ts
@@ -182,6 +182,7 @@ axint.tokens.ingest -> axint.suggest -> axint.feature with context -> axint.swif
 - \`axint.xcode.guard\`: Xcode-only drift guard that enforces fresh Axint evidence and writes \`.axint/guard/latest.json\` plus \`.axint/guard/latest.md\`.
 - \`axint.xcode.write\`: Xcode-only guarded write lane for files inside the project; Codex/Claude/Cursor/Cowork should use their native patch/edit lane unless they are actually running inside Xcode.
 - \`axint.project.pack\`: returns first-try project setup files without writing.
+- \`axint.project.syncVersion\`: updates Axint-owned project-pack version hints after an upgrade so stale local truth does not mislead agents.
 - \`axint.context.memory\`: returns compact operating memory for context recovery.
 - \`axint.context.docs\`: returns this docs context for context recovery.
 - \`axint.workflow.check\`: gates session-start, context-recovery, planning, before-write, pre-build, and pre-commit; requires the active session token by default.

--- a/src/project/upgrade.ts
+++ b/src/project/upgrade.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { syncProjectVersion, type ProjectVersionSyncResult } from "./version-sync.js";
 
 const AXINT_PACKAGE = "@axint/compiler";
 
@@ -67,6 +68,7 @@ export interface AxintUpgradeReport {
   restartRequiredAfterApply: boolean;
   commands: AxintUpgradeCommand[];
   sameThreadPrompt: string;
+  projectVersionSync?: ProjectVersionSyncResult;
   artifacts?: AxintUpgradeArtifacts;
   notes: string[];
   error?: string;
@@ -176,6 +178,16 @@ export function runAxintUpgrade(
 
   const executed = executeCommands(commands, cwd, runtime);
   const failed = executed.find((command) => command.status === "fail");
+  const projectVersionSync = failed
+    ? undefined
+    : syncProjectVersion({ targetDir: cwd, version: targetVersion });
+  if (projectVersionSync) {
+    const unavailable =
+      projectVersionSync.skipped.length + projectVersionSync.missing.length;
+    notes.push(
+      `Project version sync refreshed ${projectVersionSync.updated.length} Axint-owned file${projectVersionSync.updated.length === 1 ? "" : "s"} and skipped ${unavailable} unavailable/non-Axint-owned file${unavailable === 1 ? "" : "s"}.`
+    );
+  }
   const report = buildReport({
     cwd,
     generatedAt: now.toISOString(),
@@ -187,6 +199,7 @@ export function runAxintUpgrade(
     reinstallXcode,
     status: failed ? "fail" : "upgraded",
     commands: executed,
+    projectVersionSync,
     notes,
     error: failed?.error ?? failed?.stderr,
   });
@@ -239,6 +252,17 @@ export function renderAxintUpgradeReport(
     report.notes.length > 0
       ? ["", "## Notes", "", ...report.notes.map((note) => `- ${note}`)]
       : [];
+  const projectSync = report.projectVersionSync
+    ? [
+        "",
+        "## Project Version Sync",
+        "",
+        `- Updated: ${report.projectVersionSync.updated.length}`,
+        `- Unchanged: ${report.projectVersionSync.unchanged.length}`,
+        `- Missing: ${report.projectVersionSync.missing.length}`,
+        `- Skipped: ${report.projectVersionSync.skipped.length}`,
+      ]
+    : [];
 
   return [
     "# Axint Same-Thread Upgrade",
@@ -260,6 +284,7 @@ export function renderAxintUpgradeReport(
     "```text",
     report.sameThreadPrompt,
     "```",
+    ...projectSync,
     ...artifacts,
     ...notes,
   ].join("\n");
@@ -358,6 +383,7 @@ function buildReport(input: {
   reinstallXcode: boolean;
   status: AxintUpgradeStatus;
   commands: AxintUpgradeCommand[];
+  projectVersionSync?: ProjectVersionSyncResult;
   notes: string[];
   error?: string;
 }): AxintUpgradeReport {
@@ -377,6 +403,7 @@ function buildReport(input: {
     restartRequiredAfterApply: input.updateAvailable,
     commands: input.commands,
     sameThreadPrompt: buildSameThreadPrompt(input),
+    projectVersionSync: input.projectVersionSync,
     notes: input.notes,
     error: input.error,
   };
@@ -415,12 +442,17 @@ function buildSameThreadPrompt(input: {
     input.status === "current"
       ? "Before editing code, call axint.status if you need to prove the currently connected MCP version."
       : "After the MCP process reconnects, call axint.status and confirm the running version before editing code.";
+  const syncLine =
+    input.status === "upgraded"
+      ? `Axint already refreshed any Axint-owned project version hints it found. If another checkout still has stale hints, run: axint project sync-version --dir ${quoteShellArg(input.cwd)} --version ${input.targetVersion}`
+      : `If local project instructions still name an older Axint version, run: axint project sync-version --dir ${quoteShellArg(input.cwd)} --version ${input.targetVersion || input.currentVersion}`;
 
   return [
     action,
     "Keep this chat/thread. Do not restart from scratch.",
     reloadLine,
     statusLine,
+    syncLine,
     "Then call axint.session.start or axint.context.memory if the agent needs compact context recovery.",
     xcodeLine,
     `Project cwd: ${input.cwd}`,

--- a/src/project/version-sync.ts
+++ b/src/project/version-sync.ts
@@ -1,0 +1,276 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export type ProjectVersionSyncFormat = "markdown" | "json";
+export type ProjectVersionSyncFileStatus =
+  | "updated"
+  | "unchanged"
+  | "missing"
+  | "skipped"
+  | "error";
+
+export interface ProjectVersionSyncChange {
+  label: string;
+  before?: string;
+  after: string;
+}
+
+export interface ProjectVersionSyncFile {
+  path: string;
+  status: ProjectVersionSyncFileStatus;
+  detail: string;
+  changes: ProjectVersionSyncChange[];
+}
+
+export interface ProjectVersionSyncResult {
+  targetDir: string;
+  version: string;
+  dryRun: boolean;
+  files: ProjectVersionSyncFile[];
+  updated: string[];
+  unchanged: string[];
+  missing: string[];
+  skipped: string[];
+  errors: string[];
+}
+
+export interface ProjectVersionSyncOptions {
+  targetDir?: string;
+  version: string;
+  dryRun?: boolean;
+}
+
+const PROJECT_JSON_PATH = ".axint/project.json";
+const AXINT_OWNED_MARKDOWN_FILES = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  ".axint/AXINT_MEMORY.md",
+  ".axint/AXINT_REHYDRATE.md",
+  ".axint/AXINT_DOCS_CONTEXT.md",
+  ".axint/README.md",
+];
+
+export function syncProjectVersion(
+  options: ProjectVersionSyncOptions
+): ProjectVersionSyncResult {
+  const targetDir = resolve(options.targetDir ?? process.cwd());
+  const version = options.version.trim();
+  const dryRun = Boolean(options.dryRun);
+  const files: ProjectVersionSyncFile[] = [
+    syncProjectJson({ targetDir, version, dryRun }),
+    ...AXINT_OWNED_MARKDOWN_FILES.map((path) =>
+      syncMarkdownFile({ targetDir, path, version, dryRun })
+    ),
+  ];
+
+  return {
+    targetDir,
+    version,
+    dryRun,
+    files,
+    updated: files.filter((file) => file.status === "updated").map((file) => file.path),
+    unchanged: files
+      .filter((file) => file.status === "unchanged")
+      .map((file) => file.path),
+    missing: files.filter((file) => file.status === "missing").map((file) => file.path),
+    skipped: files.filter((file) => file.status === "skipped").map((file) => file.path),
+    errors: files.filter((file) => file.status === "error").map((file) => file.path),
+  };
+}
+
+export function renderProjectVersionSync(
+  result: ProjectVersionSyncResult,
+  format: ProjectVersionSyncFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(result, null, 2);
+
+  const lines = [
+    "# Axint Project Version Sync",
+    "",
+    `- Target: ${result.targetDir}`,
+    `- Version: ${result.version}`,
+    `- Dry run: ${result.dryRun ? "yes" : "no"}`,
+    `- Updated: ${result.updated.length}`,
+    `- Unchanged: ${result.unchanged.length}`,
+    `- Missing: ${result.missing.length}`,
+    `- Skipped: ${result.skipped.length}`,
+    `- Errors: ${result.errors.length}`,
+    "",
+    "## Files",
+  ];
+
+  for (const file of result.files) {
+    const changes = file.changes
+      .map((change) =>
+        change.before
+          ? `${change.label}: ${change.before} -> ${change.after}`
+          : `${change.label}: ${change.after}`
+      )
+      .join("; ");
+    lines.push(
+      `- ${file.status.toUpperCase()} ${file.path}: ${file.detail}${
+        changes ? ` (${changes})` : ""
+      }`
+    );
+  }
+
+  if (result.updated.length > 0 && !result.dryRun) {
+    lines.push(
+      "",
+      "Next: call `axint.status`, then `axint.workflow.check` so the active agent proves it is using the refreshed project truth."
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function syncProjectJson(input: {
+  targetDir: string;
+  version: string;
+  dryRun: boolean;
+}): ProjectVersionSyncFile {
+  const fullPath = resolve(input.targetDir, PROJECT_JSON_PATH);
+  if (!existsSync(fullPath)) {
+    return fileResult(PROJECT_JSON_PATH, "missing", "file does not exist");
+  }
+
+  try {
+    const text = readFileSync(fullPath, "utf-8");
+    const data = JSON.parse(text) as Record<string, unknown>;
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      return fileResult(PROJECT_JSON_PATH, "error", "expected a JSON object");
+    }
+
+    const changes: ProjectVersionSyncChange[] = [];
+    setVersionField(data, "axintVersion", input.version, changes);
+    if (Object.prototype.hasOwnProperty.call(data, "expectedVersion")) {
+      setVersionField(data, "expectedVersion", input.version, changes);
+    }
+
+    if (changes.length === 0) {
+      return fileResult(PROJECT_JSON_PATH, "unchanged", "already on target version");
+    }
+
+    if (!input.dryRun) {
+      writeFileSync(fullPath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+    }
+
+    return fileResult(
+      PROJECT_JSON_PATH,
+      "updated",
+      input.dryRun
+        ? "would update machine-readable project version"
+        : "updated machine-readable project version",
+      changes
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return fileResult(PROJECT_JSON_PATH, "error", message);
+  }
+}
+
+function setVersionField(
+  data: Record<string, unknown>,
+  field: string,
+  version: string,
+  changes: ProjectVersionSyncChange[]
+): void {
+  const before = typeof data[field] === "string" ? data[field] : undefined;
+  if (before === version) return;
+  data[field] = version;
+  changes.push({ label: field, before, after: version });
+}
+
+function syncMarkdownFile(input: {
+  targetDir: string;
+  path: string;
+  version: string;
+  dryRun: boolean;
+}): ProjectVersionSyncFile {
+  const fullPath = resolve(input.targetDir, input.path);
+  if (!existsSync(fullPath)) {
+    return fileResult(input.path, "missing", "file does not exist");
+  }
+
+  try {
+    const before = readFileSync(fullPath, "utf-8");
+    const changes: ProjectVersionSyncChange[] = [];
+    const hasOwnedMarker =
+      /^(?:\s*(?:[-*]\s*)?Expected Axint version:\s*.+?)\s*$/m.test(before) ||
+      /^.*Expected Axint package version from this project pack:\s*.+?\.\s*$/m.test(
+        before
+      );
+    let after = replaceVersionLine(
+      before,
+      /^(?<prefix>\s*(?:[-*]\s*)?Expected Axint version:\s*)(?<value>.+?)\s*$/gm,
+      "Expected Axint version",
+      input.version,
+      changes
+    );
+    after = replaceVersionLine(
+      after,
+      /^(?<prefix>.*Expected Axint package version from this project pack:\s*)(?<value>.+?)(?<suffix>\.)\s*$/gm,
+      "Expected Axint package version from this project pack",
+      input.version,
+      changes
+    );
+
+    if (changes.length === 0) {
+      return fileResult(
+        input.path,
+        hasOwnedMarker ? "unchanged" : "skipped",
+        hasOwnedMarker
+          ? "already on target version"
+          : "no Axint-owned version marker found"
+      );
+    }
+
+    if (after === before) {
+      return fileResult(input.path, "unchanged", "already on target version");
+    }
+
+    if (!input.dryRun) {
+      writeFileSync(fullPath, after, "utf-8");
+    }
+
+    return fileResult(
+      input.path,
+      "updated",
+      input.dryRun
+        ? "would update Axint-owned version markers"
+        : "updated Axint-owned version markers",
+      changes
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return fileResult(input.path, "error", message);
+  }
+}
+
+function replaceVersionLine(
+  text: string,
+  pattern: RegExp,
+  label: string,
+  version: string,
+  changes: ProjectVersionSyncChange[]
+): string {
+  return text.replace(pattern, (match: string, ...args: unknown[]) => {
+    const groups = args[args.length - 1] as
+      | { prefix?: string; value?: string; suffix?: string }
+      | undefined;
+    if (!groups?.prefix || !groups.value) return match;
+    const before = groups.value.trim();
+    if (before === version) return match;
+    changes.push({ label, before, after: version });
+    return `${groups.prefix}${version}${groups.suffix ?? ""}`;
+  });
+}
+
+function fileResult(
+  path: string,
+  status: ProjectVersionSyncFileStatus,
+  detail: string,
+  changes: ProjectVersionSyncChange[] = []
+): ProjectVersionSyncFile {
+  return { path, status, detail, changes };
+}

--- a/tests/mcp/machine.test.ts
+++ b/tests/mcp/machine.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -9,6 +9,7 @@ import {
   writeProjectStartPack,
 } from "../../src/project/start-pack.js";
 import { startAxintSession } from "../../src/project/session.js";
+import { syncProjectVersion } from "../../src/project/version-sync.js";
 
 let tempDirs: string[] = [];
 
@@ -131,6 +132,56 @@ describe("Axint project machine", () => {
     expect(second.skipped).toContain("AGENTS.md");
   });
 
+  it("syncs Axint-owned project pack version hints without touching unrelated notes", () => {
+    const dir = tempDir();
+    writeProjectStartPack({
+      targetDir: dir,
+      projectName: "Swarm",
+      version: "0.4.21",
+    });
+
+    const agentsPath = join(dir, "AGENTS.md");
+    const originalAgents = readFileSync(agentsPath, "utf-8");
+    const customNote = "\nUser note: keep this sentence exactly as written.\n";
+    writeFileSync(agentsPath, originalAgents + customNote, "utf-8");
+
+    const dryRun = syncProjectVersion({
+      targetDir: dir,
+      version: "0.4.24",
+      dryRun: true,
+    });
+    expect(dryRun.updated).toContain(".axint/project.json");
+    expect(readFileSync(join(dir, ".axint/project.json"), "utf-8")).toContain(
+      '"axintVersion": "0.4.21"'
+    );
+
+    const result = syncProjectVersion({
+      targetDir: dir,
+      version: "0.4.24",
+    });
+
+    expect(result.updated).toEqual([
+      ".axint/project.json",
+      "AGENTS.md",
+      "CLAUDE.md",
+      ".axint/AXINT_MEMORY.md",
+      ".axint/AXINT_REHYDRATE.md",
+      ".axint/AXINT_DOCS_CONTEXT.md",
+      ".axint/README.md",
+    ]);
+    expect(readFileSync(join(dir, ".axint/project.json"), "utf-8")).toContain(
+      '"axintVersion": "0.4.24"'
+    );
+    expect(readFileSync(agentsPath, "utf-8")).toContain("Expected Axint version: 0.4.24");
+    expect(readFileSync(agentsPath, "utf-8")).toContain(
+      "Expected Axint package version from this project pack: 0.4.24."
+    );
+    expect(readFileSync(agentsPath, "utf-8")).toContain(customNote.trim());
+    expect(readFileSync(join(dir, ".axint/AXINT_DOCS_CONTEXT.md"), "utf-8")).toContain(
+      "Expected Axint version: 0.4.24"
+    );
+  });
+
   it("starts a durable Axint session for enforced workflow gates", () => {
     const dir = tempDir();
     const result = startAxintSession({
@@ -234,5 +285,22 @@ describe("Axint project machine", () => {
     const context = JSON.parse(contextResult.content[0].text);
     expect(context.schema).toBe("https://axint.ai/schemas/project-context-index.v1.json");
     expect(context.projectName).toBe("Swarm");
+
+    writeProjectStartPack({
+      targetDir: sessionDir,
+      projectName: "Swarm",
+      version: "0.4.21",
+      force: true,
+    });
+    const syncResult = await handleToolCall("axint.project.syncVersion", {
+      targetDir: sessionDir,
+      version: "0.4.24",
+      format: "json",
+    });
+    const sync = JSON.parse(syncResult.content[0].text);
+    expect(sync.updated).toContain(".axint/project.json");
+    expect(readFileSync(join(sessionDir, ".axint/project.json"), "utf-8")).toContain(
+      '"axintVersion": "0.4.24"'
+    );
   });
 });

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.23";
+const VERSION = "0.4.24";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary

Ships Axint 0.4.24 with project-pack version sync for same-thread upgrade recovery.

## Changes

- Adds `axint project sync-version` for CLI users.
- Adds `axint.project.syncVersion` for MCP clients.
- Updates `axint.upgrade` to refresh Axint-owned project version markers after successful apply.
- Bumps npm, PyPI, extension, server, worker, metrics, README, changelog, and release-note truth to 0.4.24.
- Keeps MCP Marketplace metadata aligned at 35 tools and 5 prompts.

## Validation

- `npm audit --audit-level=moderate`
- `npm run typecheck`
- `npm run typecheck:examples`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run docs:check`
- `npm run versions:check`
- `npm run metrics:check`
- `npm run release:check`
- `python3 -m pip install -e '.[dev]' && pytest -v`
- `python3 -m build && python3 -m twine check dist/*`
- `npm pack --dry-run`
