### PR TITLE
Release Axint 0.4.25 lockfile hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+## [0.4.25] — 2026-05-06
+
+### Fixed
+
+- **GitHub security parity** — added the pnpm override and refreshed `pnpm-lock.yaml` so Dependabot, MCP Marketplace, and package scanners no longer see the stale `ip-address@10.1.0` path after the npm lock had already been hardened.
+
 ## [0.4.24] — 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.24 · 35 MCP tools + 5 prompts · 204 diagnostic codes · 1306 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.25 · 35 MCP tools + 5 prompts · 204 diagnostic codes · 1306 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## 2026-05-06 — pnpm lockfile security parity
+
+This patch closes the remaining scanner gap after the MCP SDK and npm lockfile
+were already clean.
+
+### Fixed
+
+- `pnpm-lock.yaml` now resolves `ip-address` through the safe `10.2.x` line.
+- `package.json` includes a matching pnpm override so future lockfile refreshes do not reintroduce the stale vulnerable path.
+- Public truth advances to v0.4.25 with the same 35-tool MCP surface introduced in v0.4.24.
+
 ## 2026-05-06 — Project-pack version sync and MCP Marketplace hardening
 
 This release tightens the upgrade story. When Axint updates inside a long-running

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.24",
+  "version": "0.4.25",
   "mcpTools": 35,
   "mcpToolNames": [
     "axint.status",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.24",
+      "version": "0.4.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"
@@ -117,5 +117,10 @@
   },
   "overrides": {
     "ip-address": "^10.2.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "ip-address": "^10.2.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ip-address: ^10.2.0
+
 importers:
 
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.9.0
+        specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
       commander:
         specifier: ^14.0.3
@@ -1088,8 +1091,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2589,7 +2592,7 @@ snapshots:
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -2742,7 +2745,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.24"
+__version__ = "0.4.25"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.24"
+version = "0.4.25"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.24",
+      "version": "0.4.25",
       "transport": {
         "type": "stdio"
       }
@@ -28,7 +28,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.24",
+      "version": "0.4.25",
       "transport": {
         "type": "stdio"
       }

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.24";
+const VERSION = "0.4.25";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary
- Release Axint 0.4.25 as a focused lockfile-hardening patch.
- Add a pnpm override for `ip-address` and refresh `pnpm-lock.yaml` so scanners no longer see the stale `10.1.0` dependency path.
- Advance npm, PyPI, MCP registry, README, metrics, and release-note version surfaces to 0.4.25.

## Validation
- `npm audit --audit-level=moderate`
- `npm run versions:check`
- `npm run metrics:check`
- `npm run docs:check`
- `npm run typecheck`
- `npm run typecheck:examples`
- `npm run boundary:check`
- `npm run lint`
- `npm run build`
- `npm test -- tests/mcp/machine.test.ts tests/project/upgrade.test.ts tests/mcp/server.test.ts tests/cli/status.test.ts`
- `npm test`
- `npm run release:check`
- `npm pack --dry-run`
- `python3 -m build && python3 -m twine check dist/*`
