### PR TITLE
Release Axint 0.4.26 MCP entrypoint compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+## [0.4.26] — 2026-05-06
+
+### Fixed
+
+- **MCP marketplace runtime entrypoint** — `node dist/mcp/index.js` now starts the stdio MCP server when executed directly, while remaining safe to import as `@axint/compiler/mcp`. This matches Glama-style container launch specs that run `mcp-proxy -- node dist/mcp/index.js`.
+
 ## [0.4.25] — 2026-05-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.25 · 35 MCP tools + 5 prompts · 204 diagnostic codes · 1306 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.26 · 35 MCP tools + 5 prompts · 204 diagnostic codes · 1307 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## 2026-05-06 — Glama MCP entrypoint compatibility
+
+This patch fixes the container launch path used by Glama and other MCP
+marketplaces that execute the package MCP export file directly.
+
+### Fixed
+
+- `node dist/mcp/index.js` now starts the stdio MCP server when executed
+  directly, matching `mcp-proxy -- node dist/mcp/index.js` launch specs.
+- `@axint/compiler/mcp` remains import-safe for SDK consumers and tests.
+- Added a regression test so the direct entrypoint cannot silently become
+  export-only again.
+
 ## 2026-05-06 — pnpm lockfile security parity
 
 This patch closes the remaining scanner gap after the MCP SDK and npm lockfile

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — App Intents Compiler",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.25",
+  "version": "0.4.26",
   "mcpTools": 35,
   "mcpToolNames": [
     "axint.status",
@@ -85,7 +85,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1192,
+    "typescript": 1193,
     "python": 114
   },
   "registryPackages": 58,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.25"
+__version__ = "0.4.26"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.25"
+version = "0.4.26"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "transport": {
         "type": "stdio"
       }
@@ -28,7 +28,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "transport": {
         "type": "stdio"
       }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,7 +1,30 @@
-export { createAxintServer, startMCPServer } from "./server.js";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createAxintServer, startMCPServer } from "./server.js";
+
+export { createAxintServer, startMCPServer };
 export {
   TOOL_MANIFEST,
   compactToolManifest,
   getRuntimeToolManifest,
 } from "./manifest.js";
 export { PROMPT_MANIFEST, getPromptMessages } from "./prompts.js";
+
+function isDirectEntrypoint(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+
+  try {
+    return resolve(fileURLToPath(import.meta.url)) === resolve(entry);
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectEntrypoint()) {
+  startMCPServer().catch((err: Error) => {
+    console.error("Failed to start MCP server:", err);
+    process.exit(1);
+  });
+}

--- a/tests/mcp/index.test.ts
+++ b/tests/mcp/index.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 describe("axint/mcp import surface", () => {
   it("is importable without starting the stdio server", async () => {
@@ -43,5 +49,44 @@ describe("axint/mcp import surface", () => {
     expect(JSON.stringify(compact).length).toBeLessThan(
       JSON.stringify(full).length * 0.85
     );
+  });
+
+  it("starts the stdio server when the package MCP entrypoint is executed directly", async () => {
+    const child = spawn(process.execPath, ["--import", "tsx", "src/mcp/index.ts"], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        AXINT_TELEMETRY_OPTOUT: "1",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let exit:
+      | {
+          code: number | null;
+          signal: NodeJS.Signals | null;
+        }
+      | undefined;
+    let stderr = "";
+
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("exit", (code, signal) => {
+      exit = { code, signal };
+    });
+
+    try {
+      await wait(500);
+      expect(exit, stderr).toBeUndefined();
+    } finally {
+      child.kill("SIGTERM");
+      await Promise.race([
+        once(child, "exit"),
+        wait(2_000).then(() => {
+          child.kill("SIGKILL");
+        }),
+      ]);
+    }
   });
 });

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.25";
+const VERSION = "0.4.26";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary
- Release Axint 0.4.26 as a focused MCP marketplace compatibility patch.
- Make `node dist/mcp/index.js` start the stdio MCP server when executed directly, while preserving import-safe `@axint/compiler/mcp` behavior.
- Add a regression test for the direct MCP entrypoint and advance public truth to 1307 tests.

## Glama compatibility proof
- `npx -y mcp-proxy@6.4.3 -- node dist/mcp/index.js` stayed alive locally and started the proxy instead of closing the child transport.

## Validation
- `npm audit --audit-level=moderate`
- `npm run versions:check`
- `npm run metrics:check`
- `npm run docs:check`
- `npm run typecheck`
- `npm run typecheck:examples`
- `npm run boundary:check`
- `npm run lint`
- `npm run build`
- `npm test -- tests/mcp/index.test.ts tests/mcp/server.test.ts tests/mcp/machine.test.ts`
- `npm test`
- `npm run release:check`
- `npm pack --dry-run`
- `python3 -m build && python3 -m twine check dist/*`
