### PR TITLE
Refresh GitHub project positioning

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,7 +49,7 @@ body:
     attributes:
       label: Axint Version
       description: Output of `axint --version`
-      placeholder: "0.1.0"
+      placeholder: "0.4.x"
     validations:
       required: true
 
@@ -58,10 +58,17 @@ body:
     attributes:
       label: Component
       options:
-        - Compiler (core)
+        - Create app / starter
+        - Compiler / IR
         - Validator
+        - Swift repair rules
+        - Fix Packet
+        - Axint Run / Xcode proof
         - MCP Server
         - CLI
+        - Cloud Check
+        - Registry package
+        - Telemetry / Feedback
         - Templates
         - Documentation
     validations:
@@ -71,4 +78,4 @@ body:
     id: context
     attributes:
       label: Additional Context
-      description: Any other context — OS, Node version, Xcode version, etc.
+      description: Any other context - OS, Node version, Xcode version, MCP host, `.axint/run/latest.md`, or source-free feedback packet ID.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -29,10 +29,17 @@ body:
     attributes:
       label: Component
       options:
-        - Compiler (core)
+        - Create app / starter
+        - Compiler / IR
         - Validator
+        - Swift repair rules
+        - Fix Packet
+        - Axint Run / Xcode proof
         - MCP Server
         - CLI
+        - Cloud Check
+        - Registry package
+        - Telemetry / Feedback
         - Templates
         - Documentation
         - New component

--- a/.github/ISSUE_TEMPLATE/new_template.yml
+++ b/.github/ISSUE_TEMPLATE/new_template.yml
@@ -1,18 +1,18 @@
-name: New Intent Template
-description: Propose or contribute a new App Intent template
+name: New Apple Template
+description: Propose or contribute a new Apple-native template
 title: "[Template]: "
 labels: ["template", "good first issue"]
 body:
   - type: markdown
     attributes:
       value: |
-        Intent templates are the easiest way to contribute to Axint. Describe the template you'd like to add.
+        Templates are one of the easiest ways to contribute to Axint. Describe the Apple-native capability you would like to add.
 
   - type: input
     id: name
     attributes:
       label: Template Name
-      placeholder: "e.g., Smart Home Light Control"
+      placeholder: "e.g., Smart Home Light Control, Menu Bar Timer, Focus Widget"
     validations:
       required: true
 
@@ -28,6 +28,10 @@ body:
         - Health (workouts, health data)
         - Navigation (maps, directions)
         - Finance (payments, transactions)
+        - SwiftUI view
+        - WidgetKit widget
+        - App scaffold
+        - Xcode repair fixture
         - Other
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,8 @@ Closes #
 - [ ] Documentation
 - [ ] Refactor
 - [ ] CI / tooling
+- [ ] MCP / marketplace metadata
+- [ ] Repair / Fix Packet / Xcode proof
 
 ## Checklist
 
@@ -23,4 +25,5 @@ Closes #
 - [ ] Lint and type checks pass (`npm run lint && npm run typecheck`)
 - [ ] Documentation updated (if applicable)
 - [ ] Boundary and metrics checks pass if public surfaces changed (`npm run boundary:check && npm run metrics:check`)
+- [ ] Docs checks pass if README/MCP/package surfaces changed (`npm run docs:check`)
 - [ ] Version parity and release notes checked if package/release surfaces changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,43 +10,50 @@ Thanks for considering a contribution to Axint. This guide will get you oriented
 
 ## Architecture Overview
 
-Understanding the project structure will save you time:
+Understanding the project structure will save you time. Axint is no longer only
+a TypeScript-to-Swift compiler; the repo also contains the repair loop, MCP
+surface, project memory, Xcode proof path, telemetry controls, and starter
+generation that make the compiler useful to agents.
 
 ```
 src/
 ├── core/
 │   ├── parser.ts        # Extracts defineIntent() calls → IR
-│   ├── generator.ts     # Transforms IR → Swift App Intent source
-│   ├── validator.ts     # Validates IR and generated Swift (AX001–AX202)
-│   ├── compiler.ts      # Orchestrates the full pipeline
+│   ├── view-parser.ts   # SwiftUI view parser
+│   ├── widget-parser.ts # WidgetKit parser
+│   ├── app-parser.ts    # SwiftUI app scaffold parser
+│   ├── generator.ts     # Transforms IR → Swift source
+│   ├── swift-validator.ts # Existing Swift repair/diagnostic rules
+│   ├── compiler.ts      # Orchestrates the full compile pipeline
 │   ├── types.ts         # IR types, Swift type mappings, diagnostics
 │   └── index.ts         # Barrel export
 ├── sdk/
 │   └── index.ts         # define*() APIs and helpers (exported from `@axint/compiler`)
 ├── mcp/
 │   ├── server.ts        # MCP server with axint.* tools and built-in prompts
-│   ├── index.ts         # Pure import surface for manifests + server helpers
-│   └── register.ts      # Side-effectful axint-mcp binary entry point
+│   ├── manifest.ts      # Runtime marketplace/tool description surface
+│   ├── index.ts         # Import surface and direct stdio entry point
+│   └── register.ts      # axint-mcp binary entry point
 ├── templates/
 │   └── index.ts         # Intent template registry (templates welcome!)
 └── cli/
-    └── index.ts         # CLI entry — init, compile, validate, watch, publish, xcode
+    └── index.ts         # CLI entry: create, compile, validate, repair, run, xcode
 ```
 
 **Key data flow:**
 
 ```
-TypeScript Intent Definition
+TypeScript / Python / JSON / .axint definition
         ↓
-   core/parser.ts      — extracts defineIntent() call → Intermediate Representation (IR)
+   parser or schema lowering → Intermediate Representation (IR)
         ↓
-   core/validator.ts   — checks IR against Apple API constraints
+   validator           → checks Apple API constraints
         ↓
-   core/generator.ts   — generates Swift App Intent source
+   generator           → emits Swift, plist, and entitlements
         ↓
-   core/validator.ts   — validates generated Swift (import, conformance, perform)
+   Swift validator     → catches build-time Apple and SwiftUI failures
         ↓
-   Swift App Intent
+   Fix Packet / Run proof / MCP response
 ```
 
 ## What We're Looking For
@@ -54,6 +61,7 @@ TypeScript Intent Definition
 ### Always Welcome (just open a PR)
 
 - **New intent templates** — Calendar, reminders, messaging, media playback, smart home, health, maps, payments. Each template in `src/templates/` follows a consistent pattern. Look at an existing one and add yours.
+- **Existing-product repair fixtures** — Small SwiftUI/Xcode examples where Axint should diagnose a real failure such as blocked taps, scroll regressions, missing imports, bad bindings, or concurrency issues.
 - **Documentation** — Better explanations, more examples, typo fixes.
 - **Bug fixes** — Especially with a failing test that demonstrates the issue.
 - **Test coverage** — We can always use more tests, particularly for edge cases in the compiler and validator.
@@ -61,7 +69,7 @@ TypeScript Intent Definition
 ### Welcome With Prior Discussion (open an issue first)
 
 - **New MCP tools** — Additional tools exposed through the MCP server.
-- **Compiler changes** — Modifications to the TypeScript → Swift transformation pipeline.
+- **Compiler changes** — Modifications to the TypeScript/Python/JSON/`.axint` → IR → Swift pipeline.
 - **New target surfaces** — Support for SiriKit, Shortcuts, or other Apple execution surfaces beyond App Intents.
 - **Dependency additions** — Any new runtime dependency needs justification.
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 </p>
 
 <p align="center">
-  <strong>Axint is the compiler and repair loop for agent-built Apple-native software.</strong>
+  <strong>Axint is the Apple-native execution layer for AI coding agents.</strong>
 </p>
 
 <p align="center">
-  Author in TypeScript, Python, or the preview <code>.axint</code> surface.<br>
-  Emit ordinary Swift, validate Apple-specific rules, and hand agents a repair packet when something needs work.
+  Describe App Intents, SwiftUI views, widgets, and app shells in TypeScript, Python, JSON, or the preview <code>.axint</code> surface.<br>
+  Axint emits ordinary Swift, validates Apple-specific rules, and gives agents a repair packet when something needs work.
 </p>
 
 <p align="center">
@@ -44,8 +44,8 @@ capabilities: App Intents, Siri, Shortcuts, Spotlight, widgets, SwiftUI views,
 privacy copy, entitlements, and generated metadata.
 
 General coding agents can produce Swift. Axint makes them operate through a
-smaller contract, validates the Apple-specific parts, and writes a repair
-artifact the next agent run can use.
+smaller contract, validates the Apple-specific parts, coordinates the project
+proof loop, and writes a repair artifact the next agent run can use.
 
 ```
 feature definition
@@ -65,7 +65,7 @@ The compiler is useful on its own. Registry and Cloud extend the same workflow:
 - **Repair** — `axint repair` indexes the existing Apple project, ranks likely files, classifies build/UI/runtime evidence, and returns the smallest patch/proof loop.
 - **MCP** — agents call compile, validate, fix, schema compile, templates, and packet tools directly.
 - **Registry** — install reusable Apple capabilities with source, compiler metadata, and package details attached.
-- **Cloud Check + feedback** — free hosted validation for quick results; signed-in Pro checks add the AI-ready repair prompt, history, and a shareable report. Privacy-safe feedback packets help Axint learn repeated Apple failure modes without shipping source code.
+- **Cloud Check + feedback** — free hosted validation for quick results; signed-in Pro checks add the AI-ready repair prompt, history, and a shareable report. Privacy-safe feedback packets help Axint learn repeated Apple failure modes without sending source code.
 
 [Read the thesis](https://axint.ai/thesis) · [Open proof](https://axint.ai/proof) · [View Fix Packet](https://axint.ai/fix-packet)
 
@@ -115,7 +115,7 @@ the same facts.
 
 ## Quick start
 
-### Create a wow starter
+### Create the Apple Day Agent starter
 
 If you want the fastest shareable proof path, start here:
 
@@ -133,7 +133,7 @@ This creates a premium Apple-native mini app instead of a blank scaffold:
 - `.axint/agent-prompts/` gives Codex, Claude Code, and Cursor the exact proof loop.
 - `ios/App/DayDashboardView.swift` gives the starter a real SwiftUI app shell.
 - `.axint/run/latest.md` starts the durable proof trail.
-- `share/built-with-axint.html` gives you an interactive browser preview with the generated app shell, contracts, Swift, and proof.
+- `share/built-with-axint.html` gives you an interactive proof preview with the generated app shell, contracts, Swift, and proof.
 
 The point is to make the first run feel real: agent writes Apple-native
 contracts, Axint compiles multiple capabilities, validates them, renders a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,176 +1,135 @@
 # Axint Roadmap
 
-_Last updated: April 2026 · Current release: [v0.3.9](https://github.com/agenticempire/axint/releases) · ahead of WWDC 2026_
+_Last updated: May 2026 · Current release: [v0.4.27](https://github.com/agenticempire/axint/releases/tag/v0.4.27)_
 
-Axint is the open-source compiler that turns TypeScript definitions into native Apple platform code — App Intents, SwiftUI views, WidgetKit widgets, and full app scaffolds. This roadmap tracks what's shipped, what's next, and where we need help.
+Axint is the Apple-native execution layer for AI coding agents. The open-source package gives agents a smaller contract for Apple surfaces, emits ordinary Swift, validates Apple-specific rules, writes Fix Packets, and coordinates proof loops across CLI, MCP, Xcode, Registry, and Cloud-facing workflows.
 
-We ship small, tight releases. Everything on this page is open for contribution — see [CONTRIBUTING.md](CONTRIBUTING.md) to get involved.
-
----
-
-## Shipped
-
-### v0.3.4
-
-- **Remote MCP endpoint** — Cloudflare Worker serving the compiler over HTTP for Smithery and hosted MCP clients.
-- **MCP registry metadata** — `server.json`, Dockerfile, tool annotations, and dot-notation tool names for Glama/Smithery/Pulsemcp quality scores.
-
-### v0.3.3
-
-- **Python MCP server** (`axint-mcp-py`) — parity with the TS MCP server's core compile/validate/template flow over stdio.
-- **Smithery listing** — MCP HTTP transport for the Smithery registry.
-- **402 tests** — jumped from 249 to 402 with validator, diagnostics, and generator edge case coverage. The suite has continued to grow since then.
-- **Type safety overhaul** — replaced all unsafe `as` casts with narrowing type guards across the parser and generator.
-- **defineView() + defineWidget() + defineApp()** — three new compilation surfaces shipped end-to-end.
-- **Architecture docs** (`ARCHITECTURE.md`) and shared parser utilities extraction.
-
-### v0.3.0
-
-- **Xcode SPM build plugin** (`spm-plugin/`) — `AxintCompilePlugin` and `AxintValidatePlugin` for `swift build` and Xcode builds. Discovers `axint` via `npx` or `PATH`.
-- **`axint eject`** (`src/core/eject.ts`) — generates standalone Swift with zero Axint dependency. Strips regeneration markers, adds Apple documentation references. Optional XCTest scaffold generation. 12 tests.
-- **EntityQuery + DynamicOptionsProvider** — initial SDK support (`defineEntity()`, `param.entity()`, `param.dynamicOptions()`), IR types (`entityQuery`, `dynamicOptions`, `IREntity`), validator rules AX110–AX113, and two new templates (`search-tasks`, `dynamic-playlist`). Dynamic options inner type extraction and property-based entity query codegen shipped in v0.3.2.
-- **WWDC API adapter pipeline** (`scripts/wwdc-diff.ts`) — nightly CI scanning Apple SDK headers for API changes with priority-ranked adapter recommendations and auto GitHub issue creation on detected changes.
-### v0.2.2
-
-- **`axint init` scaffolder** — one command drops a complete Axint project with pinned deps, tsconfig, a starter intent, and an MCP config pre-wired for Cursor, Claude Code, and Windsurf.
-- **`--emit-info-plist` / `--emit-entitlements` CLI flags** — wired through to the generator, so the Quick Start in the README actually works.
-- **Stage 4 validator (`--sandbox`)** — builds generated Swift in an SPM sandbox on macOS. Gives every intent a "swift build passes" badge before it ever touches Xcode.
-- **`axint templates` command** — list and print bundled templates from the CLI without touching the MCP.
-- **Logo and brand assets** — official SVG mark in `docs/assets/`.
-
-### v0.2.1
-
-- **Package rename**: `axint` → `@axint/compiler` (originally `@axintai`, migrated April 2026) with npm provenance.
-- Vendored compiler in the website sync'd to the published package.
-
-### v0.2.0
-
-- Real TypeScript AST parser (replaced the v0.1.x regex walker).
-- Numeric type fidelity: `param.int`, `param.double`, `param.float` → `Int`, `Double`, `Float`.
-- Return-type inference — `perform()` bodies emit `some IntentResult & ReturnsValue<T>`.
-- `emitInfoPlist` / `emitEntitlements` options on `CompilerOptions` (wired to CLI in v0.2.2).
-- Legacy underscore MCP aliases alongside the current dotted tool names.
-- Ten reference templates: messaging, productivity, health, commerce, smart home.
-- Intent-level metadata (`entitlements`, `infoPlistKeys`, `isDiscoverable`).
-- New validator rules AX107–AX109; new parser diagnostics AX006–AX008.
-- `ios26` / `macos26` target options ready for WWDC.
-
-### v0.1.x
-
-- Core type system and IR, parser, generator, validator with 12 diagnostic codes.
-- CLI (`compile`, `validate`, `--json`), MCP server foundations, and the original parser/generator/validator loop.
-- 117 tests with snapshot + security coverage (98%+).
-- In-browser playground on [axint.ai](https://axint.ai).
+The thesis is simple: agents can write code, but Apple-native software needs proof. Axint turns agent output into validated, repairable, inspectable Apple work.
 
 ---
 
-## Priority — v0.3.x (Target: late May 2026)
+## Shipped Now
 
-Remaining v0.3.0-scope features and polish before the public launch.
+### Execution and repair loop
 
-### 1. Template registry with `axint init --template`
+- `axint run` coordinates session recovery, workflow checks, Swift validation, Cloud Check, `xcodebuild build`, focused tests, full test runs, runtime proof, and durable `.axint/run` artifacts.
+- `axint repair` indexes existing Apple projects, classifies build/UI/runtime evidence, ranks likely files, and returns the smallest patch/proof loop.
+- Fix Packets give agents a shared repair contract through `latest.check.*` for quick verdicts and `latest.*` for full repair instructions.
+- Passing focused UI tests are reconciled with Cloud Check so stale warnings do not override real proof.
+- Failing Xcode tests are extracted into compact failure summaries with test name, file, line, assertion, likely source area, and next repair direction.
 
-Expand beyond the current 10 templates to 25+. Pre-built intents for every common pattern: messaging, health, commerce, smart home, media playback, navigation, file management, search, journaling, RSS, fitness tracking, home automation scenes. `axint init --template messaging` should produce a working intent in 5 seconds.
+### Compiler and Apple coverage
 
-_Status: foundation shipped in v0.2.2 · Target: v0.3.0 · Impact: medium_
+- TypeScript, Python, JSON schema mode, and preview `.axint` inputs compile into Apple-native Swift.
+- Supported surfaces include App Intents, SwiftUI views, WidgetKit widgets, app scaffolds, plist fragments, entitlements, and Apple metadata.
+- The validator covers 204 diagnostic codes across compiler, intent, view, widget, app, Swift build, SwiftUI, accessibility, concurrency, and Live Activity rules.
+- The suite currently tracks 1308 tests across TypeScript and Python paths.
 
-### 7. swift-format integration
+### Agent distribution
 
-Pipe every generated Swift file through Apple's `swift-format` with the default style. Free credibility and alignment with Apple's own codebase.
+- 35 MCP tools and 5 prompts expose compile, validate, repair, suggest, feature generation, project packs, memory, docs context, workflow gates, run status, run cancel, telemetry controls, feedback packets, and template access.
+- MCP marketplace bundles now start directly through `node dist/mcp/index.js` and ship clearer runtime tool descriptions for security/quality scanners.
+- Agent lanes distinguish Xcode-hosted work from Codex, Claude, Cursor, Cowork, VS Code, Windsurf, and other clients so routine edits use the active client's native patch lane while Axint handles proof.
+- Same-thread upgrades let agents update Axint without losing the current project conversation.
 
-_Status: in flight · Target: v0.3.0 · Impact: medium_
+### First-use and templates
 
-### 8. Public docs site — docs.axint.ai
+- `create-axint-app` / `axint create` generates the Apple Day Agent starter: multiple App Intent contracts, generated Swift, plist and entitlement fragments, agent prompts, proof artifacts, and an interactive local proof preview.
+- 26 bundled templates and 58 live Registry packages give agents reusable starting points instead of asking them to hallucinate every Apple surface from scratch.
 
-Astro Starlight docs with one page per concept, live playground embeds, and a searchable API reference.
+### Privacy-safe learning and adoption proof
 
-_Status: scaffolding · Target: v0.3.0 · Impact: medium_
-
----
-
-## Shipped — v0.3.x
-
-### VS Code / Cursor extension
-
-MCP-backed extension (`extensions/vscode/`) exposes the Axint MCP server to VS Code's AI features. Works with GitHub Copilot in agent mode and any VS Code AI feature that supports MCP.
-
-_Status: shipped · v0.3.0_
-
-### `--watch` mode
-
-Long-lived compiler process with 150ms debounce, inline error reporting, optional `--swift-build` for live recompilation, and `--format` for swift-format integration.
-
-_Status: shipped · v0.3.0_
-
-### `defineView()` + `defineWidget()` + `defineApp()` compilation
-
-Full SwiftUI view, WidgetKit widget, and app scaffold compilation pipelines — parser, validator, generator, and MCP schema mode for all four surfaces. 91 diagnostic codes across five validators.
-
-_Status: shipped · v0.3.2_
-
-### Python SDK
-
-Python parity for all four surfaces with a dataclass-based IR, decorator API, and cross-language compilation via `compileFromIR()`. Python and TypeScript produce byte-identical Swift output.
-
-_Status: shipped · v0.3.2_
-
-### MCP registry presence
-
-Remote MCP endpoint on Cloudflare Workers, `server.json` metadata, Dockerfile for inspection, tool annotations, and dot-notation tool names. Listed on Smithery, Glama, and Pulsemcp.
-
-_Status: shipped · v0.3.4_
-
-### Audience positioning refresh
-
-README, landing page, and all copy rewritten to lead with the "compression layer for AI agents on Apple" positioning. Token proof section on axint.ai with real compression ratios.
-
-_Status: shipped · v0.3.2_
+- Source-free telemetry records command class, MCP tool name, version, coarse host hint, OS family, Node major, CI flag, and anonymous install ID so Axint can understand which install paths actually work.
+- Source-free feedback packets capture diagnostic codes, issue class, redacted evidence, and likely Axint ownership without sending source code, prompts, generated Swift, file names, file paths, credentials, or machine IDs.
+- Users can inspect or disable these paths with `axint telemetry status`, `axint telemetry opt-out`, `axint feedback status`, and `axint feedback opt-out`.
 
 ---
 
-## Planned — v0.4.0+
+## Current Priorities
 
-### Swift → TypeScript reverse compiler
+### 1. Make the first run undeniable
 
-Read an existing Swift App Intent and emit the equivalent Axint TypeScript. Solves the cold-start problem for teams with existing codebases — import what you have, then author new intents in TypeScript going forward.
+Goal: the first command should create a real, inspectable Apple-native capability with proof, not a generic scaffold.
 
-_Target: v0.4.0_
+- Improve `create-axint-app` templates with more realistic app shells and generated Swift examples.
+- Add a "Built with Axint" gallery that links each demo to source contract, generated Swift, proof packet, and install command.
+- Add more end-to-end example repos for App Intent, SwiftUI widget, menu bar app, and existing-project repair flows.
 
-### Type system expansion
+### 2. Make existing-product repair feel senior
 
-Full support for Apple's type hierarchy: `IntentParameter<Measurement<Unit>>`, `PersonEntity`, `FileEntity`, custom `AppEntity` subclasses with snapshot-based identity, and `IntentDialog` for conversational intents.
+Goal: Axint should act like a senior Apple engineer watching the loop.
 
-_Target: v0.4.0_
+- Expand UI repair classifiers for blocked taps, invisible overlays, scroll/hittability failures, state drift, navigation regressions, and accessibility identifier mismatches.
+- Improve `.xcresult` parsing and attach focused failure context directly to repair packets.
+- Keep agent-facing output compact by default while preserving full logs and source artifacts on disk.
 
-### GitHub template repo (`axint-starter`)
+### 3. Make MCP marketplaces score Axint correctly
 
-A template repository that new contributors can clone for a 30-second setup: TypeScript config, a starter intent, and CI wired up.
+Goal: every marketplace should understand Axint as a low-risk, useful, well-documented MCP server.
 
-_Target: v0.4.0_
+- Keep runtime dependencies minimal.
+- Keep tool descriptions explicit: behavior, purpose, inputs, effects, and usage guidance.
+- Maintain Glama, Smithery, MCP Registry, and other marketplace metadata from the same version truth.
+
+### 4. Expand Apple surface coverage
+
+Goal: cover the annoying Apple edges that make agents break.
+
+- Richer `IntentDialog` support.
+- More Apple parameter and entity types.
+- App Shortcuts catalog generation.
+- Control Widgets and Live Activities starter coverage.
+- Better Swift 6 actor isolation and concurrency repair rules.
+
+### 5. Improve Registry composition
+
+Goal: agents should compose from trusted Apple-native packages before writing everything from scratch.
+
+- Better Registry search and package selection inside `axint.registry.search`.
+- Higher-quality first-party packages with proof, generated Swift, and demo prompts.
+- Source-code ingestion and candidate package extraction for future Registry contribution workflows.
+
+### 6. Keep public truth synchronized
+
+Goal: README, docs, package metadata, MCP metadata, website, org profile, and marketplace listings should always agree.
+
+- Continue running `versions:check`, `metrics:check`, `docs:check`, and downstream public-truth sync before releases.
+- Keep npm, PyPI, GitHub Releases, `server.json`, docs, and websites on the same version.
+- Treat stale public numbers as release blockers.
+
+---
+
+## Contribution Areas
+
+The best open-source contributions right now are:
+
+- new Apple templates with tests
+- validator rules for real Swift/App Intent failures
+- smaller reproductions for existing-product repair bugs
+- docs that make agent setup easier
+- MCP marketplace metadata improvements
+- examples that prove one Apple capability end to end
+- issue reports with `.axint/run/latest.md` or source-free feedback packets
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, tests, release gates, and PR expectations.
 
 ---
 
 ## Principles
 
-Every change on this roadmap is measured against four rules:
-
-1. **Sub-millisecond compile** — the browser playground compiles on every keystroke. If a feature breaks that, it doesn't ship.
-2. **Idiomatic Swift output** — the generated code has to look like what a senior Apple engineer would write by hand.
-3. **Zero telemetry** — no data leaves the user's device unless they explicitly invoke a remote service themselves.
-4. **Apache 2.0, no CLA** — every line stays forkable, vendorable, and shippable inside commercial products.
+1. **Ordinary Swift output** - generated code should be inspectable, ejectable, and shippable without runtime lock-in.
+2. **Proof beats vibes** - a clean static check is useful, but Xcode/build/test/runtime evidence decides whether work is done.
+3. **Small agent contracts** - agents should send compact definitions or schema payloads, not walls of fragile Swift.
+4. **Repair packets, not guessing** - when something fails, Axint should return a concrete repair contract.
+5. **Privacy by default** - telemetry and feedback are source-free, inspectable, and opt-out.
+6. **Apache-2.0 core** - the compiler, SDKs, CLI, MCP server, templates, tests, and editor integrations stay forkable and shippable.
 
 ---
 
 ## Release Cadence
 
-- **Patch** (0.x.y): bug fixes and diagnostic improvements — as needed, typically weekly.
-- **Minor** (0.y.0): new features from this roadmap — roughly every 4–6 weeks.
-- **Major** (x.0.0): breaking changes to the `defineIntent()` API — only when absolutely necessary, with a migration guide.
+- **Patch** (`0.x.y`): diagnostics, repair quality, templates, metadata, marketplace compatibility, and bug fixes.
+- **Minor** (`0.y.0`): new Apple surfaces, larger API additions, or major workflow improvements.
+- **Breaking changes**: only when required, with migration notes and compatibility guidance.
 
----
-
-## Get Involved
-
-- **GitHub Discussions** — [github.com/agenticempire/axint/discussions](https://github.com/agenticempire/axint/discussions) for architecture questions and feature ideas
-- **Issues** — [github.com/agenticempire/axint/issues](https://github.com/agenticempire/axint/issues) for bug reports and "help wanted" items
-Your name in the CHANGELOG, forever.
+Intentional releases should move npm and PyPI together, refresh MCP metadata, publish a GitHub Release, and sync public proof surfaces before launch or promotion.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,9 @@
 
 | Version | Supported              |
 |---------|------------------------|
-| 0.3.x   | Yes                    |
-| 0.2.x   | Security fixes only    |
+| 0.4.x   | Yes                    |
+| 0.3.x   | Critical fixes only    |
+| 0.2.x   | No (deprecated)        |
 | 0.1.x   | No (deprecated)        |
 
 ## Reporting a Vulnerability
@@ -26,6 +27,21 @@ When using Axint in production:
 2. Validate all untrusted agent definitions before compilation
 3. Review generated App Intent code before deployment
 4. Use code signing for all compiled artifacts
+
+## Privacy-Safe Telemetry and Feedback
+
+Axint includes source-free adoption telemetry and source-free feedback packets so repeated Apple failure modes can be fixed without collecting user projects.
+
+These paths do not send source code, prompts, generated Swift bodies, file names, file paths, credentials, local machine identifiers, or secrets. Users can inspect and disable them with:
+
+```bash
+axint telemetry status
+axint telemetry opt-out
+axint feedback status
+axint feedback opt-out
+```
+
+Environment controls are also supported: `AXINT_TELEMETRY=off`, `AXINT_DISABLE_TELEMETRY=1`, `AXINT_FEEDBACK=off`, and `AXINT_DISABLE_FEEDBACK=1`.
 
 ## Dependency and audit policy
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "type": "module",
-  "description": "Open-source compiler for Apple platforms. TypeScript/Python/JSON in, Swift out — App Intents, SwiftUI views, WidgetKit widgets.",
+  "description": "Apple-native execution layer for AI coding agents: compile, validate, repair, and prove Swift surfaces.",
   "author": "Axint contributors",
   "license": "Apache-2.0",
   "homepage": "https://axint.ai",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,5 +1,5 @@
 # Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
-# Axint turns TypeScript and Python into validated Swift for Apple-native features.
+# Axint is the Apple-native execution layer for AI coding agents.
 
 startCommand:
   type: http


### PR DESCRIPTION
## Summary
- Update README and package metadata around the Apple-native execution layer positioning
- Replace the stale v0.3.9 roadmap with the current v0.4.27 platform roadmap
- Refresh contributing, security, PR, and issue templates for repair, run, Cloud Check, Registry, telemetry, and MCP marketplace work

## Checks
- npm run docs:check
- npm run versions:check
- npm run metrics:check
- git diff --check