### PR TITLE
Add activation proof for first-use funnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+## [0.4.28] — 2026-05-08
+
+### Added
+
+- **Activation proof** — `axint activate` and the `axint.activate` MCP tool run a source-free compiler smoke test, return `axint_activated`, and tell agents to leave the activation result in the current thread before editing code.
+- **Install/activation telemetry split** — first-run telemetry now separates setup initialization and server-start signals from activation/value-proof events, so Pulse can tell whether people actually used Axint after install.
+- **Fresh install gauntlet** — `npm run install:gauntlet` packs the current build, installs it into a temporary clean project, verifies `axint activate`, and checks the no-install `create-axint-app` launchpad path.
+
+### Changed
+
+- Status, doctor, upgrade, Xcode setup, MCP prompts, project start packs, rehydration files, and README copy now tell agents to run `axint.activate` after setup instead of stopping at "MCP server started."
+- npm package keywords now include MCP, SwiftUI, WidgetKit, Xcode, iOS, and macOS discovery terms.
+
 ## [0.4.27] — 2026-05-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ usable app preview, and hands the agent a repair path when something breaks.
 
 ```bash
 npm install -g @axint/compiler
+axint activate
 
 # initialize Axint inside an existing Apple/Xcode project
 axint init --apple-project /path/to/MyApp --agent codex
@@ -296,7 +297,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.27 · 35 MCP tools + 5 prompts · 204 diagnostic codes · 1308 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.28 · 36 MCP tools + 5 prompts · 204 diagnostic codes · 1311 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -380,10 +381,10 @@ Agent sessions should not have to restart from scratch just because Axint shippe
 axint upgrade
 axint upgrade --apply
 axint upgrade --apply --xcode-install
-axint upgrade --target 0.4.27 --apply
+axint upgrade --target 0.4.28 --apply
 ```
 
-From MCP, call `axint.upgrade`. The tool returns the exact command plan plus a same-thread prompt that tells the agent to keep the current conversation, reload or reconnect only the Axint MCP server/tool process, then call `axint.status` to prove the running version before editing code.
+From MCP, call `axint.upgrade`. The tool returns the exact command plan plus a same-thread prompt that tells the agent to keep the current conversation, reload or reconnect only the Axint MCP server/tool process, then call `axint.status` and `axint.activate` to prove the running version and first real Axint output before editing code.
 
 ---
 
@@ -412,6 +413,7 @@ MCP tools and built-in prompts:
 | Tool | What it does |
 | --- | --- |
 | `axint.status` | Report the running MCP server version, package path, uptime, and same-thread reload/update instructions |
+| `axint.activate` | Run a source-free compiler smoke test so a fresh install proves first real Axint use |
 | `axint.upgrade` | Check or apply an Axint upgrade, refresh optional Xcode wiring, and return a same-thread continuation prompt |
 | `axint.doctor` | Audit version truth, Node/npm/npx paths, project MCP wiring, and agent start-pack files |
 | `axint.xcode.guard` | Guard Xcode agent sessions against context compaction and Axint drift, then write `.axint/guard/latest.*` proof artifacts |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Axint Roadmap
 
-_Last updated: May 2026 · Current release: [v0.4.27](https://github.com/agenticempire/axint/releases/tag/v0.4.27)_
+_Last updated: May 2026 · Current release: [v0.4.28](https://github.com/agenticempire/axint/releases/tag/v0.4.28)_
 
 Axint is the Apple-native execution layer for AI coding agents. The open-source package gives agents a smaller contract for Apple surfaces, emits ordinary Swift, validates Apple-specific rules, writes Fix Packets, and coordinates proof loops across CLI, MCP, Xcode, Registry, and Cloud-facing workflows.
 
@@ -23,11 +23,11 @@ The thesis is simple: agents can write code, but Apple-native software needs pro
 - TypeScript, Python, JSON schema mode, and preview `.axint` inputs compile into Apple-native Swift.
 - Supported surfaces include App Intents, SwiftUI views, WidgetKit widgets, app scaffolds, plist fragments, entitlements, and Apple metadata.
 - The validator covers 204 diagnostic codes across compiler, intent, view, widget, app, Swift build, SwiftUI, accessibility, concurrency, and Live Activity rules.
-- The suite currently tracks 1308 tests across TypeScript and Python paths.
+- The suite currently tracks 1311 tests across TypeScript and Python paths.
 
 ### Agent distribution
 
-- 35 MCP tools and 5 prompts expose compile, validate, repair, suggest, feature generation, project packs, memory, docs context, workflow gates, run status, run cancel, telemetry controls, feedback packets, and template access.
+- 36 MCP tools and 5 prompts expose compile, validate, activate, repair, suggest, feature generation, project packs, memory, docs context, workflow gates, run status, run cancel, telemetry controls, feedback packets, and template access.
 - MCP marketplace bundles now start directly through `node dist/mcp/index.js` and ship clearer runtime tool descriptions for security/quality scanners.
 - Agent lanes distinguish Xcode-hosted work from Codex, Claude, Cursor, Cowork, VS Code, Windsurf, and other clients so routine edits use the active client's native patch lane while Axint handles proof.
 - Same-thread upgrades let agents update Axint without losing the current project conversation.
@@ -42,6 +42,7 @@ The thesis is simple: agents can write code, but Apple-native software needs pro
 - Source-free telemetry records command class, MCP tool name, version, coarse host hint, OS family, Node major, CI flag, and anonymous install ID so Axint can understand which install paths actually work.
 - Source-free feedback packets capture diagnostic codes, issue class, redacted evidence, and likely Axint ownership without sending source code, prompts, generated Swift, file names, file paths, credentials, or machine IDs.
 - Users can inspect or disable these paths with `axint telemetry status`, `axint telemetry opt-out`, `axint feedback status`, and `axint feedback opt-out`.
+- Fresh installs can prove first real value with `axint activate` or the `axint.activate` MCP tool, so Pulse can separate setup/server-start events from activation.
 
 ---
 
@@ -54,6 +55,7 @@ Goal: the first command should create a real, inspectable Apple-native capabilit
 - Improve `create-axint-app` templates with more realistic app shells and generated Swift examples.
 - Add a "Built with Axint" gallery that links each demo to source contract, generated Swift, proof packet, and install command.
 - Add more end-to-end example repos for App Intent, SwiftUI widget, menu bar app, and existing-project repair flows.
+- Keep `npm run install:gauntlet` green before release: local dist activation, packed fresh install activation, and create-axint-app launchpad creation.
 
 ### 2. Make existing-product repair feel senior
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,44 @@
 # Release Notes
 
+## 2026-05-08 — Activation proof and first-use funnel
+
+This release closes the biggest dogfooding ambiguity: a server-start event proves
+that an MCP host launched Axint, but it does not prove the user got value from
+Axint.
+
+### Added
+
+- `axint activate`
+  - Runs a source-free compiler smoke test.
+  - Returns `status: ok` and `signal: axint_activated` when the package can
+    produce real Axint output.
+  - Gives terminal users a one-command proof path immediately after install.
+- `axint.activate`
+  - MCP equivalent for Claude, Cursor, Codex, VS Code, Xcode, and other MCP
+    hosts.
+  - Lets an agent prove the server is not merely running, but actually useful.
+- Activation telemetry
+  - Emits setup initialization separately from activation.
+  - Treats activation and completed CLI/MCP work as first-value proof.
+- `npm run install:gauntlet`
+  - Packs the current build into the same tarball shape npm will publish.
+  - Installs that tarball into a fresh temporary project.
+  - Verifies `axint activate` through both local dist and packed install.
+  - Checks that `create-axint-app --no-install` writes the launchpad proof files.
+
+### Changed
+
+- Status, doctor, upgrade, Xcode setup, MCP prompts, rehydration files, project
+  start packs, README, and website install prompts now point agents to
+  `axint activate` / `axint.activate` after setup.
+- Public truth advances to v0.4.28 with 36 MCP tools, 5 prompts, 204 diagnostic
+  codes, 1311 tests, and 26 bundled templates.
+
+### Why it matters
+
+Pulse can now answer the question that promotion raised: did someone just start
+the server, or did Axint return first value?
+
 ## 2026-05-06 — MCP Marketplace scoring and packaged dependency hardening
 
 This patch improves the public MCP marketplace surface after Glama accepted the

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — Apple-Native Execution Layer",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,8 +1,9 @@
 {
-  "version": "0.4.27",
-  "mcpTools": 35,
+  "version": "0.4.28",
+  "mcpTools": 36,
   "mcpToolNames": [
     "axint.status",
+    "axint.activate",
     "axint.upgrade",
     "axint.doctor",
     "axint.xcode.guard",
@@ -85,7 +86,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1194,
+    "typescript": 1197,
     "python": 114
   },
   "registryPackages": 58,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.27",
+      "version": "0.4.28",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"
@@ -27,6 +27,13 @@
     "ai-agents",
     "mcp",
     "code-generation",
+    "model-context-protocol",
+    "mcp-server",
+    "swiftui",
+    "widgetkit",
+    "xcode",
+    "ios",
+    "macos",
     "typescript",
     "developer-tools"
   ],
@@ -79,6 +86,7 @@
     "versions:sync": "node scripts/sync-versions.mjs",
     "versions:check": "node scripts/check-versions.mjs",
     "release:check": "node scripts/check-release-parity.mjs",
+    "install:gauntlet": "node scripts/install-gauntlet.mjs",
     "metrics:emit": "node scripts/emit-metrics.mjs",
     "metrics:check": "node scripts/check-metrics.mjs",
     "boundary:check": "node scripts/check-public-boundary.mjs",

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.27"
+__version__ = "0.4.28"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.27"
+version = "0.4.28"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/install-gauntlet.mjs
+++ b/scripts/install-gauntlet.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Fresh-install smoke for the exact tarball a user gets after publish.
+// It proves local dist, npm-packed local install, activation, and the
+// create-axint-app no-install launchpad path without touching global npm state.
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const TMP = mkdtempSync(join(tmpdir(), "axint-install-gauntlet-"));
+const env = {
+  ...process.env,
+  AXINT_DISABLE_TELEMETRY: "1",
+  npm_config_audit: "false",
+  npm_config_fund: "false",
+};
+
+const steps = [];
+
+main();
+
+function main() {
+  const distCli = resolve(ROOT, "dist/cli/index.js");
+  if (!existsSync(distCli)) {
+    fail("dist/cli/index.js is missing. Run `npm run build` before the install gauntlet.");
+  }
+
+  const localActivation = run("local dist activation", ["node", distCli, "activate", "--format", "json"], ROOT);
+  assertActivation(localActivation.stdout, "local dist activation");
+
+  const pack = run("npm pack", ["npm", "pack", "--json", "--pack-destination", TMP], ROOT);
+  const tarball = resolve(TMP, readPackedFilename(pack.stdout));
+
+  const freshProject = mkdtempSync(join(TMP, "fresh-project-"));
+  run("fresh npm init", ["npm", "init", "-y"], freshProject);
+  run(
+    "fresh tarball install",
+    ["npm", "install", tarball, "--ignore-scripts", "--no-audit", "--no-fund"],
+    freshProject,
+  );
+
+  const bin = resolve(freshProject, "node_modules/.bin/axint");
+  const createBin = resolve(freshProject, "node_modules/.bin/create-axint-app");
+  const packedActivation = run("packed activation", [bin, "activate", "--format", "json"], freshProject);
+  assertActivation(packedActivation.stdout, "packed activation");
+
+  const starterDir = resolve(freshProject, "apple-day-agent");
+  run("create-axint-app no-install", [createBin, "apple-day-agent", "--no-install"], freshProject);
+  assertExists(resolve(starterDir, "package.json"), "starter package.json");
+  assertExists(resolve(starterDir, ".axint/START_HERE.md"), "starter agent instructions");
+  assertExists(resolve(starterDir, "share/built-with-axint.html"), "starter proof preview");
+
+  console.log("");
+  console.log("install gauntlet passed");
+  for (const step of steps) console.log(`- ${step}`);
+  console.log(`temp: ${TMP}`);
+}
+
+function run(label, args, cwd) {
+  const result = spawnSync(args[0], args.slice(1), {
+    cwd,
+    env,
+    encoding: "utf-8",
+    maxBuffer: 1024 * 1024 * 12,
+  });
+  if (result.status !== 0) {
+    console.error(result.stdout);
+    console.error(result.stderr);
+    fail(`${label} failed with exit ${result.status}`);
+  }
+  steps.push(label);
+  return result;
+}
+
+function readPackedFilename(stdout) {
+  try {
+    const packed = JSON.parse(stdout);
+    const filename = packed?.[0]?.filename;
+    if (typeof filename === "string" && filename.endsWith(".tgz")) return filename;
+  } catch {
+    // Fall through to the plain-output parser for older npm versions.
+  }
+
+  const line = stdout
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .find((value) => value.endsWith(".tgz"));
+  if (line) return line;
+  fail("could not find packed tarball filename in npm pack output");
+}
+
+function assertActivation(stdout, label) {
+  const start = stdout.indexOf("{");
+  if (start === -1) fail(`${label} did not print JSON`);
+  const report = JSON.parse(stdout.slice(start));
+  if (report.status !== "ok" || report.signal !== "axint_activated") {
+    fail(`${label} did not return axint_activated`);
+  }
+}
+
+function assertExists(path, label) {
+  if (!existsSync(path)) fail(`${label} was not created at ${path}`);
+}
+
+function fail(message) {
+  console.error(`install gauntlet failed: ${message}`);
+  process.exit(1);
+}

--- a/server.json
+++ b/server.json
@@ -2,14 +2,14 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.agenticempire/axint",
   "title": "Axint",
-  "description": "Apple-native AI agent execution: 35 MCP tools, 5 prompts, compile, validate, repair, and prove.",
+  "description": "Apple-native AI agent execution: 36 MCP tools, 5 prompts, compile, validate, repair, and prove.",
   "repository": {
     "url": "https://github.com/agenticempire/axint",
     "source": "github"
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.27",
+      "version": "0.4.28",
       "transport": {
         "type": "stdio"
       }
@@ -28,14 +28,14 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.27",
+      "version": "0.4.28",
       "transport": {
         "type": "stdio"
       }
     }
   ],
   "capabilities": {
-    "tools": 35,
+    "tools": 36,
     "prompts": 5
   }
 }

--- a/src/activation/smoke-test.ts
+++ b/src/activation/smoke-test.ts
@@ -1,0 +1,91 @@
+import { compileFromIR } from "../core/compiler.js";
+import type { Diagnostic, IRIntent } from "../core/types.js";
+
+export type ActivationSmokeFormat = "markdown" | "json";
+
+export type ActivationSmokeReport = {
+  status: "ok" | "fail";
+  signal: "axint_activated";
+  intentName: string;
+  swiftFile: string | null;
+  swiftLines: number;
+  diagnostics: Array<Pick<Diagnostic, "code" | "severity" | "message">>;
+  next: string[];
+};
+
+const ACTIVATION_IR: IRIntent = {
+  name: "AxintActivationProbe",
+  title: "Axint Activation Probe",
+  description:
+    "Confirms Axint can compile a built-in App Intent without reading project source.",
+  parameters: [],
+  returnType: { kind: "primitive", value: "string" },
+  sourceFile: "<axint:activation>",
+};
+
+export function runActivationSmokeTest(): ActivationSmokeReport {
+  const result = compileFromIR(ACTIVATION_IR, {
+    validate: true,
+  });
+
+  const diagnostics = result.diagnostics.map(({ code, severity, message }) => ({
+    code,
+    severity,
+    message,
+  }));
+
+  return {
+    status: result.success ? "ok" : "fail",
+    signal: "axint_activated",
+    intentName: ACTIVATION_IR.name,
+    swiftFile: result.output?.outputPath ?? null,
+    swiftLines: countNonBlankLines(result.output?.swiftCode ?? ""),
+    diagnostics,
+    next: result.success
+      ? [
+          "Use axint.compile, axint.cloud.check, or axint.run on the project work.",
+          "Leave the activation result in the current agent thread before editing code.",
+        ]
+      : [
+          "Run axint doctor to inspect the local Axint install.",
+          "Retry after updating with axint upgrade --apply.",
+        ],
+  };
+}
+
+export function renderActivationSmokeReport(
+  report: ActivationSmokeReport,
+  format: ActivationSmokeFormat = "markdown"
+): string {
+  if (format === "json") return JSON.stringify(report, null, 2);
+
+  const lines = [
+    "# Axint Activation",
+    "",
+    `Status: ${report.status}`,
+    `Signal: ${report.signal}`,
+    `Compiler probe: ${report.intentName}`,
+    `Swift output: ${report.swiftFile ?? "not emitted"}`,
+    `Generated Swift lines: ${report.swiftLines}`,
+  ];
+
+  if (report.diagnostics.length > 0) {
+    lines.push("", "## Diagnostics");
+    for (const diagnostic of report.diagnostics) {
+      lines.push(`- ${diagnostic.severity}[${diagnostic.code}]: ${diagnostic.message}`);
+    }
+  }
+
+  lines.push("", "## Next");
+  for (const item of report.next) lines.push(`- ${item}`);
+
+  return lines.join("\n");
+}
+
+function countNonBlankLines(source: string): number {
+  let count = 0;
+  for (const line of source.split("\n")) {
+    if (line.trim()) count += 1;
+  }
+  return count;
+}

--- a/src/cli/activate.ts
+++ b/src/cli/activate.ts
@@ -1,0 +1,25 @@
+import type { Command } from "commander";
+import {
+  renderActivationSmokeReport,
+  runActivationSmokeTest,
+  type ActivationSmokeFormat,
+} from "../activation/smoke-test.js";
+
+export function registerActivate(program: Command): void {
+  program
+    .command("activate")
+    .description(
+      "Run a source-free compiler smoke test so an install proves first real Axint use"
+    )
+    .option("--format <format>", "Output format: markdown or json", "markdown")
+    .action((options: { format?: string }) => {
+      const format = parseActivationFormat(options.format);
+      const report = runActivationSmokeTest();
+      console.log(renderActivationSmokeReport(report, format));
+      if (report.status !== "ok") process.exitCode = 1;
+    });
+}
+
+function parseActivationFormat(value: string | undefined): ActivationSmokeFormat {
+  return value === "json" ? "json" : "markdown";
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@
  *
  *   axint init [dir]              Scaffold a new Axint project
  *   axint compile <file>          Compile TS intent → Swift App Intent
+ *   axint activate                Run a source-free compiler smoke test after install
  *   axint create [dir]            Create a premium Apple-native agent launchpad
  *   axint validate <file>         Validate a compiled intent
  *   axint validate-swift <path...> Validate existing Swift sources against Axint's build-time rules
@@ -64,6 +65,7 @@ import type { XcodeCheckOutput } from "./xcode-check.js";
 import type { XcodePacketKind, XcodePacketOutput } from "./xcode-packet.js";
 import { scaffoldProject } from "./scaffold.js";
 import { registerCreate } from "./create.js";
+import { registerActivate } from "./activate.js";
 import { registerCompile } from "./compile.js";
 import { registerValidate } from "./validate.js";
 import { registerValidateSwift } from "./validate-swift.js";
@@ -183,6 +185,25 @@ program.hook("preAction", async (_thisCommand, actionCommand) => {
     version: VERSION,
     command,
     host: inferAxintHost(actionCommand.opts?.() as Record<string, unknown>),
+  });
+});
+
+program.hook("postAction", async (_thisCommand, actionCommand) => {
+  const command = commandPathFor(actionCommand);
+  if (!command || command === "telemetry" || command.startsWith("telemetry ")) {
+    return;
+  }
+
+  await recordAdoptionEvent({
+    source: "cli",
+    eventName: "cli_command_completed",
+    version: VERSION,
+    command,
+    host: inferAxintHost(actionCommand.opts?.() as Record<string, unknown>),
+    result:
+      typeof process.exitCode === "number" && process.exitCode !== 0
+        ? "nonzero_exit"
+        : "ok",
   });
 });
 
@@ -313,6 +334,7 @@ program
 // ─── subcommands ──────────────────────────────────────────────────────
 
 registerCompile(program);
+registerActivate(program);
 registerValidate(program);
 registerValidateSwift(program);
 registerEject(program);

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -43,7 +43,7 @@ export function renderCliStatus(
     doctorCommand: "axint doctor",
     projectInitCommand: "axint project init",
     verificationPrompt:
-      "Call axint.status and tell me the running Axint MCP version before editing code.",
+      "Call axint.status, then call axint.activate and tell me the activation result before editing code.",
     restartInstruction:
       "After updating, reload or reconnect the Axint MCP server/tool process. Keep the current Codex or Claude thread when your client supports MCP reload; if it does not, use the generated same-thread resume prompt instead of starting blind.",
   };
@@ -56,7 +56,7 @@ export function renderCliStatus(
       status.verificationPrompt,
       "Use the active agent lane: Codex/Claude/Cursor/Cowork should patch natively, while Xcode can use axint.xcode.guard for durable guard proof.",
       `Expected local package version: ${status.version}.`,
-      "If axint.status reports an older version, run axint.upgrade or axint upgrade --apply, then reload only the MCP server/tool process.",
+      "If axint.status reports an older version, run axint.upgrade or axint upgrade --apply, then reload only the MCP server/tool process. After reload, call axint.activate so this install proves first use.",
       "After each generated Swift surface, run axint.cloud.check or axint cloud check --source <file> with build/test evidence when available.",
     ].join("\n");
   }
@@ -77,6 +77,7 @@ export function renderCliStatus(
     "",
     "```text",
     status.verificationPrompt,
+    "A server start alone is not enough; activation must return Status: ok.",
     "Use axint workflow check as the portable guard. In Xcode-hosted sessions, axint.xcode.guard can also write .axint/guard/latest.* proof.",
     "If MCP tools are visible but calls fail after a reload or transport close, run the CLI fallback: axint workflow check --dir . --stage context-recovery --agent <host> --session-token <token>.",
     "If Axint is not available, inspect the project .mcp.json or client MCP settings, make sure npx uses a durable full path, then reload the Axint MCP server/tool process.",

--- a/src/cli/xcode-setup.ts
+++ b/src/cli/xcode-setup.ts
@@ -35,8 +35,8 @@ const START_PROMPT = [
   "",
   "Then list MCP servers and confirm both xcode-tools and axint are available.",
   "Call axint.xcode.guard with stage=context-recovery so the project writes .axint/guard/latest.* proof before any long task.",
-  "Call axint.status and report the running MCP server version before editing code.",
-  "If the version is older than expected, stop and call `axint.upgrade` or tell me to run `axint upgrade --apply`, then reload only the Axint MCP server/tool process.",
+  "Call axint.status, then axint.activate, and report the running MCP server version plus activation result before editing code.",
+  "If the version is older than expected, stop and call `axint.upgrade` or tell me to run `axint upgrade --apply`, then reload only the Axint MCP server/tool process and activate again.",
   "Use Axint before guessing App Intents, widgets, SwiftUI scaffolds, entitlements, Info.plist keys, or repair prompts.",
   "Work in short checkpoints. Do not spend 20+ minutes on a task without running Axint and Xcode validation.",
   "For long build/debug work, prefer axint.run or axint.xcode.guard over raw Xcode actions so Axint proof survives context compaction.",
@@ -256,9 +256,14 @@ export async function verifyXcode(): Promise<void> {
       throw result.error;
     }
 
-    if (output.includes("axint.feature") && output.includes("axint.status")) {
+    if (
+      output.includes("axint.feature") &&
+      output.includes("axint.status") &&
+      output.includes("axint.activate")
+    ) {
       console.log(`  ${GREEN}✓${RESET} MCP server responds`);
       console.log(`  ${GREEN}✓${RESET} axint.status tool available`);
+      console.log(`  ${GREEN}✓${RESET} axint.activate tool available`);
       console.log(`  ${GREEN}✓${RESET} axint.feature tool available`);
 
       const toolCount = (output.match(/"name":\s*"axint\./g) || []).length;
@@ -266,7 +271,9 @@ export async function verifyXcode(): Promise<void> {
       console.log();
       console.log(`  ${GREEN}All checks passed.${RESET} Axint is ready for Xcode.`);
     } else if (output.includes("axint.feature")) {
-      console.log(`  ${RED}✗${RESET} MCP server is old: axint.status not found`);
+      console.log(
+        `  ${RED}✗${RESET} MCP server is old: axint.status or axint.activate not found`
+      );
       console.log(
         `  ${DIM}  Run: axint upgrade --apply, then reload the Axint MCP server/tool process${RESET}`
       );

--- a/src/mcp/doctor.ts
+++ b/src/mcp/doctor.ts
@@ -341,7 +341,7 @@ function nextStepsFor(checks: MachineDoctorCheck[]): string[] {
   const fixes = checks.filter((check) => check.fix).map((check) => check.fix!);
   if (fixes.length > 0) return [...new Set(fixes)].slice(0, 5);
   return [
-    "Start the agent session and ask it to call axint.status.",
+    "Start the agent session and ask it to call axint.status, then axint.activate.",
     "Run axint.workflow.check before planning, before writing, before building, and before committing.",
   ];
 }

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -34,6 +34,30 @@ export const TOOL_MANIFEST = [
     },
   },
   {
+    name: "axint.activate",
+    description:
+      "Run a source-free compiler smoke test through the real Axint pipeline. " +
+      "Use immediately after installing or connecting Axint so the current agent proves " +
+      "it did more than start the MCP server.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        format: {
+          type: "string",
+          enum: ["markdown", "json"],
+          description:
+            "Output format. markdown is human-readable, json is structured for automation.",
+        },
+      },
+    },
+  },
+  {
     name: "axint.upgrade",
     description:
       "Check the latest Axint package and optionally apply the upgrade while preserving " +
@@ -462,7 +486,7 @@ export const TOOL_MANIFEST = [
       "Generate the Axint project-start pack for a new Apple app without writing files. " +
       "Returns .mcp.json, AGENTS.md, CLAUDE.md, .axint/AXINT_MEMORY.md, .axint/project.json, and .axint/README.md " +
       "so an Xcode/Codex/Claude agent can install the exact first-try workflow: read docs, " +
-      "call axint.status, run workflow gates, validate Swift, run Cloud Check with evidence, " +
+      "call axint.status, call axint.activate, run workflow gates, validate Swift, run Cloud Check with evidence, " +
       "and avoid static-only bug claims.",
     annotations: {
       readOnlyHint: true,
@@ -2327,6 +2351,8 @@ function defaultEffectSummary(tool: (typeof TOOL_MANIFEST)[number]): string {
 const RUNTIME_TOOL_GUIDANCE: Record<string, string> = {
   "axint.status":
     "call first or after an MCP reload to prove the connected server version; do not use as an npm/PyPI lookup.",
+  "axint.activate":
+    "call immediately after install or first MCP connection so the agent proves real Axint use beyond server start.",
   "axint.upgrade":
     "call when axint.status shows a stale server; not for app dependency upgrades.",
   "axint.doctor":
@@ -2398,6 +2424,8 @@ const RUNTIME_TOOL_GUIDANCE: Record<string, string> = {
 
 const RUNTIME_TOOL_EFFECTS: Record<string, string> = {
   "axint.status": "read-only; writes no files; no auth or network required.",
+  "axint.activate":
+    "read-only built-in compiler smoke test; writes no files and uses no network.",
   "axint.upgrade":
     "destructive when apply=true: can run package installs, refresh Xcode wiring, and write .axint/upgrade; may use npm network.",
   "axint.doctor": "read-only inspection; writes no files; no auth or network required.",

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -178,7 +178,7 @@ export function getPromptMessages(
               xcodeStep +
               "4. Read `.axint/AXINT_REHYDRATE.md`, `.axint/AXINT_MEMORY.md`, `.axint/AXINT_DOCS_CONTEXT.md`, `AGENTS.md`, `CLAUDE.md`, or `.axint/project.json` if present.\n" +
               serverStep +
-              "6. Call `axint.status` and report the running MCP server version before editing code. If the version is older than expected, call `axint.upgrade` or tell me to run `axint upgrade --apply`, then reload only the Axint MCP server/tool process.\n" +
+              "6. Call `axint.status`, then `axint.activate`, and report the running MCP version plus activation result before editing code. If the version is older than expected, call `axint.upgrade` or tell me to run `axint upgrade --apply`, then reload only the Axint MCP server/tool process and activate again.\n" +
               "7. If axint is missing in Xcode, tell me to run `axint xcode install --project .`, reload the Xcode MCP server/tool process, and ask again for available MCP servers.\n" +
               `8. Call \`axint.workflow.check\` with agent=\`${profile.agent}\`, stage \`context-recovery\`, sessionToken, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.\n` +
               "9. Call `axint.workflow.check` with `sessionToken` at planning, before-write, and pre-build checkpoints so you do not skip the Axint loop by accident.\n" +
@@ -221,7 +221,7 @@ export function getPromptMessages(
               "3. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json if they exist.\n" +
               "4. If those files are missing, call axint.context.memory and axint.context.docs, then use them as the compact Axint operating memory and docs context.\n" +
               "5. List the available MCP servers/tools and confirm axint is present.\n" +
-              "6. Call axint.status and report the running Axint MCP version.\n" +
+              "6. Call axint.status, then axint.activate, and report the running Axint MCP version plus activation result.\n" +
               `7. Call axint.workflow.check with agent=\`${profile.agent}\`, stage \`context-recovery\`, sessionToken, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.\n` +
               "8. If Axint is missing or stale, stop and give the exact setup/restart command instead of continuing by hand.\n" +
               "9. Name the next Axint tool you will use before editing code.\n" +

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -37,6 +37,7 @@
  *   - axint.project.pack:     Generate first-try project-start files
  *   - axint.project.index:    Index the local Apple project into .axint/context
  *   - axint.project.syncVersion: Sync stale project-pack version hints
+ *   - axint.activate:         Run source-free activation smoke test
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -56,6 +57,11 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { compileAnySource } from "../core/compiler.js";
 import { formatSwift } from "../core/format.js";
+import {
+  renderActivationSmokeReport,
+  runActivationSmokeTest,
+  type ActivationSmokeFormat,
+} from "../activation/smoke-test.js";
 import { scaffoldIntent } from "./scaffold.js";
 import { generateFeature, type FeatureInput, type Surface } from "./feature.js";
 import { suggestFeaturesSmart, type SuggestInput } from "./suggest.js";
@@ -511,6 +517,8 @@ function renderStatus(format: StatusArgs["format"] = "markdown"): string {
     promptsRegistered: PROMPT_MANIFEST.length,
     restartRequiredAfterUpdate: true,
     updateCommand: "npm install -g @axint/compiler@latest",
+    activationCommand: "axint activate",
+    activationTool: "axint.activate",
     upgradeCommand: "axint upgrade --apply",
     xcodeSetupCommand: "axint xcode install --project .",
     doctorCommand: "axint doctor",
@@ -524,8 +532,9 @@ function renderStatus(format: StatusArgs["format"] = "markdown"): string {
   if (format === "prompt") {
     return [
       `The running Axint MCP server is v${status.version}.`,
+      "Next call axint.activate and report Status: ok so this connection proves first real Axint use.",
       "If this is older than the version the user expects, stop before editing code.",
-      "Call axint.upgrade first. If apply is needed, update Axint, reload only the MCP server/tool process, then call axint.status again in the same thread.",
+      "Call axint.upgrade first. If apply is needed, update Axint, reload only the MCP server/tool process, then call axint.status and axint.activate again in the same thread.",
     ].join("\n");
   }
 
@@ -561,7 +570,9 @@ function renderStatus(format: StatusArgs["format"] = "markdown"): string {
     "",
     "3. Reload or reconnect the Axint MCP server/tool process. Keep the same Codex or Claude thread when the client supports MCP reload.",
     "",
-    "4. Ask: `Call axint.status and tell me the running version.`",
+    "4. Ask: `Call axint.status, then axint.activate, and tell me the running version plus activation result.`",
+    "",
+    "A server start alone is setup proof. `axint.activate` must return `Status: ok` before the agent treats Axint as actually used.",
     "",
     "For Xcode, `axint upgrade --apply` can also refresh the optional Xcode MCP wiring. For a brand-new Apple project, run `axint xcode install --project .`, then `axint doctor` to confirm the machine is wired.",
   ].join("\n");
@@ -580,6 +591,20 @@ export async function handleToolCall(name: string, args: unknown): Promise<ToolR
   if (name === "axint.status") {
     const a = args as StatusArgs | undefined;
     return diagnosticsText(renderStatus(a?.format ?? "markdown"));
+  }
+
+  if (name === "axint.activate") {
+    const a = args as { format?: ActivationSmokeFormat } | undefined;
+    const report = runActivationSmokeTest();
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: renderActivationSmokeReport(report, a?.format ?? "markdown"),
+        },
+      ],
+      isError: report.status !== "ok",
+    };
   }
 
   if (name === "axint.upgrade") {
@@ -1336,8 +1361,27 @@ export function createAxintServer(): Server {
     });
 
     try {
-      return withStructuredText(await handleToolCall(name, args));
+      const result = withStructuredText(await handleToolCall(name, args));
+      recordAdoptionEventSoon({
+        source: "mcp",
+        eventName: "mcp_tool_completed",
+        version: pkg.version,
+        toolName: name,
+        transport: process.env.AXINT_MCP_TRANSPORT ?? "stdio",
+        host: inferAxintHost(),
+        result: result.isError ? "error" : "ok",
+      });
+      return result;
     } catch (err: unknown) {
+      recordAdoptionEventSoon({
+        source: "mcp",
+        eventName: "mcp_tool_failed",
+        version: pkg.version,
+        toolName: name,
+        transport: process.env.AXINT_MCP_TRANSPORT ?? "stdio",
+        host: inferAxintHost(),
+        result: "exception",
+      });
       return withStructuredText({
         content: [
           {

--- a/src/mcp/workflow-check.ts
+++ b/src/mcp/workflow-check.ts
@@ -142,7 +142,7 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
   if (looksLikeContextDrift(input.notes)) {
     if (!input.readRehydrationContext || !input.ranStatus) {
       required.push(
-        "Notes look like a new chat, compaction, stale MCP, or Axint drift. Run context recovery: call axint.session.start, read .axint/AXINT_REHYDRATE.md, call axint.status, then call axint.workflow.check with stage context-recovery before continuing."
+        "Notes look like a new chat, compaction, stale MCP, or Axint drift. Run context recovery: call axint.session.start, read .axint/AXINT_REHYDRATE.md, call axint.status, call axint.activate, then call axint.workflow.check with stage context-recovery before continuing."
       );
     }
   }
@@ -165,7 +165,7 @@ export function runWorkflowCheck(input: WorkflowCheckInput): WorkflowCheckReport
     }
     if (!input.ranStatus) {
       required.push(
-        "Call axint.status and report the running MCP server version before planning or editing."
+        "Call axint.status, then axint.activate, and report the running MCP server version plus activation result before planning or editing."
       );
     }
   }

--- a/src/project/agent-profile.ts
+++ b/src/project/agent-profile.ts
@@ -94,7 +94,7 @@ export function buildAgentToolProfile(
     finishAction:
       "Summarize validation, Cloud Check, build/test proof, and do not call Xcode-only guard tools unless the active host is Xcode.",
     contextRecoveryAction:
-      "Call axint.session.start, read local Axint context files, call axint.status, then axint.workflow.check.",
+      "Call axint.session.start, read local Axint context files, call axint.status, call axint.activate, then axint.workflow.check.",
     proofAction:
       "Use axint.swift.validate, axint.cloud.check, and axint.run or shell build/test evidence that the active agent can actually run.",
     avoid: [
@@ -131,7 +131,7 @@ function patchFirstProfile(input: {
     finishAction:
       "Summarize Axint validation, Cloud Check, and build/test proof. Do not call axint.xcode.guard unless this chat is actually running inside Xcode.",
     contextRecoveryAction:
-      "Call axint.session.start, read .axint context files, call axint.status, then axint.workflow.check.",
+      "Call axint.session.start, read .axint context files, call axint.status, call axint.activate, then axint.workflow.check.",
     proofAction:
       "Use axint.swift.validate, axint.cloud.check, and axint.run or shell xcodebuild evidence when available.",
     avoid: [

--- a/src/project/docs-context.ts
+++ b/src/project/docs-context.ts
@@ -53,8 +53,9 @@ When a chat is new, compacted, summarized, or confused, reload context in this o
 6. \`axint.session.start\`: writes \`.axint/session/current.json\` and returns the session token.
 7. ${xcodeGuardStep}
 8. \`axint.status\`: current MCP version and same-thread reload/setup guidance.
-9. \`axint.upgrade\`: use this if the running MCP version is stale so the agent can keep the current thread and reload only the MCP process.
-10. \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
+9. \`axint.activate\`: source-free compiler smoke test that proves first real Axint use after install or MCP reconnect.
+10. \`axint.upgrade\`: use this if the running MCP version is stale so the agent can keep the current thread and reload only the MCP process.
+11. \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
 
 If any local context file is missing, call \`axint.context.memory\` and \`axint.context.docs\`, then continue from those returned documents.
 
@@ -97,25 +98,26 @@ Use Axint for:
 Use this loop before ordinary hand-written Swift:
 
 1. \`axint.status\` confirms the running MCP version.
-2. \`axint.upgrade\` checks for a newer package when the running MCP version is stale and returns same-thread reload instructions.
-3. \`axint.session.start\` creates a durable token for the current agent pass.
-4. ${guardLoopStep}
-5. \`axint.context.memory\` reloads compact operating memory when local files are missing.
-6. \`axint.context.docs\` reloads this docs context when local files are missing.
-7. \`axint.workflow.check\` verifies the agent is at the right gate and has the active token.
-8. \`axint.suggest\` proposes relevant Apple-native surfaces from the app description.
-9. \`axint.feature\` generates a package of surfaces: intent, view, widget, component, app, store, tests, plist, and entitlements.
-10. ${writeStep}
-11. \`axint.scaffold\` creates TypeScript \`defineIntent(...)\` source for an App Intent.
-12. \`axint.compile\` compiles TypeScript intent source to Swift + Info.plist + entitlements.
-13. \`axint.schema.compile\` compiles low-token JSON directly to Swift.
-14. \`axint.tokens.ingest\` converts design tokens into SwiftUI token enums.
-15. \`axint.swift.validate\` checks changed Swift before Xcode build.
-16. \`axint.swift.fix\` applies mechanical Swift repairs when safe.
-17. \`axint.cloud.check\` runs coverage-aware Cloud Check with source plus build/test/runtime evidence.
-18. \`axint.fix-packet\` reads the latest AI-ready repair packet.
-19. \`axint.agent.advice\` and \`axint memory index\` reload the project-local brain after compaction or multi-agent handoff.
-20. Xcode build and tests provide runtime proof.
+2. \`axint.activate\` proves Axint returned first value instead of only starting a server.
+3. \`axint.upgrade\` checks for a newer package when the running MCP version is stale and returns same-thread reload instructions.
+4. \`axint.session.start\` creates a durable token for the current agent pass.
+5. ${guardLoopStep}
+6. \`axint.context.memory\` reloads compact operating memory when local files are missing.
+7. \`axint.context.docs\` reloads this docs context when local files are missing.
+8. \`axint.workflow.check\` verifies the agent is at the right gate and has the active token.
+9. \`axint.suggest\` proposes relevant Apple-native surfaces from the app description.
+10. \`axint.feature\` generates a package of surfaces: intent, view, widget, component, app, store, tests, plist, and entitlements.
+11. ${writeStep}
+12. \`axint.scaffold\` creates TypeScript \`defineIntent(...)\` source for an App Intent.
+13. \`axint.compile\` compiles TypeScript intent source to Swift + Info.plist + entitlements.
+14. \`axint.schema.compile\` compiles low-token JSON directly to Swift.
+15. \`axint.tokens.ingest\` converts design tokens into SwiftUI token enums.
+16. \`axint.swift.validate\` checks changed Swift before Xcode build.
+17. \`axint.swift.fix\` applies mechanical Swift repairs when safe.
+18. \`axint.cloud.check\` runs coverage-aware Cloud Check with source plus build/test/runtime evidence.
+19. \`axint.fix-packet\` reads the latest AI-ready repair packet.
+20. \`axint.agent.advice\` and \`axint memory index\` reload the project-local brain after compaction or multi-agent handoff.
+21. Xcode build and tests provide runtime proof.
 
 ## Axint Language And Input Surfaces
 
@@ -176,6 +178,7 @@ axint.tokens.ingest -> axint.suggest -> axint.feature with context -> axint.swif
 ## MCP Tool Map
 
 - \`axint.status\`: running version, uptime, package path, same-thread reload/update help.
+- \`axint.activate\`: source-free compiler smoke test; call after install or first MCP connection so setup proves first use.
 - \`axint.upgrade\`: checks or applies a package upgrade, writes \`.axint/upgrade/latest.*\`, and returns a same-thread continuation prompt.
 - \`axint.doctor\`: checks version truth, Node/npm/npx paths, MCP config, Xcode Claude config, and project memory files.
 - \`axint.session.start\`: starts the enforced session, writes \`.axint/session/current.json\`, and returns the token required by workflow gates.
@@ -232,7 +235,7 @@ Inside Xcode Claude or another Xcode agent:
 1. Confirm both \`xcode-tools\` and \`axint\` MCP servers are available.
 2. If Axint is missing, run the setup command in a normal terminal, then reload or reconnect the Axint MCP server/tool process.
 3. If npm/npx is missing in Xcode's restricted PATH, use the durable Homebrew path in \`.mcp.json\`.
-4. Always call \`axint.status\` after reload to verify the active version.
+4. Always call \`axint.status\` and \`axint.activate\` after reload to verify the active version and first real Axint output.
 5. Xcode build/test failures are Axint feedback if Axint passed the same code.
 
 ## Setup Commands
@@ -241,6 +244,7 @@ Typical project setup:
 
 \`\`\`bash
 npm install -g @axint/compiler
+axint activate
 axint xcode install --project .
 axint project init --dir /path/to/App --name AppName --agent claude --force
 \`\`\`
@@ -250,7 +254,7 @@ If Xcode cannot find \`npx\`, configure the project MCP file with an absolute co
 ## Context Recovery Prompt
 
 \`\`\`text
-Call axint.session.start for this project and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If any are missing, call axint.context.memory and axint.context.docs. Then list MCP servers, call axint.status, call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true, and tell me the next Axint tool you will use before editing code.
+Call axint.session.start for this project and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If any are missing, call axint.context.memory and axint.context.docs. Then list MCP servers, call axint.status, call axint.activate, call axint.workflow.check with stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true, and tell me the next Axint tool you will use before editing code.
 \`\`\`
 
 ## Runtime Freeze Prompt

--- a/src/project/operating-memory.ts
+++ b/src/project/operating-memory.ts
@@ -69,8 +69,9 @@ Models lose memory when chats compact. The project does not. When context is mis
 4. If the docs context file is missing, call \`axint.context.docs\`.
 5. List MCP servers/tools and confirm \`axint\` is present.
 6. Call \`axint.status\` and compare the running MCP version with the expected version above.
-7. Call \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
-8. Name the next Axint tool before editing code.
+7. Call \`axint.activate\` and report \`Status: ok\` so the session proves first real Axint use, not just server start.
+8. Call \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
+9. Name the next Axint tool before editing code.
 
 If Axint is missing or stale, stop. Do not continue by hand. Run \`axint.upgrade\` or tell the user to run \`axint upgrade --apply\`, then reload or reconnect only the Axint MCP server/tool process. Keep the current Codex or Claude thread when the client supports MCP reload.
 
@@ -79,6 +80,7 @@ If Axint is missing or stale, stop. Do not continue by hand. Run \`axint.upgrade
 Do not spend more than 10 minutes or make broad multi-file Swift changes without an Axint checkpoint. A checkpoint means one of:
 
 - \`axint.workflow.check\`
+- \`axint.activate\`
 - \`axint.upgrade\`
 - \`axint.xcode.guard\`
 - \`axint.xcode.write\`
@@ -121,7 +123,7 @@ ${profile.xcodeToolsAllowed ? "For Xcode work, prefer `axint.xcode.guard` as the
 ## Recovery Prompt
 
 \`\`\`text
-Call axint.session.start for this project and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If docs context is missing, call axint.context.docs. Then list MCP servers, call axint.status, call axint.workflow.check with agent="${profile.agent}", stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true. Use this write lane: ${profile.defaultWriteAction}. For build/test/runtime proof, use axint.run instead of manually remembering every Axint gate.
+Call axint.session.start for this project and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If docs context is missing, call axint.context.docs. Then list MCP servers, call axint.status, call axint.activate, call axint.workflow.check with agent="${profile.agent}", stage=context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true. Use this write lane: ${profile.defaultWriteAction}. For build/test/runtime proof, use axint.run instead of manually remembering every Axint gate.
 \`\`\`
 `;
 }

--- a/src/project/rehydration.ts
+++ b/src/project/rehydration.ts
@@ -57,7 +57,8 @@ The model's memory is not the source of truth. These project files are. If the a
 3. Read \`.axint/AXINT_REHYDRATE.md\`, \`.axint/AXINT_MEMORY.md\`, and \`.axint/AXINT_DOCS_CONTEXT.md\`.
 4. Read \`AGENTS.md\`, \`CLAUDE.md\`, or \`.axint/project.json\` if present.
 5. Call \`axint.status\` and report the running MCP version. If it is stale, call \`axint.upgrade\` or ask the user to run \`axint upgrade --apply\`, then reload only the Axint MCP server/tool process.
-6. Call \`axint.workflow.check\` with:
+6. Call \`axint.activate\` and report \`Status: ok\` before editing so this session proves first real Axint use.
+7. Call \`axint.workflow.check\` with:
 
 \`\`\`json
 {
@@ -72,7 +73,7 @@ The model's memory is not the source of truth. These project files are. If the a
 }
 \`\`\`
 
-7. State the next Axint tool before editing code.
+8. State the next Axint tool before editing code.
 
 ## Required Checkpoints
 

--- a/src/project/session.ts
+++ b/src/project/session.ts
@@ -475,7 +475,7 @@ function buildSessionRecoveryPrompt(session: AxintSessionRecord): string {
     "",
     "Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json.",
     "If either Axint context file is missing, call axint.context.memory and axint.context.docs.",
-    `Then call axint.status and axint.workflow.check with agent=${session.agent}, stage context-recovery, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, ranStatus=true, and this sessionToken.`,
+    `Then call axint.status, call axint.activate, and call axint.workflow.check with agent=${session.agent}, stage context-recovery, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, ranStatus=true, and this sessionToken.`,
     "Do not edit Apple-native code until that workflow check is ready.",
   ].join("\n");
 }

--- a/src/project/start-pack.ts
+++ b/src/project/start-pack.ts
@@ -156,6 +156,7 @@ export function buildProjectStartPack(
               "read .axint/AXINT_DOCS_CONTEXT.md or call axint.context.docs",
               "read AGENTS.md, CLAUDE.md, or .axint/project.json",
               "call axint.status",
+              "call axint.activate",
               `call axint.workflow.check with agent=${profile.agent}, stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readDocsContext=true, readAgentInstructions=true, and ranStatus=true`,
               "state the next Axint tool that will be used, or call axint.run for the full validation/build loop",
             ],
@@ -304,10 +305,10 @@ function buildStartPrompt(input: {
     "3. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, or .axint/project.json if present.",
     "4. If those files are missing, call axint.context.memory and axint.context.docs, then use those as the compact Axint operating memory and docs context.",
     mcpServerStep,
-    "6. Call axint.status and report the running MCP server version.",
+    "6. Call axint.status, then axint.activate, and report the running MCP version plus activation result.",
     `7. Call axint.workflow.check with agent=${profile.agent}, stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, and ranStatus=true.`,
     `8. Expected Axint package version from this project pack: ${input.version}.`,
-    "9. If the running MCP version is stale, stop and call axint.upgrade or tell me to run axint upgrade --apply, then reload only the Axint MCP server/tool process.",
+    "9. If the running MCP version is stale, stop and call axint.upgrade or tell me to run axint upgrade --apply, then reload only the Axint MCP server/tool process and activate again.",
     profile.xcodeToolsAllowed
       ? "10. Call axint.xcode.guard before long tasks, before broad Swift edits, and after any context recovery."
       : "10. Use axint.workflow.check as the long-task guard, plus validate/Cloud Check/build evidence. Do not fake Xcode guard packets outside Xcode.",
@@ -398,8 +399,9 @@ If the chat was restarted, compacted, summarized, or has drifted into ordinary X
 3. Read \`.axint/AXINT_REHYDRATE.md\`, \`.axint/AXINT_MEMORY.md\`, \`.axint/AXINT_DOCS_CONTEXT.md\`, \`AGENTS.md\`, \`CLAUDE.md\`, or \`.axint/project.json\`.
 4. If either Axint context file is missing, call \`axint.context.memory\` and \`axint.context.docs\`.
 5. Call \`axint.status\` and compare it with the expected version above.
-6. Call \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
-7. State the next Axint tool to use before editing code. For proof passes, prefer \`axint.run\`.
+6. Call \`axint.activate\` and report \`Status: ok\` so the session proves Axint returned first value.
+7. Call \`axint.workflow.check\` with \`stage: "context-recovery"\`, \`sessionToken\`, \`readRehydrationContext: true\`, \`readAgentInstructions: true\`, \`readDocsContext: true\`, and \`ranStatus: true\`.
+8. State the next Axint tool to use before editing code. For proof passes, prefer \`axint.run\`.
 
 Do not rely on model memory alone. Rehydrate the workflow from the files.
 
@@ -409,11 +411,12 @@ Do not rely on model memory alone. Rehydrate the workflow from the files.
 2. ${longTaskGuardLine}
 3. Read the Axint docs listed in the start prompt.
 4. Call \`axint.status\`.
-5. Call \`axint.workflow.check\` with \`sessionToken\` at session start, after context recovery, before planning, before writing, before building, and before committing.
-6. If \`axint.workflow.check\` returns \`ready\`, call the report's \`Next Axint Action\` before broad Apple-native work.
-7. Use \`axint.suggest\` for feature planning. If MCP transport is unavailable, use \`axint suggest <app-description>\` and then pass \`--ran-suggest\` to the workflow check.
-8. Use \`axint.feature\`, \`axint.scaffold\`, \`axint.compile\`, or \`axint.schema.compile\` for Apple-native surfaces.
-9. ${writeLine}
+5. Call \`axint.activate\` after install, MCP reload, or any uncertainty about whether Axint was actually used.
+6. Call \`axint.workflow.check\` with \`sessionToken\` at session start, after context recovery, before planning, before writing, before building, and before committing.
+7. If \`axint.workflow.check\` returns \`ready\`, call the report's \`Next Axint Action\` before broad Apple-native work.
+8. Use \`axint.suggest\` for feature planning. If MCP transport is unavailable, use \`axint suggest <app-description>\` and then pass \`--ran-suggest\` to the workflow check.
+9. Use \`axint.feature\`, \`axint.scaffold\`, \`axint.compile\`, or \`axint.schema.compile\` for Apple-native surfaces.
+10. ${writeLine}
 10. Run \`axint.swift.validate\` on modified Swift.
 11. Run \`axint.cloud.check\` with Xcode build, test, runtime, or behavior evidence when available.
 12. Prefer \`axint.run\` when moving toward build/test/runtime proof so Axint owns the loop instead of relying on memory.
@@ -470,7 +473,7 @@ ${input.startPrompt}
 Ask it to run the Axint context recovery loop:
 
 \`\`\`text
-Call axint.session.start for this project and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If either Axint context file is missing, call axint.context.memory and axint.context.docs. Then call axint.status and axint.workflow.check with agent=${input.profile.agent}, stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, ranStatus=true. Use this write lane: ${input.profile.defaultWriteAction}. For build/test/runtime proof, call axint.run so Axint owns the full loop.
+Call axint.session.start for this project and keep the returned sessionToken. Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json. If either Axint context file is missing, call axint.context.memory and axint.context.docs. Then call axint.status, call axint.activate, and call axint.workflow.check with agent=${input.profile.agent}, stage context-recovery, sessionToken=<token>, readRehydrationContext=true, readAgentInstructions=true, readDocsContext=true, ranStatus=true. Use this write lane: ${input.profile.defaultWriteAction}. For build/test/runtime proof, call axint.run so Axint owns the full loop.
 \`\`\`
 
 ## CLI Session Start

--- a/src/project/upgrade.ts
+++ b/src/project/upgrade.ts
@@ -430,7 +430,7 @@ function buildSameThreadPrompt(input: {
 
   const reloadLine =
     input.status === "current"
-      ? "No package upgrade is needed. If the client is still connected to a stale or confused MCP process, reload or reconnect only the Axint MCP server/tool process and call axint.status again."
+      ? "No package upgrade is needed. If the client is still connected to a stale or confused MCP process, reload or reconnect only the Axint MCP server/tool process, then call axint.status and axint.activate again."
       : "Reload or reconnect only the Axint MCP server/tool process so this same conversation can see the new package.";
   const xcodeLine =
     input.status === "current"
@@ -440,8 +440,8 @@ function buildSameThreadPrompt(input: {
         : "Xcode MCP wiring was intentionally skipped for this upgrade flow.";
   const statusLine =
     input.status === "current"
-      ? "Before editing code, call axint.status if you need to prove the currently connected MCP version."
-      : "After the MCP process reconnects, call axint.status and confirm the running version before editing code.";
+      ? "Before editing code, call axint.status and axint.activate if you need to prove the currently connected MCP version and first value."
+      : "After the MCP process reconnects, call axint.status and axint.activate before editing code.";
   const syncLine =
     input.status === "upgraded"
       ? `Axint already refreshed any Axint-owned project version hints it found. If another checkout still has stale hints, run: axint project sync-version --dir ${quoteShellArg(input.cwd)} --version ${input.targetVersion}`

--- a/src/project/version-sync.ts
+++ b/src/project/version-sync.ts
@@ -117,7 +117,7 @@ export function renderProjectVersionSync(
   if (result.updated.length > 0 && !result.dryRun) {
     lines.push(
       "",
-      "Next: call `axint.status`, then `axint.workflow.check` so the active agent proves it is using the refreshed project truth."
+      "Next: call `axint.status`, then `axint.activate`, then `axint.workflow.check` so the active agent proves it is using the refreshed project truth and real Axint output."
     );
   }
 

--- a/src/project/xcode-guard.ts
+++ b/src/project/xcode-guard.ts
@@ -730,7 +730,7 @@ function buildGuardRecoveryPrompt(cwd: string, projectName: string): string {
     `We are working in ${projectName}. Do not continue from memory.`,
     `Project path: ${cwd}`,
     "Call axint.xcode.guard with stage=context-recovery.",
-    "Then call axint.status and report the running Axint MCP version.",
+    "Then call axint.status, call axint.activate, and report the running Axint MCP version plus activation result.",
     "Read .axint/AXINT_REHYDRATE.md, .axint/AXINT_MEMORY.md, .axint/AXINT_DOCS_CONTEXT.md, AGENTS.md, CLAUDE.md, and .axint/project.json.",
     "For build/test/runtime proof, call axint.run so Axint owns the full loop.",
   ].join("\n");

--- a/src/telemetry/adoption.ts
+++ b/src/telemetry/adoption.ts
@@ -12,6 +12,8 @@ type TelemetryConfig = {
   optedOut?: boolean;
   createdAt: string;
   updatedAt: string;
+  initializedAt?: string;
+  activatedAt?: string;
 };
 
 type RecordAdoptionEventInput = {
@@ -54,10 +56,23 @@ const SENDS = [
   "Axint version",
   "command class, such as cloud check or run",
   "MCP tool name",
+  "first install and first activation lifecycle markers",
   "coarse host hint, such as terminal, Codex, Claude, Cursor, or Xcode when detectable",
   "operating system family, architecture, Node major version, and CI flag",
   "anonymous random install id that can be reset or disabled",
 ];
+
+const SETUP_ONLY_CLI_COMMANDS = new Set([
+  "status",
+  "doctor",
+  "upgrade",
+  "mcp",
+  "mcp status",
+  "mcp recover",
+  "telemetry",
+]);
+
+const SETUP_ONLY_MCP_TOOLS = new Set(["axint.status", "axint.doctor", "axint.upgrade"]);
 
 function envFlagOff(value: string | undefined): boolean {
   if (!value) return false;
@@ -106,17 +121,12 @@ function writeTelemetryConfig(config: TelemetryConfig): void {
   writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
 }
 
-function getOrCreateTelemetryConfig(): TelemetryConfig {
-  const existing = readTelemetryConfig();
-  if (existing) return existing;
-  const now = new Date().toISOString();
-  const created: TelemetryConfig = {
+function createTelemetryConfig(now = new Date().toISOString()): TelemetryConfig {
+  return {
     anonymousId: `axa_${randomUUID()}`,
     createdAt: now,
     updatedAt: now,
   };
-  writeTelemetryConfig(created);
-  return created;
 }
 
 function telemetryDisabledReason(config?: TelemetryConfig | null): string | null {
@@ -142,6 +152,8 @@ export function setAdoptionTelemetryOptOut(optedOut: boolean): TelemetryConfig {
     anonymousId: current?.anonymousId ?? `axa_${randomUUID()}`,
     createdAt: current?.createdAt ?? now,
     updatedAt: now,
+    initializedAt: current?.initializedAt ?? now,
+    activatedAt: current?.activatedAt,
     optedOut,
   };
   writeTelemetryConfig(next);
@@ -217,6 +229,43 @@ function metadataFor(input: RecordAdoptionEventInput): Record<string, string | b
   };
 }
 
+function isActivationProofEvent(input: RecordAdoptionEventInput): boolean {
+  if (input.result && input.result !== "ok") return false;
+
+  if (input.eventName === "mcp_tool_completed") {
+    return Boolean(input.toolName && !SETUP_ONLY_MCP_TOOLS.has(input.toolName));
+  }
+
+  if (input.eventName === "cli_command_completed") {
+    const command = input.command?.trim();
+    if (!command) return true;
+    return !SETUP_ONLY_CLI_COMMANDS.has(command);
+  }
+
+  return [
+    "axint_first_value",
+    "cloud_first_check_completed",
+    "cloud_repeat_check_completed",
+    "cloud_report_saved",
+  ].includes(input.eventName);
+}
+
+function adoptionEventPayload(
+  input: RecordAdoptionEventInput,
+  config: TelemetryConfig,
+  eventName: string
+) {
+  return {
+    schema: "https://axint.ai/schemas/adoption-telemetry.v1.json",
+    source: input.source,
+    event_name: eventName,
+    event_type: "adoption",
+    anonymous_id: config.anonymousId,
+    session_id: processSessionId,
+    metadata: metadataFor(input),
+  };
+}
+
 export async function recordAdoptionEvent(
   input: RecordAdoptionEventInput
 ): Promise<{ sent: boolean; reason?: string }> {
@@ -224,7 +273,24 @@ export async function recordAdoptionEvent(
   const disabled = telemetryDisabledReason(existing);
   if (disabled) return { sent: false, reason: disabled };
 
-  const config = getOrCreateTelemetryConfig();
+  const createdNow = !existing;
+  const config = existing ?? createTelemetryConfig();
+  if (createdNow) writeTelemetryConfig(config);
+
+  const shouldMarkInitialized = !config.initializedAt;
+  const shouldMarkActivated =
+    !config.activatedAt &&
+    input.eventName !== "axint_activated" &&
+    isActivationProofEvent(input);
+  const events = [
+    ...(shouldMarkInitialized
+      ? [adoptionEventPayload(input, config, "axint_install_initialized")]
+      : []),
+    adoptionEventPayload(input, config, input.eventName),
+    ...(shouldMarkActivated
+      ? [adoptionEventPayload(input, config, "axint_activated")]
+      : []),
+  ];
   const endpoint = adoptionTelemetryEndpoint();
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 450);
@@ -238,19 +304,20 @@ export async function recordAdoptionEvent(
         "X-Axint-Version": safeValue(input.version, 32) ?? "unknown",
       },
       signal: controller.signal,
-      body: JSON.stringify({
-        schema: "https://axint.ai/schemas/adoption-telemetry.v1.json",
-        source: input.source,
-        event_name: input.eventName,
-        event_type: "adoption",
-        anonymous_id: config.anonymousId,
-        session_id: processSessionId,
-        metadata: metadataFor(input),
-      }),
+      body: JSON.stringify(events.length === 1 ? events[0] : { events }),
     });
 
     if (!response.ok) {
       return { sent: false, reason: `telemetry endpoint returned ${response.status}` };
+    }
+    if (shouldMarkInitialized || shouldMarkActivated) {
+      const now = new Date().toISOString();
+      writeTelemetryConfig({
+        ...config,
+        initializedAt: config.initializedAt ?? now,
+        activatedAt: shouldMarkActivated ? now : config.activatedAt,
+        updatedAt: now,
+      });
     }
     return { sent: true };
   } catch (error) {

--- a/tests/cli/activate.test.ts
+++ b/tests/cli/activate.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderActivationSmokeReport,
+  runActivationSmokeTest,
+} from "../../src/activation/smoke-test.js";
+
+describe("axint activate", () => {
+  it("runs the source-free compiler smoke test", () => {
+    const report = runActivationSmokeTest();
+
+    expect(report.status).toBe("ok");
+    expect(report.signal).toBe("axint_activated");
+    expect(report.intentName).toBe("AxintActivationProbe");
+    expect(report.swiftFile).toBe("AxintActivationProbeIntent.swift");
+    expect(report.swiftLines).toBeGreaterThan(0);
+  });
+
+  it("renders a concise activation receipt", () => {
+    const output = renderActivationSmokeReport(runActivationSmokeTest(), "markdown");
+
+    expect(output).toContain("# Axint Activation");
+    expect(output).toContain("Status: ok");
+    expect(output).toContain("Signal: axint_activated");
+    expect(output).toContain("AxintActivationProbe");
+  });
+});

--- a/tests/cli/status.test.ts
+++ b/tests/cli/status.test.ts
@@ -7,6 +7,7 @@ describe("axint status", () => {
 
     expect(output).toContain("@axint/compiler@9.9.9");
     expect(output).toContain("Call axint.status");
+    expect(output).toContain("axint.activate");
     expect(output).toContain("axint upgrade --apply");
     expect(output).toContain("Keep the current Codex or Claude thread");
   });
@@ -15,6 +16,7 @@ describe("axint status", () => {
     const output = renderCliStatus("9.9.9", "prompt");
 
     expect(output).toContain("Call axint.status");
+    expect(output).toContain("axint.activate");
     expect(output).toContain("Expected local package version: 9.9.9");
     expect(output).toContain("axint.upgrade");
     expect(output).toContain("axint.cloud.check");

--- a/tests/cli/xcode.test.ts
+++ b/tests/cli/xcode.test.ts
@@ -87,6 +87,7 @@ describe("xcode CLI smoke coverage", () => {
       stdout: JSON.stringify({
         tools: [
           { name: "axint.status" },
+          { name: "axint.activate" },
           { name: "axint.feature" },
           { name: "axint.compile" },
           { name: "axint.validate" },
@@ -249,6 +250,7 @@ describe("xcode CLI smoke coverage", () => {
       stdout: JSON.stringify({
         tools: [
           { name: "axint.status" },
+          { name: "axint.activate" },
           { name: "axint.feature" },
           { name: "axint.project.index" },
         ],

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -71,6 +71,26 @@ describe("axint.status tool", () => {
   });
 });
 
+describe("axint.activate tool", () => {
+  it("proves first real use with a source-free compiler smoke test", async () => {
+    const result = await handleToolCall("axint.activate", { format: "json" });
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as {
+      status: string;
+      signal: string;
+      intentName: string;
+      swiftFile: string;
+      swiftLines: number;
+    };
+    expect(payload.status).toBe("ok");
+    expect(payload.signal).toBe("axint_activated");
+    expect(payload.intentName).toBe("AxintActivationProbe");
+    expect(payload.swiftFile).toBe("AxintActivationProbeIntent.swift");
+    expect(payload.swiftLines).toBeGreaterThan(0);
+  });
+});
+
 describe("axint.run tool", () => {
   it("returns a structured Axint Run report for a dry-run Xcode project", async () => {
     const dir = mkdtempSync(join(tmpdir(), "axint-mcp-run-"));

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.27";
+const VERSION = "0.4.28";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
## What changed
- Adds first-use activation proof so install/start events can be distinguished from actual usage.
- Adds the install gauntlet and activation smoke coverage for CLI and MCP flows.
- Updates version/public truth surfaces for v0.4.28.

## Why
Promotion is driving organic installs, but Pulse needs to show whether those users actually activate and use Axint afterward.

## Validation
- npm run install:gauntlet
- npm run prepublishOnly
- npm test
- npm pack --dry-run
- npm run release:check