### PR TITLE
fix(view): avoid double optional prop types

### DIFF
--- a/src/core/view-generator.ts
+++ b/src/core/view-generator.ts
@@ -30,8 +30,7 @@ export function generateSwiftUIView(view: IRView): string {
 
   // Props (let bindings from parent)
   for (const p of view.props) {
-    const swift = irTypeToSwift(p.type);
-    const decl = p.isOptional ? `${swift}?` : swift;
+    const decl = irTypeToSwift(p.type);
     if (p.defaultValue !== undefined) {
       lines.push(`    var ${p.name}: ${decl} = ${formatLiteral(p.defaultValue, p.type)}`);
     } else {

--- a/tests/core/view-compiler.test.ts
+++ b/tests/core/view-compiler.test.ts
@@ -50,6 +50,42 @@ export default defineView({
 });
 `;
 
+const DASHBOARD_CARD = `
+import { defineView, prop, state, view } from "@axint/sdk";
+
+export default defineView({
+  name: "DashboardCard",
+  props: {
+    title: prop.string("Card title", { default: "Untitled" }),
+    subtitle: prop.string("Optional subtitle", { required: false, default: "Draft" }),
+  },
+  state: {
+    isExpanded: state.boolean("Expanded state", { default: true }),
+    tapCount: state.int("Number of taps", { default: 0 }),
+  },
+  body: [
+    view.vstack([
+      view.hstack([
+        view.text("\\\\(title)"),
+        view.spacer(),
+      ], { spacing: 4 }),
+      view.conditional("isExpanded", [
+        view.vstack([
+          view.text("\\\\(subtitle ?? \\"No subtitle\\")"),
+          view.conditional("tapCount > 0", [
+            view.text("Tapped \\\\(tapCount) times"),
+          ], [
+            view.text("Not tapped"),
+          ]),
+        ], { spacing: 6 }),
+      ], [
+        view.text("Collapsed"),
+      ]),
+    ], { spacing: 10 }),
+  ],
+});
+`;
+
 const MINIMAL_VIEW = `
 import { defineView, view } from "@axint/sdk";
 
@@ -91,6 +127,26 @@ describe("compileViewSource", () => {
     expect(swift).toContain('Image(systemName: "person.circle.fill")');
     expect(swift).toContain("if isExpanded");
     expect(swift).toContain("Spacer()");
+  });
+
+  it("compiles optional props and nested conditionals with stable Swift output", () => {
+    const result = compileViewSource(DASHBOARD_CARD);
+    expect(result.success).toBe(true);
+
+    const swift = result.output!.swiftCode;
+    expect(swift).toContain("struct DashboardCard: View");
+    expect(swift).toContain('var title: String = "Untitled"');
+    expect(swift).toContain('var subtitle: String? = "Draft"');
+    expect(swift).toContain("@State private var isExpanded: Bool = true");
+    expect(swift).toContain("@State private var tapCount: Int = 0");
+    expect(swift).toContain("VStack(spacing: 10)");
+    expect(swift).toContain("HStack(spacing: 4)");
+    expect(swift).toContain("VStack(spacing: 6)");
+    expect(swift).toContain("if isExpanded");
+    expect(swift).toContain("if tapCount > 0");
+    expect(swift).toContain('Text("Collapsed")');
+    expect(swift).toContain("DashboardCard()");
+    expect(swift).not.toContain("DashboardCard(title:");
   });
 
   it("compiles a minimal view with no props or state", () => {


### PR DESCRIPTION
## Summary

Adds a targeted SwiftUI view generator regression for optional props with defaults and nested conditionals.

While adding the regression, the test exposed that optional view props could be emitted as double-optionals, for example `String??`. The parser already represents optional props as optional `IRType` nodes, so the generator now trusts `irTypeToSwift(...)` directly instead of appending another `?` from the parallel `isOptional` flag.

## Changed

- Add a `DashboardCard` view compiler fixture covering:
  - defaulted props
  - optional defaulted props
  - multiple `@State` fields
  - nested stack composition
  - nested `view.conditional(...)` output
  - preview initializer behavior
- Fix view prop type emission so optional props generate `String?`, not `String??`.

## Tests

- `npm run test -- tests/core/view-compiler.test.ts`
- `npm run typecheck`
- `npx eslint src/core/view-generator.ts tests/core/view-compiler.test.ts`
- `git diff --check`
- `npm run test -- tests/core/types.test.ts tests/core/generator.test.ts tests/core/view-compiler.test.ts tests/core/view-validator.test.ts`

Notes:

- I also sampled the full `npm run test` suite. The new and adjacent core tests passed, but the full local run still has unrelated Windows/local-environment failures around missing built `dist/cli/index.js`, path separator expectations, CRLF/LF roundtrip expectations, and unrelated scaffold/parity checks.

Closes #105.
