### PR TITLE
Update metrics after view regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.28 · 36 MCP tools + 5 prompts · 204 diagnostic codes · 1311 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.28 · 36 MCP tools + 5 prompts · 204 diagnostic codes · 1312 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -32,7 +32,7 @@ Axint.
   start packs, README, and website install prompts now point agents to
   `axint activate` / `axint.activate` after setup.
 - Public truth advances to v0.4.28 with 36 MCP tools, 5 prompts, 204 diagnostic
-  codes, 1311 tests, and 26 bundled templates.
+  codes, 1312 tests, and 26 bundled templates.
 
 ### Why it matters
 

--- a/metrics.json
+++ b/metrics.json
@@ -86,7 +86,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1197,
+    "typescript": 1198,
     "python": 114
   },
   "registryPackages": 58,


### PR DESCRIPTION
## Summary

- refresh metrics.json after PR #262 added one TypeScript regression test
- fixes CI metrics drift: tests.typescript 1197 -> 1198

## Verification

- npm audit --audit-level=moderate
- npm run versions:check
- npm run metrics:check
- npm run docs:check
- npm run boundary:check
- npm run typecheck
- npm run typecheck:examples
- npm run lint
- npm run build
- npm run test:coverage
- node dist/cli/index.js --version