### PR TITLE
Align 0.4.28 release notes metrics

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -32,7 +32,7 @@ Axint.
   start packs, README, and website install prompts now point agents to
   `axint activate` / `axint.activate` after setup.
 - Public truth advances to v0.4.28 with 36 MCP tools, 5 prompts, 204 diagnostic
-  codes, 1312 tests, and 26 bundled templates.
+  codes, 1319 tests, and 26 bundled templates.
 
 ### Why it matters
 


### PR DESCRIPTION
## Summary
- correct the v0.4.28 release notes test count from 1312 to 1319
- keep release notes aligned with metrics.json, README, roadmap, docs, npm, PyPI, and live public truth

## Verification
- npm run versions:check
- npm run metrics:check
- npm run docs:check
- rg -n "1312" .