### PR TITLE
Fix dogfood provider and codesign loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.28 · 36 MCP tools + 5 prompts · 204 diagnostic codes · 1337 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.28 · 36 MCP tools + 5 prompts · 204 diagnostic codes · 1340 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -32,7 +32,7 @@ Axint.
   start packs, README, and website install prompts now point agents to
   `axint activate` / `axint.activate` after setup.
 - Public truth advances to v0.4.28 with 36 MCP tools, 5 prompts, 204 diagnostic
-  codes, 1337 tests, and 26 bundled templates.
+  codes, 1340 tests, and 26 bundled templates.
 
 ### Why it matters
 

--- a/metrics.json
+++ b/metrics.json
@@ -86,7 +86,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1223,
+    "typescript": 1226,
     "python": 114
   },
   "registryPackages": 58,

--- a/src/cloud/check.ts
+++ b/src/cloud/check.ts
@@ -1368,6 +1368,22 @@ function diagnosticsFromBuildLog(buildLog: string, file: string): Diagnostic[] {
   const text = normalizeTextForEvidence(buildLog);
   const diagnostics: Diagnostic[] = [];
 
+  if (
+    /\bresource fork, finder information, or similar detritus not allowed\b/.test(text) ||
+    /\bcom\.apple\.finderinfo\b/.test(text) ||
+    (/\bcodesign\b/.test(text) && /\bfileprovider\b/.test(text))
+  ) {
+    diagnostics.push({
+      code: "AXCLOUD-CODESIGN-RESOURCE-FORK",
+      severity: "error",
+      file,
+      message:
+        "Xcode code signing evidence reports resource fork, FinderInfo, or FileProvider metadata inside the app bundle.",
+      suggestion:
+        "Clean extended attributes with `xattr -cr <BuiltApp.app>`, run builds with `COPYFILE_DISABLE=1`, and place DerivedData/archive output under `/tmp` or another non-synced, non-FileProvider path before rerunning codesign.",
+    });
+  }
+
   if (/\binvalid redeclaration\b|\balready declared\b|\bduplicate\b/.test(text)) {
     diagnostics.push({
       code: "AXCLOUD-BUILD-REDECLARATION",

--- a/src/mcp/suggest.ts
+++ b/src/mcp/suggest.ts
@@ -1995,22 +1995,28 @@ function looksLikeExistingProductRepair(
     "broken",
     "can't",
     "cannot",
+    "cleanup",
     "does not",
     "doesn't",
     "fails",
     "failing",
     "fix",
     "improve",
+    "no near-duplicate",
     "no longer",
     "polish",
     "premium",
     "not working",
+    "output quality",
     "regression",
     "repair",
+    "rescue pass",
     "restore",
+    "stronger",
     "stopped",
     "turning",
     "upgrade",
+    "weak",
     "won't",
   ].some((keyword) => hasKeyword(combined, keyword));
 
@@ -2032,9 +2038,13 @@ function looksLikeExistingProductRepair(
     "magic pass",
     "model routing",
     "nano banana",
+    "near-duplicate",
+    "output quality",
     "project room",
     "provider",
+    "provider output",
     "provider prompt",
+    "provider quality",
     "prompt builder",
     "prompt quality",
     "route",
@@ -2051,6 +2061,48 @@ function looksLikeExistingProductRepair(
     "zindex",
   ].some((keyword) => hasKeyword(combined, keyword));
 
+  const providerOutputCues = [
+    "background",
+    "cosmic",
+    "face",
+    "fantasy",
+    "fine-line",
+    "gemini",
+    "generated output",
+    "glow-up",
+    "glow up",
+    "identity",
+    "image generation",
+    "image provider",
+    "magic pass",
+    "nano banana",
+    "near-duplicate",
+    "output quality",
+    "provider",
+    "provider output",
+    "provider prompt",
+    "prompt contract",
+    "skin cleanup",
+    "under-eye",
+  ].filter((keyword) => hasKeyword(combined, keyword));
+
+  const providerQualityIntent =
+    providerOutputCues.length >= 2 &&
+    [
+      "contract",
+      "cleanup",
+      "friend testing",
+      "identity-safe",
+      "leaves unchanged",
+      "no near-duplicate",
+      "output quality",
+      "quality semantics",
+      "rescue pass",
+      "semantics",
+      "stronger",
+      "weak",
+    ].some((keyword) => hasKeyword(combined, keyword));
+
   if (
     /\b(create|generate|scaffold|build)\s+(?:a|an|new)\b/.test(combined) &&
     /\b(bug report|issue tracker|support ticket)\b/.test(combined)
@@ -2058,7 +2110,7 @@ function looksLikeExistingProductRepair(
     return false;
   }
 
-  return repairIntent && existingSurface;
+  return providerQualityIntent || (repairIntent && existingSurface);
 }
 
 function existingProductRepairSuggestions(
@@ -2212,7 +2264,7 @@ function repairNeedsInteractionMap(normalizedAppDescription: string): boolean {
 
 function repairProblemFocus(normalizedAppDescription: string): string {
   if (
-    /\b(provider|prompt builder|provider prompt|model routing|gemini|nano banana|image generation|identity|identity drift|face shape|head shape|hairline|beard|background|backdrop|glow-up|glow up)\b/.test(
+    /\b(provider|provider output|generated output|output quality|prompt builder|provider prompt|model routing|gemini|nano banana|image generation|identity|identity drift|identity-safe|face|face shape|head shape|hairline|beard|background|backdrop|fantasy|cosmic|skin cleanup|fine-line|under-eye|near-duplicate|10\/10|unchanged|glow-up|glow up)\b/.test(
       normalizedAppDescription
     )
   ) {
@@ -2255,7 +2307,7 @@ function repairProblemFocus(normalizedAppDescription: string): string {
 
 function repairScreenConcept(normalizedAppDescription: string): string {
   if (
-    /\b(cadabra|gemini|nano banana|image generation|image provider|magic pass)\b/.test(
+    /\b(cadabra|gemini|nano banana|image generation|image provider|provider output|output quality|magic pass)\b/.test(
       normalizedAppDescription
     )
   ) {
@@ -2288,7 +2340,7 @@ function repairPromptCues(normalizedAppDescription: string): string[] {
     [/\bdecisions?\b/, "Decisions"],
     [/\bproject context\b/, "project context"],
     [/\bdiscover\b/, "Discover"],
-    [/\blive\b|\bevents?\b/, "Live/Events"],
+    [/\blive\s+(?:activit(?:y|ies)|events?|feed|status)\b|\bevents?\b/, "Live/Events"],
     [/\bbuilders?\b/, "Builders"],
     [/\bmarketplace\b|\bmarket\b/, "Marketplace"],
     [/\btab(?:s)?\b|\btab routing\b/, "tab routing"],
@@ -2298,9 +2350,16 @@ function repairPromptCues(normalizedAppDescription: string): string[] {
     [/\bscroll\b|\btop\b/, "scroll-to-top behavior"],
     [/\bidentity\b|\bface shape\b|\bhead shape\b/, "identity preservation"],
     [/\bgemini\b|\bnano banana\b/, "image provider"],
-    [/\bprovider prompt\b|\bprompt builder\b/, "provider prompt"],
+    [
+      /\bprovider output\b|\boutput quality\b|\bgenerated output\b/,
+      "provider output quality",
+    ],
+    [/\bprovider prompt\b|\bprompt builder\b|\bprompt contract\b/, "provider prompt"],
     [/\bmodel routing\b|\bfast\/pro\/perfect\b/, "model routing"],
     [/\bmagic pass\b/, "Magic Pass"],
+    [/\bskin cleanup\b|\bfine-line\b|\bunder-eye\b/, "portrait cleanup"],
+    [/\bnear-duplicate\b|\bleaves unchanged\b|\bunchanged\b/, "near-duplicate avoidance"],
+    [/\bfantasy\b|\bcosmic\b|\bbackground\b/, "background preservation"],
   ];
 
   return unique(

--- a/tests/cloud/check.test.ts
+++ b/tests/cloud/check.test.ts
@@ -573,6 +573,36 @@ struct BrokenIntent: AppIntent {
     expect(report.learningSignal?.signals).toContain("runtime-evidence-supplied");
   });
 
+  it("classifies codesign resource fork and FinderInfo build logs", () => {
+    const report = runCloudCheck({
+      fileName: "CadabraApp.swift",
+      source: `
+import SwiftUI
+
+@main
+struct CadabraApp: App {
+    var body: some Scene {
+        WindowGroup { Text("Cadabra") }
+    }
+}
+`,
+      xcodeBuildLog: [
+        "CodeSign /Users/nimanejat/Documents/Cadabra/build/Build/Products/Debug-iphoneos/Cadabra.app",
+        "resource fork, Finder information, or similar detritus not allowed",
+        "com.apple.FinderInfo",
+      ].join("\n"),
+    });
+
+    expect(report.status).toBe("fail");
+    expect(report.gate.decision).toBe("fix_required");
+    expect(report.diagnostics.map((d) => d.code)).toContain(
+      "AXCLOUD-CODESIGN-RESOURCE-FORK"
+    );
+    expect(report.repairPrompt).toContain("COPYFILE_DISABLE");
+    expect(report.repairPrompt).toContain("/tmp");
+    expect(report.learningSignal?.signals).toContain("runtime-evidence-supplied");
+  });
+
   it("classifies common hallucinated-symbol Xcode build logs", () => {
     const report = runCloudCheck({
       fileName: "ProjectImportProgressView.swift",

--- a/tests/mcp/suggest.test.ts
+++ b/tests/mcp/suggest.test.ts
@@ -107,6 +107,38 @@ describe("axint.suggest", () => {
     expect(suggestions[0]?.featurePrompt).not.toContain("sample <AppProcessName>");
   });
 
+  it("routes provider-output rescue passes into provider repair mode", () => {
+    const suggestions = suggestFeatures({
+      appDescription:
+        "Rescue pass after live friend testing: stronger Gemini Nano Banana prompt contract, identity-safe skin cleanup, fine-line cleanup, under-eye cleanup, no near-duplicate output, history/share routing, share-card export typography, and provider-output quality semantics for Cadabra.",
+      platform: "iOS",
+      limit: 4,
+    });
+
+    expect(suggestions[0]?.domain).toBe("repair");
+    expect(suggestions[0]?.rationale).toContain("provider-behavior");
+    expect(suggestions[0]?.featurePrompt).toContain("provider behavior");
+    expect(suggestions[0]?.featurePrompt).toContain("provider prompt");
+    expect(suggestions[0]?.featurePrompt).toContain("provider output quality");
+    expect(suggestions[0]?.featurePrompt).not.toContain("Capture Rescue");
+    expect(suggestions.map((suggestion) => suggestion.domain)).not.toContain("custom");
+  });
+
+  it("keeps weak glow-up output repair out of new app-surface mode", () => {
+    const suggestions = suggestFeatures({
+      appDescription:
+        "Cadabra 10/10 Glow-Up leaves the face mostly unchanged and sometimes turns the real background into fantasy or cosmic scenes. Fix the provider output quality semantics and provider prompt contract; do not create a new Siri command.",
+      platform: "iOS",
+      limit: 3,
+    });
+
+    expect(suggestions[0]?.domain).toBe("repair");
+    expect(suggestions[0]?.rationale).toContain("provider-behavior");
+    expect(suggestions[0]?.featurePrompt).toContain("background preservation");
+    expect(suggestions[0]?.featurePrompt).not.toContain("Siri");
+    expect(suggestions.map((suggestion) => suggestion.domain)).not.toContain("custom");
+  });
+
   it("routes TestFlight metadata failures into release preflight instead of new command surfaces", () => {
     const suggestions = suggestFeatures({
       appDescription:


### PR DESCRIPTION
## What changed
- Routes provider-output quality rescue prompts into proof-first provider repair suggestions instead of fake new feature surfaces.
- Adds Cloud Check classification for Xcode code-signing failures caused by resource forks, FinderInfo, or FileProvider metadata.
- Refreshes metrics and proof lines to 1340 tests.

## Why
Dogfood exposed two gaps: Cadabra provider-output repair prompts were misclassified by axint.suggest, and a real codesign failure from building under a synced/FileProvider path was unclassified.

## Validation
- npm run typecheck
- npm run build
- npm test
- npm run lint
- npm run typecheck:examples
- npm run metrics:check
- npm run docs:check
- npm run versions:check
- npm run release:check
- npm run boundary:check
- npm run gen:swift-fixer:check
- npm audit --audit-level=moderate
- corepack pnpm audit --audit-level moderate
- CLI repros for axint suggest and axint cloud check