### PR TITLE
Release Axint 0.4.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.28 · 36 MCP tools + 5 prompts · 204 diagnostic codes · 1341 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.29 · 36 MCP tools + 5 prompts · 204 diagnostic codes · 1341 tests · 58 live packages · 26 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -381,7 +381,7 @@ Agent sessions should not have to restart from scratch just because Axint shippe
 axint upgrade
 axint upgrade --apply
 axint upgrade --apply --xcode-install
-axint upgrade --target 0.4.28 --apply
+axint upgrade --target 0.4.29 --apply
 ```
 
 From MCP, call `axint.upgrade`. The tool returns the exact command plan plus a same-thread prompt that tells the agent to keep the current conversation, reload or reconnect only the Axint MCP server/tool process, then call `axint.status` and `axint.activate` to prove the running version and first real Axint output before editing code.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,27 @@
 # Release Notes
 
+## 2026-05-24 — Dogfood routing and release-readiness patch
+
+This patch ships the Cadabra dogfood fixes needed before the next large build
+run.
+
+### Fixed
+
+- `axint.suggest` now routes product hierarchy prompts into a dedicated
+  `product-hierarchy` plan instead of collapsing launch promise, public
+  vocabulary, default lanes, feedback buttons, and hidden advanced controls
+  into generic Magic Pass controls.
+- `axint.suggest` now treats provider-output quality rescue prompts as
+  proof-first provider repair work, not fake new feature generation.
+- Cloud Check now classifies Xcode code-signing failures caused by resource
+  forks, FinderInfo, or FileProvider metadata and points the repair to `/tmp`
+  DerivedData, `xattr -cr`, and `COPYFILE_DISABLE=1`.
+
+### Changed
+
+- Public truth advances to v0.4.29 with 36 MCP tools, 5 prompts, 204 diagnostic
+  codes, 1341 tests, and 26 bundled templates.
+
 ## 2026-05-08 — Activation proof and first-use funnel
 
 This release closes the biggest dogfooding ambiguity: a server-start event proves

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,9 +1,9 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@axint/compiler": "^0.4.28"
+    "@axint/compiler": "^0.4.29"
   }
 }

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — Apple-Native Execution Layer",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.28",
+  "version": "0.4.29",
   "mcpTools": 36,
   "mcpToolNames": [
     "axint.status",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.28",
+      "version": "0.4.29",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.28"
+__version__ = "0.4.29"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.28"
+version = "0.4.29"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.28",
+      "version": "0.4.29",
       "transport": {
         "type": "stdio"
       }
@@ -28,7 +28,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.28",
+      "version": "0.4.29",
       "transport": {
         "type": "stdio"
       }

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.28";
+const VERSION = "0.4.29";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
Release Axint 0.4.29 for the latest dogfood routing and release-readiness fixes.\n\nChanges:\n- Bumps npm, PyPI, extension, server, worker, metrics, and README version surfaces to 0.4.29.\n- Adds release notes for product-hierarchy suggest routing, provider-output repair, and codesign resource-fork Cloud Check fixes.\n- Keeps release parity checks aligned so npm and PyPI publish together from the tag workflow.\n\nValidation:\n- npm run versions:check\n- npm run metrics:check\n- npm run docs:check\n- npm run typecheck\n- npm run lint\n- npm run build\n- npm test after build: 89 files, 1230 tests passed\n- npm run typecheck:examples\n- npm run boundary:check\n- npm run gen:swift-fixer:check\n- npm run release:check\n- npm audit --audit-level=moderate\n- corepack pnpm audit --audit-level moderate\n- Python pytest: 114 passed\n- Python build + twine check\n- Python ruff, pyright, mypy axint