### PR TITLE
Release 0.4.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.29 · 36 MCP tools + 5 prompts · 214 diagnostic codes · 1350 tests · 58 live packages · 34 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.30 · 36 MCP tools + 5 prompts · 214 diagnostic codes · 1350 tests · 58 live packages · 34 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -381,7 +381,7 @@ Agent sessions should not have to restart from scratch just because Axint shippe
 axint upgrade
 axint upgrade --apply
 axint upgrade --apply --xcode-install
-axint upgrade --target 0.4.29 --apply
+axint upgrade --target 0.4.30 --apply
 ```
 
 From MCP, call `axint.upgrade`. The tool returns the exact command plan plus a same-thread prompt that tells the agent to keep the current conversation, reload or reconnect only the Axint MCP server/tool process, then call `axint.status` and `axint.activate` to prove the running version and first real Axint output before editing code.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,30 @@
 # Release Notes
 
+## 2026-06-08 — WWDC26 compiler support
+
+This release adds the first Axint compiler support for the Xcode 27 / WWDC26
+Apple Intelligence and App Intents changes.
+
+### Added
+
+- App schema support for `@AppIntent(schema:)`, `@AppEntity(schema:)`, and
+  `@AppEnum(schema:)`.
+- Schema domain catalog types and SDK exports for Apple Intelligence era App
+  Intents.
+- Entity metadata for syncable, indexed, indexed query, ownership, and intent
+  value representation flows.
+- Intent metadata for schema domains, schema names, protocol conformances,
+  supported modes, and allowed execution targets.
+- P1 templates and examples for long-running progress, snippets, system
+  shortcut bridges, entity collection search, and union value routing.
+- Cloud Check diagnostics for WWDC26 schema, entity, model, long-running,
+  snippet, and union proof gaps.
+
+### Changed
+
+- Public truth advances to v0.4.30 with 36 MCP tools, 5 prompts, 214 diagnostic
+  codes, 1350 tests, 58 live packages, and 34 bundled templates.
+
 ## 2026-05-24 — Dogfood routing and release-readiness patch
 
 This patch ships the Cadabra dogfood fixes needed before the next large build

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,9 +1,9 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@axint/compiler": "^0.4.29"
+    "@axint/compiler": "^0.4.30"
   }
 }

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axint",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axint",
-      "version": "0.4.29",
+      "version": "0.4.30",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/vscode": "^1.102.0",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — Apple-Native Execution Layer",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.29",
+  "version": "0.4.30",
   "mcpTools": 36,
   "mcpToolNames": [
     "axint.status",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axint/compiler",
-      "version": "0.4.29",
+      "version": "0.4.30",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.29"
+__version__ = "0.4.30"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.29"
+version = "0.4.30"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.29",
+      "version": "0.4.30",
       "transport": {
         "type": "stdio"
       }
@@ -28,7 +28,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.29",
+      "version": "0.4.30",
       "transport": {
         "type": "stdio"
       }

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.29";
+const VERSION = "0.4.30";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary
- Bump coordinated npm/PyPI release version to 0.4.30
- Update release notes for WWDC26 compiler support
- Sync README truth, metrics, MCP server metadata, Python SDK, and extension manifests

## Verification
- npm run versions:check
- npm run metrics:check
- npm run docs:check
- npm run release:check
- npm run typecheck
- npm run lint
- npm run build
- npm test
- npm run typecheck:examples
- npm run boundary:check
- npm audit --audit-level=moderate
- python3 -m pip install -e '.[dev]'
- python3 -m pytest -v
- python3 -m build