### PR TITLE
fix readme playground links and truth source note

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <p align="center">
   <a href="https://axint.ai">Website</a> ·
-  <a href="https://axint.ai/#playground">Playground</a> ·
+  <a href="https://cloud.axint.ai">Playground</a> ·
   <a href="#create-the-apple-day-agent-starter">Create App</a> ·
   <a href="#quick-start">Quick Start</a> ·
   <a href="#mcp-server">MCP Server</a> ·
@@ -299,7 +299,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 <!-- truth:readme-proof-line:start -->v0.4.30 · 36 MCP tools + 5 prompts · 214 diagnostic codes · 1372 tests · 58 live packages · 46 bundled templates<!-- truth:readme-proof-line:end -->
 
-<!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
+<!-- truth:readme-truth-source:start -->Public proof is regenerated from the compiler's metrics pipeline on every release (`npm run metrics:emit && npm run metrics:check`).<!-- truth:readme-truth-source:end -->
 
 If release numbers, diagnostics, package counts, or MCP surfaces change, update the canonical truth layer and re-run the sync instead of editing proof values by hand.
 
@@ -513,7 +513,7 @@ Full reference: [`docs/ERRORS.md`](docs/ERRORS.md)
 
 ## Playground
 
-No install required — [axint.ai/#playground](https://axint.ai/#playground) runs the same compiler in a server-backed playground, returning Swift live without a local install.
+No install required — [cloud.axint.ai](https://cloud.axint.ai) runs the same compiler in a server-backed playground, returning Swift live without a local install.
 
 ---
 


### PR DESCRIPTION
Two stale spots in the readme. The playground links still point at axint.ai/#playground, which doesn't exist on the current homepage — the server-backed playground lives at cloud.axint.ai now. And the public-truth note referenced a `../public-truth` path plus an `npm --prefix ..` command that only make sense inside a private workspace checkout, so it reads as broken instructions to anyone who clones this repo. Reworded it around the in-repo metrics pipeline.

Proof-line values and all MCP marker blocks are untouched.