### PR TITLE
release 0.4.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+## [0.4.31] — 2026-06-10
+
+### Added
+
+- **AX849 and AX860 diagnostics** — the Swift validator now flags computed properties that declare locals but never `return` the final expression (AX849), and same-file `switch self` statements that omit a declared enum case without a `default` branch (AX860).
+- **Dogfood routing in `axint.suggest`** — prompts about repairing Axint's own classifier, Cloud Check artifact handling, or version truth now route to a dedicated `axint-dogfood` plan instead of generic app-feature suggestions.
+- **WWDC26 templates** — `foundation-models-custom-provider` (custom LanguageModel provider session with an on-device fallback profile), `app-intents-testing-harness` (intent plus an AppIntentsTesting XCTest harness), and `dynamic-profile-session` (Foundation Models session with per-context DynamicProfiles).
+- **`testHarness` intent config** — `defineIntent` accepts a `testHarness` block; the generator emits an XCTest class that drives `perform()` with sample inputs behind `#if canImport(XCTest) && canImport(AppIntentsTesting)`.
+
+### Changed
+
+- Public-facing copy now says "audit-grade" and "production readiness" instead of fundraising vocabulary.
+
 ## [0.4.28] — 2026-05-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.30 · 36 MCP tools + 5 prompts · 214 diagnostic codes · 1372 tests · 58 live packages · 46 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.31 · 36 MCP tools + 5 prompts · 216 diagnostic codes · 1377 tests · 58 live packages · 49 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -381,7 +381,7 @@ Agent sessions should not have to restart from scratch just because Axint shippe
 axint upgrade
 axint upgrade --apply
 axint upgrade --apply --xcode-install
-axint upgrade --target 0.4.30 --apply
+axint upgrade --target 0.4.31 --apply
 ```
 
 From MCP, call `axint.upgrade`. The tool returns the exact command plan plus a same-thread prompt that tells the agent to keep the current conversation, reload or reconnect only the Axint MCP server/tool process, then call `axint.status` and `axint.activate` to prove the running version and first real Axint output before editing code.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,12 @@
 # Axint Roadmap
 
-_Last updated: June 2026 · Current release: <!-- metrics:roadmap-release:start -->[v0.4.30](https://github.com/agenticempire/axint/releases/tag/v0.4.30)<!-- metrics:roadmap-release:end -->_
+_Last updated: June 2026 · Current release: <!-- metrics:roadmap-release:start -->[v0.4.31](https://github.com/agenticempire/axint/releases/tag/v0.4.31)<!-- metrics:roadmap-release:end -->_
 
 Axint is the Apple-native execution layer for AI coding agents. The open-source package gives agents a smaller contract for Apple surfaces, emits ordinary Swift, validates Apple-specific rules, writes Fix Packets, and coordinates proof loops across CLI, MCP, Xcode, Registry, and Cloud-facing workflows.
 
 The thesis is simple: agents can write code, but Apple-native software needs proof. Axint turns agent output into validated, repairable, inspectable Apple work.
 
-<!-- metrics:roadmap-snapshot:start -->Current compiler snapshot: v0.4.30 · 36 MCP tools + 5 prompts · 46 templates · 214 diagnostic codes · 1372 tests.<!-- metrics:roadmap-snapshot:end -->
+<!-- metrics:roadmap-snapshot:start -->Current compiler snapshot: v0.4.31 · 36 MCP tools + 5 prompts · 49 templates · 216 diagnostic codes · 1377 tests.<!-- metrics:roadmap-snapshot:end -->
 
 ---
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,36 @@
 # Release Notes
 
+## 2026-06-10 — Provider fallback templates and compiler-parity diagnostics
+
+This release ships the WWDC26 custom LanguageModel provider and App Intents
+testing templates, plus two Swift validator checks that catch real Xcode
+build failures before the build.
+
+### Added
+
+- `foundation-models-custom-provider` template: a session backed by a custom
+  LanguageModel provider with an on-device fallback profile.
+- `app-intents-testing-harness` template: an intent plus an AppIntentsTesting
+  XCTest harness that drives `perform()` with sample inputs behind a
+  `canImport` guard.
+- `dynamic-profile-session` template: a Foundation Models session that selects
+  a DynamicProfile per request context.
+- `testHarness` config on `defineIntent` for emitting the XCTest harness from
+  any intent definition.
+- AX849 flags computed properties that declare locals but never return the
+  final expression.
+- AX860 flags `switch self` statements that omit a declared enum case without
+  a `default` branch.
+- `axint.suggest` routes Axint dogfood prompts to a dedicated `axint-dogfood`
+  plan instead of generic app-feature suggestions.
+
+### Changed
+
+- Public-facing copy now says "audit-grade" and "production readiness" instead
+  of fundraising vocabulary.
+- Public truth advances to v0.4.31 with 36 MCP tools, 5 prompts, 216 diagnostic
+  codes, 1377 tests, 58 live packages, and 49 bundled templates.
+
 ## 2026-06-08 — WWDC26 compiler support
 
 This release adds the first Axint compiler support for the Xcode 27 / WWDC26

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — Apple-Native Execution Layer",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.30",
+  "version": "0.4.31",
   "mcpTools": 36,
   "mcpToolNames": [
     "axint.status",
@@ -47,8 +47,8 @@
     "axint.create-widget",
     "axint.create-intent"
   ],
-  "bundledTemplates": 46,
-  "diagnostics": 214,
+  "bundledTemplates": 49,
+  "diagnostics": 216,
   "xcodeFixRules": 33,
   "xcodeFixRuleCodes": [
     "AX701",
@@ -86,7 +86,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1258,
+    "typescript": 1263,
     "python": 114
   },
   "registryPackages": 58,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.30"
+__version__ = "0.4.31"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.30"
+version = "0.4.31"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.30",
+      "version": "0.4.31",
       "transport": {
         "type": "stdio"
       }
@@ -28,7 +28,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.30",
+      "version": "0.4.31",
       "transport": {
         "type": "stdio"
       }

--- a/spec/axint-lift-gauntlet.md
+++ b/spec/axint-lift-gauntlet.md
@@ -49,7 +49,7 @@ Every run records these metrics.
 | Human interventions | Times a human had to explain what to do next | Shows autonomy |
 | Apple-specific defects | Count of unresolved App Intents, plist, entitlement, SwiftUI, WidgetKit, Xcode, signing, or test issues | Shows Apple-native competence |
 | False ship claims | Times the agent said it was done while build/test/runtime proof failed | Shows trustworthiness |
-| Proof completeness | 0-5 score for source, generated Swift, static validation, Xcode/build, runtime/test, and artifact evidence | Shows investor-grade rigor |
+| Proof completeness | 0-5 score for source, generated Swift, static validation, Xcode/build, runtime/test, and artifact evidence | Shows audit-grade rigor |
 | Token cost | Approximate prompt/output tokens across the run | Shows workflow efficiency |
 | Repair precision | Number of changed files and diff lines needed to fix failures | Shows whether Axint focuses the agent |
 

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -841,6 +841,19 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticInfo> = {
       "Nested type or static member access on a project-indexed type that does not declare the accessed name (catches the IntelBriefItem.Kind class of cross-file miss that AX841 deliberately skips)",
     category: "swift-cross-file-resolution",
   },
+  AX849: {
+    code: "AX849",
+    severity: "error",
+    message:
+      "Computed property has local declarations but no explicit return; Swift rejects the final expression",
+    category: "swift-compiler-parity",
+  },
+  AX860: {
+    code: "AX860",
+    severity: "error",
+    message: "Switch over enum value omits one or more declared enum cases",
+    category: "swift-state-machine",
+  },
   AX714: {
     code: "AX714",
     severity: "error",

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -198,6 +198,11 @@ export function generateSwift(intent: IRIntent): string {
     lines.push(``);
   }
 
+  if (safeIntent.testHarness) {
+    lines.push(generateTestHarnessSupport(safeIntent));
+    lines.push(``);
+  }
+
   return lines.join("\n");
 }
 
@@ -651,6 +656,72 @@ function generatePreviewProofSupport(previewProof: IRPreviewProofConfig): string
     `// AppIntentsTesting and preview evidence should be attached before release.`
   );
   return lines.join("\n");
+}
+
+function generateTestHarnessSupport(intent: IRIntent): string {
+  const className = swiftIdentifier(
+    intent.testHarness?.className || `${intent.name}IntentTests`
+  );
+  const lines: string[] = [];
+
+  // canImport guards keep the harness inert in app targets, so the file can
+  // live in either target without an #if TESTING build setting.
+  lines.push(`#if canImport(XCTest) && canImport(AppIntentsTesting)`);
+  lines.push(`import XCTest`);
+  lines.push(`import AppIntentsTesting`);
+  lines.push(``);
+  lines.push(`@available(iOS 26.0, macOS 26.0, *)`);
+  lines.push(`final class ${className}: XCTestCase {`);
+  lines.push(`    func testPerformSucceeds() async throws {`);
+  lines.push(`        let intent = ${intent.name}Intent()`);
+  for (const param of intent.parameters) {
+    if (param.isOptional) continue;
+    const sample = sampleSwiftValue(param.type);
+    if (sample) {
+      lines.push(`        intent.${param.name} = ${sample}`);
+    } else {
+      lines.push(`        // Set ${param.name} before running the harness.`);
+    }
+  }
+  lines.push(``);
+  lines.push(`        _ = try await intent.perform()`);
+  lines.push(`    }`);
+  lines.push(`}`);
+  lines.push(`#endif`);
+  return lines.join("\n");
+}
+
+function sampleSwiftValue(type: IRType): string | undefined {
+  switch (type.kind) {
+    case "primitive":
+      switch (type.value) {
+        case "string":
+          return `"Sample"`;
+        case "int":
+          return "1";
+        case "double":
+        case "float":
+          return "1.0";
+        case "boolean":
+          return "true";
+        case "date":
+          return "Date()";
+        case "duration":
+          return "Measurement(value: 60, unit: UnitDuration.seconds)";
+        case "url":
+          return `URL(string: "https://example.com")!`;
+      }
+      return undefined;
+    case "array":
+      return "[]";
+    case "dynamicOptions":
+      return sampleSwiftValue(type.valueType);
+    case "optional":
+    case "entity":
+    case "entityQuery":
+    case "enum":
+      return undefined;
+  }
 }
 
 // ─── Info.plist Fragment Generator ───────────────────────────────────

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -33,6 +33,7 @@ import type {
   IRFoundationModelCustomProvider,
   IRFoundationModelDynamicProfile,
   IREvaluationConfig,
+  IRTestHarnessConfig,
   IRPreviewProofConfig,
   IRImagePlaygroundConfig,
 } from "./types.js";
@@ -191,6 +192,11 @@ export function parseIntentSource(
   const allowedExecutionTargets = readStringLiteral(props.get("allowedExecutionTargets"));
   const model = parseFoundationModelConfig(props.get("model"), filePath, sourceFile);
   const evaluation = parseEvaluationConfig(props.get("evaluation"), filePath, sourceFile);
+  const testHarness = parseTestHarnessConfig(
+    props.get("testHarness"),
+    filePath,
+    sourceFile
+  );
   const previewProof = parsePreviewProofConfig(
     props.get("previewProof"),
     filePath,
@@ -225,6 +231,7 @@ export function parseIntentSource(
     allowedExecutionTargets: allowedExecutionTargets || undefined,
     model,
     evaluation,
+    testHarness,
     previewProof,
     imagePlayground,
   };
@@ -831,6 +838,26 @@ function parseEvaluationConfig(
     criteria: readStringArray(props.get("criteria")),
     fixtures: readStringArray(props.get("fixtures")),
     metrics: readStringArray(props.get("metrics")),
+  };
+}
+
+function parseTestHarnessConfig(
+  node: ts.Node | undefined,
+  filePath: string,
+  sourceFile: ts.SourceFile
+): IRTestHarnessConfig | undefined {
+  if (!node) return undefined;
+  if (!ts.isObjectLiteralExpression(node)) {
+    throw new ParserError(
+      "AX056",
+      "testHarness must be an object literal",
+      filePath,
+      posOf(sourceFile, node)
+    );
+  }
+  const props = propertyMap(node);
+  return {
+    className: readStringLiteral(props.get("className")) || undefined,
   };
 }
 

--- a/src/core/swift-validator.ts
+++ b/src/core/swift-validator.ts
@@ -103,6 +103,8 @@ export function validateSwiftSource(source: string, file: string): SwiftValidati
   checkInvalidSwiftUIFrameOverloads(source, stripped, file, diagnostics);
   checkTypeErasedSwiftUIModifierChains(source, stripped, file, diagnostics);
   checkOpaqueViewReturnsNeedExplicitReturn(source, stripped, file, diagnostics);
+  checkComputedPropertiesNeedExplicitReturn(source, stripped, file, diagnostics);
+  checkEnumSwitchesCoverDeclaredCases(source, stripped, file, diagnostics);
   checkDenseViewWithoutAffordance(source, stripped, file, diagnostics);
   checkUndefinedBooleanIdentifiers(source, stripped, file, diagnostics);
   checkUndefinedStringInterpolationIdentifiers(source, stripped, file, diagnostics);
@@ -434,6 +436,86 @@ function checkOpaqueViewReturnsNeedExplicitReturn(
           "Prefer `@ViewBuilder` for SwiftUI helpers — it documents intent, supports multi-statement bodies as the surface grows, and matches the style of `var body`. Use an explicit `return` only when the helper truly returns a single expression.",
       })
     );
+  }
+}
+
+function checkComputedPropertiesNeedExplicitReturn(
+  source: string,
+  stripped: string,
+  file: string,
+  diagnostics: Diagnostic[]
+) {
+  const declaration =
+    /\bvar\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*((?!some\s+View\b)[A-Za-z_][A-Za-z0-9_<>,\s[\]?!:.&]*)\s*\{/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = declaration.exec(stripped)) !== null) {
+    const name = match[1] ?? "unnamed";
+    if (name === "body") continue;
+    if (hasViewBuilderAttribute(stripped, match.index)) continue;
+
+    const openBrace = stripped.indexOf("{", match.index);
+    const closeBrace = findMatchingBrace(stripped, openBrace);
+    if (openBrace === -1 || closeBrace === -1) continue;
+
+    const body = stripped.slice(openBrace + 1, closeBrace);
+    const originalBody = source.slice(openBrace + 1, closeBrace);
+    if (!/\b(?:let|var)\s+[A-Za-z_][A-Za-z0-9_]*\b/.test(body)) continue;
+    if (hasTopLevelReturn(body)) continue;
+    if (!endsWithLikelySwiftExpression(originalBody)) continue;
+
+    diagnostics.push(
+      makeDiagnostic("AX849", file, 1 + countNewlinesUpTo(source, match.index), {
+        message: `Computed property '${name}' declares locals and ends with an expression but has no explicit return`,
+        suggestion:
+          "Add `return` before the final expression, or refactor the property into a single-expression computed property without local declarations.",
+      })
+    );
+  }
+}
+
+function checkEnumSwitchesCoverDeclaredCases(
+  source: string,
+  stripped: string,
+  file: string,
+  diagnostics: Diagnostic[]
+) {
+  const decls = findTypeDeclarations(stripped, source);
+
+  for (const decl of decls) {
+    if (decl.kind !== "enum") continue;
+    const body = stripped.slice(decl.bodyStart, decl.bodyEnd);
+    const cases = collectEnumCases(body);
+    if (cases.length === 0) continue;
+
+    const switchPattern = /\bswitch\s+self\s*\{/g;
+    let match: RegExpExecArray | null;
+    while ((match = switchPattern.exec(body)) !== null) {
+      const switchOpen = body.indexOf("{", match.index);
+      const switchClose = findMatchingBrace(body, switchOpen);
+      if (switchOpen === -1 || switchClose === -1) continue;
+
+      const switchBody = body.slice(switchOpen + 1, switchClose);
+      if (/\b(?:default|@unknown\s+default)\b/.test(switchBody)) continue;
+
+      const seen = collectDottedSwitchCases(switchBody);
+      const missing = cases.filter((enumCase) => !seen.has(enumCase.name));
+      if (missing.length === 0) continue;
+
+      const switchOffset = decl.bodyStart + match.index;
+      diagnostics.push(
+        makeDiagnostic("AX860", file, 1 + countNewlinesUpTo(source, switchOffset), {
+          message: `Switch over '${decl.name}' is missing case${missing.length === 1 ? "" : "s"} ${missing
+            .map((enumCase) => `.${enumCase.name}`)
+            .join(", ")}`,
+          suggestion: `Add ${missing
+            .map((enumCase) => `case .${enumCase.name}:`)
+            .join(
+              " "
+            )} before the next Xcode build, or add an intentional default branch if every future case should share one behavior.`,
+        })
+      );
+    }
   }
 }
 
@@ -1130,6 +1212,36 @@ function endsWithLikelyViewExpression(body: string): boolean {
   return /(?:VStack|HStack|ZStack|Text|Button|ScrollView|List|LazyVStack|LazyHStack|Group|Section|ForEach|AnyView|Image|Label|Form|NavigationStack|NavigationSplitView|HSplitView|VSplitView)\s*(?:\(|\{)/.test(
     cleaned
   );
+}
+
+function endsWithLikelySwiftExpression(body: string): boolean {
+  const cleaned = body
+    .trim()
+    .replace(/;+\s*$/, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .at(-1);
+  if (!cleaned) return false;
+  if (
+    /^(?:let|var|if|guard|switch|for|while|do|defer|return|throw|case|default)\b/.test(
+      cleaned
+    )
+  )
+    return false;
+  return /^(?:"|\.?[A-Za-z_][A-Za-z0-9_]*|\d|\[|\(|#)/.test(cleaned);
+}
+
+function collectDottedSwitchCases(body: string): Set<string> {
+  const seen = new Set<string>();
+  const casePattern = /\bcase\s+([^:]+):/g;
+  let match: RegExpExecArray | null;
+  while ((match = casePattern.exec(body)) !== null) {
+    for (const dotted of match[1]!.matchAll(/\.([A-Za-z_][A-Za-z0-9_]*)\b/g)) {
+      seen.add(dotted[1]!);
+    }
+  }
+  return seen;
 }
 
 function collectLeadingModifierChain(

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -167,6 +167,10 @@ export interface IRPreviewProofConfig {
   liveActivityStates?: string[];
 }
 
+export interface IRTestHarnessConfig {
+  className?: string;
+}
+
 export interface IRImagePlaygroundConfig {
   conceptParam: string;
   sourceImageParam?: string;
@@ -334,6 +338,8 @@ export interface IRIntent {
   model?: IRFoundationModelConfig;
   /** Evaluation suite metadata that should accompany model-backed output. */
   evaluation?: IREvaluationConfig;
+  /** AppIntentsTesting harness emitted alongside the intent. */
+  testHarness?: IRTestHarnessConfig;
   /** Preview snapshot matrix required to prove generated UI variants. */
   previewProof?: IRPreviewProofConfig;
   /** Image Playground generation contract for image-producing App Intents. */

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -2206,7 +2206,7 @@ export const TOOL_MANIFEST = [
   {
     name: "axint.templates.list",
     description:
-      "List all 39 bundled reference templates in the Axint SDK. Returns " +
+      "List all 49 bundled reference templates in the Axint SDK. Returns " +
       "a JSON array of { id, name, description } objects — one per template. " +
       "Templates cover messaging, productivity, health, finance, commerce, " +
       "media, navigation, smart-home, and entity/query patterns. No input " +

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -741,7 +741,7 @@ export const TOOL_MANIFEST = [
           type: "array",
           items: { type: "string" },
           description:
-            "Optional product goals for Pro mode, such as activation, retention, conversion, speed, accessibility, or investor readiness.",
+            "Optional product goals for Pro mode, such as activation, retention, conversion, speed, accessibility, or production readiness.",
         },
         stage: {
           type: "string",

--- a/src/mcp/suggest.ts
+++ b/src/mcp/suggest.ts
@@ -916,12 +916,16 @@ export function suggestFeatures(input: SuggestInput): FeatureSuggestion[] {
   const productHierarchyMode = detectProductHierarchyMode(input, text);
   const additiveFeatureMode = detectAdditiveFeatureMode(input, text);
   const releasePreflightMode = detectReleasePreflightMode(input, text);
+  const axintDogfoodMode = detectAxintDogfoodMode(input, text);
 
   if (freshProductMode?.kind === "public-page") {
     return publicLanderSuggestions(input, text, limit, freshProductMode.trace);
   }
   if (freshProductMode?.kind === "brand-polish") {
     return brandPolishSuggestions(input, text, limit, freshProductMode.trace);
+  }
+  if (axintDogfoodMode) {
+    return axintDogfoodSuggestions(input, text, limit, axintDogfoodMode.trace);
   }
   if (greenfieldAppMode) {
     return greenfieldAppSuggestions(input, text, limit, greenfieldAppMode.trace);
@@ -1057,6 +1061,66 @@ type ReleasePreflightMode =
       trace: string;
     }
   | undefined;
+
+type AxintDogfoodMode =
+  | {
+      trace: string;
+    }
+  | undefined;
+
+function detectAxintDogfoodMode(
+  input: SuggestInput,
+  normalizedAppDescription: string
+): AxintDogfoodMode {
+  const goalsText = normalizeText((input.goals ?? []).join(" "));
+  const constraintsText = normalizeText((input.constraints ?? []).join(" "));
+  const combined = [normalizedAppDescription, goalsText, constraintsText]
+    .filter(Boolean)
+    .join(" ");
+
+  const axintCues = [
+    "axint",
+    "cloud check",
+    "mcp",
+    "mcp version",
+    "workflow check",
+    "fix packet",
+    "ax001",
+    "dogfood",
+    "dogfooding",
+    "non-apple artifact",
+    "non apple artifact",
+    "version metadata",
+    "version truth",
+    "release script",
+    "generic feature scaffold",
+    "classifier",
+    "cadabra dogfood",
+  ].filter((cue) => hasKeyword(combined, cue));
+
+  const toolingIntent = [
+    "atom",
+    "atoms",
+    "classify",
+    "classified",
+    "fix",
+    "misclassified",
+    "misclassification",
+    "prevent",
+    "route",
+    "routing",
+    "stale",
+    "sync",
+    "version",
+  ].some((cue) => hasKeyword(combined, cue));
+
+  if (axintCues.length < 2 || !toolingIntent) return undefined;
+
+  const cueList = axintCues.slice(0, 6).join(", ");
+  return {
+    trace: `Current prompt won as Axint dogfood/tooling work (${cueList}); Axint is repairing its own classifier, Cloud Check, and version-truth atoms instead of mapping provider words to an app image-provider repair.`,
+  };
+}
 
 function detectFreshProductMode(
   input: SuggestInput,
@@ -1733,6 +1797,79 @@ function releasePreflightSuggestions(
       loop: "Collect logs -> classify blocker -> patch metadata or portal -> rerun",
       nextStep:
         "Attach the generated evidence packet to the next Axint run or release checklist.",
+      modeTrace,
+    },
+  ];
+
+  return suggestions.slice(0, limit);
+}
+
+function axintDogfoodSuggestions(
+  input: SuggestInput,
+  normalizedAppDescription: string,
+  limit: number,
+  modeTrace: string
+): FeatureSuggestion[] {
+  const platform = input.platform ? `${input.platform} ` : "";
+  const labels = semanticLabels(normalizedAppDescription, 5);
+  const dogfoodLabel =
+    labels.find((label) => /axint|dogfood|cloud|mcp|version|classifier/i.test(label)) ??
+    "Axint Dogfood";
+  const rationale = `Mode trace: ${modeTrace} Dogfooding prompts about Axint itself need source classifier, release/version truth, and regression-harness fixes before any generated Apple surface.`;
+
+  const suggestions: FeatureSuggestion[] = [
+    {
+      name: `${dogfoodLabel} Routing Atom`,
+      description:
+        "Patch Axint's own classifier so implementation files, deployment artifacts, and dogfood repair requests route to the right proof surface.",
+      surfaces: ["store", "component"],
+      complexity: "medium",
+      featurePrompt: `Repair the ${platform}Axint dogfood routing atom: Cloud Check should treat JS/TS/Python/shell/plist/docs as non-Apple artifacts unless they are explicit Axint contracts, suggest should route Axint/Cadabra dogfood prompts to tooling or product-quality repair lanes, and provider-output words must not automatically become an image-provider SwiftUI repair.`,
+      domain: "axint-dogfood",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact:
+        "Prevents Axint from creating fake AX001 diagnostics or stale app-surface suggestions while dogfooding real products.",
+      loop: "Dogfood log -> classifier patch -> regression test -> Cloud Check proof",
+      nextStep:
+        "Add focused tests for the exact misclassification, then run the Cloud Check, suggest, repair, and version suites.",
+      modeTrace,
+    },
+    {
+      name: `${dogfoodLabel} Version Truth Guard`,
+      description:
+        "Keep MCP, CLI, extension, docs, roadmap, and release fallback versions pinned to the canonical package version.",
+      surfaces: ["store"],
+      complexity: "low",
+      featurePrompt:
+        "Extend Axint version-truth checks so MCP fallback metadata, Fix Packet compiler fallback, VS Code lockfiles, Claude Desktop manifests, Xcode extension metadata, roadmap release links, README proof lines, and release notes cannot drift from package.json.",
+      domain: "axint-dogfood",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact:
+        "Stops stale MCP metadata from undermining trust during large downstream dogfood runs.",
+      loop: "Canonical version -> tracked surfaces -> release check -> prepublish proof",
+      nextStep:
+        "Run versions:check and release:check after the patch, then publish only when both package registries match.",
+      modeTrace,
+    },
+    {
+      name: `${dogfoodLabel} Regression Harness`,
+      description:
+        "Convert Cadabra dogfood misses into durable Axint tests so the same atoms do not regress during the next release.",
+      surfaces: ["component"],
+      complexity: "medium",
+      featurePrompt:
+        "Add regression coverage for Cadabra dogfood atoms: non-Apple artifacts avoid AX001, provider-behavior repairs avoid runtime-freeze, TestFlight metadata routes to release-preflight, Magic Pass and preset-library prompts stay product-specific, and feature generation refuses generic scaffolds when product vocabulary is present.",
+      domain: "axint-dogfood",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact: "Turns anecdotal dogfooding into investor-grade product-quality evidence.",
+      loop: "Fixture -> failing test -> patch -> focused suite -> full build",
+      nextStep: "Run focused tests first, then npm run prepublishOnly before committing.",
       modeTrace,
     },
   ];

--- a/src/mcp/suggest.ts
+++ b/src/mcp/suggest.ts
@@ -1569,7 +1569,7 @@ function greenfieldAppSuggestions(
       rationale,
       confidence: "high",
       source: "local",
-      impact: "Turns greenfield generation into investor-grade evidence.",
+      impact: "Turns greenfield generation into audit-grade evidence.",
       loop: "Render -> tap -> assert -> record proof",
       nextStep:
         "Run axint.run with the generated app files and attach simulator/build evidence when available.",
@@ -1625,8 +1625,7 @@ function productHierarchySuggestions(
       rationale,
       confidence: "high",
       source: "local",
-      impact:
-        "Makes dogfood feedback actionable and investor-grade instead of anecdotal.",
+      impact: "Makes dogfood feedback actionable and audit-grade instead of anecdotal.",
       loop: "Generate -> react -> persist -> improve prompt contract",
       nextStep:
         "Add state and analytics-safe metadata first, then verify feedback survives history/share routing.",
@@ -1718,7 +1717,7 @@ function additiveFeatureSuggestions(
       confidence: "high",
       source: "local",
       impact:
-        "Makes the additive feature investor-grade by tying UX controls to durable runtime evidence.",
+        "Makes the additive feature audit-grade by tying UX controls to durable runtime evidence.",
       loop: "Select -> persist -> generate -> inspect metadata",
       nextStep:
         "Run axint.run or a focused UI/state test and attach provider prompt evidence where available.",
@@ -1793,7 +1792,7 @@ function releasePreflightSuggestions(
       confidence: "high",
       source: "local",
       impact:
-        "Turns release failures into investor-grade proof instead of mystery Xcode/App Store Connect churn.",
+        "Turns release failures into audit-grade proof instead of mystery Xcode/App Store Connect churn.",
       loop: "Collect logs -> classify blocker -> patch metadata or portal -> rerun",
       nextStep:
         "Attach the generated evidence packet to the next Axint run or release checklist.",
@@ -1867,7 +1866,7 @@ function axintDogfoodSuggestions(
       rationale,
       confidence: "high",
       source: "local",
-      impact: "Turns anecdotal dogfooding into investor-grade product-quality evidence.",
+      impact: "Turns anecdotal dogfooding into audit-grade product-quality evidence.",
       loop: "Fixture -> failing test -> patch -> focused suite -> full build",
       nextStep: "Run focused tests first, then npm run prepublishOnly before committing.",
       modeTrace,

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1536,6 +1536,128 @@ export default defineIntent({
 `,
 };
 
+const foundationModelsCustomProvider: IntentTemplate = {
+  id: "foundation-models-custom-provider",
+  name: "foundation-models-custom-provider",
+  title: "Foundation Models Custom Provider",
+  domain: "apple-intelligence",
+  category: "foundation-models",
+  description:
+    "Scaffold a session backed by a LanguageModel-protocol provider that falls back to the on-device model when the provider is unavailable.",
+  source: `import { defineIntent, param } from "@axint/compiler";
+
+export default defineIntent({
+  name: "DraftWithHouseModel",
+  title: "Draft With House Model",
+  description: "Drafts a reply through a custom LanguageModel provider with an on-device fallback.",
+  schemaDomain: "assistant",
+  params: {
+    prompt: param.string("Draft prompt"),
+  },
+  model: {
+    sessionName: "HouseModelSession",
+    provider: "custom-language-model",
+    useCase: "reply-drafting",
+    instructions: "Draft a reply in the account voice and keep claims grounded.",
+    customProvider: {
+      packageName: "HouseModelKit",
+      typeName: "HouseLanguageModel",
+      configuration: "HouseLanguageModel.Configuration(deployment: .production)",
+    },
+    dynamicProfiles: [
+      {
+        name: "houseModel",
+        provider: "custom-language-model",
+        instructions: "Use the house model whenever the provider is reachable.",
+      },
+      {
+        name: "onDeviceFallback",
+        provider: "apple-on-device",
+        instructions: "Fall back to the system model when the house provider is unavailable.",
+      },
+    ],
+  },
+  perform: async ({ prompt }) => {
+    // Swift proof hint:
+    // Attach evidence that the session degrades to the on-device profile when the provider is offline.
+    return { draft: prompt };
+  },
+});
+`,
+};
+
+const appIntentsTestingXctestHarness: IntentTemplate = {
+  id: "app-intents-testing-harness",
+  name: "app-intents-testing-harness",
+  title: "App Intents Testing Harness",
+  domain: "apple-intelligence",
+  category: "testing",
+  description:
+    "Scaffold an intent plus an AppIntentsTesting XCTest harness that drives perform() with sample inputs.",
+  source: `import { defineIntent, param } from "@axint/compiler";
+
+export default defineIntent({
+  name: "LogReadingSession",
+  title: "Log Reading Session",
+  description: "Logs a reading session so the harness can exercise perform() end to end.",
+  domain: "productivity",
+  params: {
+    bookTitle: param.string("Book title"),
+    minutes: param.int("Minutes read"),
+  },
+  testHarness: {
+    className: "LogReadingSessionIntentTests",
+  },
+  perform: async ({ bookTitle, minutes }) => {
+    return { bookTitle, minutes };
+  },
+});
+`,
+};
+
+const dynamicProfileSession: IntentTemplate = {
+  id: "dynamic-profile-session",
+  name: "dynamic-profile-session",
+  title: "Dynamic Profile Session",
+  domain: "apple-intelligence",
+  category: "foundation-models",
+  description:
+    "Scaffold a Foundation Models session that selects a DynamicProfile per request context.",
+  source: `import { defineIntent, param } from "@axint/compiler";
+
+export default defineIntent({
+  name: "CoachNextWorkout",
+  title: "Coach Next Workout",
+  description: "Coaches the next workout with a profile matched to the athlete's context.",
+  schemaDomain: "assistant",
+  params: {
+    goal: param.string("Training goal"),
+  },
+  model: {
+    sessionName: "WorkoutCoachSession",
+    provider: "apple-on-device",
+    useCase: "workout-coaching",
+    instructions: "Coach with the active profile's tone and scope.",
+    dynamicProfile: "quickTips",
+    dynamicProfiles: [
+      {
+        name: "quickTips",
+        instructions: "Short, actionable cues between sets.",
+      },
+      {
+        name: "weeklyPlan",
+        provider: "private-cloud-compute",
+        instructions: "Full-week periodized plans that need the larger model.",
+      },
+    ],
+  },
+  perform: async ({ goal }) => {
+    return { goal };
+  },
+});
+`,
+};
+
 // ─── Registry ────────────────────────────────────────────────────────
 
 export const TEMPLATES: IntentTemplate[] = [
@@ -1585,6 +1707,9 @@ export const TEMPLATES: IntentTemplate[] = [
   barcodeVisionTool,
   stringCatalogLocalizer,
   resizableLayoutProof,
+  foundationModelsCustomProvider,
+  appIntentsTestingXctestHarness,
+  dynamicProfileSession,
 ];
 
 /** @deprecated Use TEMPLATES. Kept for v0.1.x import compatibility. */

--- a/tests/core/compiler.test.ts
+++ b/tests/core/compiler.test.ts
@@ -320,6 +320,45 @@ export default defineIntent({
     expect(result.output?.swiftCode).toContain("Preview Snapshot proof matrix");
   });
 
+  it("emits a guarded AppIntentsTesting XCTest harness when testHarness is declared", () => {
+    const source = `
+import { defineIntent, param } from "@axint/sdk";
+
+export default defineIntent({
+  name: "LogReadingSession",
+  title: "Log Reading Session",
+  description: "Logs minutes read for a book.",
+  params: {
+    bookTitle: param.string("Book title"),
+    minutes: param.int("Minutes read"),
+    notes: param.string("Session notes", { required: false }),
+  },
+  testHarness: {
+    className: "LogReadingSessionIntentTests",
+  },
+  perform: async ({ bookTitle, minutes }) => {
+    return { bookTitle, minutes };
+  },
+});
+`;
+    const result = compileSource(source, "harness.ts");
+
+    expect(result.success).toBe(true);
+    expect(result.output?.ir.testHarness?.className).toBe("LogReadingSessionIntentTests");
+    expect(result.output?.swiftCode).toContain(
+      "#if canImport(XCTest) && canImport(AppIntentsTesting)"
+    );
+    expect(result.output?.swiftCode).toContain(
+      "final class LogReadingSessionIntentTests: XCTestCase"
+    );
+    expect(result.output?.swiftCode).toContain("@available(iOS 26.0, macOS 26.0, *)");
+    expect(result.output?.swiftCode).toContain("let intent = LogReadingSessionIntent()");
+    expect(result.output?.swiftCode).toContain('intent.bookTitle = "Sample"');
+    expect(result.output?.swiftCode).toContain("intent.minutes = 1");
+    expect(result.output?.swiftCode).not.toContain("intent.notes =");
+    expect(result.output?.swiftCode).toContain("_ = try await intent.perform()");
+  });
+
   it("emits multimodal Foundation Models, dynamic profiles, custom providers, and Image Playground contracts", () => {
     const source = `
 import { defineIntent, param } from "@axint/sdk";

--- a/tests/core/swift-validator.test.ts
+++ b/tests/core/swift-validator.test.ts
@@ -175,6 +175,49 @@ describe("swift validator — SwiftUI compiler parity", () => {
     expect(diagnostics.map((d) => d.code)).toContain("AX767");
   });
 
+  it("flags non-View computed properties with local declarations but no explicit return", () => {
+    const source = `
+      struct CadabraSettings {
+          var magicSummary: String {
+              let tier = "Better"
+              "Magic Level: \\(tier)"
+          }
+      }
+    `;
+
+    const { diagnostics } = validate(source);
+    const diagnostic = diagnostics.find((d) => d.code === "AX849");
+    expect(diagnostic?.message).toContain("magicSummary");
+    expect(diagnostic?.suggestion).toContain("return");
+  });
+
+  it("flags same-file switches over enum values that omit a declared case", () => {
+    const source = `
+      enum CadabraPreset {
+          case better
+          case outfit
+          case wild
+          case noirFrame
+
+          var suggestedCameraFeel: String {
+              switch self {
+              case .better:
+                  return "Clean"
+              case .outfit:
+                  return "Styled"
+              case .wild:
+                  return "Chaotic"
+              }
+          }
+      }
+    `;
+
+    const { diagnostics } = validate(source);
+    const diagnostic = diagnostics.find((d) => d.code === "AX860");
+    expect(diagnostic?.message).toContain("noirFrame");
+    expect(diagnostic?.suggestion).toContain("case .noirFrame");
+  });
+
   it("accepts some View helpers that explicitly return the final expression", () => {
     const source = `
       import SwiftUI

--- a/tests/mcp/suggest.test.ts
+++ b/tests/mcp/suggest.test.ts
@@ -178,4 +178,23 @@ describe("axint.suggest", () => {
     expect(suggestions[0]?.featurePrompt).not.toContain("Capture Testflight");
     expect(suggestions.map((suggestion) => suggestion.domain)).not.toContain("custom");
   });
+
+  it("routes Axint dogfood atom fixes to tooling repair instead of app-provider repair", () => {
+    const suggestions = suggestFeatures({
+      appDescription:
+        "Fix Axint dogfood atoms from Cadabra without touching Cadabra: route non-Apple artifacts away from fake AX001 diagnostics, keep MCP version metadata current, classify release/preflight/provider-output repair loops correctly, and prevent generic feature scaffolds for product-specific preset-library requests.",
+      platform: "iOS",
+      limit: 3,
+    });
+
+    expect(suggestions[0]?.domain).toBe("axint-dogfood");
+    expect(suggestions[0]?.featurePrompt).toContain("Cloud Check");
+    expect(suggestions[0]?.featurePrompt).toContain("non-Apple artifacts");
+    expect(suggestions[0]?.featurePrompt).toContain("provider-output words");
+    expect(suggestions.map((suggestion) => suggestion.name).join("\n")).toContain(
+      "Version Truth Guard"
+    );
+    expect(suggestions.map((suggestion) => suggestion.domain)).not.toContain("repair");
+    expect(suggestions[0]?.name).not.toContain("Repair Existing");
+  });
 });

--- a/tests/templates/index.test.ts
+++ b/tests/templates/index.test.ts
@@ -92,4 +92,39 @@ describe("templates registry", () => {
       expect(result.output?.swiftCode, id).toContain("struct");
     }
   });
+
+  it("ships WWDC26 provider fallback and testing-harness templates that compile", () => {
+    const ids = [
+      "foundation-models-custom-provider",
+      "app-intents-testing-harness",
+      "dynamic-profile-session",
+    ];
+
+    for (const id of ids) {
+      const template = getTemplate(id);
+      expect(template, id).toBeDefined();
+
+      const result = compileSource(template!.source, `${id}.ts`);
+      expect(result.success, id).toBe(true);
+      expect(result.output?.swiftCode, id).toContain("struct");
+    }
+
+    const harness = compileSource(
+      getTemplate("app-intents-testing-harness")!.source,
+      "app-intents-testing-harness.ts"
+    );
+    expect(harness.output?.swiftCode).toContain(
+      "#if canImport(XCTest) && canImport(AppIntentsTesting)"
+    );
+    expect(harness.output?.swiftCode).toContain(
+      "final class LogReadingSessionIntentTests: XCTestCase"
+    );
+
+    const provider = compileSource(
+      getTemplate("foundation-models-custom-provider")!.source,
+      "foundation-models-custom-provider.ts"
+    );
+    expect(provider.output?.swiftCode).toContain("HouseLanguageModel");
+    expect(provider.output?.swiftCode).toContain("onDeviceFallback");
+  });
 });

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.30";
+const VERSION = "0.4.31";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
Two new validator diagnostics pulled from real Swift failures: AX849 catches computed properties that declare locals and end on a bare expression without a return, AX860 catches same-file switch self over an enum that misses a case with no default. The suggest tool gets a dogfood mode that routes prompts about Axint's own tooling to a repair plan instead of generic app suggestions.

Three new templates for the WWDC26 surface: a custom LanguageModel provider session, a DynamicProfile session, and an AppIntentsTesting harness — backed by a new testHarness config that makes the compiler emit the XCTest file alongside the intent, guarded for the new frameworks. Generated intents should arrive with their tests now that Apple ships a first-party way to run them.

Also swaps the last fundraising vocabulary out of public tool descriptions. 216 diagnostics, 49 templates, 1266 tests passing.