### PR TITLE
release 0.4.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+## [0.4.32] — 2026-06-10
+
+### Added
+
+- **AX127 diagnostic** — a param default that disagrees with the declared type (`param.string("Length", { default: 8 })`) now fails both `axint validate` and `axint compile` before any Swift is emitted, with a computed fix ("change the default to a string, or change the param to param.int(...)"). Covers every param type; date and duration params reject literal defaults outright.
+- **Diagnostic spans and snippets** — TypeScript diagnostics now print `--> file.ts:line:col` plus a short source excerpt with a caret underline, rust-style. JSON output gains additive `line` and `column` fields.
+- **Perform-body notice** — `axint compile` prints a one-line note when a TS `perform` body is discarded into the Swift stub, so nobody discovers the TODO in Xcode later.
+
+### Changed
+
+- `axint --help` now leads with a Core section (init, compile, validate, validate-swift, templates, suggest, mcp) and groups the remaining commands into Authoring, Registry & cloud, and Project & agents sections.
+- Successful `compile`, `validate-swift`, and `watch` runs no longer print Fix Packet paths or the `axint login` tip — pass `--verbose` to bring them back. Failures still print everything.
+- ANSI color is disabled when output is piped or `NO_COLOR` is set, so agents reading CLI output stop receiving escape bytes.
+- `axint.suggest` matches consumer phrases to stock domains (habit/streak → health, todo/task/note → productivity, budget/expense/spending → finance) and gives each suggestion in a plan its own rationale instead of repeating one sentence.
+- The default MCP tool manifest is ~45% smaller and lists the hero tools first (compile, validate, swift.validate, swift.fix, scaffold, templates.list, templates.get, repair). Full prose stays behind `AXINT_MCP_MANIFEST_MODE=full`.
+- `param.url` string defaults now emit `URL(string: "...")!` and array defaults emit Swift array literals, so every default the validator accepts produces Swift that compiles.
+
+### Fixed
+
+- AX849 no longer blames the property above the real offender when a stored property precedes a computed property that is missing its `return`.
+
 ## [0.4.31] — 2026-06-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+## [0.4.31] — 2026-06-10
+
+### Added
+
+- **AX849 and AX860 diagnostics** — the Swift validator now flags computed properties that declare locals but never `return` the final expression (AX849), and same-file `switch self` statements that omit a declared enum case without a `default` branch (AX860).
+- **Dogfood routing in `axint.suggest`** — prompts about repairing Axint's own classifier, Cloud Check artifact handling, or version truth now route to a dedicated `axint-dogfood` plan instead of generic app-feature suggestions.
+- **WWDC26 templates** — `foundation-models-custom-provider` (custom LanguageModel provider session with an on-device fallback profile), `app-intents-testing-harness` (intent plus an AppIntentsTesting XCTest harness), and `dynamic-profile-session` (Foundation Models session with per-context DynamicProfiles).
+- **`testHarness` intent config** — `defineIntent` accepts a `testHarness` block; the generator emits an XCTest class that drives `perform()` with sample inputs behind `#if canImport(XCTest) && canImport(AppIntentsTesting)`.
+
+### Changed
+
+- Public-facing copy now says "audit-grade" and "production readiness" instead of fundraising vocabulary.
+
 ## [0.4.28] — 2026-05-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <p align="center">
   <a href="https://axint.ai">Website</a> ·
-  <a href="https://axint.ai/#playground">Playground</a> ·
+  <a href="https://cloud.axint.ai">Playground</a> ·
   <a href="#create-the-apple-day-agent-starter">Create App</a> ·
   <a href="#quick-start">Quick Start</a> ·
   <a href="#mcp-server">MCP Server</a> ·
@@ -299,7 +299,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 <!-- truth:readme-proof-line:start -->v0.4.31 · 36 MCP tools + 5 prompts · 216 diagnostic codes · 1377 tests · 58 live packages · 49 bundled templates<!-- truth:readme-proof-line:end -->
 
-<!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
+<!-- truth:readme-truth-source:start -->Public proof is regenerated from the compiler's metrics pipeline on every release (`npm run metrics:emit && npm run metrics:check`).<!-- truth:readme-truth-source:end -->
 
 If release numbers, diagnostics, package counts, or MCP surfaces change, update the canonical truth layer and re-run the sync instead of editing proof values by hand.
 
@@ -513,7 +513,7 @@ Full reference: [`docs/ERRORS.md`](docs/ERRORS.md)
 
 ## Playground
 
-No install required — [axint.ai/#playground](https://axint.ai/#playground) runs the same compiler in a server-backed playground, returning Swift live without a local install.
+No install required — [cloud.axint.ai](https://cloud.axint.ai) runs the same compiler in a server-backed playground, returning Swift live without a local install.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.30 · 36 MCP tools + 5 prompts · 214 diagnostic codes · 1372 tests · 58 live packages · 46 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.31 · 36 MCP tools + 5 prompts · 216 diagnostic codes · 1377 tests · 58 live packages · 49 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is generated from `../public-truth/public-truth.json` via `npm --prefix .. run truth:sync`.<!-- truth:readme-truth-source:end -->
 
@@ -381,7 +381,7 @@ Agent sessions should not have to restart from scratch just because Axint shippe
 axint upgrade
 axint upgrade --apply
 axint upgrade --apply --xcode-install
-axint upgrade --target 0.4.30 --apply
+axint upgrade --target 0.4.31 --apply
 ```
 
 From MCP, call `axint.upgrade`. The tool returns the exact command plan plus a same-thread prompt that tells the agent to keep the current conversation, reload or reconnect only the Axint MCP server/tool process, then call `axint.status` and `axint.activate` to prove the running version and first real Axint output before editing code.

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.31 · 36 MCP tools + 5 prompts · 216 diagnostic codes · 1377 tests · 58 live packages · 49 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.32 · 36 MCP tools + 5 prompts · 217 diagnostic codes · 1426 tests · 58 live packages · 49 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is regenerated from the compiler's metrics pipeline on every release (`npm run metrics:emit && npm run metrics:check`).<!-- truth:readme-truth-source:end -->
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,12 @@
 # Axint Roadmap
 
-_Last updated: June 2026 · Current release: <!-- metrics:roadmap-release:start -->[v0.4.30](https://github.com/agenticempire/axint/releases/tag/v0.4.30)<!-- metrics:roadmap-release:end -->_
+_Last updated: June 2026 · Current release: <!-- metrics:roadmap-release:start -->[v0.4.31](https://github.com/agenticempire/axint/releases/tag/v0.4.31)<!-- metrics:roadmap-release:end -->_
 
 Axint is the Apple-native execution layer for AI coding agents. The open-source package gives agents a smaller contract for Apple surfaces, emits ordinary Swift, validates Apple-specific rules, writes Fix Packets, and coordinates proof loops across CLI, MCP, Xcode, Registry, and Cloud-facing workflows.
 
 The thesis is simple: agents can write code, but Apple-native software needs proof. Axint turns agent output into validated, repairable, inspectable Apple work.
 
-<!-- metrics:roadmap-snapshot:start -->Current compiler snapshot: v0.4.30 · 36 MCP tools + 5 prompts · 46 templates · 214 diagnostic codes · 1372 tests.<!-- metrics:roadmap-snapshot:end -->
+<!-- metrics:roadmap-snapshot:start -->Current compiler snapshot: v0.4.31 · 36 MCP tools + 5 prompts · 49 templates · 216 diagnostic codes · 1377 tests.<!-- metrics:roadmap-snapshot:end -->
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,12 @@
 # Axint Roadmap
 
-_Last updated: June 2026 · Current release: <!-- metrics:roadmap-release:start -->[v0.4.31](https://github.com/agenticempire/axint/releases/tag/v0.4.31)<!-- metrics:roadmap-release:end -->_
+_Last updated: June 2026 · Current release: <!-- metrics:roadmap-release:start -->[v0.4.32](https://github.com/agenticempire/axint/releases/tag/v0.4.32)<!-- metrics:roadmap-release:end -->_
 
 Axint is the Apple-native execution layer for AI coding agents. The open-source package gives agents a smaller contract for Apple surfaces, emits ordinary Swift, validates Apple-specific rules, writes Fix Packets, and coordinates proof loops across CLI, MCP, Xcode, Registry, and Cloud-facing workflows.
 
 The thesis is simple: agents can write code, but Apple-native software needs proof. Axint turns agent output into validated, repairable, inspectable Apple work.
 
-<!-- metrics:roadmap-snapshot:start -->Current compiler snapshot: v0.4.31 · 36 MCP tools + 5 prompts · 49 templates · 216 diagnostic codes · 1377 tests.<!-- metrics:roadmap-snapshot:end -->
+<!-- metrics:roadmap-snapshot:start -->Current compiler snapshot: v0.4.32 · 36 MCP tools + 5 prompts · 49 templates · 217 diagnostic codes · 1426 tests.<!-- metrics:roadmap-snapshot:end -->
 
 ---
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,45 @@
 # Release Notes
 
+## 2026-06-10 — First-hour polish: validated defaults, diagnostic spans, quieter pipes
+
+This release closes the gap between "validated Swift" and what a cold user
+actually sees in their first hour: a default/type mismatch can no longer
+sail through a green check, diagnostics point at the exact line and column
+with a source excerpt, and piped output stays clean for agents.
+
+### Added
+
+- AX127 rejects param defaults that disagree with the declared type — both
+  `axint validate` and `axint compile` stop before emit and suggest the
+  concrete fix. Every param type is covered; date and duration params reject
+  literal defaults outright.
+- TS diagnostics print `--> file.ts:line:col` plus a caret-underlined source
+  excerpt; JSON output gains additive `line` and `column` fields.
+- `axint compile` prints a one-line note when a TS `perform` body is
+  discarded into the Swift stub.
+
+### Changed
+
+- `axint --help` leads with a Core section of hero commands and groups the
+  rest under Authoring, Registry & cloud, and Project & agents.
+- Successful runs no longer print Fix Packet paths or the sign-in tip
+  (`--verbose` restores them), and ANSI color turns off for non-TTY output
+  and `NO_COLOR`.
+- `axint.suggest` maps consumer phrases like "habit tracker with streaks"
+  onto the stock health/productivity/finance domains and writes a distinct
+  rationale for every suggestion in a plan.
+- The default MCP manifest drops to ~40 KB (about 45% smaller) with hero
+  tools listed first; `AXINT_MCP_MANIFEST_MODE=full` keeps the full prose.
+- `param.url` and array defaults now emit compilable Swift
+  (`URL(string: "...")!`, array literals).
+- Public truth advances to v0.4.32 with 36 MCP tools, 5 prompts, 217
+  diagnostic codes, 1426 tests, 58 live packages, and 49 bundled templates.
+
+### Fixed
+
+- AX849 attributes a missing `return` to the offending computed property
+  instead of the stored property above it.
+
 ## 2026-06-10 — Provider fallback templates and compiler-parity diagnostics
 
 This release ships the WWDC26 custom LanguageModel provider and App Intents

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,36 @@
 # Release Notes
 
+## 2026-06-10 — Provider fallback templates and compiler-parity diagnostics
+
+This release ships the WWDC26 custom LanguageModel provider and App Intents
+testing templates, plus two Swift validator checks that catch real Xcode
+build failures before the build.
+
+### Added
+
+- `foundation-models-custom-provider` template: a session backed by a custom
+  LanguageModel provider with an on-device fallback profile.
+- `app-intents-testing-harness` template: an intent plus an AppIntentsTesting
+  XCTest harness that drives `perform()` with sample inputs behind a
+  `canImport` guard.
+- `dynamic-profile-session` template: a Foundation Models session that selects
+  a DynamicProfile per request context.
+- `testHarness` config on `defineIntent` for emitting the XCTest harness from
+  any intent definition.
+- AX849 flags computed properties that declare locals but never return the
+  final expression.
+- AX860 flags `switch self` statements that omit a declared enum case without
+  a `default` branch.
+- `axint.suggest` routes Axint dogfood prompts to a dedicated `axint-dogfood`
+  plan instead of generic app-feature suggestions.
+
+### Changed
+
+- Public-facing copy now says "audit-grade" and "production readiness" instead
+  of fundraising vocabulary.
+- Public truth advances to v0.4.31 with 36 MCP tools, 5 prompts, 216 diagnostic
+  codes, 1377 tests, 58 live packages, and 49 bundled templates.
+
 ## 2026-06-08 — WWDC26 compiler support
 
 This release adds the first Axint compiler support for the Xcode 27 / WWDC26

--- a/examples/calendar-assistant.ts
+++ b/examples/calendar-assistant.ts
@@ -18,7 +18,7 @@ export default defineIntent({
   params: {
     title: param.string("Event title"),
     date: param.date("Event date"),
-    duration: param.duration("Event duration", { default: "1h" }),
+    duration: param.duration("Event duration"),
     location: param.string("Location", { required: false }),
   },
   perform: async ({ title, date, duration: _duration, location: _location }) => {

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/claude-desktop/server/package.json
+++ b/extensions/claude-desktop/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axint-desktop-extension-server",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — Apple-Native Execution Layer",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axint",
   "displayName": "Axint — Apple-Native Execution Layer",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "publisher": "agenticempire",
   "description": "Preview, validate, browse templates, and open shareable Axint Cloud reports from VS Code. Compile TypeScript or Python into Apple-native surfaces from your editor.",
   "license": "Apache-2.0",

--- a/metrics.json
+++ b/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.31",
+  "version": "0.4.32",
   "mcpTools": 36,
   "mcpToolNames": [
     "axint.status",
@@ -48,7 +48,7 @@
     "axint.create-intent"
   ],
   "bundledTemplates": 49,
-  "diagnostics": 216,
+  "diagnostics": 217,
   "xcodeFixRules": 33,
   "xcodeFixRuleCodes": [
     "AX701",
@@ -86,7 +86,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1263,
+    "typescript": 1312,
     "python": 114
   },
   "registryPackages": 58,

--- a/metrics.json
+++ b/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.30",
+  "version": "0.4.31",
   "mcpTools": 36,
   "mcpToolNames": [
     "axint.status",
@@ -47,8 +47,8 @@
     "axint.create-widget",
     "axint.create-intent"
   ],
-  "bundledTemplates": 46,
-  "diagnostics": 214,
+  "bundledTemplates": 49,
+  "diagnostics": 216,
   "xcodeFixRules": 33,
   "xcodeFixRuleCodes": [
     "AX701",
@@ -86,7 +86,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1258,
+    "typescript": 1263,
     "python": 114
   },
   "registryPackages": 58,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axint/compiler",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "mcpName": "io.github.agenticempire/axint",
   "publishConfig": {
     "access": "public"

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.30"
+__version__ = "0.4.31"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/axint/__init__.py
+++ b/python/axint/__init__.py
@@ -27,7 +27,7 @@ the same Swift generator and hits the same validator rules.
 
 from __future__ import annotations
 
-__version__ = "0.4.31"
+__version__ = "0.4.32"
 
 from .generator import (
     generate_entitlements_fragment,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.31"
+version = "0.4.32"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axint"
-version = "0.4.30"
+version = "0.4.31"
 description = "Python SDK for Axint — define Apple App Intents, Views, Widgets, and Apps in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.31",
+      "version": "0.4.32",
       "transport": {
         "type": "stdio"
       }
@@ -28,7 +28,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.31",
+      "version": "0.4.32",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://axint.ai",
   "documentation": "https://docs.axint.ai",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
     {
       "registryType": "npm",
       "identifier": "@axint/compiler",
-      "version": "0.4.30",
+      "version": "0.4.31",
       "transport": {
         "type": "stdio"
       }
@@ -28,7 +28,7 @@
     {
       "registryType": "pypi",
       "identifier": "axint",
-      "version": "0.4.30",
+      "version": "0.4.31",
       "transport": {
         "type": "stdio"
       }

--- a/spec/axint-lift-gauntlet.md
+++ b/spec/axint-lift-gauntlet.md
@@ -49,7 +49,7 @@ Every run records these metrics.
 | Human interventions | Times a human had to explain what to do next | Shows autonomy |
 | Apple-specific defects | Count of unresolved App Intents, plist, entitlement, SwiftUI, WidgetKit, Xcode, signing, or test issues | Shows Apple-native competence |
 | False ship claims | Times the agent said it was done while build/test/runtime proof failed | Shows trustworthiness |
-| Proof completeness | 0-5 score for source, generated Swift, static validation, Xcode/build, runtime/test, and artifact evidence | Shows investor-grade rigor |
+| Proof completeness | 0-5 score for source, generated Swift, static validation, Xcode/build, runtime/test, and artifact evidence | Shows audit-grade rigor |
 | Token cost | Approximate prompt/output tokens across the run | Shows workflow efficiency |
 | Repair precision | Number of changed files and diff lines needed to fix failures | Shows whether Axint focuses the agent |
 

--- a/src/cli/color.ts
+++ b/src/cli/color.ts
@@ -1,0 +1,14 @@
+/**
+ * Central ANSI color policy for the CLI. Color is for humans on TTYs —
+ * agents and CI read piped output, which must stay free of escape bytes.
+ */
+
+export function shouldUseColor(forceColor = false): boolean {
+  if (forceColor) return true;
+  if ("NO_COLOR" in process.env) return false;
+  return process.stdout.isTTY === true && process.stderr.isTTY === true;
+}
+
+export function stripAnsi(value: string): string {
+  return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g"), "");
+}

--- a/src/cli/compile.ts
+++ b/src/cli/compile.ts
@@ -48,6 +48,7 @@ interface UnifiedOutput {
   irName: string;
   infoPlistFragment?: string;
   entitlementsFragment?: string;
+  hasPerformBody?: boolean;
 }
 
 /**
@@ -65,6 +66,7 @@ function unifyOutput(result: AnyCompileResult): UnifiedOutput | null {
       irName: result.output.ir.name,
       infoPlistFragment: result.output.infoPlistFragment,
       entitlementsFragment: result.output.entitlementsFragment,
+      hasPerformBody: result.output.ir.hasPerformBody,
     };
   }
 
@@ -396,6 +398,14 @@ export function registerCompile(program: Command) {
                 `\x1b[33mwarning:\x1b[0m swift-format skipped — ${(fmtErr as Error).message}`
               );
             }
+          }
+
+          // The TS perform body never crosses into Swift — saying so up
+          // front beats the user discovering a TODO stub in Xcode later.
+          if (surface === "intent" && output.hasPerformBody) {
+            console.error(
+              "note: perform body is not translated yet — Swift stub emitted (implement perform() in the generated file)"
+            );
           }
 
           if (options.stdout) {

--- a/src/cli/compile.ts
+++ b/src/cli/compile.ts
@@ -8,6 +8,7 @@ import {
   type AnyCompileResult,
 } from "../core/compiler.js";
 import type { Diagnostic } from "../core/types.js";
+import { renderDiagnostic } from "./render-diagnostics.js";
 import {
   printRepairArtifactLines,
   tryEmitRepairArtifacts,
@@ -85,18 +86,12 @@ function unifyOutput(result: AnyCompileResult): UnifiedOutput | null {
   };
 }
 
-function printDiagnostics(diagnostics: Diagnostic[]): void {
+function printDiagnostics(
+  diagnostics: Diagnostic[],
+  sources?: ReadonlyMap<string, string>
+): void {
   for (const d of diagnostics) {
-    const prefix =
-      d.severity === "error"
-        ? "\x1b[31merror\x1b[0m"
-        : d.severity === "warning"
-          ? "\x1b[33mwarning\x1b[0m"
-          : "\x1b[36minfo\x1b[0m";
-
-    console.error(`  ${prefix}[${d.code}]: ${d.message}`);
-    if (d.file) console.error(`    --> ${d.file}${d.line ? `:${d.line}` : ""}`);
-    if (d.suggestion) console.error(`    = help: ${d.suggestion}`);
+    console.error(renderDiagnostic(d, { color: true, sources }));
     console.error();
   }
 }
@@ -348,6 +343,7 @@ export function registerCompile(program: Command) {
                     message: d.message,
                     file: d.file,
                     line: d.line,
+                    column: d.column,
                     suggestion: d.suggestion,
                   })),
                   fixPacketPath: repairArtifacts?.packet.jsonPath ?? null,
@@ -361,7 +357,11 @@ export function registerCompile(program: Command) {
             return;
           }
 
-          printDiagnostics(diagnostics);
+          const sources =
+            inputSource !== undefined && inputFilePath !== undefined
+              ? new Map([[inputFilePath, inputSource]])
+              : undefined;
+          printDiagnostics(diagnostics, sources);
 
           if (!success || !output) {
             if (repairArtifacts) {

--- a/src/cli/compile.ts
+++ b/src/cli/compile.ts
@@ -9,6 +9,7 @@ import {
 } from "../core/compiler.js";
 import type { Diagnostic } from "../core/types.js";
 import { renderDiagnostic } from "./render-diagnostics.js";
+import { shouldUseColor } from "./color.js";
 import {
   printRepairArtifactLines,
   tryEmitRepairArtifacts,
@@ -90,10 +91,11 @@ function unifyOutput(result: AnyCompileResult): UnifiedOutput | null {
 
 function printDiagnostics(
   diagnostics: Diagnostic[],
+  color: boolean,
   sources?: ReadonlyMap<string, string>
 ): void {
   for (const d of diagnostics) {
-    console.error(renderDiagnostic(d, { color: true, sources }));
+    console.error(renderDiagnostic(d, { color, sources }));
     console.error();
   }
 }
@@ -142,6 +144,10 @@ export function registerCompile(program: Command) {
       "Directory for the emitted Fix Packet artifacts",
       ".axint/fix"
     )
+    .option(
+      "--verbose",
+      "Print Fix Packet paths and sign-in tips even when compilation succeeds"
+    )
     .action(
       async (
         file: string,
@@ -158,9 +164,13 @@ export function registerCompile(program: Command) {
           fromIr: boolean;
           fixPacket: boolean;
           fixPacketDir: string;
+          verbose?: boolean;
         }
       ) => {
         const filePath = resolve(file);
+        const color = shouldUseColor();
+        const paint = (ansi: string, text: string) =>
+          color ? `${ansi}${text}\x1b[0m` : text;
 
         try {
           let surface:
@@ -198,7 +208,7 @@ export function registerCompile(program: Command) {
             try {
               parsed = JSON.parse(irRaw);
             } catch {
-              console.error(`\x1b[31merror:\x1b[0m Invalid JSON in ${file}`);
+              console.error(`${paint("\x1b[31m", "error:")} Invalid JSON in ${file}`);
               process.exit(1);
             }
 
@@ -207,7 +217,7 @@ export function registerCompile(program: Command) {
               : (parsed as Record<string, unknown>);
             if (!irData || typeof irData !== "object") {
               console.error(
-                `\x1b[31merror:\x1b[0m Expected an IR object or array in ${file}`
+                `${paint("\x1b[31m", "error:")} Expected an IR object or array in ${file}`
               );
               process.exit(1);
             }
@@ -257,7 +267,7 @@ export function registerCompile(program: Command) {
               (options.emitInfoPlist || options.emitEntitlements)
             ) {
               console.error(
-                `\x1b[33mwarning:\x1b[0m --emit-info-plist and --emit-entitlements apply to intents only; ignored for ${result.surface}.`
+                `${paint("\x1b[33m", "warning:")} --emit-info-plist and --emit-entitlements apply to intents only; ignored for ${result.surface}.`
               );
             }
           }
@@ -324,7 +334,7 @@ export function registerCompile(program: Command) {
             repairArtifacts = repairResult.artifacts;
             if (repairResult.error) {
               console.error(
-                `\x1b[33mwarning:\x1b[0m Fix Packet skipped — ${repairResult.error.message}`
+                `${paint("\x1b[33m", "warning:")} Fix Packet skipped — ${repairResult.error.message}`
               );
             }
           }
@@ -363,15 +373,15 @@ export function registerCompile(program: Command) {
             inputSource !== undefined && inputFilePath !== undefined
               ? new Map([[inputFilePath, inputSource]])
               : undefined;
-          printDiagnostics(diagnostics, sources);
+          printDiagnostics(diagnostics, color, sources);
 
           if (!success || !output) {
             if (repairArtifacts) {
-              printRepairArtifactLines(repairArtifacts, console.error);
+              printRepairArtifactLines(repairArtifacts, console.error, { color });
             }
             const errorCount = diagnostics.filter((d) => d.severity === "error").length;
             console.error(
-              `\x1b[31mCompilation failed with ${errorCount} error(s)\x1b[0m`
+              paint("\x1b[31m", `Compilation failed with ${errorCount} error(s)`)
             );
             process.exit(1);
           }
@@ -386,16 +396,18 @@ export function registerCompile(program: Command) {
                 output.swiftCode = fmt.formatted;
               } else {
                 console.error(
-                  `\x1b[33mwarning:\x1b[0m swift-format skipped — ${fmt.reason}`
+                  `${paint("\x1b[33m", "warning:")} swift-format skipped — ${fmt.reason}`
                 );
               }
             } catch (fmtErr: unknown) {
               if (options.strictFormat) {
-                console.error(`\x1b[31merror:\x1b[0m ${(fmtErr as Error).message}`);
+                console.error(
+                  `${paint("\x1b[31m", "error:")} ${(fmtErr as Error).message}`
+                );
                 process.exit(1);
               }
               console.error(
-                `\x1b[33mwarning:\x1b[0m swift-format skipped — ${(fmtErr as Error).message}`
+                `${paint("\x1b[33m", "warning:")} swift-format skipped — ${(fmtErr as Error).message}`
               );
             }
           }
@@ -415,7 +427,7 @@ export function registerCompile(program: Command) {
             mkdirSync(dirname(outPath), { recursive: true });
             writeFileSync(outPath, output.swiftCode, "utf-8");
             console.log(
-              `\x1b[32m✓\x1b[0m Compiled ${surface} ${output.irName} → ${outPath}`
+              `${paint("\x1b[32m", "✓")} Compiled ${surface} ${output.irName} → ${outPath}`
             );
 
             // Show TS-to-Swift compression so authors can eyeball whether
@@ -429,7 +441,7 @@ export function registerCompile(program: Command) {
                 if (ratio !== null) {
                   const label = swiftLines > tsLines ? "Expansion" : "Compression";
                   console.log(
-                    `\x1b[36m→\x1b[0m ${label}: ${tsLines} TS → ${swiftLines} Swift (${ratio})`
+                    `${paint("\x1b[36m", "→")} ${label}: ${tsLines} TS → ${swiftLines} Swift (${ratio})`
                   );
                 }
               } catch {
@@ -445,7 +457,7 @@ export function registerCompile(program: Command) {
             ) {
               const plistPath = outPath.replace(/\.swift$/, ".plist.fragment.xml");
               writeFileSync(plistPath, output.infoPlistFragment, "utf-8");
-              console.log(`\x1b[32m✓\x1b[0m Info.plist fragment → ${plistPath}`);
+              console.log(`${paint("\x1b[32m", "✓")} Info.plist fragment → ${plistPath}`);
             }
 
             if (
@@ -455,7 +467,7 @@ export function registerCompile(program: Command) {
             ) {
               const entPath = outPath.replace(/\.swift$/, ".entitlements.fragment.xml");
               writeFileSync(entPath, output.entitlementsFragment, "utf-8");
-              console.log(`\x1b[32m✓\x1b[0m Entitlements fragment → ${entPath}`);
+              console.log(`${paint("\x1b[32m", "✓")} Entitlements fragment → ${entPath}`);
             }
 
             // Extensions always ship with an NSExtension Info.plist fragment —
@@ -464,11 +476,11 @@ export function registerCompile(program: Command) {
             if (surface === "extension" && output.infoPlistFragment) {
               const plistPath = outPath.replace(/\.swift$/, ".plist.fragment.xml");
               writeFileSync(plistPath, output.infoPlistFragment, "utf-8");
-              console.log(`\x1b[32m✓\x1b[0m Info.plist fragment → ${plistPath}`);
+              console.log(`${paint("\x1b[32m", "✓")} Info.plist fragment → ${plistPath}`);
             }
 
-            if (repairArtifacts) {
-              printRepairArtifactLines(repairArtifacts, console.log);
+            if (repairArtifacts && options.verbose) {
+              printRepairArtifactLines(repairArtifacts, console.log, { color });
             }
           }
 
@@ -476,23 +488,23 @@ export function registerCompile(program: Command) {
             try {
               const { sandboxCompile } = await import("../core/sandbox.js");
               console.log();
-              console.log(`\x1b[36m→\x1b[0m Stage 4: SPM sandbox compile...`);
+              console.log(`${paint("\x1b[36m", "→")} Stage 4: SPM sandbox compile...`);
               const sandboxResult = await sandboxCompile(output.swiftCode, {
                 intentName: output.irName,
               });
               if (sandboxResult.ok) {
                 console.log(
-                  `\x1b[32m✓\x1b[0m Swift builds cleanly (${sandboxResult.durationMs}ms in ${sandboxResult.sandboxPath})`
+                  `${paint("\x1b[32m", "✓")} Swift builds cleanly (${sandboxResult.durationMs}ms in ${sandboxResult.sandboxPath})`
                 );
               } else {
                 console.error(
-                  `\x1b[31m✗\x1b[0m Sandbox compile failed:\n${sandboxResult.stderr}`
+                  `${paint("\x1b[31m", "✗")} Sandbox compile failed:\n${sandboxResult.stderr}`
                 );
                 process.exit(1);
               }
             } catch (sbErr: unknown) {
               console.error(
-                `\x1b[33mwarning:\x1b[0m sandbox compile skipped — ${(sbErr as Error).message}`
+                `${paint("\x1b[33m", "warning:")} sandbox compile skipped — ${(sbErr as Error).message}`
               );
             }
           }
@@ -510,7 +522,7 @@ export function registerCompile(program: Command) {
           ) {
             console.error((err as { format: () => string }).format());
           } else {
-            console.error(`\x1b[31merror:\x1b[0m ${err}`);
+            console.error(`${paint("\x1b[31m", "error:")} ${err}`);
           }
           process.exit(1);
         }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -669,6 +669,67 @@ xcodeExtension
     await xcodeExtensionStatus();
   });
 
+// ─── help layout ─────────────────────────────────────────────────────
+// A first-time user should see the seven hero commands before the long
+// tail. Everything stays registered and functional — the sections only
+// shape `axint --help`.
+
+const HELP_SECTIONS: ReadonlyArray<readonly [string, ReadonlyArray<string>]> = [
+  [
+    "Core:",
+    ["init", "compile", "validate", "validate-swift", "templates", "suggest", "mcp"],
+  ],
+  [
+    "Authoring:",
+    [
+      "create",
+      "activate",
+      "eject",
+      "format",
+      "tokens",
+      "schema",
+      "feature",
+      "watch",
+      "paint-test",
+    ],
+  ],
+  [
+    "Registry & cloud:",
+    ["login", "cloud", "publish", "add", "search", "feedback", "telemetry"],
+  ],
+  [
+    "Project & agents:",
+    [
+      "repair",
+      "agent",
+      "memory",
+      "project",
+      "session",
+      "workflow",
+      "run",
+      "runner",
+      "status",
+      "upgrade",
+      "doctor",
+      "xcode",
+    ],
+  ],
+];
+
+const helpSectionByCommand = new Map(
+  HELP_SECTIONS.flatMap(([heading, names]) =>
+    names.map((name) => [name, heading] as const)
+  )
+);
+
+for (const command of program.commands) {
+  command.helpGroup(helpSectionByCommand.get(command.name()) ?? "Project & agents:");
+}
+
+// The implicit `help` command belongs with the hero commands.
+program.commandsGroup("Core:");
+program.helpCommand(true);
+
 // Helper used by scaffold to avoid a circular import
 export function __axintExistsSync(p: string) {
   return existsSync(p);

--- a/src/cli/render-diagnostics.ts
+++ b/src/cli/render-diagnostics.ts
@@ -1,0 +1,114 @@
+/**
+ * Human-facing diagnostic renderer (rust-style).
+ *
+ *   error[AX127]: Parameter "value" is declared param.string() but its default is the number 8
+ *     --> intents/make-thing.ts:8:46
+ *      |
+ *    7 |   params: {
+ *    8 |     value: param.string("Length", { default: 8 }),
+ *      |                                              ^
+ *     = help: Change the default to a string (e.g. "8"), or change the param to param.int(...).
+ *
+ * The snippet renders only when the caller can supply the original
+ * source for the diagnostic's file; everything degrades gracefully to
+ * the plain `--> file:line:col` form.
+ */
+
+import type { Diagnostic } from "../core/types.js";
+
+export interface DiagnosticRenderContext {
+  color: boolean;
+  /** Original source text keyed by the file path diagnostics point at. */
+  sources?: ReadonlyMap<string, string>;
+}
+
+const SEVERITY_ANSI: Record<Diagnostic["severity"], string> = {
+  error: "\x1b[31m",
+  warning: "\x1b[33m",
+  info: "\x1b[36m",
+};
+
+export function renderDiagnostic(d: Diagnostic, ctx: DiagnosticRenderContext): string {
+  const paint = (ansi: string, text: string) =>
+    ctx.color ? `${ansi}${text}\x1b[0m` : text;
+
+  const lines = [
+    `  ${paint(SEVERITY_ANSI[d.severity], d.severity)}[${d.code}]: ${d.message}`,
+  ];
+
+  if (d.file) {
+    const location = d.line
+      ? d.column
+        ? `${d.file}:${d.line}:${d.column}`
+        : `${d.file}:${d.line}`
+      : d.file;
+    lines.push(`    --> ${location}`);
+    lines.push(...renderSnippet(d, ctx, paint));
+  }
+
+  if (d.suggestion) {
+    lines.push(`    = ${paint("\x1b[2m", "help:")} ${d.suggestion}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function renderDiagnostics(
+  diagnostics: Diagnostic[],
+  ctx: DiagnosticRenderContext
+): string[] {
+  return diagnostics.map((d) => renderDiagnostic(d, ctx));
+}
+
+function renderSnippet(
+  d: Diagnostic,
+  ctx: DiagnosticRenderContext,
+  paint: (ansi: string, text: string) => string
+): string[] {
+  if (!d.file || !d.line) return [];
+  const source = ctx.sources?.get(d.file);
+  if (!source) return [];
+
+  const allLines = source.split(/\r?\n/);
+  const target = allLines[d.line - 1];
+  if (target === undefined) return [];
+
+  const width = String(d.line).length;
+  const bar = `   ${" ".repeat(width)} ${paint("\x1b[2m", "|")}`;
+  const codeRow = (line: number, text: string) =>
+    `   ${paint("\x1b[2m", `${String(line).padStart(width)} |`)} ${text}`;
+
+  const rows = [bar];
+  const previous = d.line > 1 ? allLines[d.line - 2] : undefined;
+  if (previous !== undefined && previous.trim().length > 0) {
+    rows.push(codeRow(d.line - 1, previous));
+  }
+  rows.push(codeRow(d.line, target));
+
+  if (d.column && d.column <= target.length + 1) {
+    const marker = `^${"~".repeat(Math.max(0, underlineLength(target, d.column) - 1))}`;
+    rows.push(
+      `${bar} ${" ".repeat(d.column - 1)}${paint(SEVERITY_ANSI[d.severity], marker)}`
+    );
+  }
+
+  return rows;
+}
+
+/**
+ * Underline the token starting at the caret: a full string literal when
+ * the caret sits on a quote, otherwise the contiguous identifier/number.
+ */
+function underlineLength(lineText: string, column: number): number {
+  const rest = lineText.slice(column - 1);
+  if (!rest) return 1;
+
+  const first = rest[0];
+  if (first === '"' || first === "'" || first === "`") {
+    const close = rest.indexOf(first, 1);
+    if (close > 0) return close + 1;
+  }
+
+  const token = rest.match(/^[A-Za-z0-9_$.]+/);
+  return token ? token[0].length : 1;
+}

--- a/src/cli/validate-swift.ts
+++ b/src/cli/validate-swift.ts
@@ -4,6 +4,7 @@ import { resolve, join, extname } from "node:path";
 import { validateSwiftSources } from "../core/swift-validator.js";
 import type { Diagnostic } from "../core/types.js";
 import { getAxintLoginState } from "../core/credentials.js";
+import { shouldUseColor } from "./color.js";
 import {
   renderRepairArtifactLines,
   tryEmitRepairArtifacts,
@@ -17,6 +18,10 @@ export function registerValidateSwift(program: Command) {
     )
     .argument("<paths...>", "Swift file(s) or directories to validate")
     .option("--quiet", "Only print errors, not the success banner")
+    .option(
+      "--verbose",
+      "Print Fix Packet paths and sign-in tips even when validation passes"
+    )
     .option("--json", "Emit a machine-readable JSON report to stdout")
     .option("--color", "Force ANSI color output even when stdout/stderr are not TTYs")
     .option(
@@ -37,6 +42,7 @@ export function registerValidateSwift(program: Command) {
         pathArgs: string[],
         options: {
           quiet?: boolean;
+          verbose?: boolean;
           json?: boolean;
           color?: boolean;
           quietSystemSymbols?: boolean;
@@ -167,7 +173,7 @@ export function registerValidateSwift(program: Command) {
         }
 
         if (!options.quiet) {
-          if (repairArtifacts) {
+          if (repairArtifacts && options.verbose) {
             printRepairArtifactLinesWithColor(repairArtifacts, color, console.log);
           }
           printLine(
@@ -230,12 +236,6 @@ function printDiagnostic(d: Diagnostic, color: boolean) {
   }
 }
 
-function shouldUseColor(forceColor: boolean): boolean {
-  if (forceColor) return true;
-  if ("NO_COLOR" in process.env) return false;
-  return process.stdout.isTTY === true && process.stderr.isTTY === true;
-}
-
 function printRepairArtifactLinesWithColor(
   artifacts: NonNullable<ReturnType<typeof tryEmitRepairArtifacts>["artifacts"]>,
   color: boolean,
@@ -243,13 +243,10 @@ function printRepairArtifactLinesWithColor(
 ) {
   for (const line of renderRepairArtifactLines(artifacts, {
     signedIn: getAxintLoginState().signedIn,
+    color,
   })) {
-    writeLine(color ? line : stripAnsi(line));
+    writeLine(line);
   }
-}
-
-function stripAnsi(value: string): string {
-  return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g"), "");
 }
 
 function printLine(

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -1,6 +1,8 @@
 import type { Command } from "commander";
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { compileFile } from "../core/compiler.js";
+import { renderDiagnostic } from "./render-diagnostics.js";
 
 export function registerValidate(program: Command) {
   program
@@ -17,15 +19,15 @@ export function registerValidate(program: Command) {
       try {
         const result = compileFile(filePath, { validate: true });
 
+        let sources: Map<string, string> | undefined;
+        try {
+          sources = new Map([[filePath, readFileSync(filePath, "utf-8")]]);
+        } catch {
+          sources = undefined;
+        }
+
         for (const d of result.diagnostics) {
-          const prefix =
-            d.severity === "error"
-              ? "\x1b[31merror\x1b[0m"
-              : d.severity === "warning"
-                ? "\x1b[33mwarning\x1b[0m"
-                : "\x1b[36minfo\x1b[0m";
-          console.error(`  ${prefix}[${d.code}]: ${d.message}`);
-          if (d.suggestion) console.error(`    = help: ${d.suggestion}`);
+          console.error(renderDiagnostic(d, { color: true, sources }));
         }
 
         if (!result.success) {

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { compileFile } from "../core/compiler.js";
 import { renderDiagnostic } from "./render-diagnostics.js";
+import { shouldUseColor } from "./color.js";
 
 export function registerValidate(program: Command) {
   program
@@ -15,6 +16,9 @@ export function registerValidate(program: Command) {
     )
     .action(async (file: string, options: { sandbox: boolean }) => {
       const filePath = resolve(file);
+      const color = shouldUseColor();
+      const paint = (ansi: string, text: string) =>
+        color ? `${ansi}${text}\x1b[0m` : text;
 
       try {
         const result = compileFile(filePath, { validate: true });
@@ -27,7 +31,7 @@ export function registerValidate(program: Command) {
         }
 
         for (const d of result.diagnostics) {
-          console.error(renderDiagnostic(d, { color: true, sources }));
+          console.error(renderDiagnostic(d, { color, sources }));
         }
 
         if (!result.success) {
@@ -36,19 +40,19 @@ export function registerValidate(program: Command) {
 
         if (options.sandbox && result.output) {
           const { sandboxCompile } = await import("../core/sandbox.js");
-          console.log(`\x1b[36m→\x1b[0m Stage 4: SPM sandbox compile...`);
+          console.log(`${paint("\x1b[36m", "→")} Stage 4: SPM sandbox compile...`);
           const sandboxResult = await sandboxCompile(result.output.swiftCode, {
             intentName: result.output.ir.name,
           });
           if (!sandboxResult.ok) {
-            console.error(`\x1b[31m✗\x1b[0m ${sandboxResult.stderr}`);
+            console.error(`${paint("\x1b[31m", "✗")} ${sandboxResult.stderr}`);
             process.exit(1);
           }
           console.log(
-            `\x1b[32m✓\x1b[0m Valid intent definition (sandbox-verified, ${sandboxResult.durationMs}ms)`
+            `${paint("\x1b[32m", "✓")} Valid intent definition (sandbox-verified, ${sandboxResult.durationMs}ms)`
           );
         } else {
-          console.log(`\x1b[32m✓\x1b[0m Valid intent definition`);
+          console.log(`${paint("\x1b[32m", "✓")} Valid intent definition`);
         }
       } catch (err: unknown) {
         if (
@@ -59,7 +63,7 @@ export function registerValidate(program: Command) {
         ) {
           console.error((err as { format: () => string }).format());
         } else {
-          console.error(`\x1b[31merror:\x1b[0m ${err}`);
+          console.error(`${paint("\x1b[31m", "error:")} ${err}`);
         }
         process.exit(1);
       }

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -83,6 +83,10 @@ export function registerWatch(program: Command) {
       "Directory for the emitted Fix Packet artifacts",
       ".axint/fix"
     )
+    .option(
+      "--verbose",
+      "Print Fix Packet paths and sign-in tips after successful recompiles"
+    )
     .action(
       async (
         file: string,
@@ -97,6 +101,7 @@ export function registerWatch(program: Command) {
           swiftProject?: string;
           fixPacket: boolean;
           fixPacketDir: string;
+          verbose?: boolean;
         }
       ) => {
         const target = resolve(file);
@@ -225,7 +230,7 @@ export function registerWatch(program: Command) {
             `\x1b[32m✓\x1b[0m ${result.output.ir.name} → ${outPath} \x1b[90m(${dt}ms)\x1b[0m`
           );
           const packetArtifacts = emitPacket(filePath, result);
-          if (packetArtifacts) {
+          if (packetArtifacts && options.verbose) {
             printRepairArtifactLines(packetArtifacts, console.log);
           }
           return true;
@@ -304,7 +309,7 @@ export function registerWatch(program: Command) {
             `\x1b[32m✓\x1b[0m ${result.output.ir.name} → ${outPath} \x1b[90m(${dt}ms)\x1b[0m`
           );
           const packetArtifacts = emitPacket(filePath, result);
-          if (packetArtifacts) {
+          if (packetArtifacts && options.verbose) {
             printRepairArtifactLines(packetArtifacts, console.log);
           }
           return true;

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -246,6 +246,12 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticInfo> = {
       "HealthKit Info.plist usage-description key uses shorthand instead of Apple's real key",
     category: "intent-validator",
   },
+  AX127: {
+    code: "AX127",
+    severity: "error",
+    message: "Parameter default value does not match the declared param type",
+    category: "intent-validator",
+  },
 
   // ─── Intent Generator (AX200–AX299) ──────────────────────
   AX200: {

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -841,6 +841,19 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticInfo> = {
       "Nested type or static member access on a project-indexed type that does not declare the accessed name (catches the IntelBriefItem.Kind class of cross-file miss that AX841 deliberately skips)",
     category: "swift-cross-file-resolution",
   },
+  AX849: {
+    code: "AX849",
+    severity: "error",
+    message:
+      "Computed property has local declarations but no explicit return; Swift rejects the final expression",
+    category: "swift-compiler-parity",
+  },
+  AX860: {
+    code: "AX860",
+    severity: "error",
+    message: "Switch over enum value omits one or more declared enum cases",
+    category: "swift-state-machine",
+  },
   AX714: {
     code: "AX714",
     severity: "error",

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -198,6 +198,11 @@ export function generateSwift(intent: IRIntent): string {
     lines.push(``);
   }
 
+  if (safeIntent.testHarness) {
+    lines.push(generateTestHarnessSupport(safeIntent));
+    lines.push(``);
+  }
+
   return lines.join("\n");
 }
 
@@ -651,6 +656,72 @@ function generatePreviewProofSupport(previewProof: IRPreviewProofConfig): string
     `// AppIntentsTesting and preview evidence should be attached before release.`
   );
   return lines.join("\n");
+}
+
+function generateTestHarnessSupport(intent: IRIntent): string {
+  const className = swiftIdentifier(
+    intent.testHarness?.className || `${intent.name}IntentTests`
+  );
+  const lines: string[] = [];
+
+  // canImport guards keep the harness inert in app targets, so the file can
+  // live in either target without an #if TESTING build setting.
+  lines.push(`#if canImport(XCTest) && canImport(AppIntentsTesting)`);
+  lines.push(`import XCTest`);
+  lines.push(`import AppIntentsTesting`);
+  lines.push(``);
+  lines.push(`@available(iOS 26.0, macOS 26.0, *)`);
+  lines.push(`final class ${className}: XCTestCase {`);
+  lines.push(`    func testPerformSucceeds() async throws {`);
+  lines.push(`        let intent = ${intent.name}Intent()`);
+  for (const param of intent.parameters) {
+    if (param.isOptional) continue;
+    const sample = sampleSwiftValue(param.type);
+    if (sample) {
+      lines.push(`        intent.${param.name} = ${sample}`);
+    } else {
+      lines.push(`        // Set ${param.name} before running the harness.`);
+    }
+  }
+  lines.push(``);
+  lines.push(`        _ = try await intent.perform()`);
+  lines.push(`    }`);
+  lines.push(`}`);
+  lines.push(`#endif`);
+  return lines.join("\n");
+}
+
+function sampleSwiftValue(type: IRType): string | undefined {
+  switch (type.kind) {
+    case "primitive":
+      switch (type.value) {
+        case "string":
+          return `"Sample"`;
+        case "int":
+          return "1";
+        case "double":
+        case "float":
+          return "1.0";
+        case "boolean":
+          return "true";
+        case "date":
+          return "Date()";
+        case "duration":
+          return "Measurement(value: 60, unit: UnitDuration.seconds)";
+        case "url":
+          return `URL(string: "https://example.com")!`;
+      }
+      return undefined;
+    case "array":
+      return "[]";
+    case "dynamicOptions":
+      return sampleSwiftValue(type.valueType);
+    case "optional":
+    case "entity":
+    case "entityQuery":
+    case "enum":
+      return undefined;
+  }
 }
 
 // ─── Info.plist Fragment Generator ───────────────────────────────────

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -1002,7 +1002,24 @@ function defaultLiteralFor(primitive: string): string {
   }
 }
 
-function formatSwiftDefault(value: unknown, _type: IRType): string {
+function formatSwiftDefault(value: unknown, type: IRType): string {
+  const base =
+    type.kind === "optional"
+      ? type.innerType
+      : type.kind === "dynamicOptions"
+        ? type.valueType
+        : type;
+
+  if (base.kind === "array" && Array.isArray(value)) {
+    return `[${value.map((element) => formatSwiftDefault(element, base.elementType)).join(", ")}]`;
+  }
+
+  // A bare string literal is not a URL in Swift — wrap it in the
+  // failable initializer the way hand-written App Intents code would.
+  if (base.kind === "primitive" && base.value === "url" && typeof value === "string") {
+    return `URL(string: "${escapeSwiftString(value)}")!`;
+  }
+
   if (typeof value === "string") return `"${escapeSwiftString(value)}"`;
   if (typeof value === "number") {
     if (!Number.isFinite(value)) return `0`; // Guard against NaN/Infinity

--- a/src/core/parser-utils.ts
+++ b/src/core/parser-utils.ts
@@ -5,6 +5,7 @@
  */
 
 import ts from "typescript";
+import type { SourceSpan } from "./types.js";
 
 export function propertyMap(obj: ts.ObjectLiteralExpression): Map<string, ts.Node> {
   const map = new Map<string, ts.Node>();
@@ -98,9 +99,17 @@ export function evaluateLiteral(node: ts.Node): unknown {
 }
 
 export function posOf(sourceFile: ts.SourceFile, node: ts.Node): number | undefined {
+  return spanOf(sourceFile, node)?.line;
+}
+
+export function spanOf(
+  sourceFile: ts.SourceFile,
+  node: ts.Node | undefined
+): SourceSpan | undefined {
+  if (!node) return undefined;
   try {
-    const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart());
-    return line + 1;
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+    return { line: line + 1, column: character + 1 };
   } catch {
     return undefined;
   }

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -47,6 +47,7 @@ import {
   readStringRecord,
   evaluateLiteral,
   posOf,
+  spanOf,
   findCallExpression,
   findAllCallExpressions,
 } from "./parser-utils.js";
@@ -212,6 +213,12 @@ export function parseIntentSource(
     name,
     title,
     description,
+    spans: {
+      name: spanOf(sourceFile, props.get("name")),
+      title: spanOf(sourceFile, props.get("title")),
+      description: spanOf(sourceFile, props.get("description")),
+    },
+    hasPerformBody: performNode !== undefined,
     domain: domain || undefined,
     schemaDomain: (schemaDomain as IRAppSchemaDomain | null) || undefined,
     schema: schema || undefined,
@@ -1021,6 +1028,8 @@ function extractParameters(
       description,
       isOptional,
       defaultValue,
+      span: spanOf(sourceFile, prop),
+      defaultSpan: spanOf(sourceFile, defaultExpr),
     });
   }
 

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -33,6 +33,7 @@ import type {
   IRFoundationModelCustomProvider,
   IRFoundationModelDynamicProfile,
   IREvaluationConfig,
+  IRTestHarnessConfig,
   IRPreviewProofConfig,
   IRImagePlaygroundConfig,
 } from "./types.js";
@@ -191,6 +192,11 @@ export function parseIntentSource(
   const allowedExecutionTargets = readStringLiteral(props.get("allowedExecutionTargets"));
   const model = parseFoundationModelConfig(props.get("model"), filePath, sourceFile);
   const evaluation = parseEvaluationConfig(props.get("evaluation"), filePath, sourceFile);
+  const testHarness = parseTestHarnessConfig(
+    props.get("testHarness"),
+    filePath,
+    sourceFile
+  );
   const previewProof = parsePreviewProofConfig(
     props.get("previewProof"),
     filePath,
@@ -225,6 +231,7 @@ export function parseIntentSource(
     allowedExecutionTargets: allowedExecutionTargets || undefined,
     model,
     evaluation,
+    testHarness,
     previewProof,
     imagePlayground,
   };
@@ -831,6 +838,26 @@ function parseEvaluationConfig(
     criteria: readStringArray(props.get("criteria")),
     fixtures: readStringArray(props.get("fixtures")),
     metrics: readStringArray(props.get("metrics")),
+  };
+}
+
+function parseTestHarnessConfig(
+  node: ts.Node | undefined,
+  filePath: string,
+  sourceFile: ts.SourceFile
+): IRTestHarnessConfig | undefined {
+  if (!node) return undefined;
+  if (!ts.isObjectLiteralExpression(node)) {
+    throw new ParserError(
+      "AX056",
+      "testHarness must be an object literal",
+      filePath,
+      posOf(sourceFile, node)
+    );
+  }
+  const props = propertyMap(node);
+  return {
+    className: readStringLiteral(props.get("className")) || undefined,
   };
 }
 

--- a/src/core/swift-validator.ts
+++ b/src/core/swift-validator.ts
@@ -445,8 +445,11 @@ function checkComputedPropertiesNeedExplicitReturn(
   file: string,
   diagnostics: Diagnostic[]
 ) {
+  // The type annotation must stay on the declaration line — letting it
+  // span newlines made a stored `var count: Int` swallow the next
+  // property's declaration and attribute its body to the wrong name.
   const declaration =
-    /\bvar\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*((?!some\s+View\b)[A-Za-z_][A-Za-z0-9_<>,\s[\]?!:.&]*)\s*\{/g;
+    /\bvar\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*((?!some\s+View\b)[A-Za-z_][A-Za-z0-9_<>,\t [\]?!:.&]*)\{/g;
   let match: RegExpExecArray | null;
 
   while ((match = declaration.exec(stripped)) !== null) {

--- a/src/core/swift-validator.ts
+++ b/src/core/swift-validator.ts
@@ -103,6 +103,8 @@ export function validateSwiftSource(source: string, file: string): SwiftValidati
   checkInvalidSwiftUIFrameOverloads(source, stripped, file, diagnostics);
   checkTypeErasedSwiftUIModifierChains(source, stripped, file, diagnostics);
   checkOpaqueViewReturnsNeedExplicitReturn(source, stripped, file, diagnostics);
+  checkComputedPropertiesNeedExplicitReturn(source, stripped, file, diagnostics);
+  checkEnumSwitchesCoverDeclaredCases(source, stripped, file, diagnostics);
   checkDenseViewWithoutAffordance(source, stripped, file, diagnostics);
   checkUndefinedBooleanIdentifiers(source, stripped, file, diagnostics);
   checkUndefinedStringInterpolationIdentifiers(source, stripped, file, diagnostics);
@@ -434,6 +436,86 @@ function checkOpaqueViewReturnsNeedExplicitReturn(
           "Prefer `@ViewBuilder` for SwiftUI helpers — it documents intent, supports multi-statement bodies as the surface grows, and matches the style of `var body`. Use an explicit `return` only when the helper truly returns a single expression.",
       })
     );
+  }
+}
+
+function checkComputedPropertiesNeedExplicitReturn(
+  source: string,
+  stripped: string,
+  file: string,
+  diagnostics: Diagnostic[]
+) {
+  const declaration =
+    /\bvar\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*((?!some\s+View\b)[A-Za-z_][A-Za-z0-9_<>,\s[\]?!:.&]*)\s*\{/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = declaration.exec(stripped)) !== null) {
+    const name = match[1] ?? "unnamed";
+    if (name === "body") continue;
+    if (hasViewBuilderAttribute(stripped, match.index)) continue;
+
+    const openBrace = stripped.indexOf("{", match.index);
+    const closeBrace = findMatchingBrace(stripped, openBrace);
+    if (openBrace === -1 || closeBrace === -1) continue;
+
+    const body = stripped.slice(openBrace + 1, closeBrace);
+    const originalBody = source.slice(openBrace + 1, closeBrace);
+    if (!/\b(?:let|var)\s+[A-Za-z_][A-Za-z0-9_]*\b/.test(body)) continue;
+    if (hasTopLevelReturn(body)) continue;
+    if (!endsWithLikelySwiftExpression(originalBody)) continue;
+
+    diagnostics.push(
+      makeDiagnostic("AX849", file, 1 + countNewlinesUpTo(source, match.index), {
+        message: `Computed property '${name}' declares locals and ends with an expression but has no explicit return`,
+        suggestion:
+          "Add `return` before the final expression, or refactor the property into a single-expression computed property without local declarations.",
+      })
+    );
+  }
+}
+
+function checkEnumSwitchesCoverDeclaredCases(
+  source: string,
+  stripped: string,
+  file: string,
+  diagnostics: Diagnostic[]
+) {
+  const decls = findTypeDeclarations(stripped, source);
+
+  for (const decl of decls) {
+    if (decl.kind !== "enum") continue;
+    const body = stripped.slice(decl.bodyStart, decl.bodyEnd);
+    const cases = collectEnumCases(body);
+    if (cases.length === 0) continue;
+
+    const switchPattern = /\bswitch\s+self\s*\{/g;
+    let match: RegExpExecArray | null;
+    while ((match = switchPattern.exec(body)) !== null) {
+      const switchOpen = body.indexOf("{", match.index);
+      const switchClose = findMatchingBrace(body, switchOpen);
+      if (switchOpen === -1 || switchClose === -1) continue;
+
+      const switchBody = body.slice(switchOpen + 1, switchClose);
+      if (/\b(?:default|@unknown\s+default)\b/.test(switchBody)) continue;
+
+      const seen = collectDottedSwitchCases(switchBody);
+      const missing = cases.filter((enumCase) => !seen.has(enumCase.name));
+      if (missing.length === 0) continue;
+
+      const switchOffset = decl.bodyStart + match.index;
+      diagnostics.push(
+        makeDiagnostic("AX860", file, 1 + countNewlinesUpTo(source, switchOffset), {
+          message: `Switch over '${decl.name}' is missing case${missing.length === 1 ? "" : "s"} ${missing
+            .map((enumCase) => `.${enumCase.name}`)
+            .join(", ")}`,
+          suggestion: `Add ${missing
+            .map((enumCase) => `case .${enumCase.name}:`)
+            .join(
+              " "
+            )} before the next Xcode build, or add an intentional default branch if every future case should share one behavior.`,
+        })
+      );
+    }
   }
 }
 
@@ -1130,6 +1212,36 @@ function endsWithLikelyViewExpression(body: string): boolean {
   return /(?:VStack|HStack|ZStack|Text|Button|ScrollView|List|LazyVStack|LazyHStack|Group|Section|ForEach|AnyView|Image|Label|Form|NavigationStack|NavigationSplitView|HSplitView|VSplitView)\s*(?:\(|\{)/.test(
     cleaned
   );
+}
+
+function endsWithLikelySwiftExpression(body: string): boolean {
+  const cleaned = body
+    .trim()
+    .replace(/;+\s*$/, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .at(-1);
+  if (!cleaned) return false;
+  if (
+    /^(?:let|var|if|guard|switch|for|while|do|defer|return|throw|case|default)\b/.test(
+      cleaned
+    )
+  )
+    return false;
+  return /^(?:"|\.?[A-Za-z_][A-Za-z0-9_]*|\d|\[|\(|#)/.test(cleaned);
+}
+
+function collectDottedSwitchCases(body: string): Set<string> {
+  const seen = new Set<string>();
+  const casePattern = /\bcase\s+([^:]+):/g;
+  let match: RegExpExecArray | null;
+  while ((match = casePattern.exec(body)) !== null) {
+    for (const dotted of match[1]!.matchAll(/\.([A-Za-z_][A-Za-z0-9_]*)\b/g)) {
+      seen.add(dotted[1]!);
+    }
+  }
+  return seen;
 }
 
 function collectLeadingModifierChain(

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -32,6 +32,12 @@ export type IRType =
   | { kind: "dynamicOptions"; valueType: IRType; providerName: string }
   | { kind: "enum"; name: string; cases: string[] };
 
+/** 1-based source position of a node in the original TypeScript file */
+export interface SourceSpan {
+  line: number;
+  column: number;
+}
+
 /** A single parameter in an intent definition */
 export interface IRParameter {
   name: string;
@@ -40,6 +46,8 @@ export interface IRParameter {
   description: string;
   isOptional: boolean;
   defaultValue?: unknown;
+  span?: SourceSpan;
+  defaultSpan?: SourceSpan;
 }
 
 /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -322,6 +322,14 @@ export interface IRIntent {
   parameters: IRParameter[];
   returnType: IRType;
   sourceFile: string;
+  /** Source positions of the name/title/description fields, when parsed from TS */
+  spans?: {
+    name?: SourceSpan;
+    title?: SourceSpan;
+    description?: SourceSpan;
+  };
+  /** Whether the TS definition carried a perform body (discarded into the Swift stub) */
+  hasPerformBody?: boolean;
   /** Entitlements required by this intent (e.g., "com.apple.developer.siri") */
   entitlements?: string[];
   /** Info.plist keys required by this intent (e.g., "NSCalendarsUsageDescription") */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -167,6 +167,10 @@ export interface IRPreviewProofConfig {
   liveActivityStates?: string[];
 }
 
+export interface IRTestHarnessConfig {
+  className?: string;
+}
+
 export interface IRImagePlaygroundConfig {
   conceptParam: string;
   sourceImageParam?: string;
@@ -334,6 +338,8 @@ export interface IRIntent {
   model?: IRFoundationModelConfig;
   /** Evaluation suite metadata that should accompany model-backed output. */
   evaluation?: IREvaluationConfig;
+  /** AppIntentsTesting harness emitted alongside the intent. */
+  testHarness?: IRTestHarnessConfig;
   /** Preview snapshot matrix required to prove generated UI variants. */
   previewProof?: IRPreviewProofConfig;
   /** Image Playground generation contract for image-producing App Intents. */

--- a/src/core/validator.ts
+++ b/src/core/validator.ts
@@ -99,6 +99,8 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
       severity: "error",
       message: `Intent name "${intent.name}" must be PascalCase (e.g., "CreateEvent")`,
       file: intent.sourceFile,
+      line: intent.spans?.name?.line,
+      column: intent.spans?.name?.column,
       suggestion: `Rename to "${toPascalCase(intent.name)}"`,
     });
   }
@@ -110,6 +112,8 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
       severity: "error",
       message: "Intent title must not be empty",
       file: intent.sourceFile,
+      line: intent.spans?.title?.line,
+      column: intent.spans?.title?.column,
       suggestion: "Add a human-readable title for Siri and Shortcuts display",
     });
   }
@@ -121,6 +125,8 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
       severity: "error",
       message: "Intent description must not be empty",
       file: intent.sourceFile,
+      line: intent.spans?.description?.line,
+      column: intent.spans?.description?.column,
       suggestion: "Add a description explaining what this intent does",
     });
   }
@@ -133,6 +139,8 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
         severity: "error",
         message: `Parameter name "${param.name}" is not a valid Swift identifier`,
         file: intent.sourceFile,
+        line: param.span?.line,
+        column: param.span?.column,
         suggestion: `Rename to "${param.name.replace(/[^a-zA-Z0-9_]/g, "_")}"`,
       });
     }
@@ -144,6 +152,8 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
         severity: "warning",
         message: `Parameter "${param.name}" has no description — Siri will display it without context`,
         file: intent.sourceFile,
+        line: param.span?.line,
+        column: param.span?.column,
         suggestion: "Add a description for better Siri/Shortcuts display",
       });
     }
@@ -185,6 +195,8 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
       severity: "warning",
       message: `Intent title is ${intent.title.length} characters. Siri display may truncate titles over ${MAX_TITLE_LENGTH} characters.`,
       file: intent.sourceFile,
+      line: intent.spans?.title?.line,
+      column: intent.spans?.title?.column,
     });
   }
 
@@ -197,6 +209,8 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
         severity: "error",
         message: `Duplicate parameter name "${param.name}"`,
         file: intent.sourceFile,
+        line: param.span?.line,
+        column: param.span?.column,
         suggestion: "Each parameter in a single intent must have a unique name",
       });
     }

--- a/src/core/validator.ts
+++ b/src/core/validator.ts
@@ -5,7 +5,7 @@
  * Returns diagnostics with error codes, locations, and fix suggestions.
  */
 
-import type { Diagnostic, IRIntent, IREntity } from "./types.js";
+import type { Diagnostic, IRIntent, IRParameter, IRType, IREntity } from "./types.js";
 
 /** Apple-recommended maximum parameters per intent for usability */
 const MAX_PARAMETERS = 10;
@@ -145,6 +145,23 @@ export function validateIntent(intent: IRIntent): Diagnostic[] {
         message: `Parameter "${param.name}" has no description — Siri will display it without context`,
         file: intent.sourceFile,
         suggestion: "Add a description for better Siri/Shortcuts display",
+      });
+    }
+  }
+
+  // Rule: a literal default must match the declared param type, otherwise
+  // the generated Swift (`var x: String = 8`) fails to build under a green check
+  for (const param of intent.parameters) {
+    const mismatch = checkDefaultMatchesType(param);
+    if (mismatch) {
+      diagnostics.push({
+        code: "AX127",
+        severity: "error",
+        message: mismatch.message,
+        file: intent.sourceFile,
+        line: param.defaultSpan?.line ?? param.span?.line,
+        column: param.defaultSpan?.column ?? param.span?.column,
+        suggestion: mismatch.suggestion,
       });
     }
   }
@@ -482,6 +499,131 @@ export function validateSwiftSource(swift: string): Diagnostic[] {
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────
+
+interface DefaultMismatch {
+  message: string;
+  suggestion: string;
+}
+
+/**
+ * Defaults are emitted verbatim into the generated Swift property, so a
+ * default whose JS type disagrees with the declared param type produces
+ * Swift that cannot compile. Returns the mismatch, or null when the
+ * default is absent or valid.
+ */
+function checkDefaultMatchesType(param: IRParameter): DefaultMismatch | null {
+  if (param.defaultValue === undefined) return null;
+  return checkDefaultAgainst(param.name, param.defaultValue, param.type);
+}
+
+function checkDefaultAgainst(
+  name: string,
+  value: unknown,
+  type: IRType
+): DefaultMismatch | null {
+  switch (type.kind) {
+    case "optional":
+      return checkDefaultAgainst(name, value, type.innerType);
+    case "dynamicOptions":
+      return checkDefaultAgainst(name, value, type.valueType);
+    case "primitive":
+      return checkPrimitiveDefault(name, value, type.value);
+    case "array":
+      if (!Array.isArray(value)) {
+        return {
+          message: `Parameter "${name}" declares an array type but its default is ${describeDefault(value)}`,
+          suggestion: `Change the default to an array literal, or change the param to ${suggestedHelperFor(value)}.`,
+        };
+      }
+      for (const element of value) {
+        const elementMismatch = checkDefaultAgainst(name, element, type.elementType);
+        if (elementMismatch) return elementMismatch;
+      }
+      return null;
+    case "enum":
+      if (typeof value === "string" && type.cases.includes(value)) return null;
+      return {
+        message: `Parameter "${name}" has default ${describeDefault(value)}, which is not one of its enum cases`,
+        suggestion: `Use one of: ${type.cases.join(", ")}.`,
+      };
+    case "entity":
+    case "entityQuery":
+      return {
+        message: `Parameter "${name}" is an entity reference and cannot take a literal default`,
+        suggestion:
+          "Remove the default — entity values are resolved at runtime by the entity query.",
+      };
+  }
+}
+
+function checkPrimitiveDefault(
+  name: string,
+  value: unknown,
+  primitive: string
+): DefaultMismatch | null {
+  const change = (to: string) =>
+    `Change the default to ${to}, or change the param to ${suggestedHelperFor(value)}.`;
+
+  switch (primitive) {
+    case "string":
+      if (typeof value === "string") return null;
+      return {
+        message: `Parameter "${name}" is declared param.string() but its default is ${describeDefault(value)}`,
+        suggestion: change(`a string (e.g. ${JSON.stringify(String(value))})`),
+      };
+    case "int":
+      if (typeof value === "number" && Number.isInteger(value)) return null;
+      return {
+        message: `Parameter "${name}" is declared as an integer but its default is ${describeDefault(value)}`,
+        suggestion: change("a whole number (e.g. 8)"),
+      };
+    case "double":
+    case "float":
+      if (typeof value === "number" && Number.isFinite(value)) return null;
+      return {
+        message: `Parameter "${name}" is declared param.${primitive}() but its default is ${describeDefault(value)}`,
+        suggestion: change("a number (e.g. 1.5)"),
+      };
+    case "boolean":
+      if (typeof value === "boolean") return null;
+      return {
+        message: `Parameter "${name}" is declared param.boolean() but its default is ${describeDefault(value)}`,
+        suggestion: change("true or false"),
+      };
+    case "url":
+      if (typeof value === "string" && value.trim().length > 0) return null;
+      return {
+        message: `Parameter "${name}" is declared param.url() but its default is ${describeDefault(value)}`,
+        suggestion: change('a non-empty URL string (e.g. "https://example.com")'),
+      };
+    case "date":
+    case "duration":
+      return {
+        message: `Parameter "${name}" is declared param.${primitive}() — ${primitive} params do not support literal defaults`,
+        suggestion: `Remove the default and set the initial ${primitive} inside perform(), or change the param to ${suggestedHelperFor(value)}.`,
+      };
+    default:
+      return null;
+  }
+}
+
+function describeDefault(value: unknown): string {
+  if (typeof value === "string") return `the string ${JSON.stringify(value)}`;
+  if (typeof value === "number") return `the number ${value}`;
+  if (typeof value === "boolean") return `the boolean ${value}`;
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "an array";
+  return `a ${typeof value}`;
+}
+
+function suggestedHelperFor(value: unknown): string {
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? "param.int(...)" : "param.double(...)";
+  }
+  if (typeof value === "boolean") return "param.boolean(...)";
+  if (Array.isArray(value)) return "param.array(...)";
+  return "param.string(...)";
+}
 
 function toPascalCase(s: string): string {
   if (!s) return "UnnamedIntent";

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -2289,57 +2289,95 @@ type CompactManifestOptions = {
   nestedDescriptionChars: number;
 };
 
-const DEFAULT_RUNTIME_TOOL_DESCRIPTION_CHARS = 420;
-const DEFAULT_RUNTIME_SCHEMA_DESCRIPTION_CHARS = 112;
-const DEFAULT_RUNTIME_NESTED_DESCRIPTION_CHARS = 80;
+const DEFAULT_RUNTIME_TOOL_DESCRIPTION_CHARS = 156;
+const DEFAULT_RUNTIME_SCHEMA_DESCRIPTION_CHARS = 64;
+const DEFAULT_RUNTIME_NESTED_DESCRIPTION_CHARS = 0;
+
+/** Optional params keep a short hint; the full prose stays in full mode. */
+const OPTIONAL_PROPERTY_DESCRIPTION_CHARS = 20;
+
+/** Compact mode ships the output contract without the prose around it. */
+const MINIMAL_TEXT_OUTPUT_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    text: { type: "string" as const },
+    isError: { type: "boolean" as const },
+  },
+  required: ["text"],
+  additionalProperties: false,
+};
+
+// Hero tools lead the listing so a first-time agent sees the compile and
+// validation loop before the long tail of session/agent plumbing.
+const HERO_TOOL_ORDER = [
+  "axint.compile",
+  "axint.validate",
+  "axint.swift.validate",
+  "axint.swift.fix",
+  "axint.scaffold",
+  "axint.templates.list",
+  "axint.templates.get",
+  "axint.repair",
+] as const;
+
+function heroFirst<T extends { name: string }>(tools: readonly T[]): T[] {
+  const rank = new Map<string, number>(
+    HERO_TOOL_ORDER.map((name, index) => [name, index])
+  );
+  const heroes = [...tools]
+    .filter((tool) => rank.has(tool.name))
+    .sort((a, b) => rank.get(a.name)! - rank.get(b.name)!);
+  return [...heroes, ...tools.filter((tool) => !rank.has(tool.name))];
+}
 
 export function getRuntimeToolManifest(env: RuntimeManifestEnv = {}) {
   const mode = env.AXINT_MCP_MANIFEST_MODE?.trim().toLowerCase();
   if (env.AXINT_MCP_FULL_MANIFEST === "1" || mode === "full" || mode === "verbose") {
-    return withOutputSchemas(TOOL_MANIFEST);
+    return heroFirst(withOutputSchemas(TOOL_MANIFEST));
   }
 
-  return compactToolManifest({
-    toolDescriptionChars: positiveEnvInt(
-      env.AXINT_MCP_TOOL_DESCRIPTION_CHARS,
-      DEFAULT_RUNTIME_TOOL_DESCRIPTION_CHARS
-    ),
-    schemaDescriptionChars: positiveEnvInt(
-      env.AXINT_MCP_SCHEMA_DESCRIPTION_CHARS,
-      DEFAULT_RUNTIME_SCHEMA_DESCRIPTION_CHARS
-    ),
-    nestedDescriptionChars: positiveEnvInt(
-      env.AXINT_MCP_NESTED_DESCRIPTION_CHARS,
-      DEFAULT_RUNTIME_NESTED_DESCRIPTION_CHARS
-    ),
-  });
+  return heroFirst(
+    compactToolManifest({
+      toolDescriptionChars: positiveEnvInt(
+        env.AXINT_MCP_TOOL_DESCRIPTION_CHARS,
+        DEFAULT_RUNTIME_TOOL_DESCRIPTION_CHARS
+      ),
+      schemaDescriptionChars: positiveEnvInt(
+        env.AXINT_MCP_SCHEMA_DESCRIPTION_CHARS,
+        DEFAULT_RUNTIME_SCHEMA_DESCRIPTION_CHARS
+      ),
+      nestedDescriptionChars: positiveEnvInt(
+        env.AXINT_MCP_NESTED_DESCRIPTION_CHARS,
+        DEFAULT_RUNTIME_NESTED_DESCRIPTION_CHARS
+      ),
+    })
+  );
 }
 
 export function compactToolManifest(options: CompactManifestOptions) {
-  return withOutputSchemas(
-    TOOL_MANIFEST.map((tool) => ({
-      ...tool,
-      description: compactToolDescription(tool, options.toolDescriptionChars),
-      inputSchema: compactSchemaValue(tool.inputSchema, options, 0),
-    }))
-  ) as unknown as typeof TOOL_MANIFEST;
+  return TOOL_MANIFEST.map((tool) => ({
+    ...tool,
+    description: compactToolDescription(tool, options.toolDescriptionChars),
+    inputSchema: compactSchemaValue(tool.inputSchema, options, 0),
+    outputSchema: MINIMAL_TEXT_OUTPUT_SCHEMA,
+  })) as unknown as typeof TOOL_MANIFEST;
 }
 
 function compactToolDescription(
   tool: (typeof TOOL_MANIFEST)[number],
   maxChars: number
 ): string {
+  // Each segment is compacted on its own so the Use/Effects markers
+  // survive however small the budget gets.
   const effects = RUNTIME_TOOL_EFFECTS[tool.name] ?? defaultEffectSummary(tool);
   const guidance = RUNTIME_TOOL_GUIDANCE[tool.name];
-  const suffix = [guidance ? `Use: ${guidance}` : undefined, `Effects: ${effects}`]
-    .filter(Boolean)
-    .join(" ");
-  const suffixLength = suffix.length + 1;
-  const summaryChars = Math.max(96, maxChars - suffixLength);
-  return compactDescription(
-    `${compactDescription(tool.description, summaryChars)} ${suffix}`,
-    maxChars
-  );
+  const summaryChars = Math.max(60, Math.floor(maxChars * 0.45));
+  const detailChars = Math.max(36, Math.floor((maxChars - summaryChars) / 2));
+
+  const parts = [compactDescription(tool.description, summaryChars)];
+  if (guidance) parts.push(`Use: ${compactDescription(guidance, detailChars)}`);
+  parts.push(`Effects: ${compactDescription(effects, detailChars)}`);
+  return parts.join(" ");
 }
 
 function defaultEffectSummary(tool: (typeof TOOL_MANIFEST)[number]): string {
@@ -2503,7 +2541,7 @@ const RUNTIME_TOOL_EFFECTS: Record<string, string> = {
     "read-only template source; writes no files and uses no network.",
 };
 
-function withOutputSchemas<T extends readonly Record<string, unknown>[]>(tools: T) {
+function withOutputSchemas<T extends { name: string }>(tools: readonly T[]) {
   return tools.map((tool) => ({
     ...tool,
     outputSchema: TOOL_TEXT_OUTPUT_SCHEMA,
@@ -2513,7 +2551,8 @@ function withOutputSchemas<T extends readonly Record<string, unknown>[]>(tools: 
 function compactSchemaValue(
   value: unknown,
   options: CompactManifestOptions,
-  depth: number
+  depth: number,
+  ownDescriptionChars?: number
 ): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => compactSchemaValue(item, options, depth + 1));
@@ -2521,20 +2560,55 @@ function compactSchemaValue(
 
   if (!value || typeof value !== "object") return value;
 
+  const record = value as Record<string, unknown>;
+  const limit =
+    ownDescriptionChars ??
+    (depth <= 2 ? options.schemaDescriptionChars : options.nestedDescriptionChars);
+  const requiredNames = new Set(
+    Array.isArray(record.required)
+      ? record.required.filter((name): name is string => typeof name === "string")
+      : []
+  );
+
   const compacted: Record<string, unknown> = {};
-  for (const [key, nestedValue] of Object.entries(value)) {
+  for (const [key, nestedValue] of Object.entries(record)) {
     if (key === "description" && typeof nestedValue === "string") {
-      const limit =
-        depth <= 2 ? options.schemaDescriptionChars : options.nestedDescriptionChars;
       if (limit <= 0) continue;
       compacted[key] = compactDescription(nestedValue, limit);
+      continue;
+    }
+
+    if (
+      depth === 0 &&
+      key === "properties" &&
+      nestedValue &&
+      typeof nestedValue === "object" &&
+      !Array.isArray(nestedValue)
+    ) {
+      // Required params keep the full (capped) docs an agent needs to
+      // call the tool; optional ones shrink to a short hint.
+      const properties: Record<string, unknown> = {};
+      for (const [name, property] of Object.entries(nestedValue)) {
+        const propertyChars = requiredNames.has(name)
+          ? options.schemaDescriptionChars
+          : Math.min(OPTIONAL_PROPERTY_DESCRIPTION_CHARS, options.schemaDescriptionChars);
+        properties[name] = compactSchemaValue(
+          property,
+          options,
+          depth + 2,
+          propertyChars
+        );
+      }
+      compacted[key] = properties;
       continue;
     }
 
     compacted[key] = compactSchemaValue(nestedValue, options, depth + 1);
   }
 
-  if (shouldAddFallbackDescription(compacted, depth)) {
+  // No fallback where descriptions are budgeted out — re-adding filler
+  // text would undo the compaction.
+  if (limit > 0 && shouldAddFallbackDescription(compacted, depth)) {
     compacted.description = fallbackSchemaDescription(compacted);
   }
 
@@ -2565,9 +2639,9 @@ function compactDescription(value: string, maxChars: number): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (normalized.length <= maxChars) return normalized;
 
-  const safeLimit = Math.max(32, maxChars);
+  const safeLimit = Math.max(16, maxChars);
   const wordBoundary = normalized.lastIndexOf(" ", safeLimit - 4);
-  const end = wordBoundary > 32 ? wordBoundary : safeLimit - 3;
+  const end = wordBoundary > 16 ? wordBoundary : safeLimit - 3;
   return `${normalized.slice(0, end).trim()}...`;
 }
 

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -2206,7 +2206,7 @@ export const TOOL_MANIFEST = [
   {
     name: "axint.templates.list",
     description:
-      "List all 39 bundled reference templates in the Axint SDK. Returns " +
+      "List all 49 bundled reference templates in the Axint SDK. Returns " +
       "a JSON array of { id, name, description } objects — one per template. " +
       "Templates cover messaging, productivity, health, finance, commerce, " +
       "media, navigation, smart-home, and entity/query patterns. No input " +

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -741,7 +741,7 @@ export const TOOL_MANIFEST = [
           type: "array",
           items: { type: "string" },
           description:
-            "Optional product goals for Pro mode, such as activation, retention, conversion, speed, accessibility, or investor readiness.",
+            "Optional product goals for Pro mode, such as activation, retention, conversion, speed, accessibility, or production readiness.",
         },
         stage: {
           type: "string",

--- a/src/mcp/suggest.ts
+++ b/src/mcp/suggest.ts
@@ -916,12 +916,16 @@ export function suggestFeatures(input: SuggestInput): FeatureSuggestion[] {
   const productHierarchyMode = detectProductHierarchyMode(input, text);
   const additiveFeatureMode = detectAdditiveFeatureMode(input, text);
   const releasePreflightMode = detectReleasePreflightMode(input, text);
+  const axintDogfoodMode = detectAxintDogfoodMode(input, text);
 
   if (freshProductMode?.kind === "public-page") {
     return publicLanderSuggestions(input, text, limit, freshProductMode.trace);
   }
   if (freshProductMode?.kind === "brand-polish") {
     return brandPolishSuggestions(input, text, limit, freshProductMode.trace);
+  }
+  if (axintDogfoodMode) {
+    return axintDogfoodSuggestions(input, text, limit, axintDogfoodMode.trace);
   }
   if (greenfieldAppMode) {
     return greenfieldAppSuggestions(input, text, limit, greenfieldAppMode.trace);
@@ -1057,6 +1061,66 @@ type ReleasePreflightMode =
       trace: string;
     }
   | undefined;
+
+type AxintDogfoodMode =
+  | {
+      trace: string;
+    }
+  | undefined;
+
+function detectAxintDogfoodMode(
+  input: SuggestInput,
+  normalizedAppDescription: string
+): AxintDogfoodMode {
+  const goalsText = normalizeText((input.goals ?? []).join(" "));
+  const constraintsText = normalizeText((input.constraints ?? []).join(" "));
+  const combined = [normalizedAppDescription, goalsText, constraintsText]
+    .filter(Boolean)
+    .join(" ");
+
+  const axintCues = [
+    "axint",
+    "cloud check",
+    "mcp",
+    "mcp version",
+    "workflow check",
+    "fix packet",
+    "ax001",
+    "dogfood",
+    "dogfooding",
+    "non-apple artifact",
+    "non apple artifact",
+    "version metadata",
+    "version truth",
+    "release script",
+    "generic feature scaffold",
+    "classifier",
+    "cadabra dogfood",
+  ].filter((cue) => hasKeyword(combined, cue));
+
+  const toolingIntent = [
+    "atom",
+    "atoms",
+    "classify",
+    "classified",
+    "fix",
+    "misclassified",
+    "misclassification",
+    "prevent",
+    "route",
+    "routing",
+    "stale",
+    "sync",
+    "version",
+  ].some((cue) => hasKeyword(combined, cue));
+
+  if (axintCues.length < 2 || !toolingIntent) return undefined;
+
+  const cueList = axintCues.slice(0, 6).join(", ");
+  return {
+    trace: `Current prompt won as Axint dogfood/tooling work (${cueList}); Axint is repairing its own classifier, Cloud Check, and version-truth atoms instead of mapping provider words to an app image-provider repair.`,
+  };
+}
 
 function detectFreshProductMode(
   input: SuggestInput,
@@ -1733,6 +1797,79 @@ function releasePreflightSuggestions(
       loop: "Collect logs -> classify blocker -> patch metadata or portal -> rerun",
       nextStep:
         "Attach the generated evidence packet to the next Axint run or release checklist.",
+      modeTrace,
+    },
+  ];
+
+  return suggestions.slice(0, limit);
+}
+
+function axintDogfoodSuggestions(
+  input: SuggestInput,
+  normalizedAppDescription: string,
+  limit: number,
+  modeTrace: string
+): FeatureSuggestion[] {
+  const platform = input.platform ? `${input.platform} ` : "";
+  const labels = semanticLabels(normalizedAppDescription, 5);
+  const dogfoodLabel =
+    labels.find((label) => /axint|dogfood|cloud|mcp|version|classifier/i.test(label)) ??
+    "Axint Dogfood";
+  const rationale = `Mode trace: ${modeTrace} Dogfooding prompts about Axint itself need source classifier, release/version truth, and regression-harness fixes before any generated Apple surface.`;
+
+  const suggestions: FeatureSuggestion[] = [
+    {
+      name: `${dogfoodLabel} Routing Atom`,
+      description:
+        "Patch Axint's own classifier so implementation files, deployment artifacts, and dogfood repair requests route to the right proof surface.",
+      surfaces: ["store", "component"],
+      complexity: "medium",
+      featurePrompt: `Repair the ${platform}Axint dogfood routing atom: Cloud Check should treat JS/TS/Python/shell/plist/docs as non-Apple artifacts unless they are explicit Axint contracts, suggest should route Axint/Cadabra dogfood prompts to tooling or product-quality repair lanes, and provider-output words must not automatically become an image-provider SwiftUI repair.`,
+      domain: "axint-dogfood",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact:
+        "Prevents Axint from creating fake AX001 diagnostics or stale app-surface suggestions while dogfooding real products.",
+      loop: "Dogfood log -> classifier patch -> regression test -> Cloud Check proof",
+      nextStep:
+        "Add focused tests for the exact misclassification, then run the Cloud Check, suggest, repair, and version suites.",
+      modeTrace,
+    },
+    {
+      name: `${dogfoodLabel} Version Truth Guard`,
+      description:
+        "Keep MCP, CLI, extension, docs, roadmap, and release fallback versions pinned to the canonical package version.",
+      surfaces: ["store"],
+      complexity: "low",
+      featurePrompt:
+        "Extend Axint version-truth checks so MCP fallback metadata, Fix Packet compiler fallback, VS Code lockfiles, Claude Desktop manifests, Xcode extension metadata, roadmap release links, README proof lines, and release notes cannot drift from package.json.",
+      domain: "axint-dogfood",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact:
+        "Stops stale MCP metadata from undermining trust during large downstream dogfood runs.",
+      loop: "Canonical version -> tracked surfaces -> release check -> prepublish proof",
+      nextStep:
+        "Run versions:check and release:check after the patch, then publish only when both package registries match.",
+      modeTrace,
+    },
+    {
+      name: `${dogfoodLabel} Regression Harness`,
+      description:
+        "Convert Cadabra dogfood misses into durable Axint tests so the same atoms do not regress during the next release.",
+      surfaces: ["component"],
+      complexity: "medium",
+      featurePrompt:
+        "Add regression coverage for Cadabra dogfood atoms: non-Apple artifacts avoid AX001, provider-behavior repairs avoid runtime-freeze, TestFlight metadata routes to release-preflight, Magic Pass and preset-library prompts stay product-specific, and feature generation refuses generic scaffolds when product vocabulary is present.",
+      domain: "axint-dogfood",
+      rationale,
+      confidence: "high",
+      source: "local",
+      impact: "Turns anecdotal dogfooding into investor-grade product-quality evidence.",
+      loop: "Fixture -> failing test -> patch -> focused suite -> full build",
+      nextStep: "Run focused tests first, then npm run prepublishOnly before committing.",
       modeTrace,
     },
   ];

--- a/src/mcp/suggest.ts
+++ b/src/mcp/suggest.ts
@@ -365,6 +365,11 @@ const FEATURE_CATALOG: DomainFeatureSet[] = [
       "running",
       "gym",
       "track",
+      "habit",
+      "streak",
+      "meditation",
+      "mindfulness",
+      "wellness",
     ],
     blockers: [
       "not a fitness app",
@@ -592,6 +597,10 @@ const FEATURE_CATALOG: DomainFeatureSet[] = [
       "bookmark",
       "document",
       "organize",
+      "checklist",
+      "planner",
+      "agenda",
+      "deadline",
     ],
     features: [
       {
@@ -661,6 +670,9 @@ const FEATURE_CATALOG: DomainFeatureSet[] = [
       "portfolio",
       "stock",
       "crypto",
+      "spending",
+      "debt",
+      "receipt",
     ],
     features: [
       {
@@ -968,7 +980,7 @@ export function suggestFeatures(input: SuggestInput): FeatureSuggestion[] {
           suggestion: {
             ...feature,
             domain: domainSet.domain,
-            rationale: buildRationale(domainSet.domain, descriptionScore, text),
+            rationale: buildRationale(domainSet.domain, descriptionScore, text, feature),
             confidence: confidenceFor(score),
             source: "local",
           } satisfies FeatureSuggestion,
@@ -2107,8 +2119,8 @@ function appSpecificFallbackSuggestions(
 
   const concept = titleCase(tokens.slice(0, 3).join(" "));
   const lowerConcept = concept.toLowerCase();
-  const rationale =
-    "No stock domain strongly matched, so Axint generated app-specific Apple-native surfaces from the current app description instead of falling back to a generic domain.";
+  const rationale = (angle: string) =>
+    `No stock domain strongly matched, so Axint generated app-specific surfaces from the description — ${angle}`;
 
   const suggestions: FeatureSuggestion[] = [
     {
@@ -2118,7 +2130,7 @@ function appSpecificFallbackSuggestions(
       complexity: "low",
       featurePrompt: `Let users capture a new ${lowerConcept} item with title, notes, and priority via Siri and Shortcuts`,
       domain: "custom",
-      rationale,
+      rationale: rationale("this one covers hands-free capture via Siri and Shortcuts."),
       confidence: "medium",
       source: "local",
     },
@@ -2129,7 +2141,7 @@ function appSpecificFallbackSuggestions(
       complexity: "medium",
       featurePrompt: `Show the latest ${lowerConcept} state, blockers, and next action in a widget`,
       domain: "custom",
-      rationale,
+      rationale: rationale("this one keeps glanceable state on the Home Screen."),
       confidence: "medium",
       source: "local",
     },
@@ -2140,7 +2152,7 @@ function appSpecificFallbackSuggestions(
       complexity: "medium",
       featurePrompt: `Create a ${lowerConcept} review view with status, details, and follow-up actions`,
       domain: "custom",
-      rationale,
+      rationale: rationale("this one gives the in-app review surface."),
       confidence: "medium",
       source: "local",
     },
@@ -2163,9 +2175,10 @@ function adaptiveSemanticSuggestions(
   const concept = labels.slice(0, 2).join(" ");
   const lowerConcept = concept.toLowerCase();
   const platform = input.platform ? `${input.platform} ` : "";
-  const rationale = `Generated from the app description terms ${labels
-    .slice(0, 4)
-    .join(", ")} instead of relying only on a stock domain template.`;
+  const rationale = (angle: string) =>
+    `Generated from the app description terms ${labels
+      .slice(0, 4)
+      .join(", ")} — ${angle}`;
 
   const suggestions: FeatureSuggestion[] = [
     {
@@ -2175,7 +2188,9 @@ function adaptiveSemanticSuggestions(
       complexity: "medium",
       featurePrompt: `Create a ${platform}${lowerConcept} command surface with intent entry, visible status, and next action controls`,
       domain,
-      rationale,
+      rationale: rationale(
+        "the command surface turns the core noun into an Apple-native action loop."
+      ),
       confidence: "medium",
       source: "local",
       impact: "Turns the app's core noun into an Apple-native action loop.",
@@ -2189,7 +2204,9 @@ function adaptiveSemanticSuggestions(
       complexity: "medium",
       featurePrompt: `Create a shared ${lowerConcept} store with a review view and App Intent that reads and updates the same state`,
       domain,
-      rationale,
+      rationale: rationale(
+        "the shared store keeps views, widgets, and intents on one source of truth."
+      ),
       confidence: "medium",
       source: "local",
       impact: "Prevents generated surfaces from becoming isolated demo files.",
@@ -2203,7 +2220,9 @@ function adaptiveSemanticSuggestions(
       complexity: "medium",
       featurePrompt: `Create a ${platform}${lowerConcept} review queue component kit with rows, status pills, owner metadata, and approve or defer actions`,
       domain,
-      rationale,
+      rationale: rationale(
+        "the review queue makes the app feel operational instead of static."
+      ),
       confidence: "medium",
       source: "local",
       impact: "Makes the app feel operational instead of static.",
@@ -2219,7 +2238,9 @@ function shouldLeadWithAdaptive(
   normalizedAppDescription: string,
   strongestDescriptionScore: number
 ): boolean {
-  if (strongestDescriptionScore < 3) return true;
+  // Two stock-domain cues (e.g. "habit" + "streak") are a real domain hit —
+  // those plans should lead with the curated features, not the generic trio.
+  if (strongestDescriptionScore < 2) return true;
   return [
     "agent",
     "approval",
@@ -2732,19 +2753,47 @@ function meaningfulTokens(text: string): string[] {
 function buildRationale(
   domain: string,
   descriptionScore: number,
-  normalizedAppDescription: string
+  normalizedAppDescription: string,
+  feature: Omit<FeatureSuggestion, "domain" | "rationale" | "confidence">
 ): string {
   const cues = meaningfulTokens(normalizedAppDescription)
     .filter((token) => token.length > 3)
     .slice(0, 4);
   const cueText = cues.length > 0 ? ` from cues like ${cues.join(", ")}` : "";
+  const angle = featureAngle(feature);
   if (descriptionScore >= 3) {
-    return `Strong match for ${domain} workflows${cueText}.`;
+    return `Strong match for ${domain} workflows${cueText} — ${angle}`;
   }
   if (descriptionScore >= 1) {
-    return `Matched ${domain} cues${cueText}.`;
+    return `Matched ${domain} cues${cueText} — ${angle}`;
   }
-  return `Included from a weak ${domain} hint; validate fit before generating.`;
+  return `Included from a weak ${domain} hint — ${angle} Validate fit before generating.`;
+}
+
+/**
+ * One plan often pulls several features from the same domain; without a
+ * per-feature angle every rationale reads identically and tells the
+ * user nothing about why *this* suggestion is on the list.
+ */
+function featureAngle(
+  feature: Omit<FeatureSuggestion, "domain" | "rationale" | "confidence">
+): string {
+  switch (feature.surfaces[0]) {
+    case "intent":
+      return `${feature.name} covers the hands-free capture/action loop in Siri and Shortcuts.`;
+    case "widget":
+      return `${feature.name} keeps glanceable state on the Home/Lock Screen.`;
+    case "view":
+      return `${feature.name} gives the in-app surface for reviewing details.`;
+    case "component":
+      return `${feature.name} is a reusable building block for the app's screens.`;
+    case "app":
+      return `${feature.name} frames the app shell the other surfaces plug into.`;
+    case "store":
+      return `${feature.name} prepares the App Store-facing side of the release.`;
+    default:
+      return `${feature.name} rounds out the Apple-native surface set.`;
+  }
 }
 
 function confidenceFor(score: number): "low" | "medium" | "high" {

--- a/src/mcp/suggest.ts
+++ b/src/mcp/suggest.ts
@@ -1569,7 +1569,7 @@ function greenfieldAppSuggestions(
       rationale,
       confidence: "high",
       source: "local",
-      impact: "Turns greenfield generation into investor-grade evidence.",
+      impact: "Turns greenfield generation into audit-grade evidence.",
       loop: "Render -> tap -> assert -> record proof",
       nextStep:
         "Run axint.run with the generated app files and attach simulator/build evidence when available.",
@@ -1625,8 +1625,7 @@ function productHierarchySuggestions(
       rationale,
       confidence: "high",
       source: "local",
-      impact:
-        "Makes dogfood feedback actionable and investor-grade instead of anecdotal.",
+      impact: "Makes dogfood feedback actionable and audit-grade instead of anecdotal.",
       loop: "Generate -> react -> persist -> improve prompt contract",
       nextStep:
         "Add state and analytics-safe metadata first, then verify feedback survives history/share routing.",
@@ -1718,7 +1717,7 @@ function additiveFeatureSuggestions(
       confidence: "high",
       source: "local",
       impact:
-        "Makes the additive feature investor-grade by tying UX controls to durable runtime evidence.",
+        "Makes the additive feature audit-grade by tying UX controls to durable runtime evidence.",
       loop: "Select -> persist -> generate -> inspect metadata",
       nextStep:
         "Run axint.run or a focused UI/state test and attach provider prompt evidence where available.",
@@ -1793,7 +1792,7 @@ function releasePreflightSuggestions(
       confidence: "high",
       source: "local",
       impact:
-        "Turns release failures into investor-grade proof instead of mystery Xcode/App Store Connect churn.",
+        "Turns release failures into audit-grade proof instead of mystery Xcode/App Store Connect churn.",
       loop: "Collect logs -> classify blocker -> patch metadata or portal -> rerun",
       nextStep:
         "Attach the generated evidence packet to the next Axint run or release checklist.",
@@ -1867,7 +1866,7 @@ function axintDogfoodSuggestions(
       rationale,
       confidence: "high",
       source: "local",
-      impact: "Turns anecdotal dogfooding into investor-grade product-quality evidence.",
+      impact: "Turns anecdotal dogfooding into audit-grade product-quality evidence.",
       loop: "Fixture -> failing test -> patch -> focused suite -> full build",
       nextStep: "Run focused tests first, then npm run prepublishOnly before committing.",
       modeTrace,

--- a/src/repair/repair-artifacts.ts
+++ b/src/repair/repair-artifacts.ts
@@ -40,10 +40,12 @@ export function tryEmitRepairArtifacts(
 
 export function printRepairArtifactLines(
   artifacts: RepairArtifacts,
-  writeLine: (line: string) => void
+  writeLine: (line: string) => void,
+  options: { color?: boolean } = {}
 ) {
   for (const line of renderRepairArtifactLines(artifacts, {
     signedIn: getAxintLoginState().signedIn,
+    color: options.color,
   })) {
     writeLine(line);
   }
@@ -51,25 +53,31 @@ export function printRepairArtifactLines(
 
 export function renderRepairArtifactLines(
   artifacts: RepairArtifacts,
-  options: { signedIn?: boolean } = {}
+  options: { signedIn?: boolean; color?: boolean } = {}
 ): string[] {
+  const color = options.color ?? true;
+  const paint = (ansi: string, text: string) => (color ? `${ansi}${text}\x1b[0m` : text);
+
   const lines = [
-    `\x1b[36m→\x1b[0m Axint Check → ${artifacts.check.jsonPath}`,
-    `\x1b[36m→\x1b[0m Fix Packet → ${artifacts.packet.jsonPath}`,
+    `${paint("\x1b[36m", "→")} Axint Check → ${artifacts.check.jsonPath}`,
+    `${paint("\x1b[36m", "→")} Fix Packet → ${artifacts.packet.jsonPath}`,
   ];
 
   if (options.signedIn) {
-    lines.push(...renderSignedInSummaryLines(artifacts.check.summary));
+    lines.push(...renderSignedInSummaryLines(artifacts.check.summary, paint));
   } else {
     lines.push(
-      "  \x1b[2mTip:\x1b[0m Run `axint login` to unlock fuller repair summaries in terminal, `axint publish`, and Axint Cloud features like saved runs, reopenable history, and shareable links as they roll out."
+      `  ${paint("\x1b[2m", "Tip:")} Run \`axint login\` to unlock fuller repair summaries in terminal, \`axint publish\`, and Axint Cloud features like saved runs, reopenable history, and shareable links as they roll out.`
     );
   }
 
   return lines;
 }
 
-function renderSignedInSummaryLines(summary: CheckSummary): string[] {
+function renderSignedInSummaryLines(
+  summary: CheckSummary,
+  paint: (ansi: string, text: string) => string
+): string[] {
   const verdict =
     summary.outcome.verdict === "needs_review"
       ? "Needs review"
@@ -77,7 +85,7 @@ function renderSignedInSummaryLines(summary: CheckSummary): string[] {
   const topFinding = summary.topFindings[0];
 
   const lines = [
-    "  \x1b[35m↳\x1b[0m Signed in · fuller repair report enabled",
+    `  ${paint("\x1b[35m", "↳")} Signed in · fuller repair report enabled`,
     `    Verdict: ${verdict} · ${summary.outcome.headline}`,
   ];
 

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1536,6 +1536,128 @@ export default defineIntent({
 `,
 };
 
+const foundationModelsCustomProvider: IntentTemplate = {
+  id: "foundation-models-custom-provider",
+  name: "foundation-models-custom-provider",
+  title: "Foundation Models Custom Provider",
+  domain: "apple-intelligence",
+  category: "foundation-models",
+  description:
+    "Scaffold a session backed by a LanguageModel-protocol provider that falls back to the on-device model when the provider is unavailable.",
+  source: `import { defineIntent, param } from "@axint/compiler";
+
+export default defineIntent({
+  name: "DraftWithHouseModel",
+  title: "Draft With House Model",
+  description: "Drafts a reply through a custom LanguageModel provider with an on-device fallback.",
+  schemaDomain: "assistant",
+  params: {
+    prompt: param.string("Draft prompt"),
+  },
+  model: {
+    sessionName: "HouseModelSession",
+    provider: "custom-language-model",
+    useCase: "reply-drafting",
+    instructions: "Draft a reply in the account voice and keep claims grounded.",
+    customProvider: {
+      packageName: "HouseModelKit",
+      typeName: "HouseLanguageModel",
+      configuration: "HouseLanguageModel.Configuration(deployment: .production)",
+    },
+    dynamicProfiles: [
+      {
+        name: "houseModel",
+        provider: "custom-language-model",
+        instructions: "Use the house model whenever the provider is reachable.",
+      },
+      {
+        name: "onDeviceFallback",
+        provider: "apple-on-device",
+        instructions: "Fall back to the system model when the house provider is unavailable.",
+      },
+    ],
+  },
+  perform: async ({ prompt }) => {
+    // Swift proof hint:
+    // Attach evidence that the session degrades to the on-device profile when the provider is offline.
+    return { draft: prompt };
+  },
+});
+`,
+};
+
+const appIntentsTestingXctestHarness: IntentTemplate = {
+  id: "app-intents-testing-harness",
+  name: "app-intents-testing-harness",
+  title: "App Intents Testing Harness",
+  domain: "apple-intelligence",
+  category: "testing",
+  description:
+    "Scaffold an intent plus an AppIntentsTesting XCTest harness that drives perform() with sample inputs.",
+  source: `import { defineIntent, param } from "@axint/compiler";
+
+export default defineIntent({
+  name: "LogReadingSession",
+  title: "Log Reading Session",
+  description: "Logs a reading session so the harness can exercise perform() end to end.",
+  domain: "productivity",
+  params: {
+    bookTitle: param.string("Book title"),
+    minutes: param.int("Minutes read"),
+  },
+  testHarness: {
+    className: "LogReadingSessionIntentTests",
+  },
+  perform: async ({ bookTitle, minutes }) => {
+    return { bookTitle, minutes };
+  },
+});
+`,
+};
+
+const dynamicProfileSession: IntentTemplate = {
+  id: "dynamic-profile-session",
+  name: "dynamic-profile-session",
+  title: "Dynamic Profile Session",
+  domain: "apple-intelligence",
+  category: "foundation-models",
+  description:
+    "Scaffold a Foundation Models session that selects a DynamicProfile per request context.",
+  source: `import { defineIntent, param } from "@axint/compiler";
+
+export default defineIntent({
+  name: "CoachNextWorkout",
+  title: "Coach Next Workout",
+  description: "Coaches the next workout with a profile matched to the athlete's context.",
+  schemaDomain: "assistant",
+  params: {
+    goal: param.string("Training goal"),
+  },
+  model: {
+    sessionName: "WorkoutCoachSession",
+    provider: "apple-on-device",
+    useCase: "workout-coaching",
+    instructions: "Coach with the active profile's tone and scope.",
+    dynamicProfile: "quickTips",
+    dynamicProfiles: [
+      {
+        name: "quickTips",
+        instructions: "Short, actionable cues between sets.",
+      },
+      {
+        name: "weeklyPlan",
+        provider: "private-cloud-compute",
+        instructions: "Full-week periodized plans that need the larger model.",
+      },
+    ],
+  },
+  perform: async ({ goal }) => {
+    return { goal };
+  },
+});
+`,
+};
+
 // ─── Registry ────────────────────────────────────────────────────────
 
 export const TEMPLATES: IntentTemplate[] = [
@@ -1585,6 +1707,9 @@ export const TEMPLATES: IntentTemplate[] = [
   barcodeVisionTool,
   stringCatalogLocalizer,
   resizableLayoutProof,
+  foundationModelsCustomProvider,
+  appIntentsTestingXctestHarness,
+  dynamicProfileSession,
 ];
 
 /** @deprecated Use TEMPLATES. Kept for v0.1.x import compatibility. */

--- a/tests/cli/compile.test.ts
+++ b/tests/cli/compile.test.ts
@@ -101,3 +101,84 @@ export default defineIntent({
     expect(result.stderr).not.toContain("perform body");
   });
 });
+
+describe("axint compile — quiet success and clean pipes", () => {
+  const cli = resolve(__dirname, "../../dist/cli/index.js");
+  const ansi = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`);
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = resolve(tmpdir(), `axint-compile-quiet-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const VALID = `
+import { defineIntent, param } from "@axint/compiler";
+
+export default defineIntent({
+  name: "MakeThing",
+  title: "Make Thing",
+  description: "Makes a thing",
+  params: { length: param.string("Length") },
+});
+`;
+
+  it("keeps Fix Packet lines and the login tip out of successful runs", () => {
+    const file = join(tmpDir, "make-thing.ts");
+    writeFileSync(file, VALID, "utf-8");
+
+    const result = spawnSync("node", [cli, "compile", file, "--out", tmpDir], {
+      cwd: tmpDir,
+      encoding: "utf-8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toContain("Fix Packet");
+    expect(result.stdout).not.toContain("axint login");
+  });
+
+  it("prints Fix Packet lines on success when --verbose is set", () => {
+    const file = join(tmpDir, "make-thing.ts");
+    writeFileSync(file, VALID, "utf-8");
+
+    const result = spawnSync(
+      "node",
+      [cli, "compile", file, "--out", tmpDir, "--verbose"],
+      { cwd: tmpDir, encoding: "utf-8" }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Fix Packet");
+  });
+
+  it("still prints Fix Packet lines when compilation fails", () => {
+    const file = join(tmpDir, "broken.ts");
+    writeFileSync(file, VALID.replace('"MakeThing"', '"makeThing"'), "utf-8");
+
+    const result = spawnSync("node", [cli, "compile", file, "--out", tmpDir], {
+      cwd: tmpDir,
+      encoding: "utf-8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Fix Packet");
+  });
+
+  it("emits no ANSI escapes when output is piped", () => {
+    const file = join(tmpDir, "broken.ts");
+    writeFileSync(file, VALID.replace('"MakeThing"', '"makeThing"'), "utf-8");
+
+    const result = spawnSync("node", [cli, "compile", file, "--out", tmpDir], {
+      cwd: tmpDir,
+      encoding: "utf-8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).not.toMatch(ansi);
+    expect(result.stderr).not.toMatch(ansi);
+  });
+});

--- a/tests/cli/compile.test.ts
+++ b/tests/cli/compile.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
 
 import { countNonBlankLines, compressionRatio } from "../../src/cli/compile.js";
 
@@ -40,5 +44,60 @@ describe("compressionRatio", () => {
     expect(compressionRatio(0, 10)).toBeNull();
     expect(compressionRatio(10, 0)).toBeNull();
     expect(compressionRatio(0, 0)).toBeNull();
+  });
+});
+
+describe("axint compile — perform stub notice", () => {
+  const cli = resolve(__dirname, "../../dist/cli/index.js");
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = resolve(tmpdir(), `axint-compile-notice-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const intentSource = (perform: string) => `
+import { defineIntent, param } from "@axint/compiler";
+
+export default defineIntent({
+  name: "MakeThing",
+  title: "Make Thing",
+  description: "Makes a thing",
+  params: {
+    length: param.string("Length"),
+  },${perform}
+});
+`;
+
+  it("notes that a perform body was discarded into the stub", () => {
+    const file = join(tmpDir, "make-thing.ts");
+    writeFileSync(file, intentSource('\n  perform: async () => "done",'), "utf-8");
+
+    const result = spawnSync(
+      "node",
+      [cli, "compile", file, "--out", tmpDir, "--no-fix-packet"],
+      { cwd: tmpDir, encoding: "utf-8" }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("perform body is not translated yet");
+  });
+
+  it("stays quiet when the definition has no perform body", () => {
+    const file = join(tmpDir, "make-thing.ts");
+    writeFileSync(file, intentSource(""), "utf-8");
+
+    const result = spawnSync(
+      "node",
+      [cli, "compile", file, "--out", tmpDir, "--no-fix-packet"],
+      { cwd: tmpDir, encoding: "utf-8" }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("perform body");
   });
 });

--- a/tests/cli/help.test.ts
+++ b/tests/cli/help.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const CLI = resolve(__dirname, "../../dist/cli/index.js");
+
+const ALL_COMMANDS = [
+  "init",
+  "compile",
+  "activate",
+  "validate",
+  "validate-swift",
+  "eject",
+  "format",
+  "templates",
+  "create",
+  "login",
+  "cloud",
+  "tokens",
+  "schema",
+  "suggest",
+  "feature",
+  "repair",
+  "agent",
+  "memory",
+  "feedback",
+  "telemetry",
+  "publish",
+  "add",
+  "search",
+  "watch",
+  "status",
+  "upgrade",
+  "doctor",
+  "project",
+  "session",
+  "workflow",
+  "run",
+  "runner",
+  "paint-test",
+  "mcp",
+  "xcode",
+];
+
+describe("axint --help", () => {
+  const result = spawnSync("node", [CLI, "--help"], { encoding: "utf-8" });
+  const stdout = result.stdout;
+
+  it("leads with a Core section of hero commands", () => {
+    const core = stdout.indexOf("Core:");
+    expect(core).toBeGreaterThan(-1);
+    for (const heading of ["Authoring:", "Registry & cloud:", "Project & agents:"]) {
+      expect(stdout.indexOf(heading)).toBeGreaterThan(core);
+    }
+
+    const coreSection = stdout.slice(core, stdout.indexOf("Authoring:"));
+    for (const name of [
+      "init",
+      "compile",
+      "validate",
+      "validate-swift",
+      "templates",
+      "suggest",
+      "mcp",
+    ]) {
+      expect(coreSection).toContain(`\n  ${name} `);
+    }
+  });
+
+  it("keeps every command listed", () => {
+    for (const name of ALL_COMMANDS) {
+      expect(stdout).toMatch(new RegExp(`^  ${name.replace("-", "\\-")} `, "m"));
+    }
+  });
+
+  it("keeps help itself working as a command", () => {
+    const helpRun = spawnSync("node", [CLI, "help", "compile"], { encoding: "utf-8" });
+    expect(helpRun.status).toBe(0);
+    expect(helpRun.stdout).toContain("Usage: axint compile");
+  });
+});

--- a/tests/cli/render-diagnostics.test.ts
+++ b/tests/cli/render-diagnostics.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { renderDiagnostic } from "../../src/cli/render-diagnostics.js";
+import type { Diagnostic } from "../../src/core/types.js";
+
+const SOURCE = `defineIntent({
+  name: "MakeThing",
+  params: {
+    length: param.string("Length", { default: 8 }),
+  },
+});
+`;
+
+const diagnostic: Diagnostic = {
+  code: "AX127",
+  severity: "error",
+  message:
+    'Parameter "length" is declared param.string() but its default is the number 8',
+  file: "make-thing.ts",
+  line: 4,
+  column: 47,
+  suggestion: "Change the default to a string.",
+};
+
+describe("renderDiagnostic", () => {
+  it("prints a rust-style location with line and column", () => {
+    const rendered = renderDiagnostic(diagnostic, { color: false });
+    expect(rendered).toContain("error[AX127]:");
+    expect(rendered).toContain("--> make-thing.ts:4:47");
+    expect(rendered).toContain("= help: Change the default to a string.");
+  });
+
+  it("renders a snippet with a caret under the offending column", () => {
+    const rendered = renderDiagnostic(diagnostic, {
+      color: false,
+      sources: new Map([["make-thing.ts", SOURCE]]),
+    });
+    const lines = rendered.split("\n");
+    expect(lines).toContain("   3 |   params: {");
+    expect(lines).toContain('   4 |     length: param.string("Length", { default: 8 }),');
+    const underline = lines.find((line) => line.includes("^"));
+    expect(underline).toBeDefined();
+    // The caret column lines up with the default literal in the code row.
+    const codeRow = lines.find((line) => line.startsWith("   4 |"))!;
+    expect(codeRow[underline!.indexOf("^")]).toBe("8");
+  });
+
+  it("underlines an entire string literal when the caret sits on a quote", () => {
+    const rendered = renderDiagnostic(
+      { ...diagnostic, line: 2, column: 9 },
+      { color: false, sources: new Map([["make-thing.ts", SOURCE]]) }
+    );
+    expect(rendered).toContain("^~~~~~~~~~~");
+  });
+
+  it("omits the snippet when no source is available", () => {
+    const rendered = renderDiagnostic(diagnostic, { color: false });
+    expect(rendered).not.toContain(" | ");
+  });
+
+  it("keeps output free of escape bytes when color is off", () => {
+    const rendered = renderDiagnostic(diagnostic, {
+      color: false,
+      sources: new Map([["make-thing.ts", SOURCE]]),
+    });
+    expect(rendered).not.toContain("\x1b[");
+  });
+});

--- a/tests/cli/validate-swift.test.ts
+++ b/tests/cli/validate-swift.test.ts
@@ -81,7 +81,7 @@ describe("axint validate-swift", () => {
 
     const result = spawnSync(
       "node",
-      [CLI, "validate-swift", swiftFile, "--fix-packet-dir", packetDir],
+      [CLI, "validate-swift", swiftFile, "--fix-packet-dir", packetDir, "--verbose"],
       {
         cwd: tmpDir,
         encoding: "utf-8",
@@ -141,6 +141,21 @@ struct SecondSwift {
 
     expect(packet.outcome.verdict).toBe("pass");
     expect(packet.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps successful runs free of Fix Packet and login-tip noise", () => {
+    const swiftFile = join(tmpDir, "PlainSwift.swift");
+    writeFileSync(swiftFile, VALID_SWIFT, "utf-8");
+
+    const result = spawnSync("node", [CLI, "validate-swift", swiftFile], {
+      cwd: tmpDir,
+      encoding: "utf-8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toContain("Fix Packet");
+    expect(result.stdout).not.toContain("axint login");
+    expect(result.stdout).toContain("passed axint validation");
   });
 
   it("disables ANSI color in non-TTY output by default", () => {

--- a/tests/core/axint-dsl/round-trip.test.ts
+++ b/tests/core/axint-dsl/round-trip.test.ts
@@ -349,9 +349,19 @@ export default defineIntent({
 ];
 
 // The DSL and TS paths both stamp the intent with the sourceFile they were
-// given. That field isn't part of the contract — it's provenance. Strip it
-// before comparing, along with any undefined-valued field JSON.stringify
-// already hides but structural equality doesn't.
+// given, and the TS parser additionally records source spans and whether a
+// perform body was present. None of that is part of the contract — it's
+// provenance about where the definition came from. Strip it before
+// comparing, along with any undefined-valued field JSON.stringify already
+// hides but structural equality doesn't.
+const PROVENANCE_KEYS = new Set([
+  "sourceFile",
+  "spans",
+  "span",
+  "defaultSpan",
+  "hasPerformBody",
+]);
+
 function canonicalize(value: unknown): unknown {
   if (value === null || value === undefined) return value;
   if (Array.isArray(value)) return value.map(canonicalize);
@@ -359,7 +369,7 @@ function canonicalize(value: unknown): unknown {
   const source = value as Record<string, unknown>;
   const out: Record<string, unknown> = {};
   for (const key of Object.keys(source).sort()) {
-    if (key === "sourceFile") continue;
+    if (PROVENANCE_KEYS.has(key)) continue;
     const v = source[key];
     if (v === undefined) continue;
     out[key] = canonicalize(v);

--- a/tests/core/compiler.test.ts
+++ b/tests/core/compiler.test.ts
@@ -320,6 +320,45 @@ export default defineIntent({
     expect(result.output?.swiftCode).toContain("Preview Snapshot proof matrix");
   });
 
+  it("emits a guarded AppIntentsTesting XCTest harness when testHarness is declared", () => {
+    const source = `
+import { defineIntent, param } from "@axint/sdk";
+
+export default defineIntent({
+  name: "LogReadingSession",
+  title: "Log Reading Session",
+  description: "Logs minutes read for a book.",
+  params: {
+    bookTitle: param.string("Book title"),
+    minutes: param.int("Minutes read"),
+    notes: param.string("Session notes", { required: false }),
+  },
+  testHarness: {
+    className: "LogReadingSessionIntentTests",
+  },
+  perform: async ({ bookTitle, minutes }) => {
+    return { bookTitle, minutes };
+  },
+});
+`;
+    const result = compileSource(source, "harness.ts");
+
+    expect(result.success).toBe(true);
+    expect(result.output?.ir.testHarness?.className).toBe("LogReadingSessionIntentTests");
+    expect(result.output?.swiftCode).toContain(
+      "#if canImport(XCTest) && canImport(AppIntentsTesting)"
+    );
+    expect(result.output?.swiftCode).toContain(
+      "final class LogReadingSessionIntentTests: XCTestCase"
+    );
+    expect(result.output?.swiftCode).toContain("@available(iOS 26.0, macOS 26.0, *)");
+    expect(result.output?.swiftCode).toContain("let intent = LogReadingSessionIntent()");
+    expect(result.output?.swiftCode).toContain('intent.bookTitle = "Sample"');
+    expect(result.output?.swiftCode).toContain("intent.minutes = 1");
+    expect(result.output?.swiftCode).not.toContain("intent.notes =");
+    expect(result.output?.swiftCode).toContain("_ = try await intent.perform()");
+  });
+
   it("emits multimodal Foundation Models, dynamic profiles, custom providers, and Image Playground contracts", () => {
     const source = `
 import { defineIntent, param } from "@axint/sdk";

--- a/tests/core/compiler.test.ts
+++ b/tests/core/compiler.test.ts
@@ -517,3 +517,48 @@ export default defineIntent({
     expect(result.output?.swiftCode).toContain("Research notes in the current account");
   });
 });
+
+describe("compileSource — default/type mismatches stop emit (AX127)", () => {
+  const intentWith = (paramSource: string) => `
+defineIntent({
+  name: "MakeThing",
+  title: "Make Thing",
+  description: "Makes a thing",
+  params: {
+    value: ${paramSource},
+  },
+  perform: async () => "done",
+});
+`;
+
+  it("fails compile when a string param defaults to a number", () => {
+    const result = compileSource(intentWith('param.string("Length", { default: 8 })'));
+    expect(result.success).toBe(false);
+    const diagnostic = result.diagnostics.find((d) => d.code === "AX127");
+    expect(diagnostic?.suggestion).toContain("param.int(...)");
+  });
+
+  it("fails compile when a number param defaults to a string", () => {
+    const result = compileSource(intentWith('param.number("Length", { default: "x" })'));
+    expect(result.success).toBe(false);
+    expect(result.diagnostics.some((d) => d.code === "AX127")).toBe(true);
+  });
+
+  it("emits a URL initializer for url params with string defaults", () => {
+    const result = compileSource(
+      intentWith('param.url("Endpoint", { default: "https://example.com" })')
+    );
+    expect(result.success).toBe(true);
+    expect(result.output!.swiftCode).toContain(
+      'var value: URL = URL(string: "https://example.com")!'
+    );
+  });
+
+  it("emits a Swift array literal for array params with defaults", () => {
+    const result = compileSource(
+      intentWith('param.array(param.string("Tag"), "Tags", { default: ["a", "b"] })')
+    );
+    expect(result.success).toBe(true);
+    expect(result.output!.swiftCode).toContain('var value: [String] = ["a", "b"]');
+  });
+});

--- a/tests/core/parser.test.ts
+++ b/tests/core/parser.test.ts
@@ -283,3 +283,36 @@ defineIntent({
     });
   });
 });
+
+describe("source spans", () => {
+  it("records spans for name, title, description, and params", () => {
+    const source = `defineIntent({
+  name: "MakeThing",
+  title: "Make Thing",
+  description: "Makes a thing",
+  params: {
+    length: param.string("Length", { default: "8" }),
+  },
+  perform: async () => "done",
+});
+`;
+
+    const ir = parseIntentSource(source, "make-thing.ts");
+    expect(ir.spans?.name).toEqual({ line: 2, column: 9 });
+    expect(ir.spans?.title).toEqual({ line: 3, column: 10 });
+    expect(ir.spans?.description).toEqual({ line: 4, column: 16 });
+
+    const [length] = ir.parameters;
+    expect(length!.span).toEqual({ line: 6, column: 5 });
+    expect(length!.defaultSpan).toEqual({ line: 6, column: 47 });
+    expect(ir.hasPerformBody).toBe(true);
+  });
+
+  it("leaves hasPerformBody unset-friendly when perform is missing", () => {
+    const ir = parseIntentSource(
+      `defineIntent({ name: "A", title: "A", description: "A" });`,
+      "a.ts"
+    );
+    expect(ir.hasPerformBody).toBe(false);
+  });
+});

--- a/tests/core/swift-validator.test.ts
+++ b/tests/core/swift-validator.test.ts
@@ -175,6 +175,49 @@ describe("swift validator — SwiftUI compiler parity", () => {
     expect(diagnostics.map((d) => d.code)).toContain("AX767");
   });
 
+  it("flags non-View computed properties with local declarations but no explicit return", () => {
+    const source = `
+      struct CadabraSettings {
+          var magicSummary: String {
+              let tier = "Better"
+              "Magic Level: \\(tier)"
+          }
+      }
+    `;
+
+    const { diagnostics } = validate(source);
+    const diagnostic = diagnostics.find((d) => d.code === "AX849");
+    expect(diagnostic?.message).toContain("magicSummary");
+    expect(diagnostic?.suggestion).toContain("return");
+  });
+
+  it("flags same-file switches over enum values that omit a declared case", () => {
+    const source = `
+      enum CadabraPreset {
+          case better
+          case outfit
+          case wild
+          case noirFrame
+
+          var suggestedCameraFeel: String {
+              switch self {
+              case .better:
+                  return "Clean"
+              case .outfit:
+                  return "Styled"
+              case .wild:
+                  return "Chaotic"
+              }
+          }
+      }
+    `;
+
+    const { diagnostics } = validate(source);
+    const diagnostic = diagnostics.find((d) => d.code === "AX860");
+    expect(diagnostic?.message).toContain("noirFrame");
+    expect(diagnostic?.suggestion).toContain("case .noirFrame");
+  });
+
   it("accepts some View helpers that explicitly return the final expression", () => {
     const source = `
       import SwiftUI

--- a/tests/core/swift-validator.test.ts
+++ b/tests/core/swift-validator.test.ts
@@ -191,6 +191,56 @@ describe("swift validator — SwiftUI compiler parity", () => {
     expect(diagnostic?.suggestion).toContain("return");
   });
 
+  it("attributes the missing return to the offending property, not its neighbor", () => {
+    // A stored property above the offender used to get blamed: the type
+    // annotation regex crossed newlines and swallowed the next declaration.
+    const source = `import SwiftUI
+
+struct StatsView: View {
+    let items: [String]
+    let completed: Int
+
+    var body: some View {
+        VStack {
+            Text(subtitle)
+        }
+    }
+
+    // Done count for the header row.
+
+    var count: Int
+
+    var subtitle: String {
+        let done = completed
+        "\\(done) of \\(items.count) done"
+    }
+}
+`;
+
+    const { diagnostics } = validate(source);
+    const matches = diagnostics.filter((d) => d.code === "AX849");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.message).toContain("'subtitle'");
+    expect(matches[0]!.line).toBe(17);
+  });
+
+  it("keeps attribution straight across two adjacent computed properties", () => {
+    const source = `struct Stats {
+    var count: Int { 3 }
+    var subtitle: String {
+        let done = 2
+        "\\(done) of 3 done"
+    }
+}
+`;
+
+    const { diagnostics } = validate(source);
+    const matches = diagnostics.filter((d) => d.code === "AX849");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.message).toContain("'subtitle'");
+    expect(matches[0]!.line).toBe(3);
+  });
+
   it("flags same-file switches over enum values that omit a declared case", () => {
     const source = `
       enum CadabraPreset {

--- a/tests/core/validator.test.ts
+++ b/tests/core/validator.test.ts
@@ -217,3 +217,125 @@ struct TestIntent: AppIntent {
     expect(diagnostics.some((d) => d.code === "AX202")).toBe(true);
   });
 });
+
+describe("validateIntent — param default type checks (AX127)", () => {
+  const paramWith = (
+    type: IRIntent["parameters"][number]["type"],
+    defaultValue: unknown
+  ) =>
+    makeIntent({
+      parameters: [
+        {
+          name: "value",
+          type,
+          title: "Value",
+          description: "A value",
+          isOptional: false,
+          defaultValue,
+        },
+      ],
+    });
+
+  const primitive = (value: string) =>
+    ({ kind: "primitive", value }) as IRIntent["parameters"][number]["type"];
+
+  const ax127 = (intent: IRIntent) =>
+    validateIntent(intent).find((d) => d.code === "AX127");
+
+  it("rejects a number default on a string param", () => {
+    const diagnostic = ax127(paramWith(primitive("string"), 8));
+    expect(diagnostic?.severity).toBe("error");
+    expect(diagnostic?.message).toContain("the number 8");
+    expect(diagnostic?.suggestion).toContain("param.int(...)");
+  });
+
+  it("rejects a string default on an int param", () => {
+    const diagnostic = ax127(paramWith(primitive("int"), "x"));
+    expect(diagnostic?.message).toContain('the string "x"');
+    expect(diagnostic?.suggestion).toContain("whole number");
+  });
+
+  it("rejects a fractional default on an int param", () => {
+    expect(ax127(paramWith(primitive("int"), 1.5))).toBeDefined();
+  });
+
+  it("rejects a boolean default on a double param", () => {
+    expect(ax127(paramWith(primitive("double"), true))).toBeDefined();
+  });
+
+  it("rejects a string default on a float param", () => {
+    expect(ax127(paramWith(primitive("float"), "fast"))).toBeDefined();
+  });
+
+  it("rejects a string default on a boolean param", () => {
+    const diagnostic = ax127(paramWith(primitive("boolean"), "yes"));
+    expect(diagnostic?.suggestion).toContain("true or false");
+  });
+
+  it("rejects any literal default on a date param", () => {
+    const diagnostic = ax127(paramWith(primitive("date"), "2026-01-01"));
+    expect(diagnostic?.message).toContain("do not support literal defaults");
+    expect(diagnostic?.suggestion).toContain("perform()");
+  });
+
+  it("rejects any literal default on a duration param", () => {
+    expect(ax127(paramWith(primitive("duration"), 30))).toBeDefined();
+  });
+
+  it("rejects a number default on a url param", () => {
+    expect(ax127(paramWith(primitive("url"), 8080))).toBeDefined();
+  });
+
+  it("rejects an empty-string default on a url param", () => {
+    expect(ax127(paramWith(primitive("url"), ""))).toBeDefined();
+  });
+
+  it("rejects a mismatched default inside an optional wrapper", () => {
+    expect(
+      ax127(paramWith({ kind: "optional", innerType: primitive("string") }, 8))
+    ).toBeDefined();
+  });
+
+  it("rejects a mismatched element in an array default", () => {
+    expect(
+      ax127(paramWith({ kind: "array", elementType: primitive("string") }, ["a", 2]))
+    ).toBeDefined();
+  });
+
+  it("rejects a default that is not one of the enum cases", () => {
+    const diagnostic = ax127(
+      paramWith({ kind: "enum", name: "ModeOption", cases: ["fast", "slow"] }, "medium")
+    );
+    expect(diagnostic?.suggestion).toContain("fast, slow");
+  });
+
+  it("accepts matching defaults for every literal-friendly type", () => {
+    const valid: Array<[IRIntent["parameters"][number]["type"], unknown]> = [
+      [primitive("string"), "hello"],
+      [primitive("int"), 8],
+      [primitive("double"), 1.5],
+      [primitive("float"), 2.5],
+      [primitive("boolean"), false],
+      [primitive("url"), "https://example.com"],
+      [{ kind: "optional", innerType: primitive("int") }, 3],
+      [{ kind: "array", elementType: primitive("string") }, ["a", "b"]],
+      [{ kind: "enum", name: "ModeOption", cases: ["fast", "slow"] }, "fast"],
+      [
+        {
+          kind: "dynamicOptions",
+          valueType: primitive("string"),
+          providerName: "Provider",
+        },
+        "a",
+      ],
+    ];
+
+    for (const [type, defaultValue] of valid) {
+      expect(ax127(paramWith(type, defaultValue))).toBeUndefined();
+    }
+  });
+
+  it("accepts params without a default", () => {
+    expect(ax127(paramWith(primitive("date"), undefined))).toBeUndefined();
+  });
+});

--- a/tests/mcp/http-transport.test.ts
+++ b/tests/mcp/http-transport.test.ts
@@ -109,9 +109,10 @@ describe("axint HTTP MCP transport", () => {
 
     expect(response.status).toBe(200);
     expect(payload.result.tools).toHaveLength(TOOL_MANIFEST.length);
-    expect(payload.result.tools.map((tool: { name: string }) => tool.name)).toEqual(
-      TOOL_MANIFEST.map((tool) => tool.name)
-    );
+    expect(
+      payload.result.tools.map((tool: { name: string }) => tool.name).sort()
+    ).toEqual(TOOL_MANIFEST.map((tool) => tool.name).sort());
+    expect(payload.result.tools[0].name).toBe("axint.compile");
     expect(payload.result.tools).toEqual(compactManifest);
     expect(
       payload.result.tools.every((tool: { description?: string }) =>
@@ -265,35 +266,17 @@ describe("axint HTTP MCP transport", () => {
   });
 });
 
+// The compact manifest documents every top-level parameter; nested
+// structure relies on types, with the full prose behind
+// AXINT_MCP_MANIFEST_MODE=full.
 function schemaHasParameterDescriptions(schema: unknown): boolean {
-  const properties = asObject(schema)?.properties;
-  if (!properties || typeof properties !== "object") return true;
-  return Object.values(properties).every(parameterSchemaHasDescription);
-}
-
-function parameterSchemaHasDescription(schema: unknown): boolean {
-  const object = asObject(schema);
-  if (!object) return true;
-  if (typeof object.description !== "string" || object.description.trim() === "") {
-    return false;
-  }
-
-  const properties = asObject(object.properties);
-  if (properties && !Object.values(properties).every(parameterSchemaHasDescription)) {
-    return false;
-  }
-
-  if (object.items && !parameterSchemaHasDescription(object.items)) return false;
-
-  if (
-    object.additionalProperties &&
-    typeof object.additionalProperties === "object" &&
-    !parameterSchemaHasDescription(object.additionalProperties)
-  ) {
-    return false;
-  }
-
-  return true;
+  const properties = asObject(asObject(schema)?.properties);
+  if (!properties) return true;
+  return Object.values(properties).every((parameter) => {
+    const object = asObject(parameter);
+    if (!object) return true;
+    return typeof object.description === "string" && object.description.trim() !== "";
+  });
 }
 
 function asObject(value: unknown): Record<string, unknown> | undefined {

--- a/tests/mcp/index.test.ts
+++ b/tests/mcp/index.test.ts
@@ -40,14 +40,21 @@ describe("axint/mcp import surface", () => {
     const full = mod.getRuntimeToolManifest({ AXINT_MCP_MANIFEST_MODE: "full" });
 
     expect(compact).toHaveLength(mod.TOOL_MANIFEST.length);
-    expect(compact.map((tool: { name: string }) => tool.name)).toEqual(
-      mod.TOOL_MANIFEST.map((tool: { name: string }) => tool.name)
+    expect(compact.map((tool: { name: string }) => tool.name).sort()).toEqual(
+      mod.TOOL_MANIFEST.map((tool: { name: string }) => tool.name).sort()
     );
     expect(full).toHaveLength(mod.TOOL_MANIFEST.length);
     expect(
       full.every((tool: { outputSchema?: unknown }) => Boolean(tool.outputSchema))
     ).toBe(true);
-    expect(JSON.stringify(compact).length).toBeLessThan(JSON.stringify(full).length);
+    expect(
+      compact.every((tool: { outputSchema?: unknown }) => Boolean(tool.outputSchema))
+    ).toBe(true);
+    // The compact manifest is the default agents pay context for — keep
+    // it well under two-thirds of the full prose listing.
+    expect(JSON.stringify(compact).length).toBeLessThan(
+      JSON.stringify(full).length * 0.6
+    );
     expect(
       compact.every((tool: { description?: string }) =>
         Boolean(
@@ -55,6 +62,27 @@ describe("axint/mcp import surface", () => {
         )
       )
     ).toBe(true);
+  });
+
+  it("lists the hero tools first in both manifest modes", async () => {
+    const mod = await import("../../src/mcp/index.js");
+    const heroes = [
+      "axint.compile",
+      "axint.validate",
+      "axint.swift.validate",
+      "axint.swift.fix",
+      "axint.scaffold",
+      "axint.templates.list",
+      "axint.templates.get",
+      "axint.repair",
+    ];
+
+    for (const env of [{}, { AXINT_MCP_MANIFEST_MODE: "full" }]) {
+      const manifest = mod.getRuntimeToolManifest(env);
+      expect(
+        manifest.slice(0, heroes.length).map((tool: { name: string }) => tool.name)
+      ).toEqual(heroes);
+    }
   });
 
   it("keeps the MCP SDK bundled out of published runtime dependencies", () => {

--- a/tests/mcp/suggest.test.ts
+++ b/tests/mcp/suggest.test.ts
@@ -178,4 +178,23 @@ describe("axint.suggest", () => {
     expect(suggestions[0]?.featurePrompt).not.toContain("Capture Testflight");
     expect(suggestions.map((suggestion) => suggestion.domain)).not.toContain("custom");
   });
+
+  it("routes Axint dogfood atom fixes to tooling repair instead of app-provider repair", () => {
+    const suggestions = suggestFeatures({
+      appDescription:
+        "Fix Axint dogfood atoms from Cadabra without touching Cadabra: route non-Apple artifacts away from fake AX001 diagnostics, keep MCP version metadata current, classify release/preflight/provider-output repair loops correctly, and prevent generic feature scaffolds for product-specific preset-library requests.",
+      platform: "iOS",
+      limit: 3,
+    });
+
+    expect(suggestions[0]?.domain).toBe("axint-dogfood");
+    expect(suggestions[0]?.featurePrompt).toContain("Cloud Check");
+    expect(suggestions[0]?.featurePrompt).toContain("non-Apple artifacts");
+    expect(suggestions[0]?.featurePrompt).toContain("provider-output words");
+    expect(suggestions.map((suggestion) => suggestion.name).join("\n")).toContain(
+      "Version Truth Guard"
+    );
+    expect(suggestions.map((suggestion) => suggestion.domain)).not.toContain("repair");
+    expect(suggestions[0]?.name).not.toContain("Repair Existing");
+  });
 });

--- a/tests/mcp/suggest.test.ts
+++ b/tests/mcp/suggest.test.ts
@@ -198,3 +198,30 @@ describe("axint.suggest", () => {
     expect(suggestions[0]?.name).not.toContain("Repair Existing");
   });
 });
+
+describe("stock domain matching for consumer phrases", () => {
+  const cases: Array<{ prompt: string; domain: string }> = [
+    { prompt: "habit tracker with streaks and a home screen widget", domain: "health" },
+    { prompt: "todo list app with tasks and reminders", domain: "productivity" },
+    { prompt: "budget app to track expenses and spending", domain: "finance" },
+    { prompt: "sleep tracker that also logs workouts", domain: "health" },
+    { prompt: "note taking app with a calendar and deadlines", domain: "productivity" },
+  ];
+
+  for (const { prompt, domain } of cases) {
+    it(`matches "${prompt}" to the ${domain} domain`, () => {
+      const suggestions = suggestFeatures({ appDescription: prompt, limit: 5 });
+      expect(suggestions.length).toBeGreaterThan(0);
+      expect(suggestions[0]?.domain).toBe(domain);
+      expect(
+        suggestions.filter((s) => s.domain === domain).length
+      ).toBeGreaterThanOrEqual(2);
+    });
+
+    it(`gives every suggestion for "${prompt}" its own rationale`, () => {
+      const suggestions = suggestFeatures({ appDescription: prompt, limit: 5 });
+      const rationales = suggestions.map((s) => s.rationale);
+      expect(new Set(rationales).size).toBe(rationales.length);
+    });
+  }
+});

--- a/tests/templates/index.test.ts
+++ b/tests/templates/index.test.ts
@@ -92,4 +92,39 @@ describe("templates registry", () => {
       expect(result.output?.swiftCode, id).toContain("struct");
     }
   });
+
+  it("ships WWDC26 provider fallback and testing-harness templates that compile", () => {
+    const ids = [
+      "foundation-models-custom-provider",
+      "app-intents-testing-harness",
+      "dynamic-profile-session",
+    ];
+
+    for (const id of ids) {
+      const template = getTemplate(id);
+      expect(template, id).toBeDefined();
+
+      const result = compileSource(template!.source, `${id}.ts`);
+      expect(result.success, id).toBe(true);
+      expect(result.output?.swiftCode, id).toContain("struct");
+    }
+
+    const harness = compileSource(
+      getTemplate("app-intents-testing-harness")!.source,
+      "app-intents-testing-harness.ts"
+    );
+    expect(harness.output?.swiftCode).toContain(
+      "#if canImport(XCTest) && canImport(AppIntentsTesting)"
+    );
+    expect(harness.output?.swiftCode).toContain(
+      "final class LogReadingSessionIntentTests: XCTestCase"
+    );
+
+    const provider = compileSource(
+      getTemplate("foundation-models-custom-provider")!.source,
+      "foundation-models-custom-provider.ts"
+    );
+    expect(provider.output?.swiftCode).toContain("HouseLanguageModel");
+    expect(provider.output?.swiftCode).toContain("onDeviceFallback");
+  });
 });

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.30";
+const VERSION = "0.4.31";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -69,7 +69,7 @@ import type {
 } from "../../../src/core/types.js";
 import { isPrimitiveType, isSceneKind } from "../../../src/core/types.js";
 
-const VERSION = "0.4.31";
+const VERSION = "0.4.32";
 
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
 


### PR DESCRIPTION
Replaces #292, which was cut from the pre-squash 0.4.31 branch and conflicted with main. Same content, rebuilt on main's lineage.

First-hour quality pass, driven by a cold-start review of 0.4.31. The headline is AX127: param defaults that don't match the declared type now fail validation with a computed fix instead of compiling into Swift that can't build — our own calendar-assistant example was hitting this. TypeScript diagnostics print line:col spans with a source snippet and caret underline. AX849 stopped blaming the property above the real offender. Compile notes when a perform body is discarded into the stub. Success runs are quiet, piped output carries no ANSI escapes, help groups core commands, suggest matches consumer phrases to stock domains, and the default MCP manifest dropped 45% with hero tools first.

217 diagnostics, 1426 tests across TS and Python, all gates green.