### PR TITLE
Add SwiftUI interaction readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 - **WWDC26 Siri/App Schema readiness** — the compiler now normalizes and emits `EntityCollection<T>` parameters, `ValueRepresentation(...)` aliases, and `RelevantEntities` helper methods from TypeScript and JSON IR so schema-backed entities can stay current for Siri, Shortcuts, Spotlight, and Apple Intelligence paths.
 - **Cloud Check security diagnostics** — `axint.cloud.check` now has a Siri/App Schema readiness coverage row plus diagnostics for confirmation-required actions, authorization boundaries, prompt-injection mitigation, and data-boundary proof around Foundation Models code.
 - **Foundation Models tool-calling proof cues** — the `foundation-model-tool` template now names the generated `Tool`, prompt-version metadata, transcript capture, and sensitive-field redaction proof expected before demoing model-backed Apple actions.
+- **SwiftUI interaction template** — `swiftui-reorderable-swipe-container` shows the WWDC26 custom-container path for `reorderable()`, `reorderContainer(...)`, and `swipeActionsContainer()`.
+- **SwiftUI modernization diagnostic** — Cloud Check now suggests the new `swipeActionsContainer()` path when a SwiftUI view still appears to use `List` primarily to host swipe actions.
+- **Dynamic Profile proof cues** — `dynamic-profile-session` now names selected-profile logging, transcript metadata, and tool-call proof for Foundation Models sessions that switch profiles at runtime.
 
 ## [0.4.32] — 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ the CLI fallback, then continue the same workflow check with `--ran-suggest`.
 
 ## Public truth
 
-<!-- truth:readme-proof-line:start -->v0.4.32 · 36 MCP tools + 5 prompts · 217 diagnostic codes · 1429 tests · 58 live packages · 49 bundled templates<!-- truth:readme-proof-line:end -->
+<!-- truth:readme-proof-line:start -->v0.4.32 · 36 MCP tools + 5 prompts · 217 diagnostic codes · 1432 tests · 58 live packages · 50 bundled templates<!-- truth:readme-proof-line:end -->
 
 <!-- truth:readme-truth-source:start -->Public proof is regenerated from the compiler's metrics pipeline on every release (`npm run metrics:emit && npm run metrics:check`).<!-- truth:readme-truth-source:end -->
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,23 @@
 # Release Notes
 
+## 2026-06-16 — SwiftUI container interactions and Dynamic Profile proof
+
+This release picks up two lower-noise WWDC26 signals that matter for real app
+work: SwiftUI custom containers no longer need to fall back to `List` just to
+get native swipe actions, and Foundation Models Dynamic Profiles need proof
+that the selected model/tools/instructions actually changed.
+
+### Added
+
+- `swiftui-reorderable-swipe-container` template: a compileable proof scaffold
+  with SwiftUI notes for `ScrollView`, `LazyVStack`, `reorderable()`,
+  `reorderContainer(...)`, and `swipeActionsContainer()`.
+- Cloud Check diagnostic `AXCLOUD-WWDC26-SWIFTUI-SWIPE-CONTAINER`, which points
+  SwiftUI views using `List` plus `.swipeActions` toward the WWDC26 custom
+  container path when appropriate.
+- Stronger Dynamic Profile template cues for selected-profile logging,
+  `LanguageModelSession` tools, transcript metadata, and profile-switch proof.
+
 ## 2026-06-15 — Siri/App Schema readiness and Foundation Models safety proof
 
 This release tightens the WWDC26 path Apple just made more important:

--- a/metrics.json
+++ b/metrics.json
@@ -47,7 +47,7 @@
     "axint.create-widget",
     "axint.create-intent"
   ],
-  "bundledTemplates": 49,
+  "bundledTemplates": 50,
   "diagnostics": 217,
   "xcodeFixRules": 33,
   "xcodeFixRuleCodes": [
@@ -86,7 +86,7 @@
     "AX748"
   ],
   "tests": {
-    "typescript": 1315,
+    "typescript": 1318,
     "python": 114
   },
   "registryPackages": 58,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@eslint/js": "^10.0.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@types/node": "^25.6.0",
-        "@vitest/coverage-v8": "^4.1.4",
+        "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.2.1",
         "husky": "^9.0.0",
         "lint-staged": "^17.0.7",
@@ -30,7 +30,7 @@
         "tsup": "^8.5.0",
         "tsx": "^4.19.0",
         "typescript-eslint": "^8.0.0",
-        "vitest": "^4.1.4"
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=22"

--- a/src/cloud/check.ts
+++ b/src/cloud/check.ts
@@ -1261,6 +1261,11 @@ function diagnosticsFromWwdc26Readiness(
     /\b(StringCatalog|String Catalog|Localizable\.xcstrings|\.xcstrings|generated translations?)\b/i.test(
       source
     );
+  const touchesSwiftUISwipeContainerModernization =
+    /\bSwiftUI\b/.test(source) &&
+    /\bList\s*\{/.test(source) &&
+    /\.swipeActions\s*\{/.test(source) &&
+    !/\.swipeActionsContainer\s*\(/.test(source);
   const touchesResizableIosLayout =
     /\bSwiftUI\b/.test(source) &&
     /\bView\b/.test(source) &&
@@ -1285,6 +1290,7 @@ function diagnosticsFromWwdc26Readiness(
     touchesSemanticIndex ||
     touchesPcc ||
     touchesStringCatalog ||
+    touchesSwiftUISwipeContainerModernization ||
     touchesResizableIosLayout;
 
   if (!touchesAppleIntelligence) return diagnostics;
@@ -1666,6 +1672,19 @@ function diagnosticsFromWwdc26Readiness(
         "SwiftUI layouts with fixed large frame dimensions need resizable iOS proof.",
       suggestion:
         "Replace fixed device-sized frames with adaptive layout, or attach Preview Snapshot evidence across compact/regular, landscape, and accessibility-size variants.",
+    });
+  }
+
+  if (touchesSwiftUISwipeContainerModernization) {
+    diagnostics.push({
+      code: "AXCLOUD-WWDC26-SWIFTUI-SWIPE-CONTAINER",
+      severity: "warning",
+      file,
+      line: findLine(source, ".swipeActions") ?? findLine(source, "List"),
+      message:
+        "This SwiftUI view still uses List to host swipe actions; WWDC26 lets custom containers own swipe actions directly.",
+      suggestion:
+        "If the UI wants a custom ScrollView, LazyVStack, grid, or card layout, move the rows into that container, add .swipeActionsContainer() to the scrollable parent, and pair .reorderable() with .reorderContainer(...) when drag ordering matters.",
     });
   }
 

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1550,6 +1550,57 @@ export default defineIntent({
 `,
 };
 
+const swiftuiReorderableSwipeContainer: IntentTemplate = {
+  id: "swiftui-reorderable-swipe-container",
+  name: "swiftui-reorderable-swipe-container",
+  title: "SwiftUI Reorderable Swipe Container",
+  domain: "developer-tools",
+  category: "swiftui",
+  description:
+    "Scaffold a proof intent with WWDC26 SwiftUI notes for reorderable custom containers and swipe actions outside List.",
+  source: `import { defineIntent, param } from "@axint/compiler";
+
+export default defineIntent({
+  name: "ManageQueue",
+  title: "Manage Queue",
+  description: "Records the SwiftUI proof plan for a custom reorderable queue with swipe actions.",
+  domain: "developer-tools",
+  params: {
+    collectionName: param.string("Name of the collection being reordered"),
+    itemCount: param.int("Number of visible items", { default: 5 }),
+  },
+  perform: async ({ collectionName, itemCount }) => {
+    // SwiftUI implementation hint:
+    // struct QueueView: View {
+    //   @State private var items: [QueueItem]
+    //
+    //   var body: some View {
+    //     ScrollView {
+    //       LazyVStack(spacing: 8) {
+    //         ForEach(items) { item in
+    //           QueueRow(item: item)
+    //             .swipeActions {
+    //               Button("Archive", role: .destructive) { archive(item) }
+    //             }
+    //         }
+    //         .reorderable()
+    //       }
+    //     }
+    //     .swipeActionsContainer()
+    //     .reorderContainer(for: QueueItem.self) { difference in
+    //       difference.apply(to: &items)
+    //     }
+    //   }
+    // }
+    //
+    // Proof: attach a UI test that drags two rows, performs one swipe action,
+    // and records the before/after order plus the archived item identifier.
+    return { collectionName, itemCount };
+  },
+});
+`,
+};
+
 const foundationModelsCustomProvider: IntentTemplate = {
   id: "foundation-models-custom-provider",
   name: "foundation-models-custom-provider",
@@ -1666,6 +1717,18 @@ export default defineIntent({
     ],
   },
   perform: async ({ goal }) => {
+    // Swift implementation hint:
+    // import FoundationModels
+    // let selectedProfile = goal.contains("week") ? "weeklyPlan" : "quickTips"
+    // let profileSwitchProof = "selectedProfile=\\(selectedProfile)"
+    // let session = LanguageModelSession(
+    //   tools: [WorkoutHistoryTool()],
+    //   profile: DynamicProfile(selectedProfile),
+    //   instructions: "Use the selected profile's tools and instruction scope."
+    // )
+    // let response = try await session.respond(to: Prompt(goal))
+    // let transcript = session.transcript
+    // Persist selectedProfile, profileSwitchProof, transcript metadata, and tool-call counts.
     return { goal };
   },
 });
@@ -1721,6 +1784,7 @@ export const TEMPLATES: IntentTemplate[] = [
   barcodeVisionTool,
   stringCatalogLocalizer,
   resizableLayoutProof,
+  swiftuiReorderableSwipeContainer,
   foundationModelsCustomProvider,
   appIntentsTestingXctestHarness,
   dynamicProfileSession,

--- a/tests/cloud/check.test.ts
+++ b/tests/cloud/check.test.ts
@@ -253,6 +253,37 @@ struct DeleteSharedMessageIntent: AppIntent, LongRunningIntent {
     );
   });
 
+  it("suggests WWDC26 SwiftUI swipeActionsContainer modernization", () => {
+    const report = runCloudCheck({
+      fileName: "QueueView.swift",
+      source: `
+import SwiftUI
+
+struct QueueView: View {
+    @State private var items: [QueueItem]
+
+    var body: some View {
+        List {
+            ForEach(items) { item in
+                QueueRow(item: item)
+                    .swipeActions {
+                        Button("Archive") {}
+                    }
+            }
+            .onMove { from, to in
+                items.move(fromOffsets: from, toOffset: to)
+            }
+        }
+    }
+}
+`,
+    });
+
+    const codes = report.diagnostics.map((d) => d.code);
+    expect(codes).toContain("AXCLOUD-WWDC26-SWIFTUI-SWIPE-CONTAINER");
+    expect(renderCloudCheckReport(report, "markdown")).toContain("swipeActionsContainer");
+  });
+
   it("asks evaluation suites for scenario proof", () => {
     const report = runCloudCheck({
       fileName: "MessageSummaryEvaluations.swift",

--- a/tests/templates/index.test.ts
+++ b/tests/templates/index.test.ts
@@ -53,6 +53,32 @@ describe("templates registry", () => {
     expect(t?.source).toContain("redactSensitiveFields");
   });
 
+  it("ships a SwiftUI reorderable swipe container template", () => {
+    const t = getTemplate("swiftui-reorderable-swipe-container");
+
+    expect(t?.category).toBe("swiftui");
+    expect(t?.source).toContain("reorderable()");
+    expect(t?.source).toContain("reorderContainer");
+    expect(t?.source).toContain("swipeActionsContainer");
+    expect(t?.source).toContain("LazyVStack");
+    expect(t?.source).toContain("apply(to: &items)");
+
+    const result = compileSource(t!.source, "swiftui-reorderable-swipe-container.ts");
+    expect(result.success).toBe(true);
+    expect(result.output?.swiftCode).toContain("struct ManageQueueIntent");
+  });
+
+  it("Dynamic Profile template includes profile switching and transcript proof cues", () => {
+    const t = getTemplate("dynamic-profile-session");
+
+    expect(t?.source).toContain("DynamicProfile");
+    expect(t?.source).toContain("LanguageModelSession");
+    expect(t?.source).toContain("selectedProfile");
+    expect(t?.source).toContain("profileSwitchProof");
+    expect(t?.source).toContain("session.transcript");
+    expect(t?.source).toContain("tools:");
+  });
+
   it("listTemplates() returns every template when no category is given", () => {
     expect(listTemplates().length).toBe(TEMPLATES.length);
   });


### PR DESCRIPTION
## Summary
- Add a compile-backed SwiftUI template for custom reorderable/swipe-action containers.
- Add a Cloud Check diagnostic for SwiftUI views that still use List primarily to host swipe actions.
- Strengthen the Dynamic Profile template with selected-profile, transcript, and tool-call proof cues.
- Refresh metrics, README proof counts, release notes, changelog, and lockfile root metadata.

## Validation
- npm test
- npm run typecheck
- npm run lint
- npm run build
- npm run typecheck:examples
- npm run boundary:check
- npm run versions:check
- npm run gen:swift-fixer:check
- npm run metrics:check
- npm run docs:check
- npm audit --audit-level=moderate
- python3 -m pytest python/tests

## Notes
This branch only touches the public Axint compiler repo. Private website, Cloud, and Registry surfaces are untouched.