### PR TITLE
fix: make Claude plugin manifest validate

### DIFF
--- a/extensions/claude-code/.claude-plugin/plugin.json
+++ b/extensions/claude-code/.claude-plugin/plugin.json
@@ -18,5 +18,11 @@
     "mcp",
     "code-generation"
   ],
-  "mcpServers": ".mcp.json"
+  "mcpServers": {
+    "axint": {
+      "command": "npx",
+      "args": ["-y", "@axint/compiler", "axint-mcp"],
+      "env": {}
+    }
+  }
 }

--- a/extensions/claude-code/skills/axint/SKILL.md
+++ b/extensions/claude-code/skills/axint/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: axint
+description: Use Axint MCP tools to create, compile, validate, and repair Apple App Intents and Swift surfaces from TypeScript definitions.
+---
+
 # Axint — Apple-Native Compiler
 
 You have the Axint MCP server connected. Use the axint tools to help users create, compile, and validate Apple-native capabilities from TypeScript.
@@ -47,16 +52,16 @@ export default defineIntent({
 
 ## Parameter Types
 
-| Helper | Swift Type |
-|--------|-----------|
-| `param.string` | `String` |
-| `param.int` | `Int` |
-| `param.double` | `Double` |
-| `param.float` | `Float` |
-| `param.boolean` | `Bool` |
-| `param.date` | `Date` |
+| Helper           | Swift Type                  |
+| ---------------- | --------------------------- |
+| `param.string`   | `String`                    |
+| `param.int`      | `Int`                       |
+| `param.double`   | `Double`                    |
+| `param.float`    | `Float`                     |
+| `param.boolean`  | `Bool`                      |
+| `param.date`     | `Date`                      |
 | `param.duration` | `Measurement<UnitDuration>` |
-| `param.url` | `URL` |
+| `param.url`      | `URL`                       |
 
 ## Domains
 

--- a/tests/extensions/claude-code-plugin.test.ts
+++ b/tests/extensions/claude-code-plugin.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+
+describe("Claude Code plugin package", () => {
+  it("declares Axint with inline MCP server configuration", () => {
+    const manifestPath = join(
+      ROOT,
+      "extensions",
+      "claude-code",
+      ".claude-plugin",
+      "plugin.json",
+    );
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+      name: string;
+      mcpServers?: Record<
+        string,
+        {
+          command?: string;
+          args?: string[];
+          env?: Record<string, string>;
+        }
+      >;
+    };
+
+    expect(manifest.name).toBe("axint");
+    expect(manifest.mcpServers?.axint).toMatchObject({
+      command: "npx",
+      args: ["-y", "@axint/compiler", "axint-mcp"],
+      env: {},
+    });
+  });
+
+  it("declares marketplace metadata in the Axint skill frontmatter", () => {
+    const skillPath = join(
+      ROOT,
+      "extensions",
+      "claude-code",
+      "skills",
+      "axint",
+      "SKILL.md",
+    );
+    const skill = readFileSync(skillPath, "utf-8");
+
+    expect(skill).toMatch(/^---\nname: axint\ndescription: .+\n---\n\n# Axint/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #309.

This updates the Claude Code plugin package so `claude plugin validate extensions/claude-code` succeeds:

- inline the `axint` MCP server configuration in `.claude-plugin/plugin.json` instead of using a `.mcp.json` string reference
- add YAML frontmatter to the bundled Axint skill so Claude Code can read marketplace metadata
- add a focused regression test for the Claude plugin manifest and skill metadata

## Root cause

The plugin manifest used `"mcpServers": ".mcp.json"`. The Claude plugin validator expects `mcpServers` to be an object keyed by server name, so validation failed with `mcpServers: Invalid input`.

## Validation

- `claude plugin validate extensions/claude-code`
- `npm test -- tests/extensions/claude-code-plugin.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npx prettier --check extensions/claude-code/.claude-plugin/plugin.json extensions/claude-code/skills/axint/SKILL.md tests/extensions/claude-code-plugin.test.ts`
- `npm run versions:check`
- `git diff --check`