### PR TITLE
fix: keep public session copy client-neutral

### DIFF
--- a/src/cli/session.ts
+++ b/src/cli/session.ts
@@ -9,7 +9,7 @@ import {
 export function registerSession(program: Command, version: string) {
   const session = program
     .command("session")
-    .description("Start and enforce an Axint agent session for Xcode/Codex work");
+    .description("Start and enforce an Axint agent session for Apple project work");
 
   session
     .command("start")


### PR DESCRIPTION
Removes the remaining named-client reference from the top-level session help while preserving compatibility behavior.