### PR TITLE
Stabilize proof integration tests in release CI

### DIFF
--- a/tests/proof/prove.test.ts
+++ b/tests/proof/prove.test.ts
@@ -50,7 +50,7 @@ function installRepairAwareXcodebuild(dir: string): string {
   return bin;
 }
 
-describe.sequential("Axint proof platform", () => {
+describe.sequential("Axint proof platform", { timeout: 20_000 }, () => {
   let previousHome: string | undefined;
   let previousPath: string | undefined;
 


### PR DESCRIPTION
Declares a 20-second timeout for the proof integration suite, which creates temporary projects, cryptographic identities, signed receipts, and feedback artifacts. This removes release-runner flakiness without changing production behavior. The focused suite passes with one worker.