### PR TITLE
chore: defer unsupported TypeScript major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,12 @@ updates:
       - "javascript"
     commit-message:
       prefix: "deps"
+    # typescript-eslint 8 currently declares TypeScript support below 6.1.
+    # Keep receiving 6.x updates without reopening an uninstallable 7.x group.
+    ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
     groups:
       javascript-runtime:
         patterns:


### PR DESCRIPTION
## Summary

- keep supported TypeScript 6 updates enabled
- defer TypeScript 7 until the lint toolchain declares compatibility
- prevent the known `npm ci` peer-resolution failure from reopening as a grouped update

## Verification

- parsed `.github/dependabot.yml` with the repository's YAML parser
- ran `git diff --check`