### PR TITLE
Fix public license and MCP Registry metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - run: npm ci
       - run: npm audit --audit-level=moderate
       - run: npm run versions:check
+      - run: npm run mcp:registry:check
       - run: npm run metrics:check
       - run: npm run benchmark:brownfield:check
       - run: npm run docs:check
@@ -94,6 +95,7 @@ jobs:
       - run: npm ci
       - run: npm audit --audit-level=moderate
       - run: npm run versions:check
+      - run: npm run mcp:registry:check
       - run: npm run typecheck
       - run: npm run build
       - run: npm run package:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
+      - run: npm run versions:check
+      - run: npm run mcp:registry:check
       - run: npm run typecheck
       - run: npm run lint
       - run: npm run build

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -48,7 +49,7 @@
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
+      submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent
@@ -60,7 +61,7 @@
       designated in writing by the copyright owner as "Not a Contribution."
 
       "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by the Licensor and
+      on behalf of whom a Contribution has been received by Licensor and
       subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
@@ -106,7 +107,7 @@
       (d) If the Work includes a "NOTICE" text file as part of its
           distribution, then any Derivative Works that You distribute must
           include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding any notices that do not
+          within such NOTICE file, excluding those notices that do not
           pertain to any part of the Derivative Works, in at least one
           of the following places: within a NOTICE text file distributed
           as part of the Derivative Works; within the Source form or
@@ -175,7 +176,18 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2025-2026 Agentic Empire
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "gen:swift-fixer:check": "tsx scripts/gen-swift-fixer.ts --check",
     "versions:sync": "node scripts/sync-versions.mjs",
     "versions:check": "node scripts/check-versions.mjs",
+    "mcp:registry:check": "node scripts/check-mcp-registry-manifest.mjs",
     "release:check": "node scripts/check-release-parity.mjs",
     "release:notes": "tsx scripts/render-release-notes.ts",
     "install:gauntlet": "node scripts/install-gauntlet.mjs",
@@ -97,9 +98,9 @@
     "boundary:check": "node scripts/check-public-boundary.mjs",
     "docs:check": "node scripts/check-readme-mcp-docs.mjs && node scripts/sync-roadmap-metrics.mjs --check && node scripts/check-public-docs.mjs && node scripts/check-local-links.mjs",
     "roadmap:sync": "node scripts/sync-roadmap-metrics.mjs",
-    "quality:local": "npm run versions:check && npm run metrics:check && npm run benchmark:brownfield:check && npm run docs:check && npm run boundary:check && npm run gen:swift-fixer:check && npm run typecheck && npm run typecheck:examples && npm run lint && npm run build && npm run package:check && npm test && npm audit --audit-level=moderate",
+    "quality:local": "npm run versions:check && npm run mcp:registry:check && npm run metrics:check && npm run benchmark:brownfield:check && npm run docs:check && npm run boundary:check && npm run gen:swift-fixer:check && npm run typecheck && npm run typecheck:examples && npm run lint && npm run build && npm run package:check && npm test && npm audit --audit-level=moderate",
     "quality:production": "npm run quality:local && npm run install:gauntlet && npm run mcp:production:check",
-    "prepublishOnly": "npm run versions:check && npm run metrics:check && npm run docs:check && npm run clean && npm run build",
+    "prepublishOnly": "npm run versions:check && npm run mcp:registry:check && npm run metrics:check && npm run docs:check && npm run clean && npm run build",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/scripts/check-mcp-registry-manifest.mjs
+++ b/scripts/check-mcp-registry-manifest.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const manifest = readJson("server.json");
+const pkg = readJson("package.json");
+const errors = [];
+
+requireExact(
+  manifest.$schema,
+  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "server.json $schema"
+);
+requireExact(manifest.name, pkg.mcpName, "server.json name");
+requireNonEmpty(manifest.title, "server.json title");
+requireNonEmpty(manifest.description, "server.json description");
+requireExact(manifest.version, pkg.version, "server.json version");
+
+if (typeof manifest.description === "string" && manifest.description.length > 100) {
+  errors.push(
+    `server.json description is ${manifest.description.length} characters; the MCP Registry limit is 100`
+  );
+}
+
+const expectedPackages = new Map([
+  ["npm", { identifier: pkg.name, version: pkg.version }],
+  ["pypi", { identifier: "axint", version: pkg.version }],
+]);
+
+for (const [registryType, expected] of expectedPackages) {
+  const entry = manifest.packages?.find(
+    (candidate) => candidate.registryType === registryType
+  );
+  if (!entry) {
+    errors.push(`server.json packages is missing ${registryType}`);
+    continue;
+  }
+  requireExact(
+    entry.identifier,
+    expected.identifier,
+    `server.json ${registryType} identifier`
+  );
+  requireExact(entry.version, expected.version, `server.json ${registryType} version`);
+  requireExact(entry.transport?.type, "stdio", `server.json ${registryType} transport`);
+}
+
+const hosted = manifest.remotes?.find(
+  (remote) =>
+    remote.type === "streamable-http" && remote.url === "https://mcp.axint.ai/mcp"
+);
+if (!hosted) {
+  errors.push("server.json remotes must include the production streamable-http endpoint");
+}
+
+for (const capability of ["tools", "prompts"]) {
+  const value = manifest.capabilities?.[capability];
+  if (!Number.isInteger(value) || value < 1) {
+    errors.push(`server.json capabilities.${capability} must be a positive integer`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error("MCP Registry manifest check failed:\n");
+  for (const error of errors) console.error(`  - ${error}`);
+  process.exit(1);
+}
+
+console.log(
+  [
+    "MCP Registry manifest verified",
+    `version=${manifest.version}`,
+    `description=${manifest.description.length}/100 characters`,
+    `packages=${manifest.packages.length}`,
+    `tools=${manifest.capabilities.tools}`,
+    `prompts=${manifest.capabilities.prompts}`,
+  ].join(" · ")
+);
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(resolve(ROOT, relativePath), "utf8"));
+}
+
+function requireNonEmpty(value, label) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    errors.push(`${label} must be a non-empty string`);
+  }
+}
+
+function requireExact(actual, expected, label) {
+  if (actual !== expected) {
+    errors.push(
+      `${label} is ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`
+    );
+  }
+}

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.agenticempire/axint",
   "title": "Axint",
-  "description": "Proof and repair for Apple coding agents through MCP: validate Swift, run Xcode evidence, repair failures, and generate inspectable Apple-native capabilities.",
+  "description": "Proof and repair for Apple coding agents: validate Swift, run Xcode evidence, and repair failures.",
   "repository": {
     "url": "https://github.com/agenticempire/axint",
     "source": "github"

--- a/tests/mcp/http-transport.test.ts
+++ b/tests/mcp/http-transport.test.ts
@@ -8,6 +8,9 @@ import { PROMPT_MANIFEST } from "../../src/mcp/prompts.js";
 const packageVersion = JSON.parse(
   readFileSync(resolve(process.cwd(), "package.json"), "utf-8")
 ).version as string;
+const registryManifest = JSON.parse(
+  readFileSync(resolve(process.cwd(), "server.json"), "utf-8")
+) as { description: string };
 
 const env = {
   ALLOWED_ORIGINS: "https://axint.ai",
@@ -70,12 +73,14 @@ describe("axint HTTP MCP transport", () => {
       expect(response.status).toBe(200);
       expect(payload).toMatchObject({
         name: "io.github.agenticempire/axint",
+        description: registryManifest.description,
         version: packageVersion,
         capabilities: {
           tools: TOOL_MANIFEST.length,
           prompts: PROMPT_MANIFEST.length,
         },
       });
+      expect(payload.description.length).toBeLessThanOrEqual(100);
     }
   });
 

--- a/workers/mcp-http/src/worker.ts
+++ b/workers/mcp-http/src/worker.ts
@@ -86,7 +86,7 @@ const SERVER_CARD = {
   name: "io.github.agenticempire/axint",
   title: "Axint",
   description:
-    "Compiler and repair loop for agent-built Apple-native software: App Intents, SwiftUI, WidgetKit, Cloud Check, Fix Packets, and Xcode agent workflow tools.",
+    "Proof and repair for Apple coding agents: validate Swift, run Xcode evidence, and repair failures.",
   repository: {
     url: "https://github.com/agenticempire/axint",
     source: "github",


### PR DESCRIPTION
## Summary
- restore the canonical Apache License 2.0 text so GitHub and downstream scanners can identify the repository license
- retain Axint attribution and trademark terms in the existing `NOTICE` and `TRADEMARKS.md` files
- bring the official MCP Registry manifest under its 100-character description limit
- add a release guard so an invalid Registry description cannot reach a tag again

## Verification
- canonical Apache text comparison
- `npm run package:check`
- `npm run docs:check`
- `npm run versions:check`
- `git diff --check`