### PR TITLE
Fix MCP worker clean deployment

### DIFF
--- a/workers/mcp-http/package-lock.json
+++ b/workers/mcp-http/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "axint-mcp-worker",
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260716.1",
+        "@cloudflare/workers-types": "5.20260717.1",
         "@types/node": "^26.0.0",
         "typescript": "^6.0.3",
         "wrangler": "^4.111.0"
@@ -122,6 +122,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260717.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260717.1.tgz",
+      "integrity": "sha512-En+uoU8kbQoUcJMAPOQU+3hyQ4INEpiPO04GIyuh5b0Q5+uPB6az+icvkl+SoSzN3gbQFHZACpShRY+AK3zD1Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/workers/mcp-http/package.json
+++ b/workers/mcp-http/package.json
@@ -9,7 +9,7 @@
     "deploy": "wrangler deploy"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260716.1",
+    "@cloudflare/workers-types": "5.20260717.1",
     "@types/node": "^26.0.0",
     "typescript": "^6.0.3",
     "wrangler": "^4.111.0"


### PR DESCRIPTION
## Summary
- replace the unpublished `@cloudflare/workers-types` range with the current published release
- restore a complete lockfile entry so `npm ci` succeeds on clean GitHub runners
- keep the worker type package aligned with Wrangler 4.111 peer requirements

## Verification
- `npm ci` in `workers/mcp-http`
- `npm audit --audit-level=moderate` in `workers/mcp-http`
- `npm run typecheck` in `workers/mcp-http`
- `npx wrangler deploy --dry-run` in `workers/mcp-http`
- `npm run quality:local`
- `node scripts/check-mcp-production.mjs`

The protected `mcp-production` environment now also has the least-privilege Cloudflare credential required by the deployment workflow.