### PR TITLE
Add secure A2A proof and repair server

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,6 +154,29 @@ so a caller can reconnect, inspect, or cancel without keeping the original
 request alive. Full logs remain on disk; MCP responses carry summaries and
 artifact references.
 
+## A2A boundary
+
+The A2A adapter exposes complete Apple check, diagnosis, proof, and
+repair-planning jobs to other agents. It is additive to MCP: MCP remains the
+fine-grained tool surface, while A2A owns durable task identity, streaming
+status, cancellation, owner-scoped persistence, and result artifacts.
+
+`src/a2a/` contains five explicit boundaries:
+
+1. Request parsing validates the structured contract and confines every local
+   path to the operator-selected project root.
+2. The service adapter calls existing cloud-check, repair, run, and proof
+   services without introducing a second implementation of product logic.
+3. Result shaping excludes source, raw logs, and absolute paths before an
+   artifact reaches the protocol layer.
+4. The task store scopes durable JSON by tenant and authenticated caller.
+5. The Express transport owns Agent Card discovery, bearer authentication,
+   body limits, rate limits, security headers, and A2A version negotiation.
+
+Cancellation reaches the existing Xcode runner through `AbortSignal` and stops
+the child process group. Automatic fixes, repository cloning, outbound agent
+delegation, and push notifications are intentionally outside this boundary.
+
 ## Distribution boundary
 
 The public repository ships the open-source compiler, TypeScript and Python
@@ -171,6 +194,7 @@ src/run/                  Resumable project jobs and Xcode evidence
 src/repair/               Fix Packets and project repair plans
 src/feedback/             Source-free finding review and feedback
 src/mcp/                  MCP server, manifest, and transports
+src/a2a/                  A2A Agent Card, task adapter, persistence, and HTTP transport
 src/cli/                  Command-line entry points
 python/axint/             Native Python parser, IR, validator, generator, MCP
 spm-plugin/               Xcode build and validation plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ This project follows [Semantic Versioning](https://semver.org/) and the format i
 
 ## [Unreleased]
 
+### Added
+
+- **A2A proof and repair server** - added a discoverable A2A Agent Card and an
+  authenticated JSON-RPC server for Apple code checks, failure diagnosis,
+  project proof, and repair planning, with streaming status and cancellation.
+- **Durable isolated tasks** - A2A task state is stored atomically and scoped by
+  both tenant and authenticated caller, while original input content is omitted
+  from durable history.
+
+### Changed
+
+- **Cancelable Xcode execution** - proof cancellation now propagates to active
+  build, test, and runtime child process groups through `AbortSignal`.
+- **Dependency security floors** - refreshed npm and pnpm resolution policy for
+  patched transitive releases; the npm audit reports zero known vulnerabilities.
+
 ## [0.6.0] — 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ identify leads; Xcode build and test output can confirm, contextualize, or
 suppress them. The result stays compact enough for the next agent turn while
 full logs and artifacts remain on disk.
 
-| Evidence class | What it means |
-| --- | --- |
-| **Confirmed** | Deterministic analysis or matching compiler, build, or test evidence supports the finding. |
-| **Probable** | Strong static evidence identifies a likely problem, but decisive Apple-tooling evidence is incomplete. |
-| **Advisory** | A heuristic identifies a quality, accessibility, privacy, interaction, design, or runtime concern for review. |
+| Evidence class | What it means                                                                                                               |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **Confirmed**  | Deterministic analysis or matching compiler, build, or test evidence supports the finding.                                  |
+| **Probable**   | Strong static evidence identifies a likely problem, but decisive Apple-tooling evidence is incomplete.                      |
+| **Advisory**   | A heuristic identifies a quality, accessibility, privacy, interaction, design, or runtime concern for review.               |
 | **Suppressed** | Stronger evidence or a project-local review contradicts the finding; it remains in the receipt without blocking the result. |
 
 ## Prove an existing project
@@ -101,13 +101,13 @@ signing key.
 Generate, Check, Run, Team, and Cloud are different entry points into the same
 contract: verdict, evidence, findings, next actions, and artifact paths.
 
-| Mode | Role in the proof loop |
-| --- | --- |
-| **Check** | Validate generated or existing Swift with evidence-aware diagnostics and appropriate abstention. |
-| **Run** | Orchestrate resumable build, test, runtime, and `.xcresult` evidence on a local or your own Mac runner. |
+| Mode         | Role in the proof loop                                                                                                            |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Check**    | Validate generated or existing Swift with evidence-aware diagnostics and appropriate abstention.                                  |
+| **Run**      | Orchestrate resumable build, test, runtime, and `.xcresult` evidence on a local or your own Mac runner.                           |
 | **Generate** | Compile smaller contracts into inspectable App Intents, SwiftUI views, widgets, Live Activities, app shells, metadata, and tests. |
-| **Team** | Preserve project context, sessions, file claims, repair packets, and handoffs across agents. |
-| **Cloud** | Run hosted checks and preserve shared proof history when local Apple tooling is unavailable. |
+| **Team**     | Preserve project context, sessions, file claims, repair packets, and handoffs across agents.                                      |
+| **Cloud**    | Run hosted checks and preserve shared proof history when local Apple tooling is unavailable.                                      |
 
 ## Generate when it helps
 
@@ -169,6 +169,19 @@ clients and the current stateless protocol generation. Compatibility is
 continuously checked with official SDK clients; see the
 [protocol compatibility contract](docs/MCP_2026_COMPATIBILITY.md).
 
+For orchestrators that delegate durable work between agents, Axint also ships
+an authenticated [A2A server](docs/A2A.md). MCP exposes individual tools; A2A
+exposes complete check, diagnosis, proof, and repair-planning tasks with status,
+streaming updates, cancellation, and source-free result artifacts.
+
+```bash
+npx -y -p @axint/compiler axint-a2a --project-root /path/to/MyApp
+```
+
+The Agent Card is served at `/.well-known/agent-card.json`. Loopback use works
+without setup; non-loopback deployments require bearer authentication by
+default.
+
 <details>
 <summary><strong>MCP tool and prompt inventory</strong></summary>
 
@@ -215,20 +228,22 @@ continuously checked with official SDK clients; see the
   accessibility evidence into a reviewable App Store readiness report.
 - [MCP compatibility](docs/MCP_2026_COMPATIBILITY.md) documents the hosted
   server's dual-era transport contract and verification path.
-- [Architecture](ARCHITECTURE.md) explains the compiler, proof, MCP, Python, and runtime boundaries.
+- [A2A](docs/A2A.md) documents durable agent-to-agent proof delegation,
+  authentication, task isolation, and the local execution boundary.
+- [Architecture](ARCHITECTURE.md) explains the compiler, proof, MCP, A2A, Python, and runtime boundaries.
 - [Release notes](docs/RELEASE_NOTES.md) record shipped behavior and compatibility changes.
 - [Security](SECURITY.md) documents reporting, supported releases, telemetry, and dependency policy.
 
 ## Ecosystem
 
-| Surface | Use it for |
-| --- | --- |
-| [npm](https://www.npmjs.com/package/@axint/compiler) | CLI, TypeScript SDK, compiler, proof runtime, and MCP server |
-| [PyPI](https://pypi.org/project/axint/) | Native Python authoring, validation, generation, and its focused MCP surface |
-| [Cloud Preview](https://axint.ai/cloud/preview) | Explore the remote proof and macOS build workflow from any operating system |
-| [Registry](https://registry.axint.ai) | Discover reusable Apple capability packages |
-| [Examples](https://github.com/agenticempire/axint-examples) | Inspect compact App Intent, SwiftUI, and WidgetKit generation examples |
-| [Editor integrations](extensions) | Connect Xcode, VS Code, Cursor, JetBrains, Neovim, and other hosts |
+| Surface                                                     | Use it for                                                                   |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| [npm](https://www.npmjs.com/package/@axint/compiler)        | CLI, TypeScript SDK, compiler, proof runtime, MCP server, and A2A server     |
+| [PyPI](https://pypi.org/project/axint/)                     | Native Python authoring, validation, generation, and its focused MCP surface |
+| [Cloud Preview](https://axint.ai/cloud/preview)             | Explore the remote proof and macOS build workflow from any operating system  |
+| [Registry](https://registry.axint.ai)                       | Discover reusable Apple capability packages                                  |
+| [Examples](https://github.com/agenticempire/axint-examples) | Inspect compact App Intent, SwiftUI, and WidgetKit generation examples       |
+| [Editor integrations](extensions)                           | Connect Xcode, VS Code, Cursor, JetBrains, Neovim, and other hosts           |
 
 ## Contribute
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ _Last updated: July 2026 · Current release: <!-- metrics:roadmap-release:start 
 
 Axint is the proof and repair layer for Apple coding agents. It checks the Swift an agent wrote, runs real Xcode build and test evidence, reconciles static findings with Apple tooling, and returns signed proof with the exact repairs to make next. The compiler, SDKs, MCP server, Registry, Team features, and Cloud all support that shared proof contract.
 
-<!-- metrics:roadmap-snapshot:start -->Current verified snapshot: 36 MCP tools + 5 prompts · 53 templates · 235 diagnostic codes · 1512 tests.<!-- metrics:roadmap-snapshot:end -->
+<!-- metrics:roadmap-snapshot:start -->Current verified snapshot: 36 MCP tools + 5 prompts · 53 templates · 235 diagnostic codes · 1519 tests.<!-- metrics:roadmap-snapshot:end -->
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,23 @@ axint feedback opt-out
 
 Environment controls are also supported: `AXINT_TELEMETRY=off`, `AXINT_DISABLE_TELEMETRY=1`, `AXINT_FEEDBACK=off`, and `AXINT_DISABLE_FEEDBACK=1`.
 
+## A2A deployment security
+
+The packaged A2A server binds to loopback by default. Non-loopback deployments
+must configure named bearer tokens through `AXINT_A2A_TOKENS` unless the
+operator explicitly overrides the guard. Production deployments should use a
+TLS reverse proxy, unique tokens per caller, the narrowest possible
+`--project-root`, and encrypted operator-only storage for A2A state.
+
+A2A project and source paths are confined to the configured root after
+symbolic-link resolution. Request bodies, inline source, failure evidence, raw
+logs, authorization headers, and absolute paths are not persisted in task
+history or returned in result artifacts. Full proof logs remain only in the
+operator-controlled A2A state directory and can contain paths and command
+output. Durable tasks are scoped by both tenant and authenticated token
+identity. See [docs/A2A.md](docs/A2A.md) for the full operation and
+threat-boundary checklist.
+
 ## Dependency and audit policy
 
 - Dependabot version updates are configured in `.github/dependabot.yml` for npm,
@@ -58,7 +75,7 @@ Environment controls are also supported: `AXINT_TELEMETRY=off`, `AXINT_DISABLE_T
   post-deploy protocol verification. Release CI also requires the hosted
   runtime to report the package version being published.
 - The npm package manifest is checked before publication for required
-  executables and declarations, unexpected development files, sensitive file
+  executables and declarations, including A2A, unexpected development files, sensitive file
   patterns, and accidental size growth.
 - If an advisory must be temporarily tolerated, document the rationale in a
   visible pull request or follow-up issue instead of masking the audit step.

--- a/docs/A2A.md
+++ b/docs/A2A.md
@@ -1,0 +1,135 @@
+# Axint A2A
+
+Axint exposes its Apple proof and repair loop as an A2A agent. An orchestrator
+can delegate a complete check or Xcode proof, observe task progress, cancel the
+underlying work, reconnect later, and retrieve compact result artifacts.
+
+Use MCP when a host needs individual Axint tools inside one agent session. Use
+A2A when one agent or workflow engine needs to delegate a durable job to Axint.
+Both transports call the same check, repair, run, and proof services.
+
+## Start locally
+
+```bash
+npx -y -p @axint/compiler axint-a2a --project-root /path/to/MyApp
+```
+
+The default server listens on `127.0.0.1:41242` and advertises:
+
+- Agent Card: `http://127.0.0.1:41242/.well-known/agent-card.json`
+- JSON-RPC endpoint: `http://127.0.0.1:41242/a2a`
+- Health check: `http://127.0.0.1:41242/healthz`
+
+Loopback is unauthenticated unless tokens are configured. For shared or remote
+access, configure one or more named bearer tokens:
+
+```bash
+export AXINT_A2A_SECRET="$(openssl rand -hex 32)"
+export AXINT_A2A_TOKENS="local=$AXINT_A2A_SECRET"
+axint-a2a \
+  --host 0.0.0.0 \
+  --public-url https://proof.example.com \
+  --project-root /srv/apple-projects
+```
+
+Terminate TLS at a trusted reverse proxy and forward only the A2A endpoint,
+Agent Card, and health route. Axint refuses unauthenticated non-loopback access
+unless the operator passes `--allow-unauthenticated` explicitly.
+
+## Skills
+
+| Skill                    | Result                                                                                                |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `check_apple_code`       | Compiler-grounded static findings, confidence, coverage, and the evidence still needed.               |
+| `diagnose_apple_failure` | Ranked hypotheses for build, test, runtime, interaction, and Apple-platform failures.                 |
+| `prove_apple_project`    | Local Xcode build/test evidence and a signed, source-free proof receipt.                              |
+| `plan_apple_repair`      | Likely causes, files to inspect, evidence to collect, and an exact proof plan without source changes. |
+
+All four skills complete with a domain verdict of `pass`, `needs_review`, or
+`fail`. A failed Xcode build is a valid completed A2A task with a `fail` result;
+the A2A task itself enters `failed` only when Axint cannot execute the request.
+
+## Request contract
+
+Structured data is preferred:
+
+```json
+{
+  "schema": "https://axint.ai/schemas/a2a-request.v1.json",
+  "skill": "prove_apple_project",
+  "input": {
+    "projectPath": ".",
+    "scheme": "MyApp",
+    "platform": "iOS",
+    "timeoutSeconds": 900
+  }
+}
+```
+
+Send the object as an A2A message data part with media type
+`application/vnd.axint.a2a-request+json`. Axint also accepts a JSON object in a
+text part and four compact local commands: `check <path>`, `diagnose <issue>`,
+`prove <path>`, and `repair <issue>`.
+
+Common input fields:
+
+| Field                                                                        | Meaning                                                                                        |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `projectPath`                                                                | Project directory beneath the configured project root.                                         |
+| `sourcePath`                                                                 | Existing source file beneath the selected project directory.                                   |
+| `source` / `fileName`                                                        | Optional inline source and its display name. Inline source is never persisted in task history. |
+| `issue`                                                                      | Failure or repair objective.                                                                   |
+| `xcodeBuildLog`, `testFailure`, `runtimeFailure`                             | Bounded evidence consumed for diagnosis and omitted from durable task history.                 |
+| `workspace`, `project`, `scheme`, `destination`, `configuration`, `testPlan` | Xcode selection controls. Paths remain confined to the project directory.                      |
+| `skipBuild`, `skipTests`, `runtime`, `timeoutSeconds`                        | Proof execution controls. Automatic fixes are intentionally unavailable over A2A.              |
+
+Input and evidence sizes are bounded. Paths are resolved through the local file
+system and must stay within `--project-root`, including after symbolic-link
+resolution. Repository URLs, outbound delegation, automatic source edits, and
+push-notification webhooks are not part of this initial server surface.
+
+## Results and task lifecycle
+
+The result artifact contains both structured JSON and Markdown. It excludes
+input source, raw command logs, and absolute local paths. The signed proof
+receipt preserves command outcomes, evidence steps, environment facts, hashes,
+and diagnostics under the same source-free receipt contract used by the CLI.
+
+Full local proof reports, `.xcresult` bundles, and command logs remain beneath
+the operator-controlled A2A state directory so failures can be investigated.
+Those local files can contain absolute project paths and command output; they
+are not embedded in task history or sent in the A2A result artifact.
+
+Task states follow the protocol lifecycle:
+
+```text
+submitted -> working -> completed
+                     -> failed
+                     -> canceled
+submitted -> input-required
+submitted -> rejected
+```
+
+Long-running proof calls support streaming updates and protocol cancellation.
+Cancellation propagates through Axint's proof runner to the active Xcode child
+process group. Durable task JSON lives under `~/.axint/a2a` by default, scoped
+by both tenant and authenticated token identity. Original input content is not
+written into task history.
+
+## Platform boundary
+
+Static checking and repair planning can run wherever the JavaScript package and
+the relevant Swift toolchain run. Xcode build, simulator, test, `.xcresult`, and
+runtime proof still require macOS with Xcode. A Linux or Windows orchestrator
+can call an Axint A2A server running on a Mac; this transport does not emulate
+Apple's toolchain on a non-Apple host.
+
+## Production checklist
+
+1. Run behind HTTPS and do not publish the plain HTTP port directly.
+2. Set unique, randomly generated bearer tokens for each caller or trust domain.
+3. Set `--project-root` to the smallest directory the server needs.
+4. Keep the state directory on encrypted storage with operator-only permissions.
+5. Rotate tokens by adding the replacement, moving callers, then removing the old token.
+6. Apply reverse-proxy request, connection, and concurrency limits in addition to Axint's per-IP rate limit.
+7. Monitor `/healthz`, process exits, disk use, and Xcode runner capacity without logging authorization headers or request bodies.

--- a/metrics.json
+++ b/metrics.json
@@ -88,7 +88,7 @@
     "AX866"
   ],
   "tests": {
-    "typescript": 1392,
+    "typescript": 1399,
     "python": 120
   },
   "registryPackages": 60,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,22 @@
       "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@a2a-js/sdk": "1.0.1",
         "commander": "^15.0.0",
+        "express": "^5.1.0",
         "typescript": "^6.0.3"
       },
       "bin": {
         "axint": "dist/cli/index.js",
+        "axint-a2a": "dist/a2a/index.js",
         "axint-mcp": "dist/mcp/register.js",
         "axint-mcp-http": "dist/mcp/http.js",
         "create-axint-app": "dist/cli/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "@types/express": "^5.0.3",
         "@types/node": "^26.0.0",
         "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.2.1",
@@ -35,6 +39,44 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@a2a-js/sdk": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-1.0.1.tgz",
+      "integrity": "sha512-CJQdh3Wzwo8qIx5UUkSJ7+7BEI16PB+MXMHHNSmx8JQsQed2HlQgvx1ENOiKUfYA3PlcEvxIwv14dBblhDuPmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^6.2.3",
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "@grpc/grpc-js": "^1.11.0",
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        },
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@a2a-js/sdk/node_modules/jose": {
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.7.tgz",
+      "integrity": "sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -702,13 +744,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -844,6 +886,16 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.7.tgz",
+      "integrity": "sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1507,6 +1559,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1516,6 +1579,16 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -1539,6 +1612,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+      "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1554,6 +1659,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1934,7 +2074,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -2032,21 +2171,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
-      "dev": true,
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -2056,17 +2194,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/brace-expansion/node_modules/balanced-match": {
@@ -2099,7 +2250,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2119,7 +2269,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2133,7 +2282,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2202,7 +2350,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2216,7 +2363,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2233,7 +2379,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2243,7 +2388,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -2286,7 +2430,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2311,7 +2454,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2331,7 +2473,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2346,14 +2487,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2363,7 +2502,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2373,7 +2511,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2390,7 +2527,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2445,7 +2581,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -2654,7 +2789,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2697,7 +2831,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -2811,7 +2944,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -2883,7 +3015,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2893,7 +3024,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2918,7 +3048,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2928,7 +3057,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2953,7 +3081,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -2980,7 +3107,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3003,7 +3129,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3016,7 +3141,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3026,9 +3150,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3046,7 +3170,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -3083,7 +3206,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3120,7 +3242,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -3137,7 +3258,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -3170,7 +3290,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -3217,16 +3336,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {
@@ -3681,7 +3790,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3691,7 +3799,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3701,7 +3808,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3714,7 +3820,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3724,7 +3829,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -3770,7 +3874,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -3815,7 +3918,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3835,7 +3937,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3859,7 +3960,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -3872,7 +3972,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -3932,7 +4031,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3962,7 +4060,6 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4130,7 +4227,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -4154,7 +4250,6 @@
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
       "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4170,7 +4265,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4180,7 +4274,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -4299,7 +4392,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -4316,7 +4408,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -4336,7 +4427,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -4363,7 +4453,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -4383,7 +4472,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
@@ -4413,7 +4501,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4433,7 +4520,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4450,7 +4536,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4469,7 +4554,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4523,7 +4607,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4678,7 +4761,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -4818,18 +4900,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -4887,7 +4985,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4903,11 +5000,23 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5138,7 +5247,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "siri",
     "shortcuts",
     "ai-agents",
+    "a2a",
+    "agent2agent",
     "mcp",
     "code-generation",
     "model-context-protocol",
@@ -43,6 +45,7 @@
   "bin": {
     "axint": "dist/cli/index.js",
     "create-axint-app": "dist/cli/index.js",
+    "axint-a2a": "dist/a2a/index.js",
     "axint-mcp": "dist/mcp/register.js",
     "axint-mcp-http": "dist/mcp/http.js"
   },
@@ -60,6 +63,10 @@
     "./mcp": {
       "import": "./dist/mcp/index.js",
       "types": "./dist/mcp/index.d.ts"
+    },
+    "./a2a": {
+      "import": "./dist/a2a/index.js",
+      "types": "./dist/a2a/index.d.ts"
     }
   },
   "files": [
@@ -115,7 +122,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@types/express": "^5.0.3",
     "@types/node": "^26.0.0",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.2.1",
@@ -129,21 +137,21 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
+    "@a2a-js/sdk": "1.0.1",
     "commander": "^15.0.0",
+    "express": "^5.1.0",
     "typescript": "^6.0.3"
   },
   "overrides": {
+    "@hono/node-server": "2.0.12",
+    "body-parser": "2.3.0",
+    "brace-expansion": "5.0.9",
     "esbuild": "^0.28.1",
-    "hono": "^4.12.25",
+    "fast-uri@>=3.0.0 <3.1.5": "3.1.5",
+    "hono": "4.12.34",
     "ip-address": "^10.4.0",
+    "jose": "6.2.7",
+    "postcss": "8.5.25",
     "vite": "^8.1.5"
-  },
-  "pnpm": {
-    "overrides": {
-      "esbuild": "^0.28.1",
-      "hono": "^4.12.25",
-      "ip-address": "^10.4.0",
-      "vite": "^8.1.5"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,18 +5,30 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@hono/node-server': 2.0.12
+  body-parser: 2.3.0
+  brace-expansion: 5.0.9
   esbuild: ^0.28.1
-  hono: ^4.12.25
+  fast-uri@>=3.0.0 <3.1.5: 3.1.5
+  hono: 4.12.34
   ip-address: ^10.4.0
+  jose: 6.2.7
+  postcss: 8.5.25
   vite: ^8.1.5
 
 importers:
 
   .:
     dependencies:
+      '@a2a-js/sdk':
+        specifier: 1.0.1
+        version: 1.0.1(express@5.2.1)
       commander:
         specifier: ^15.0.0
         version: 15.0.0
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -25,8 +37,11 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.0)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.30.0(zod@4.3.6)
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.4.3)
+      '@types/express':
+        specifier: ^5.0.3
+        version: 5.0.6
       '@types/node':
         specifier: ^26.0.0
         version: 26.1.2
@@ -47,21 +62,36 @@ importers:
         version: 3.9.6
       tsup:
         specifier: ^8.5.0
-        version: 8.5.1(postcss@8.5.20)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.25)(tsx@4.23.5)(typescript@6.0.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.19.0
-        version: 4.23.1
+        version: 4.23.5
       typescript-eslint:
         specifier: ^8.64.0
         version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.5)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.5)(yaml@2.9.0))
 
 packages:
+
+  '@a2a-js/sdk@1.0.1':
+    resolution: {integrity: sha512-CJQdh3Wzwo8qIx5UUkSJ7+7BEI16PB+MXMHHNSmx8JQsQed2HlQgvx1ENOiKUfYA3PlcEvxIwv14dBblhDuPmw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.10.2
+      '@grpc/grpc-js': ^1.11.0
+      express: ^4.21.2 || ^5.1.0
+    peerDependenciesMeta:
+      '@bufbuild/protobuf':
+        optional: true
+      '@grpc/grpc-js':
+        optional: true
+      express:
+        optional: true
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
@@ -71,27 +101,27 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.7':
-    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/types@7.29.7':
-    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@emnapi/core@1.11.1':
-    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+  '@emnapi/core@2.0.0-alpha.3':
+    resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
 
-  '@emnapi/runtime@1.11.1':
-    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+  '@emnapi/runtime@2.0.0-alpha.3':
+    resolution: {integrity: sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==}
 
-  '@emnapi/wasi-threads@1.2.2':
-    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+  '@emnapi/wasi-threads@2.0.1':
+    resolution: {integrity: sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -292,7 +322,7 @@ packages:
     resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4.12.25
+      hono: 4.12.34
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -337,106 +367,113 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@napi-rs/wasm-runtime@1.1.6':
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/wasm-runtime@1.2.2':
+    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
-  '@oxc-project/types@0.139.0':
-    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
-  '@rolldown/binding-android-arm64@1.1.5':
-    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+  '@rolldown/binding-android-arm64@1.2.1':
+    resolution: {integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
-    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+  '@rolldown/binding-darwin-arm64@1.2.1':
+    resolution: {integrity: sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.5':
-    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+  '@rolldown/binding-darwin-x64@1.2.1':
+    resolution: {integrity: sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
-    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+  '@rolldown/binding-freebsd-x64@1.2.1':
+    resolution: {integrity: sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
-    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
+    resolution: {integrity: sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
-    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.1':
+    resolution: {integrity: sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
-    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+  '@rolldown/binding-linux-arm64-musl@1.2.1':
+    resolution: {integrity: sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
-    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.1':
+    resolution: {integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
-    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.1':
+    resolution: {integrity: sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
-    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+  '@rolldown/binding-linux-x64-gnu@1.2.1':
+    resolution: {integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.1.5':
-    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+  '@rolldown/binding-linux-x64-musl@1.2.1':
+    resolution: {integrity: sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.1.5':
-    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+  '@rolldown/binding-openharmony-arm64@1.2.1':
+    resolution: {integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.1.5':
-    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
+  '@rolldown/binding-wasm32-wasi@1.2.1':
+    resolution: {integrity: sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
-    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.1':
+    resolution: {integrity: sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
-    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+  '@rolldown/binding-win32-x64-msvc@1.2.1':
+    resolution: {integrity: sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -444,141 +481,141 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@rollup/rollup-android-arm-eabi@4.60.2':
-    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.60.2':
-    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.2':
-    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.2':
-    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.2':
-    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.60.2':
-    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
-    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
-    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.2':
-    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.2':
-    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.2':
-    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.60.2':
-    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
-    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.2':
-    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
-    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.2':
-    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.2':
-    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.2':
-    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.60.2':
-    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.2':
-    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.60.2':
-    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.2':
-    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.2':
-    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.2':
-    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.2':
-    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
     cpu: [x64]
     os: [win32]
 
@@ -588,8 +625,14 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -597,17 +640,35 @@ packages:
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/express-serve-static-core@5.1.3':
+    resolution: {integrity: sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
+
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
@@ -715,8 +776,8 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.17.0:
-    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -741,8 +802,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@1.0.4:
-    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -752,8 +813,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   bundle-require@5.1.0:
@@ -871,8 +932,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -947,8 +1008,8 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.6.1:
@@ -1001,8 +1062,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.4.3:
-    resolution: {integrity: sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==}
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1117,8 +1178,8 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
-  jose@6.2.8:
-    resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
+  jose@6.2.7:
+    resolution: {integrity: sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1246,8 +1307,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.5.3:
-    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -1273,8 +1334,8 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
 
   mlly@1.8.2:
@@ -1306,8 +1367,8 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  obug@2.1.3:
-    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
 
   on-finished@2.4.1:
@@ -1370,7 +1431,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: 8.5.25
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -1383,8 +1444,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.20:
-    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1428,13 +1489,13 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
-  rolldown@1.1.5:
-    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+  rolldown@1.2.1:
+    resolution: {integrity: sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup@4.60.2:
-    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -1503,8 +1564,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@4.1.0:
-    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -1532,24 +1593,16 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinyrainbow@3.1.0:
-    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
@@ -1579,7 +1632,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.12
+      postcss: 8.5.25
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -1591,8 +1644,8 @@ packages:
       typescript:
         optional: true
 
-  tsx@4.23.1:
-    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+  tsx@4.23.5:
+    resolution: {integrity: sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -1616,8 +1669,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@1.6.3:
-    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
@@ -1629,17 +1682,21 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite@8.1.5:
-    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+  vite@8.2.0:
+    resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.3.0
+      '@vitejs/devtools': ^0.4.0
       esbuild: ^0.28.1
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -1748,38 +1805,45 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@a2a-js/sdk@1.0.1(express@5.2.1)':
+    dependencies:
+      jose: 6.2.7
+      uuid: 11.1.1
+    optionalDependencies:
+      express: 5.2.1
 
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/parser@7.29.7':
+  '@babel/parser@7.29.8':
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
-  '@babel/types@7.29.7':
+  '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@emnapi/core@1.11.1':
+  '@emnapi/core@2.0.0-alpha.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 2.0.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.1':
+  '@emnapi/runtime@2.0.0-alpha.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.2':
+  '@emnapi/wasi-threads@2.0.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1873,7 +1937,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
     transitivePeerDependencies:
       - supports-color
 
@@ -1930,7 +1994,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/sdk@1.30.0(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 2.0.12(hono@4.12.34)
       ajv: 8.20.0
@@ -1943,148 +2007,151 @@ snapshots:
       express: 5.2.1
       express-rate-limit: 8.6.1(express@5.2.1)
       hono: 4.12.34
-      jose: 6.2.8
+      jose: 6.2.7
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@oxc-project/types@0.139.0': {}
+  '@oxc-project/types@0.142.0': {}
 
-  '@rolldown/binding-android-arm64@1.1.5':
+  '@rolldown/binding-android-arm64@1.2.1':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
+  '@rolldown/binding-darwin-arm64@1.2.1':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.5':
+  '@rolldown/binding-darwin-x64@1.2.1':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
+  '@rolldown/binding-freebsd-x64@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+  '@rolldown/binding-linux-arm64-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
+  '@rolldown/binding-linux-arm64-musl@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+  '@rolldown/binding-linux-s390x-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
+  '@rolldown/binding-linux-x64-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.5':
+  '@rolldown/binding-linux-x64-musl@1.2.1':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.5':
+  '@rolldown/binding-openharmony-arm64@1.2.1':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.5':
+  '@rolldown/binding-wasm32-wasi@1.2.1':
     dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+  '@rolldown/binding-win32-arm64-msvc@1.2.1':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
+  '@rolldown/binding-win32-x64-msvc@1.2.1':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/rollup-android-arm-eabi@4.60.2':
+  '@rollup/rollup-android-arm-eabi@4.62.4':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.2':
+  '@rollup/rollup-android-arm64@4.62.4':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.2':
+  '@rollup/rollup-darwin-arm64@4.62.4':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.2':
+  '@rollup/rollup-darwin-x64@4.62.4':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.2':
+  '@rollup/rollup-freebsd-arm64@4.62.4':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.2':
+  '@rollup/rollup-freebsd-x64@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.2':
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.2':
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.2':
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.2':
+  '@rollup/rollup-linux-x64-musl@4.62.4':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.60.2':
+  '@rollup/rollup-openbsd-x64@4.62.4':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.2':
+  '@rollup/rollup-openharmony-arm64@4.62.4':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.2':
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.60.2':
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
@@ -2094,24 +2161,59 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 26.1.2
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 26.1.2
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
-  '@types/estree@1.0.8': {}
-
   '@types/estree@1.0.9': {}
+
+  '@types/express-serve-static-core@5.1.3':
+    dependencies:
+      '@types/node': 26.1.2
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.3
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/json-schema@7.0.15': {}
 
   '@types/node@26.1.2':
     dependencies:
       undici-types: 8.3.0
+
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 26.1.2
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 26.1.2
 
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)':
     dependencies:
@@ -2180,7 +2282,7 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -2208,15 +2310,15 @@ snapshots:
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.10
-      ast-v8-to-istanbul: 1.0.4
+      ast-v8-to-istanbul: 1.0.5
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      magicast: 0.5.3
-      obug: 2.1.3
-      std-env: 4.1.0
-      tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
+      magicast: 0.5.4
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.5)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -2225,19 +2327,19 @@ snapshots:
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
       chai: 6.2.2
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.5)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.5)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
   '@vitest/runner@4.1.10':
     dependencies:
@@ -2257,18 +2359,18 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-jsx@5.3.2(acorn@8.17.0):
+  acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.18.0
 
-  acorn@8.17.0: {}
+  acorn@8.18.0: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -2292,7 +2394,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@1.0.4:
+  ast-v8-to-istanbul@1.0.5:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -2314,7 +2416,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2398,7 +2500,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@2.0.0: {}
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -2477,7 +2579,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
@@ -2485,8 +2587,8 @@ snapshots:
 
   espree@11.2.0:
     dependencies:
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 5.0.1
 
   esquery@1.7.0:
@@ -2513,7 +2615,7 @@ snapshots:
     dependencies:
       eventsource-parser: 3.1.0
 
-  expect-type@1.3.0: {}
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.6.1(express@5.2.1):
     dependencies:
@@ -2592,14 +2694,14 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.2
-      rollup: 4.60.2
+      rollup: 4.62.4
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.3
+      flatted: 3.4.4
       keyv: 4.5.4
 
-  flatted@3.4.3: {}
+  flatted@3.4.4: {}
 
   forwarded@0.2.0: {}
 
@@ -2695,7 +2797,7 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
-  jose@6.2.8: {}
+  jose@6.2.7: {}
 
   joycon@3.1.1: {}
 
@@ -2791,10 +2893,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.5.3:
+  magicast@0.5.4:
     dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -2813,16 +2915,16 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  minimatch@10.2.5:
+  minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   mlly@1.8.2:
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.18.0
       pathe: 2.0.3
       pkg-types: 1.3.1
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   ms@2.1.3: {}
 
@@ -2842,7 +2944,7 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  obug@2.1.3: {}
+  obug@2.1.4: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -2893,15 +2995,15 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.20)(tsx@4.23.1)(yaml@2.9.0):
+  postcss-load-config@6.0.1(postcss@8.5.25)(tsx@4.23.5)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.20
-      tsx: 4.23.1
+      postcss: 8.5.25
+      tsx: 4.23.5
       yaml: 2.9.0
 
-  postcss@8.5.20:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -2938,56 +3040,57 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  rolldown@1.1.5:
+  rolldown@1.2.1:
     dependencies:
-      '@oxc-project/types': 0.139.0
+      '@oxc-project/types': 0.142.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.5
-      '@rolldown/binding-darwin-arm64': 1.1.5
-      '@rolldown/binding-darwin-x64': 1.1.5
-      '@rolldown/binding-freebsd-x64': 1.1.5
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
-      '@rolldown/binding-linux-arm64-gnu': 1.1.5
-      '@rolldown/binding-linux-arm64-musl': 1.1.5
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
-      '@rolldown/binding-linux-s390x-gnu': 1.1.5
-      '@rolldown/binding-linux-x64-gnu': 1.1.5
-      '@rolldown/binding-linux-x64-musl': 1.1.5
-      '@rolldown/binding-openharmony-arm64': 1.1.5
-      '@rolldown/binding-wasm32-wasi': 1.1.5
-      '@rolldown/binding-win32-arm64-msvc': 1.1.5
-      '@rolldown/binding-win32-x64-msvc': 1.1.5
+      '@rolldown/binding-android-arm64': 1.2.1
+      '@rolldown/binding-darwin-arm64': 1.2.1
+      '@rolldown/binding-darwin-x64': 1.2.1
+      '@rolldown/binding-freebsd-x64': 1.2.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.1
+      '@rolldown/binding-linux-arm64-gnu': 1.2.1
+      '@rolldown/binding-linux-arm64-musl': 1.2.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.1
+      '@rolldown/binding-linux-s390x-gnu': 1.2.1
+      '@rolldown/binding-linux-x64-gnu': 1.2.1
+      '@rolldown/binding-linux-x64-musl': 1.2.1
+      '@rolldown/binding-openharmony-arm64': 1.2.1
+      '@rolldown/binding-wasm32-wasi': 1.2.1
+      '@rolldown/binding-win32-arm64-msvc': 1.2.1
+      '@rolldown/binding-win32-x64-msvc': 1.2.1
 
-  rollup@4.60.2:
+  rollup@4.62.4:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.2
-      '@rollup/rollup-android-arm64': 4.60.2
-      '@rollup/rollup-darwin-arm64': 4.60.2
-      '@rollup/rollup-darwin-x64': 4.60.2
-      '@rollup/rollup-freebsd-arm64': 4.60.2
-      '@rollup/rollup-freebsd-x64': 4.60.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
-      '@rollup/rollup-linux-arm64-gnu': 4.60.2
-      '@rollup/rollup-linux-arm64-musl': 4.60.2
-      '@rollup/rollup-linux-loong64-gnu': 4.60.2
-      '@rollup/rollup-linux-loong64-musl': 4.60.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
-      '@rollup/rollup-linux-ppc64-musl': 4.60.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
-      '@rollup/rollup-linux-riscv64-musl': 4.60.2
-      '@rollup/rollup-linux-s390x-gnu': 4.60.2
-      '@rollup/rollup-linux-x64-gnu': 4.60.2
-      '@rollup/rollup-linux-x64-musl': 4.60.2
-      '@rollup/rollup-openbsd-x64': 4.60.2
-      '@rollup/rollup-openharmony-arm64': 4.60.2
-      '@rollup/rollup-win32-arm64-msvc': 4.60.2
-      '@rollup/rollup-win32-ia32-msvc': 4.60.2
-      '@rollup/rollup-win32-x64-gnu': 4.60.2
-      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -3075,7 +3178,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@4.1.0: {}
+  std-env@4.2.0: {}
 
   string-argv@0.3.2: {}
 
@@ -3086,7 +3189,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
   supports-color@7.2.0:
@@ -3105,21 +3208,14 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyexec@1.2.4: {}
-
   tinyexec@1.3.0: {}
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
-  tinyrainbow@3.1.0: {}
+  tinyrainbow@3.1.1: {}
 
   toidentifier@1.0.1: {}
 
@@ -3134,7 +3230,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(postcss@8.5.20)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0):
+  tsup@8.5.1(postcss@8.5.25)(tsx@4.23.5)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
@@ -3145,16 +3241,16 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.20)(tsx@4.23.1)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(postcss@8.5.25)(tsx@4.23.5)(yaml@2.9.0)
       resolve-from: 5.0.0
-      rollup: 4.60.2
+      rollup: 4.62.4
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.20
+      postcss: 8.5.25
       typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
@@ -3162,7 +3258,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsx@4.23.1:
+  tsx@4.23.5:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
@@ -3191,7 +3287,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  ufo@1.6.3: {}
+  ufo@1.6.4: {}
 
   undici-types@8.3.0: {}
 
@@ -3201,43 +3297,45 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  uuid@11.1.1: {}
+
   vary@1.1.2: {}
 
-  vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0):
+  vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.5)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.20
-      rolldown: 1.1.5
+      postcss: 8.5.25
+      rolldown: 1.2.1
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.1.2
       esbuild: 0.28.1
       fsevents: 2.3.3
-      tsx: 4.23.1
+      tsx: 4.23.5
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.5)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.5)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
-      std-env: 4.1.0
+      std-env: 4.2.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
+      tinyrainbow: 3.1.1
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.5)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.2
@@ -3263,8 +3361,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-to-json-schema@3.25.2(zod@4.3.6):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,14 @@
+packages:
+  - "."
+
+overrides:
+  "@hono/node-server": "2.0.12"
+  body-parser: "2.3.0"
+  brace-expansion: "5.0.9"
+  esbuild: "^0.28.1"
+  "fast-uri@>=3.0.0 <3.1.5": "3.1.5"
+  hono: "4.12.34"
+  ip-address: "^10.4.0"
+  jose: "6.2.7"
+  postcss: "8.5.25"
+  vite: "^8.1.5"

--- a/python/axint/mcp_server.py
+++ b/python/axint/mcp_server.py
@@ -40,15 +40,12 @@ except ImportError as exc:  # pragma: no cover - exercised only without optional
     MCP_V2 = False
 else:
     MCP_IMPORT_ERROR = None
+    MCP_V2 = not hasattr(Server, "list_tools")
     try:
         from mcp.types import Tool, ToolAnnotations
     except ImportError:
         from mcp import Tool
         from mcp_types import ToolAnnotations
-
-        MCP_V2 = True
-    else:
-        MCP_V2 = False
 
 from .generator import (
     generate_entitlements_fragment,

--- a/scripts/check-package-artifact.mjs
+++ b/scripts/check-package-artifact.mjs
@@ -37,6 +37,8 @@ const required = [
   "TRADEMARKS.md",
   "package.json",
   "dist/cli/index.js",
+  "dist/a2a/index.js",
+  "dist/a2a/index.d.ts",
   "dist/core/index.js",
   "dist/core/index.d.ts",
   "dist/mcp/index.js",

--- a/scripts/install-gauntlet.mjs
+++ b/scripts/install-gauntlet.mjs
@@ -25,13 +25,23 @@ main();
 function main() {
   const distCli = resolve(ROOT, "dist/cli/index.js");
   if (!existsSync(distCli)) {
-    fail("dist/cli/index.js is missing. Run `npm run build` before the install gauntlet.");
+    fail(
+      "dist/cli/index.js is missing. Run `npm run build` before the install gauntlet."
+    );
   }
 
-  const localActivation = run("local dist activation", ["node", distCli, "activate", "--format", "json"], ROOT);
+  const localActivation = run(
+    "local dist activation",
+    ["node", distCli, "activate", "--format", "json"],
+    ROOT
+  );
   assertActivation(localActivation.stdout, "local dist activation");
 
-  const pack = run("npm pack", ["npm", "pack", "--json", "--pack-destination", TMP], ROOT);
+  const pack = run(
+    "npm pack",
+    ["npm", "pack", "--json", "--pack-destination", TMP],
+    ROOT
+  );
   const tarball = resolve(TMP, readPackedFilename(pack.stdout));
 
   const freshProject = mkdtempSync(join(TMP, "fresh-project-"));
@@ -39,19 +49,45 @@ function main() {
   run(
     "fresh tarball install",
     ["npm", "install", tarball, "--ignore-scripts", "--no-audit", "--no-fund"],
-    freshProject,
+    freshProject
   );
 
   const bin = resolve(freshProject, "node_modules/.bin/axint");
+  const a2aBin = resolve(freshProject, "node_modules/.bin/axint-a2a");
   const createBin = resolve(freshProject, "node_modules/.bin/create-axint-app");
-  const packedActivation = run("packed activation", [bin, "activate", "--format", "json"], freshProject);
+  const packedActivation = run(
+    "packed activation",
+    [bin, "activate", "--format", "json"],
+    freshProject
+  );
   assertActivation(packedActivation.stdout, "packed activation");
+  const a2aHelp = run("packed A2A executable", [a2aBin, "--help"], freshProject);
+  if (!a2aHelp.stdout.includes("Run Axint's A2A v1.0 proof and repair server")) {
+    fail("packed A2A executable did not print the expected help");
+  }
+  run(
+    "packed A2A import",
+    [
+      "node",
+      "--input-type=module",
+      "--eval",
+      "const api = await import('@axint/compiler/a2a'); if (typeof api.createAxintA2AApp !== 'function') process.exit(1);",
+    ],
+    freshProject
+  );
 
   const starterDir = resolve(freshProject, "apple-day-agent");
-  run("create-axint-app no-install", [createBin, "apple-day-agent", "--no-install"], freshProject);
+  run(
+    "create-axint-app no-install",
+    [createBin, "apple-day-agent", "--no-install"],
+    freshProject
+  );
   assertExists(resolve(starterDir, "package.json"), "starter package.json");
   assertExists(resolve(starterDir, ".axint/START_HERE.md"), "starter agent instructions");
-  assertExists(resolve(starterDir, "share/built-with-axint.html"), "starter proof preview");
+  assertExists(
+    resolve(starterDir, "share/built-with-axint.html"),
+    "starter proof preview"
+  );
 
   console.log("");
   console.log("install gauntlet passed");

--- a/src/a2a/agent-card.ts
+++ b/src/a2a/agent-card.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from "node:fs";
+import {
+  A2A_PROTOCOL_VERSION,
+  type AgentCard,
+  type SecurityRequirement,
+} from "@a2a-js/sdk";
+import { AXINT_A2A_INPUT_MEDIA_TYPE, AXINT_A2A_RESULT_MEDIA_TYPE } from "./types.js";
+
+export interface AxintAgentCardOptions {
+  endpointUrl: string;
+  authenticationRequired: boolean;
+  documentationUrl?: string;
+  iconUrl?: string;
+}
+
+export function createAxintAgentCard(options: AxintAgentCardOptions): AgentCard {
+  const securityRequirements: SecurityRequirement[] = options.authenticationRequired
+    ? [{ schemes: { Bearer: { list: [] } } }]
+    : [];
+  const skillSecurity = securityRequirements.map((requirement) =>
+    structuredClone(requirement)
+  );
+  return {
+    name: "Axint Apple Proof and Repair",
+    description:
+      "Checks Apple code, diagnoses Xcode failures, plans repairs, and produces signed build-and-test proof without retaining input source in task history or returning raw logs.",
+    supportedInterfaces: [
+      {
+        url: options.endpointUrl,
+        protocolBinding: "JSONRPC",
+        tenant: "",
+        protocolVersion: A2A_PROTOCOL_VERSION,
+      },
+    ],
+    provider: {
+      organization: "Axint",
+      url: "https://axint.ai",
+    },
+    version: packageVersion(),
+    documentationUrl: options.documentationUrl ?? "https://docs.axint.ai/a2a",
+    iconUrl: options.iconUrl ?? "https://axint.ai/favicon.svg",
+    capabilities: {
+      streaming: true,
+      pushNotifications: false,
+      extendedAgentCard: false,
+      extensions: [],
+    },
+    securitySchemes: options.authenticationRequired
+      ? {
+          Bearer: {
+            scheme: {
+              $case: "httpAuthSecurityScheme",
+              value: {
+                description: "Bearer token configured by the Axint A2A operator.",
+                scheme: "bearer",
+                bearerFormat: "Opaque",
+              },
+            },
+          },
+        }
+      : {},
+    securityRequirements,
+    defaultInputModes: [AXINT_A2A_INPUT_MEDIA_TYPE, "application/json", "text/plain"],
+    defaultOutputModes: [
+      AXINT_A2A_RESULT_MEDIA_TYPE,
+      "application/json",
+      "text/markdown",
+    ],
+    skills: [
+      {
+        id: "check_apple_code",
+        name: "Check Apple code",
+        description:
+          "Validate Swift or Axint source and return compiler-grounded diagnostics with confidence and evidence requirements.",
+        tags: ["swift", "static-analysis", "app-intents", "swiftui", "accessibility"],
+        examples: [
+          'Send {"skill":"check_apple_code","input":{"sourcePath":"Sources/App.swift"}}.',
+        ],
+        inputModes: [AXINT_A2A_INPUT_MEDIA_TYPE, "application/json", "text/plain"],
+        outputModes: [AXINT_A2A_RESULT_MEDIA_TYPE, "application/json", "text/markdown"],
+        securityRequirements: skillSecurity,
+      },
+      {
+        id: "diagnose_apple_failure",
+        name: "Diagnose an Apple failure",
+        description:
+          "Classify Xcode build, test, runtime, and Apple-platform failures and return ranked, source-free hypotheses.",
+        tags: ["xcode", "diagnostics", "tests", "runtime", "repair"],
+        examples: [
+          'Send {"skill":"diagnose_apple_failure","input":{"issue":"The UI test cannot find the Save button"}}.',
+        ],
+        inputModes: [AXINT_A2A_INPUT_MEDIA_TYPE, "application/json", "text/plain"],
+        outputModes: [AXINT_A2A_RESULT_MEDIA_TYPE, "application/json", "text/markdown"],
+        securityRequirements: skillSecurity,
+      },
+      {
+        id: "prove_apple_project",
+        name: "Prove an Apple project",
+        description:
+          "Run resumable Xcode build and test evidence locally and return a signed, source-free proof receipt.",
+        tags: ["xcodebuild", "xcresult", "build", "test", "proof"],
+        examples: [
+          'Send {"skill":"prove_apple_project","input":{"projectPath":".","scheme":"App"}}.',
+        ],
+        inputModes: [AXINT_A2A_INPUT_MEDIA_TYPE, "application/json", "text/plain"],
+        outputModes: [AXINT_A2A_RESULT_MEDIA_TYPE, "application/json", "text/markdown"],
+        securityRequirements: skillSecurity,
+      },
+      {
+        id: "plan_apple_repair",
+        name: "Plan an Apple repair",
+        description:
+          "Produce an evidence-first repair plan with likely causes, files to inspect, and the exact proof sequence, without modifying source.",
+        tags: ["repair", "planning", "swift", "xcode", "evidence"],
+        examples: [
+          'Send {"skill":"plan_apple_repair","input":{"issue":"The App Intent fails after authorization"}}.',
+        ],
+        inputModes: [AXINT_A2A_INPUT_MEDIA_TYPE, "application/json", "text/plain"],
+        outputModes: [AXINT_A2A_RESULT_MEDIA_TYPE, "application/json", "text/markdown"],
+        securityRequirements: skillSecurity,
+      },
+    ],
+    signatures: [],
+  };
+}
+
+function packageVersion(): string {
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf8")
+    ) as { version?: string };
+    return packageJson.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}

--- a/src/a2a/auth.ts
+++ b/src/a2a/auth.ts
@@ -1,0 +1,99 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { Request, RequestHandler } from "express";
+import type { User } from "@a2a-js/sdk/server";
+
+export interface AxintA2AToken {
+  id: string;
+  digest: Buffer;
+}
+
+export interface AxintA2AAuthOptions {
+  tokens?: string;
+  allowUnauthenticated?: boolean;
+}
+
+export class AxintA2AUser implements User {
+  constructor(
+    readonly userName: string,
+    readonly isAuthenticated: boolean
+  ) {}
+}
+
+export class AxintA2AAuthenticator {
+  readonly tokens: AxintA2AToken[];
+  readonly allowUnauthenticated: boolean;
+  private readonly requestUsers = new WeakMap<Request, User>();
+
+  constructor(options: AxintA2AAuthOptions = {}) {
+    this.tokens = parseTokens(options.tokens ?? process.env.AXINT_A2A_TOKENS ?? "");
+    this.allowUnauthenticated = options.allowUnauthenticated === true;
+    if (this.tokens.length === 0 && !this.allowUnauthenticated) {
+      throw new Error(
+        "A2A authentication is required. Set AXINT_A2A_TOKENS=id=secret or explicitly allow unauthenticated local access."
+      );
+    }
+  }
+
+  middleware(): RequestHandler {
+    return (request, response, next) => {
+      const user = this.authenticate(request.headers.authorization);
+      if (!user) {
+        response.setHeader("WWW-Authenticate", 'Bearer realm="Axint A2A"');
+        response.status(401).json({
+          error: "unauthorized",
+          message: "A valid bearer token is required.",
+        });
+        return;
+      }
+      this.requestUsers.set(request, user);
+      next();
+    };
+  }
+
+  userBuilder = async (request: Request): Promise<User> => {
+    const cached = this.requestUsers.get(request);
+    if (cached) return cached;
+    const user = this.authenticate(request.headers.authorization);
+    if (!user)
+      throw new Error("Unauthenticated A2A request reached the protocol handler.");
+    return user;
+  };
+
+  authenticate(authorization: string | undefined): User | undefined {
+    if (this.tokens.length === 0) {
+      return this.allowUnauthenticated
+        ? new AxintA2AUser("local-anonymous", false)
+        : undefined;
+    }
+    const match = /^Bearer\s+(.+)$/i.exec(authorization ?? "");
+    if (!match) return undefined;
+    const candidate = digest(match[1]);
+    let matched: AxintA2AToken | undefined;
+    for (const token of this.tokens) {
+      if (timingSafeEqual(candidate, token.digest)) matched = token;
+    }
+    return matched ? new AxintA2AUser(`token:${matched.id}`, true) : undefined;
+  }
+}
+
+export function parseTokens(value: string): AxintA2AToken[] {
+  if (!value.trim()) return [];
+  const seen = new Set<string>();
+  return value.split(",").map((entry) => {
+    const separator = entry.indexOf("=");
+    const id = entry.slice(0, separator).trim();
+    const secret = separator >= 0 ? entry.slice(separator + 1).trim() : "";
+    if (!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$/.test(id) || secret.length < 16) {
+      throw new Error(
+        "AXINT_A2A_TOKENS must contain comma-separated id=secret entries with secrets of at least 16 characters."
+      );
+    }
+    if (seen.has(id)) throw new Error(`Duplicate A2A token id: ${id}.`);
+    seen.add(id);
+    return { id, digest: digest(secret) };
+  });
+}
+
+function digest(value: string): Buffer {
+  return createHash("sha256").update(value, "utf8").digest();
+}

--- a/src/a2a/executor.ts
+++ b/src/a2a/executor.ts
@@ -1,0 +1,302 @@
+import { randomUUID } from "node:crypto";
+import {
+  Role,
+  TaskState,
+  type Artifact,
+  type Message,
+  type Task,
+  type TaskStatusUpdateEvent,
+} from "@a2a-js/sdk";
+import {
+  AgentEvent,
+  type AgentExecutor,
+  type ExecutionEventBus,
+  type RequestContext,
+} from "@a2a-js/sdk/server";
+import { TaskNotCancelableError } from "@a2a-js/sdk/errors";
+import { parseAxintA2ARequest } from "./request.js";
+import { AxintA2ACancelledError } from "./service.js";
+import {
+  AXINT_A2A_RESULT_MEDIA_TYPE,
+  AxintA2AInputError,
+  AxintA2APolicyError,
+  type AxintA2AResult,
+  type AxintA2ARunner,
+} from "./types.js";
+
+export interface AxintA2AExecutorOptions {
+  projectRoot: string;
+  runner: AxintA2ARunner;
+  heartbeatMs?: number;
+}
+
+interface ActiveExecution {
+  controller: AbortController;
+  contextId: string;
+  canceledPublished: boolean;
+}
+
+export class AxintA2AExecutor implements AgentExecutor {
+  private readonly active = new Map<string, ActiveExecution>();
+  private readonly heartbeatMs: number;
+
+  constructor(private readonly options: AxintA2AExecutorOptions) {
+    this.heartbeatMs = Math.max(options.heartbeatMs ?? 15_000, 1_000);
+  }
+
+  async execute(
+    requestContext: RequestContext,
+    eventBus: ExecutionEventBus
+  ): Promise<void> {
+    const task = initialTask(requestContext);
+    eventBus.publish(AgentEvent.task(task));
+
+    if (this.active.has(task.id)) {
+      publishStatus(
+        eventBus,
+        task.id,
+        task.contextId,
+        TaskState.TASK_STATE_REJECTED,
+        "This task is already running."
+      );
+      return;
+    }
+
+    let parsed;
+    try {
+      parsed = parseAxintA2ARequest(requestContext.userMessage, {
+        projectRoot: this.options.projectRoot,
+      });
+    } catch (error) {
+      if (error instanceof AxintA2AInputError) {
+        publishStatus(
+          eventBus,
+          task.id,
+          task.contextId,
+          TaskState.TASK_STATE_INPUT_REQUIRED,
+          error.message
+        );
+        return;
+      }
+      if (error instanceof AxintA2APolicyError) {
+        publishStatus(
+          eventBus,
+          task.id,
+          task.contextId,
+          TaskState.TASK_STATE_REJECTED,
+          error.message
+        );
+        return;
+      }
+      throw error;
+    }
+
+    const active: ActiveExecution = {
+      controller: new AbortController(),
+      contextId: task.contextId,
+      canceledPublished: false,
+    };
+    this.active.set(task.id, active);
+    publishStatus(
+      eventBus,
+      task.id,
+      task.contextId,
+      TaskState.TASK_STATE_WORKING,
+      `Running ${parsed.skill}.`
+    );
+    const heartbeat = setInterval(() => {
+      if (!active.controller.signal.aborted) {
+        publishStatus(
+          eventBus,
+          task.id,
+          task.contextId,
+          TaskState.TASK_STATE_WORKING,
+          `${parsed.skill} is still running.`
+        );
+      }
+    }, this.heartbeatMs);
+    heartbeat.unref();
+
+    try {
+      const execution = await this.options.runner({
+        request: parsed,
+        signal: active.controller.signal,
+      });
+      if (active.controller.signal.aborted) throw new AxintA2ACancelledError();
+      const artifact = resultArtifact(execution.result, execution.markdown);
+      eventBus.publish(
+        AgentEvent.artifactUpdate({
+          taskId: task.id,
+          contextId: task.contextId,
+          artifact,
+          append: false,
+          lastChunk: true,
+          metadata: { skill: parsed.skill },
+        })
+      );
+      publishStatus(
+        eventBus,
+        task.id,
+        task.contextId,
+        TaskState.TASK_STATE_COMPLETED,
+        execution.result.summary
+      );
+    } catch (error) {
+      if (error instanceof AxintA2ACancelledError || active.controller.signal.aborted) {
+        if (!active.canceledPublished) {
+          publishStatus(
+            eventBus,
+            task.id,
+            task.contextId,
+            TaskState.TASK_STATE_CANCELED,
+            "Task canceled."
+          );
+        }
+        return;
+      }
+      publishStatus(
+        eventBus,
+        task.id,
+        task.contextId,
+        TaskState.TASK_STATE_FAILED,
+        safeFailureMessage(error, this.options.projectRoot)
+      );
+    } finally {
+      clearInterval(heartbeat);
+      if (this.active.get(task.id) === active) this.active.delete(task.id);
+    }
+  }
+
+  async cancelTask(taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+    const active = this.active.get(taskId);
+    if (!active) throw new TaskNotCancelableError(`Task not cancelable: ${taskId}`);
+    active.controller.abort();
+    active.canceledPublished = true;
+    publishStatus(
+      eventBus,
+      taskId,
+      active.contextId,
+      TaskState.TASK_STATE_CANCELED,
+      "Task canceled."
+    );
+  }
+}
+
+function initialTask(context: RequestContext): Task {
+  const previous = context.task;
+  return {
+    id: context.taskId,
+    contextId: context.contextId,
+    status: {
+      state: TaskState.TASK_STATE_SUBMITTED,
+      message: agentMessage(context.taskId, context.contextId, "Task accepted."),
+      timestamp: new Date().toISOString(),
+    },
+    artifacts: previous?.artifacts ?? [],
+    history: [...(previous?.history ?? []), redactedUserMessage(context.userMessage)],
+    metadata: {
+      ...(previous?.metadata ?? {}),
+      service: "axint-a2a",
+    },
+  };
+}
+
+function redactedUserMessage(message: Message): Message {
+  return {
+    ...message,
+    parts: [
+      {
+        content: {
+          $case: "text",
+          value: "Request accepted. Input content is omitted from durable task history.",
+        },
+        metadata: { redaction: "input_not_persisted" },
+        filename: "",
+        mediaType: "text/plain",
+      },
+    ],
+    metadata: {
+      redaction: "input_not_persisted",
+    },
+  };
+}
+
+function publishStatus(
+  eventBus: ExecutionEventBus,
+  taskId: string,
+  contextId: string,
+  state: TaskState,
+  text: string
+): void {
+  const update: TaskStatusUpdateEvent = {
+    taskId,
+    contextId,
+    status: {
+      state,
+      message: agentMessage(taskId, contextId, text),
+      timestamp: new Date().toISOString(),
+    },
+    metadata: undefined,
+  };
+  eventBus.publish(AgentEvent.statusUpdate(update));
+}
+
+function agentMessage(taskId: string, contextId: string, text: string): Message {
+  return {
+    messageId: randomUUID(),
+    contextId,
+    taskId,
+    role: Role.ROLE_AGENT,
+    parts: [
+      {
+        content: { $case: "text", value: text },
+        metadata: undefined,
+        filename: "",
+        mediaType: "text/plain",
+      },
+    ],
+    metadata: undefined,
+    extensions: [],
+    referenceTaskIds: [],
+  };
+}
+
+function resultArtifact(result: AxintA2AResult, markdown: string): Artifact {
+  return {
+    artifactId: randomUUID(),
+    name: "axint-result",
+    description: "Source-free Axint result and evidence summary.",
+    parts: [
+      {
+        content: { $case: "data", value: result },
+        metadata: undefined,
+        filename: "axint-result.json",
+        mediaType: AXINT_A2A_RESULT_MEDIA_TYPE,
+      },
+      {
+        content: { $case: "text", value: markdown },
+        metadata: undefined,
+        filename: "axint-result.md",
+        mediaType: "text/markdown",
+      },
+    ],
+    metadata: {
+      sourceIncluded: false,
+      rawLogsIncluded: false,
+      absolutePathsIncluded: false,
+    },
+    extensions: [],
+  };
+}
+
+function safeFailureMessage(error: unknown, projectRoot: string): string {
+  const message = error instanceof Error ? error.message : "Unknown execution error.";
+  const redacted = message
+    .split(projectRoot)
+    .join("<project>")
+    .replace(
+      /(^|[\s("'`])\/(?:private|tmp|var|Users|home|Volumes)\/[\w@%+.,:=\-/]+/g,
+      (_match, prefix: string) => `${prefix}<local-path>`
+    );
+  return `Axint could not complete the task: ${redacted.slice(0, 1_000)}`;
+}

--- a/src/a2a/http.ts
+++ b/src/a2a/http.ts
@@ -1,0 +1,66 @@
+import { Command } from "commander";
+import { startAxintA2AServer } from "./server.js";
+
+export async function runAxintA2AHttpCli(argv: string[] = process.argv): Promise<void> {
+  const program = new Command()
+    .name("axint-a2a")
+    .description("Run Axint's A2A v1.0 proof and repair server.")
+    .option("--host <host>", "Host interface", "127.0.0.1")
+    .option("--port <port>", "HTTP port", parsePort, 41_242)
+    .option("--public-url <url>", "Public base URL advertised in the Agent Card")
+    .option(
+      "--project-root <path>",
+      "Highest directory A2A tasks may access",
+      process.cwd()
+    )
+    .option("--state-dir <path>", "Durable task and proof artifact directory")
+    .option(
+      "--allow-unauthenticated",
+      "Explicitly allow requests without bearer authentication",
+      false
+    )
+    .parse(argv);
+
+  const values = program.opts<{
+    host: string;
+    port: number;
+    publicUrl?: string;
+    projectRoot: string;
+    stateDir?: string;
+    allowUnauthenticated: boolean;
+  }>();
+  const running = await startAxintA2AServer({
+    host: values.host,
+    port: values.port,
+    publicUrl: values.publicUrl,
+    projectRoot: values.projectRoot,
+    stateDirectory: values.stateDir,
+    allowUnauthenticated: values.allowUnauthenticated,
+  });
+
+  process.stdout.write(
+    `Axint A2A server listening at http://${displayHost(running.host)}:${running.port}\n` +
+      `Agent Card: http://${displayHost(running.host)}:${running.port}/.well-known/agent-card.json\n`
+  );
+
+  let closing = false;
+  const shutdown = async () => {
+    if (closing) return;
+    closing = true;
+    await running.close();
+  };
+  process.once("SIGINT", () => void shutdown());
+  process.once("SIGTERM", () => void shutdown());
+}
+
+function parsePort(value: string): number {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("Port must be an integer from 1 through 65535.");
+  }
+  return port;
+}
+
+function displayHost(host: string): string {
+  return host.includes(":") ? `[${host}]` : host;
+}

--- a/src/a2a/index.ts
+++ b/src/a2a/index.ts
@@ -1,0 +1,33 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runAxintA2AHttpCli } from "./http.js";
+
+export * from "./agent-card.js";
+export * from "./auth.js";
+export * from "./executor.js";
+export * from "./request.js";
+export * from "./server.js";
+export * from "./service.js";
+export * from "./task-store.js";
+export * from "./types.js";
+
+function isDirectEntrypoint(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return (
+      realpathSync(resolve(fileURLToPath(import.meta.url))) ===
+      realpathSync(resolve(entry))
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectEntrypoint()) {
+  runAxintA2AHttpCli().catch((error: Error) => {
+    console.error(`Failed to start Axint A2A server: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/src/a2a/request.ts
+++ b/src/a2a/request.ts
@@ -1,0 +1,306 @@
+import { realpathSync, statSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+import type { Message } from "@a2a-js/sdk";
+import {
+  AXINT_A2A_REQUEST_SCHEMA,
+  AxintA2AInputError,
+  AxintA2APolicyError,
+  isAxintA2ASkillId,
+  messageText,
+  type AxintA2ARequest,
+  type AxintA2ARequestInput,
+  type AxintA2ASkillId,
+  type ParseAxintA2ARequestOptions,
+  type ParsedAxintA2ARequest,
+} from "./types.js";
+
+const MAX_SOURCE_CHARS = 256 * 1024;
+const MAX_EVIDENCE_CHARS = 128 * 1024;
+const MAX_ISSUE_CHARS = 16 * 1024;
+const MAX_LIST_ITEMS = 100;
+
+export function parseAxintA2ARequest(
+  message: Message,
+  options: ParseAxintA2ARequestOptions
+): ParsedAxintA2ARequest {
+  const payload = structuredPayload(message) ?? textPayload(messageText(message));
+  if (!payload) {
+    throw new AxintA2AInputError(
+      "Send structured data with { skill, input }. Supported skills: check_apple_code, diagnose_apple_failure, prove_apple_project, plan_apple_repair."
+    );
+  }
+  if (!isAxintA2ASkillId(payload.skill)) {
+    throw new AxintA2AInputError(`Unsupported Axint skill: ${String(payload.skill)}.`);
+  }
+
+  const projectRoot = canonicalDirectory(options.projectRoot, "Configured project root");
+  const rawInput = plainObject(payload.input) ? payload.input : {};
+  const input = normalizeInput(rawInput);
+  const projectDirectory = input.projectPath
+    ? confinedDirectory(projectRoot, input.projectPath, "projectPath")
+    : projectRoot;
+
+  if (input.sourcePath) {
+    input.sourcePath = confinedFile(projectDirectory, input.sourcePath, "sourcePath");
+  }
+  input.workspace = optionalConfinedExistingRelativePath(
+    projectDirectory,
+    input.workspace,
+    "workspace"
+  );
+  input.project = optionalConfinedExistingRelativePath(
+    projectDirectory,
+    input.project,
+    "project"
+  );
+  input.modifiedFiles = input.modifiedFiles?.map((path) =>
+    confinedPossiblyMissingRelativePath(projectDirectory, path, "modifiedFiles")
+  );
+
+  validateSkillInput(payload.skill, input);
+  return {
+    schema: AXINT_A2A_REQUEST_SCHEMA,
+    skill: payload.skill,
+    input,
+    projectRoot,
+    projectDirectory,
+  };
+}
+
+function structuredPayload(message: Message): Partial<AxintA2ARequest> | undefined {
+  for (const part of message.parts) {
+    if (part.content?.$case !== "data" || !plainObject(part.content.value)) continue;
+    const value = part.content.value;
+    if ("skill" in value || value.schema === AXINT_A2A_REQUEST_SCHEMA) {
+      return value as Partial<AxintA2ARequest>;
+    }
+  }
+  return undefined;
+}
+
+function textPayload(text: string): Partial<AxintA2ARequest> | undefined {
+  if (!text) return undefined;
+  if (text.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      if (plainObject(parsed)) return parsed as Partial<AxintA2ARequest>;
+    } catch {
+      throw new AxintA2AInputError(
+        "The text part looks like JSON but is not valid JSON."
+      );
+    }
+  }
+
+  const command = /^(check|diagnose|prove|repair)\b\s*(.*)$/is.exec(text);
+  if (!command) return undefined;
+  const skill = commandSkill(command[1].toLowerCase());
+  const value = command[2].trim();
+  if (skill === "check_apple_code") {
+    return { skill, input: value ? { sourcePath: value } : {} };
+  }
+  if (skill === "prove_apple_project") {
+    return { skill, input: value ? { projectPath: value } : {} };
+  }
+  return { skill, input: value ? { issue: value } : {} };
+}
+
+function commandSkill(command: string): AxintA2ASkillId {
+  if (command === "check") return "check_apple_code";
+  if (command === "diagnose") return "diagnose_apple_failure";
+  if (command === "prove") return "prove_apple_project";
+  return "plan_apple_repair";
+}
+
+function normalizeInput(value: Record<string, unknown>): AxintA2ARequestInput {
+  const input: AxintA2ARequestInput = {
+    projectPath: optionalString(value.projectPath, "projectPath", 4_096),
+    source: optionalString(value.source, "source", MAX_SOURCE_CHARS),
+    sourcePath: optionalString(value.sourcePath, "sourcePath", 4_096),
+    fileName: optionalString(value.fileName, "fileName", 1_024),
+    issue: optionalString(value.issue, "issue", MAX_ISSUE_CHARS),
+    platform: optionalPlatform(value.platform),
+    scheme: optionalString(value.scheme, "scheme", 512),
+    workspace: optionalString(value.workspace, "workspace", 4_096),
+    project: optionalString(value.project, "project", 4_096),
+    destination: optionalString(value.destination, "destination", 2_048),
+    configuration: optionalString(value.configuration, "configuration", 512),
+    testPlan: optionalString(value.testPlan, "testPlan", 512),
+    onlyTesting: optionalStringArray(value.onlyTesting, "onlyTesting"),
+    modifiedFiles: optionalStringArray(value.modifiedFiles, "modifiedFiles"),
+    skipBuild: optionalBoolean(value.skipBuild, "skipBuild"),
+    skipTests: optionalBoolean(value.skipTests, "skipTests"),
+    runtime: optionalBoolean(value.runtime, "runtime"),
+    timeoutSeconds: optionalTimeout(value.timeoutSeconds),
+    xcodeBuildLog: optionalString(
+      value.xcodeBuildLog,
+      "xcodeBuildLog",
+      MAX_EVIDENCE_CHARS
+    ),
+    testFailure: optionalString(value.testFailure, "testFailure", MAX_EVIDENCE_CHARS),
+    runtimeFailure: optionalString(
+      value.runtimeFailure,
+      "runtimeFailure",
+      MAX_EVIDENCE_CHARS
+    ),
+    expectedBehavior: optionalString(
+      value.expectedBehavior,
+      "expectedBehavior",
+      MAX_EVIDENCE_CHARS
+    ),
+    actualBehavior: optionalString(
+      value.actualBehavior,
+      "actualBehavior",
+      MAX_EVIDENCE_CHARS
+    ),
+  };
+  return Object.fromEntries(
+    Object.entries(input).filter(([, item]) => item !== undefined)
+  ) as AxintA2ARequestInput;
+}
+
+function validateSkillInput(skill: AxintA2ASkillId, input: AxintA2ARequestInput): void {
+  if (skill === "check_apple_code" && !input.source && !input.sourcePath) {
+    throw new AxintA2AInputError(
+      "check_apple_code requires input.source or a sourcePath inside the configured project root."
+    );
+  }
+  if (
+    (skill === "diagnose_apple_failure" || skill === "plan_apple_repair") &&
+    !input.issue &&
+    !input.xcodeBuildLog &&
+    !input.testFailure &&
+    !input.runtimeFailure
+  ) {
+    throw new AxintA2AInputError(
+      `${skill} requires an issue description or build, test, or runtime failure evidence.`
+    );
+  }
+}
+
+function canonicalDirectory(path: string, label: string): string {
+  try {
+    const canonical = realpathSync(resolve(path));
+    if (!statSync(canonical).isDirectory()) throw new Error("not a directory");
+    return canonical;
+  } catch {
+    throw new AxintA2APolicyError(`${label} must be an existing directory.`);
+  }
+}
+
+function confinedDirectory(root: string, path: string, label: string): string {
+  const candidate = canonicalDirectory(resolve(root, path), label);
+  assertContained(root, candidate, label);
+  return candidate;
+}
+
+function confinedFile(root: string, path: string, label: string): string {
+  try {
+    const candidate = realpathSync(resolve(root, path));
+    assertContained(root, candidate, label);
+    if (!statSync(candidate).isFile()) throw new Error("not a file");
+    return candidate;
+  } catch (error) {
+    if (error instanceof AxintA2APolicyError) throw error;
+    throw new AxintA2APolicyError(
+      `${label} must be an existing file inside the project.`
+    );
+  }
+}
+
+function optionalConfinedExistingRelativePath(
+  root: string,
+  path: string | undefined,
+  label: string
+): string | undefined {
+  if (!path) return undefined;
+  try {
+    const candidate = realpathSync(resolve(root, path));
+    assertContained(root, candidate, label);
+    return relative(root, candidate) || ".";
+  } catch (error) {
+    if (error instanceof AxintA2APolicyError) throw error;
+    throw new AxintA2APolicyError(`${label} must exist inside the project.`);
+  }
+}
+
+function confinedPossiblyMissingRelativePath(
+  root: string,
+  path: string,
+  label: string
+): string {
+  if (path.includes("\0"))
+    throw new AxintA2APolicyError(`${label} contains invalid data.`);
+  const resolved = resolve(root, path);
+  let candidate = resolved;
+  try {
+    candidate = realpathSync(resolved);
+  } catch {
+    // Deleted changed files cannot be resolved; the lexical boundary still applies.
+  }
+  assertContained(root, candidate, label);
+  return relative(root, resolved) || ".";
+}
+
+function assertContained(root: string, candidate: string, label: string): void {
+  const rel = relative(root, candidate);
+  if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) return;
+  throw new AxintA2APolicyError(`${label} must stay inside the configured project root.`);
+}
+
+function optionalString(
+  value: unknown,
+  label: string,
+  maxLength: number
+): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "string")
+    throw new AxintA2AInputError(`${label} must be a string.`);
+  if (value.length > maxLength) {
+    throw new AxintA2AInputError(`${label} exceeds the ${maxLength}-character limit.`);
+  }
+  return value;
+}
+
+function optionalBoolean(value: unknown, label: string): boolean | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "boolean")
+    throw new AxintA2AInputError(`${label} must be boolean.`);
+  return value;
+}
+
+function optionalTimeout(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Number.isInteger(value) || Number(value) < 1 || Number(value) > 3_600) {
+    throw new AxintA2AInputError(
+      "timeoutSeconds must be an integer from 1 through 3600."
+    );
+  }
+  return Number(value);
+}
+
+function optionalPlatform(value: unknown): AxintA2ARequestInput["platform"] {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (!["iOS", "macOS", "watchOS", "visionOS", "all"].includes(String(value))) {
+    throw new AxintA2AInputError(
+      "platform must be iOS, macOS, watchOS, visionOS, or all."
+    );
+  }
+  return value as AxintA2ARequestInput["platform"];
+}
+
+function optionalStringArray(value: unknown, label: string): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value) || value.length > MAX_LIST_ITEMS) {
+    throw new AxintA2AInputError(
+      `${label} must be an array of at most ${MAX_LIST_ITEMS} strings.`
+    );
+  }
+  if (value.some((item) => typeof item !== "string" || item.length > 4_096)) {
+    throw new AxintA2AInputError(`${label} contains an invalid item.`);
+  }
+  return value as string[];
+}
+
+function plainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/a2a/server.ts
+++ b/src/a2a/server.ts
@@ -1,0 +1,248 @@
+import { randomUUID } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import express, { type Express, type RequestHandler } from "express";
+import { A2A_PROTOCOL_VERSION } from "@a2a-js/sdk";
+import { DefaultRequestHandler } from "@a2a-js/sdk/server";
+import { agentCardHandler, jsonRpcHandler } from "@a2a-js/sdk/server/express";
+import { createAxintAgentCard } from "./agent-card.js";
+import { AxintA2AAuthenticator } from "./auth.js";
+import { AxintA2AExecutor } from "./executor.js";
+import { createAxintA2ARunner } from "./service.js";
+import { AxintA2ATaskStore } from "./task-store.js";
+
+export interface AxintA2AServerOptions {
+  host?: string;
+  port?: number;
+  publicUrl?: string;
+  projectRoot?: string;
+  stateDirectory?: string;
+  tokens?: string;
+  allowUnauthenticated?: boolean;
+  bodyLimit?: string;
+  rateLimitPerMinute?: number;
+}
+
+export interface AxintA2AApp {
+  app: Express;
+  endpointUrl: string;
+  projectRoot: string;
+  stateDirectory: string;
+}
+
+export interface RunningAxintA2AServer extends AxintA2AApp {
+  server: Server;
+  host: string;
+  port: number;
+  close(): Promise<void>;
+}
+
+export function createAxintA2AApp(options: AxintA2AServerOptions = {}): AxintA2AApp {
+  const host = options.host ?? "127.0.0.1";
+  const port = validPort(options.port ?? 41_242);
+  const projectRoot = resolve(options.projectRoot ?? process.cwd());
+  const stateDirectory = resolve(
+    options.stateDirectory ??
+      process.env.AXINT_A2A_STATE_DIR ??
+      resolve(homedir(), ".axint", "a2a")
+  );
+  const publicUrl = normalizePublicUrl(
+    options.publicUrl ?? `http://${displayHost(host)}:${port}`
+  );
+  const endpointUrl = new URL("/a2a", publicUrl).toString();
+  const tokens = options.tokens ?? process.env.AXINT_A2A_TOKENS ?? "";
+  const allowUnauthenticated = options.allowUnauthenticated === true;
+  if (!isLoopback(host) && !tokens.trim() && !allowUnauthenticated) {
+    throw new Error(
+      "Refusing to expose an unauthenticated A2A server off loopback. Configure AXINT_A2A_TOKENS."
+    );
+  }
+
+  const authenticator = new AxintA2AAuthenticator({
+    tokens,
+    allowUnauthenticated: allowUnauthenticated || (isLoopback(host) && !tokens.trim()),
+  });
+  const card = createAxintAgentCard({
+    endpointUrl,
+    authenticationRequired: authenticator.tokens.length > 0,
+  });
+  const taskStore = new AxintA2ATaskStore({ stateDirectory });
+  const executor = new AxintA2AExecutor({
+    projectRoot,
+    runner: createAxintA2ARunner({ stateDirectory }),
+  });
+  const requestHandler = new DefaultRequestHandler(card, taskStore, executor);
+  const app = express();
+
+  app.disable("x-powered-by");
+  app.set("trust proxy", false);
+  app.use((request, response, next) => {
+    const requestId = request.header("x-request-id")?.slice(0, 128) || randomUUID();
+    response.setHeader("X-Request-Id", requestId);
+    response.setHeader("X-Content-Type-Options", "nosniff");
+    response.setHeader("Referrer-Policy", "no-referrer");
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader("Cross-Origin-Resource-Policy", "same-site");
+    next();
+  });
+  app.get("/healthz", (_request, response) => {
+    response.json({ status: "ok", protocol: "A2A", version: card.version });
+  });
+  app.use(
+    "/.well-known/agent-card.json",
+    agentCardHandler({ agentCardProvider: requestHandler, cache: { maxAge: 300 } })
+  );
+  app.use(
+    "/a2a",
+    createRateLimiter(options.rateLimitPerMinute ?? 60),
+    express.json({ limit: options.bodyLimit ?? "1mb", strict: true }),
+    authenticator.middleware(),
+    requireA2AVersion(),
+    jsonRpcHandler({
+      requestHandler,
+      userBuilder: authenticator.userBuilder,
+    })
+  );
+  app.use(
+    (
+      error: unknown,
+      _request: express.Request,
+      response: express.Response,
+      next: express.NextFunction
+    ) => {
+      if (response.headersSent) {
+        next(error);
+        return;
+      }
+      const status = bodyErrorStatus(error);
+      response.status(status).json({
+        error: status === 413 ? "payload_too_large" : "invalid_request",
+        message:
+          status === 413
+            ? "The request body exceeds the configured limit."
+            : "The request body is not valid JSON.",
+      });
+    }
+  );
+
+  return { app, endpointUrl, projectRoot, stateDirectory };
+}
+
+function requireA2AVersion(): RequestHandler {
+  return (request, response, next) => {
+    const requested = request.header("a2a-version") ?? "0.3";
+    if (requested === A2A_PROTOCOL_VERSION) {
+      next();
+      return;
+    }
+    const id =
+      request.body && typeof request.body === "object" && "id" in request.body
+        ? request.body.id
+        : null;
+    response.status(400).json({
+      jsonrpc: "2.0",
+      id: id ?? null,
+      error: {
+        code: -32_009,
+        message: `The requested A2A protocol version '${requested}' is not supported. Supported versions: ${A2A_PROTOCOL_VERSION}`,
+      },
+    });
+  };
+}
+
+export async function startAxintA2AServer(
+  options: AxintA2AServerOptions = {}
+): Promise<RunningAxintA2AServer> {
+  const host = options.host ?? "127.0.0.1";
+  const port = validPort(options.port ?? 41_242);
+  const created = createAxintA2AApp({ ...options, host, port });
+  const server = createServer(created.app);
+  await new Promise<void>((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.off("error", reject);
+      resolveListen();
+    });
+  });
+  const address = server.address();
+  const actualPort = typeof address === "object" && address ? address.port : port;
+  return {
+    ...created,
+    server,
+    host,
+    port: actualPort,
+    close: () =>
+      new Promise<void>((resolveClose, reject) => {
+        server.close((error) => (error ? reject(error) : resolveClose()));
+      }),
+  };
+}
+
+function createRateLimiter(limit: number): RequestHandler {
+  const boundedLimit = Math.min(Math.max(Math.floor(limit), 1), 10_000);
+  const windows = new Map<string, { startedAt: number; count: number }>();
+  return (request, response, next) => {
+    const now = Date.now();
+    const key = request.socket.remoteAddress ?? "unknown";
+    const current = windows.get(key);
+    const window =
+      !current || now - current.startedAt >= 60_000
+        ? { startedAt: now, count: 0 }
+        : current;
+    window.count += 1;
+    windows.set(key, window);
+    response.setHeader("RateLimit-Limit", String(boundedLimit));
+    response.setHeader(
+      "RateLimit-Remaining",
+      String(Math.max(0, boundedLimit - window.count))
+    );
+    if (window.count > boundedLimit) {
+      response.setHeader(
+        "Retry-After",
+        String(Math.ceil((window.startedAt + 60_000 - now) / 1_000))
+      );
+      response
+        .status(429)
+        .json({ error: "rate_limited", message: "Too many A2A requests." });
+      return;
+    }
+    if (windows.size > 1_000) {
+      for (const [candidate, value] of windows) {
+        if (now - value.startedAt >= 60_000) windows.delete(candidate);
+      }
+    }
+    next();
+  };
+}
+
+function normalizePublicUrl(value: string): URL {
+  const url = new URL(value.endsWith("/") ? value : `${value}/`);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("A2A public URL must use http or https.");
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error("A2A public URL cannot contain credentials, a query, or a fragment.");
+  }
+  return url;
+}
+
+function validPort(value: number): number {
+  if (!Number.isInteger(value) || value < 1 || value > 65_535) {
+    throw new Error("A2A port must be an integer from 1 through 65535.");
+  }
+  return value;
+}
+
+function isLoopback(host: string): boolean {
+  return ["127.0.0.1", "::1", "localhost"].includes(host.toLowerCase());
+}
+
+function displayHost(host: string): string {
+  return host.includes(":") ? `[${host}]` : host;
+}
+
+function bodyErrorStatus(error: unknown): number {
+  const status = (error as { status?: unknown }).status;
+  return status === 413 ? 413 : 400;
+}

--- a/src/a2a/service.ts
+++ b/src/a2a/service.ts
@@ -1,0 +1,346 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, isAbsolute, relative, resolve } from "node:path";
+import { runCloudCheck } from "../cloud/check.js";
+import type { Diagnostic } from "../core/types.js";
+import { proveAxintProject } from "../proof/prove.js";
+import { runAxintRepair } from "../repair/project-repair.js";
+import {
+  AXINT_A2A_RESULT_SCHEMA,
+  type AxintA2AExecutionResult,
+  type AxintA2ARequestInput,
+  type AxintA2AResult,
+  type AxintA2ARunner,
+  type AxintA2AVerdict,
+  type ParsedAxintA2ARequest,
+} from "./types.js";
+
+export interface AxintA2ARunnerOptions {
+  stateDirectory: string;
+}
+
+export class AxintA2ACancelledError extends Error {
+  constructor() {
+    super("The A2A task was canceled.");
+    this.name = "AxintA2ACancelledError";
+  }
+}
+
+export function createAxintA2ARunner(options: AxintA2ARunnerOptions): AxintA2ARunner {
+  return async ({ request, signal }) => {
+    throwIfAborted(signal);
+    let execution: AxintA2AExecutionResult;
+    switch (request.skill) {
+      case "check_apple_code":
+        execution = runCheck(request);
+        break;
+      case "diagnose_apple_failure":
+      case "plan_apple_repair":
+        execution = runRepair(request);
+        break;
+      case "prove_apple_project":
+        execution = await runProof(request, signal, options.stateDirectory);
+        break;
+    }
+    throwIfAborted(signal);
+    return sanitizeExecution(execution, request.projectDirectory);
+  };
+}
+
+function runCheck(request: ParsedAxintA2ARequest): AxintA2AExecutionResult {
+  const input = request.input;
+  const report = runCloudCheck({
+    source: input.source,
+    sourcePath: input.sourcePath,
+    fileName:
+      input.fileName ?? (input.sourcePath ? basename(input.sourcePath) : undefined),
+    platform: input.platform,
+    xcodeBuildLog: input.xcodeBuildLog,
+    testFailure: input.testFailure,
+    runtimeFailure: input.runtimeFailure,
+    expectedBehavior: input.expectedBehavior,
+    actualBehavior: input.actualBehavior,
+    typecheck: true,
+    typecheckProjectRoot: request.projectDirectory,
+  });
+  const result = resultEnvelope(request, report.status, checkSummary(report.status), {
+    id: report.id,
+    status: report.status,
+    label: report.label,
+    confidence: report.confidence,
+    gate: report.gate,
+    compilerVersion: report.compilerVersion,
+    language: report.language,
+    surface: report.surface,
+    fileName: report.fileName,
+    counts: {
+      errors: report.errors,
+      warnings: report.warnings,
+      information: report.infos,
+    },
+    diagnostics: report.diagnostics.slice(0, 100).map(compactDiagnostic),
+    checks: report.checks,
+    coverage: report.coverage,
+    typecheck: report.typecheck,
+  });
+  return { result, markdown: renderResultMarkdown(result) };
+}
+
+function runRepair(request: ParsedAxintA2ARequest): AxintA2AExecutionResult {
+  const input = request.input;
+  const issue =
+    input.issue ??
+    input.testFailure ??
+    input.runtimeFailure ??
+    input.xcodeBuildLog ??
+    "Apple project failure requires diagnosis.";
+  const report = runAxintRepair({
+    cwd: request.projectDirectory,
+    issue,
+    source: input.source,
+    sourcePath: input.sourcePath,
+    fileName: input.fileName,
+    platform: input.platform,
+    expectedBehavior: input.expectedBehavior,
+    actualBehavior: input.actualBehavior,
+    xcodeBuildLog: input.xcodeBuildLog,
+    testFailure: input.testFailure,
+    runtimeFailure: input.runtimeFailure,
+    changedFiles: input.modifiedFiles,
+    writeReport: false,
+    writeFeedback: false,
+  });
+  const verdict: AxintA2AVerdict =
+    report.status === "fix_required" ? "fail" : "needs_review";
+  const summary =
+    request.skill === "diagnose_apple_failure"
+      ? `${report.hypotheses.length} ranked repair hypotheses; confidence ${report.confidence.level}.`
+      : `${report.proofPlan.length} proof steps prepared; no source changes were made.`;
+  const result = resultEnvelope(request, verdict, summary, {
+    id: report.id,
+    status: report.status,
+    priority: report.priority,
+    issueClass: report.issueClass,
+    confidence: report.confidence,
+    projectShape: {
+      swiftFiles: report.projectContext.swiftFiles,
+      swiftUIFiles: report.projectContext.swiftUIFiles,
+      appIntentFiles: report.projectContext.appIntentFiles,
+      inputCapableFiles: report.projectContext.inputCapableFiles,
+      interactionRiskFiles: report.projectContext.interactionRiskFiles,
+    },
+    hypotheses: report.hypotheses.map((hypothesis) => ({
+      title: hypothesis.title,
+      confidence: hypothesis.confidence,
+      detail: hypothesis.detail,
+      evidence: hypothesis.evidence,
+      inspect: hypothesis.inspect,
+      suggestedPatch: hypothesis.suggestedPatch,
+    })),
+    filesToInspect: report.filesToInspect,
+    evidenceToCollect: report.evidenceToCollect,
+    proofPlan: report.proofPlan,
+  });
+  return { result, markdown: renderResultMarkdown(result) };
+}
+
+async function runProof(
+  request: ParsedAxintA2ARequest,
+  signal: AbortSignal,
+  stateDirectory: string
+): Promise<AxintA2AExecutionResult> {
+  const input = request.input;
+  const artifactDirectory = resolve(stateDirectory, "artifacts", randomUUID());
+  mkdirSync(artifactDirectory, { recursive: true, mode: 0o700 });
+  const report = await proveAxintProject({
+    cwd: request.projectDirectory,
+    version: packageVersion(),
+    scheme: input.scheme,
+    workspace: input.workspace,
+    project: input.project,
+    destination: input.destination,
+    configuration: input.configuration,
+    testPlan: input.testPlan,
+    onlyTesting: input.onlyTesting,
+    modifiedFiles: input.modifiedFiles,
+    platform: proofPlatform(input.platform),
+    skipBuild: input.skipBuild,
+    skipTests: input.skipTests,
+    runtime: input.runtime,
+    timeoutSeconds: input.timeoutSeconds,
+    fix: false,
+    outputDir: artifactDirectory,
+    signal,
+  });
+  const result = resultEnvelope(
+    request,
+    report.status,
+    `Proof ${report.status}; gate decision ${report.gate.decision}.`,
+    {
+      status: report.status,
+      gate: report.gate,
+      testDiscovery: report.testDiscovery,
+      repairs: report.repairs,
+      receipt: report.receipt,
+      steps: report.run.steps.map((step) => ({
+        name: step.name,
+        state: step.state,
+        detail: step.detail,
+        durationMs: step.durationMs,
+      })),
+      failureIntelligence: report.run.failureIntelligence,
+    }
+  );
+  return { result, markdown: renderResultMarkdown(result) };
+}
+
+function resultEnvelope(
+  request: ParsedAxintA2ARequest,
+  verdict: AxintA2AVerdict,
+  summary: string,
+  data: Record<string, unknown>
+): AxintA2AResult {
+  return {
+    schema: AXINT_A2A_RESULT_SCHEMA,
+    skill: request.skill,
+    verdict,
+    summary,
+    createdAt: new Date().toISOString(),
+    data,
+    privacy: {
+      sourceIncluded: false,
+      absolutePathsIncluded: false,
+      rawLogsIncluded: false,
+    },
+  };
+}
+
+function compactDiagnostic(diagnostic: Diagnostic): Record<string, unknown> {
+  return compactObject({
+    id: diagnostic.id,
+    code: diagnostic.code,
+    severity: diagnostic.severity,
+    originalSeverity: diagnostic.originalSeverity,
+    confidence: diagnostic.confidence,
+    status: diagnostic.status,
+    blocking: diagnostic.blocking,
+    evidenceClass: diagnostic.evidenceClass,
+    message: diagnostic.message,
+    file: diagnostic.file ? basename(diagnostic.file) : undefined,
+    line: diagnostic.line,
+    column: diagnostic.column,
+    evidence: diagnostic.evidence?.map((item) => ({
+      source: item.source,
+      relation: item.relation,
+      summary: item.summary,
+    })),
+  });
+}
+
+function compactObject(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, item]) => item !== undefined)
+  );
+}
+
+function sanitizeExecution(
+  execution: AxintA2AExecutionResult,
+  projectDirectory: string
+): AxintA2AExecutionResult {
+  return sanitizeValue(execution, projectDirectory) as AxintA2AExecutionResult;
+}
+
+function sanitizeValue(value: unknown, projectDirectory: string): unknown {
+  if (typeof value === "string") return sanitizeString(value, projectDirectory);
+  if (Array.isArray(value))
+    return value.map((item) => sanitizeValue(item, projectDirectory));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        sanitizeValue(item, projectDirectory),
+      ])
+    );
+  }
+  return value;
+}
+
+function sanitizeString(value: string, projectDirectory: string): string {
+  let sanitized = value
+    .split(projectDirectory)
+    .join("<project>")
+    .split(homedir())
+    .join("<home>");
+  sanitized = sanitized.replace(
+    /(^|[\s("'`])\/(?:private|tmp|var|Users|home|Volumes)\/[\w@%+.,:=\-/]+/g,
+    (_match, prefix: string) => `${prefix}<local-path>`
+  );
+  return sanitized;
+}
+
+function renderResultMarkdown(result: AxintA2AResult): string {
+  const lines = [
+    `# ${skillTitle(result.skill)}`,
+    "",
+    `**Verdict:** ${result.verdict}`,
+    "",
+    result.summary,
+    "",
+    "## Result",
+    "",
+    "```json",
+    JSON.stringify(result.data, null, 2),
+    "```",
+    "",
+    "Source, raw logs, and absolute local paths are excluded from this artifact.",
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+function skillTitle(skill: ParsedAxintA2ARequest["skill"]): string {
+  switch (skill) {
+    case "check_apple_code":
+      return "Apple Code Check";
+    case "diagnose_apple_failure":
+      return "Apple Failure Diagnosis";
+    case "prove_apple_project":
+      return "Apple Project Proof";
+    case "plan_apple_repair":
+      return "Apple Repair Plan";
+  }
+}
+
+function checkSummary(status: AxintA2AVerdict): string {
+  if (status === "pass")
+    return "No blocking findings were detected in the supplied code.";
+  if (status === "fail") return "Blocking findings require repair before proof can pass.";
+  return "Advisory findings or missing runtime evidence require review.";
+}
+
+function proofPlatform(
+  platform: AxintA2ARequestInput["platform"]
+): "iOS" | "macOS" | "watchOS" | "visionOS" | "all" | undefined {
+  return platform;
+}
+
+function packageVersion(): string {
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf8")
+    ) as { version?: string };
+    return packageJson.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw new AxintA2ACancelledError();
+}
+
+export function projectRelativePath(projectDirectory: string, path: string): string {
+  if (!isAbsolute(path)) return path;
+  const result = relative(projectDirectory, path);
+  return result && !result.startsWith("..") ? result : basename(path);
+}

--- a/src/a2a/task-store.ts
+++ b/src/a2a/task-store.ts
@@ -1,0 +1,142 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  TaskState,
+  type ListTasksRequest,
+  type ListTasksResponse,
+  type Task,
+} from "@a2a-js/sdk";
+import type { ServerCallContext, TaskStore } from "@a2a-js/sdk/server";
+
+export interface AxintA2ATaskStoreOptions {
+  stateDirectory: string;
+}
+
+export class AxintA2ATaskStore implements TaskStore {
+  readonly stateDirectory: string;
+
+  constructor(options: AxintA2ATaskStoreOptions) {
+    this.stateDirectory = options.stateDirectory;
+  }
+
+  async save(task: Task, context: ServerCallContext): Promise<void> {
+    const directory = this.scopeDirectory(context);
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    const destination = join(directory, taskFileName(task.id));
+    const temporary = `${destination}.${randomUUID()}.tmp`;
+    await writeFile(temporary, `${JSON.stringify(task)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(temporary, destination);
+  }
+
+  async load(taskId: string, context: ServerCallContext): Promise<Task | undefined> {
+    try {
+      const contents = await readFile(
+        join(this.scopeDirectory(context), taskFileName(taskId)),
+        "utf8"
+      );
+      const task = JSON.parse(contents) as Task;
+      return task.id === taskId ? structuredClone(task) : undefined;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw error;
+    }
+  }
+
+  async list(
+    params: ListTasksRequest,
+    context: ServerCallContext
+  ): Promise<ListTasksResponse> {
+    const tasks = await this.readScope(context);
+    const filtered = tasks
+      .filter((task) => !params.contextId || task.contextId === params.contextId)
+      .filter(
+        (task) =>
+          params.status === TaskState.TASK_STATE_UNSPECIFIED ||
+          task.status?.state === params.status
+      )
+      .filter((task) => {
+        if (!params.statusTimestampAfter) return true;
+        const timestamp = task.status?.timestamp;
+        return Boolean(timestamp && timestamp >= params.statusTimestampAfter);
+      })
+      .sort((left, right) =>
+        (right.status?.timestamp ?? "").localeCompare(left.status?.timestamp ?? "")
+      );
+
+    const pageSize = Math.min(Math.max(params.pageSize ?? 50, 1), 100);
+    const offset = decodePageToken(params.pageToken);
+    const page = filtered.slice(offset, offset + pageSize).map((task) => {
+      const copy = structuredClone(task);
+      if (params.historyLength !== undefined) {
+        copy.history =
+          params.historyLength === 0
+            ? []
+            : copy.history.slice(-Math.max(0, params.historyLength));
+      }
+      if (params.includeArtifacts !== true) copy.artifacts = [];
+      return copy;
+    });
+    const nextOffset = offset + page.length;
+    return {
+      tasks: page,
+      nextPageToken: nextOffset < filtered.length ? encodePageToken(nextOffset) : "",
+      pageSize,
+      totalSize: filtered.length,
+    };
+  }
+
+  private async readScope(context: ServerCallContext): Promise<Task[]> {
+    const directory = this.scopeDirectory(context);
+    let names: string[];
+    try {
+      names = await readdir(directory);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }
+    const tasks = await Promise.all(
+      names
+        .filter((name) => name.endsWith(".json"))
+        .map(async (name) => {
+          try {
+            return JSON.parse(await readFile(join(directory, name), "utf8")) as Task;
+          } catch {
+            return undefined;
+          }
+        })
+    );
+    return tasks.filter((task): task is Task => Boolean(task?.id));
+  }
+
+  private scopeDirectory(context: ServerCallContext): string {
+    const tenant = context.tenant || "default";
+    const owner = context.user?.userName || "anonymous";
+    const scope = createHash("sha256").update(`${tenant}\0${owner}`).digest("hex");
+    return join(this.stateDirectory, "tasks", scope);
+  }
+}
+
+function taskFileName(taskId: string): string {
+  return `${createHash("sha256").update(taskId).digest("hex")}.json`;
+}
+
+function encodePageToken(offset: number): string {
+  return Buffer.from(JSON.stringify({ offset }), "utf8").toString("base64url");
+}
+
+function decodePageToken(token: string): number {
+  if (!token) return 0;
+  try {
+    const parsed = JSON.parse(Buffer.from(token, "base64url").toString("utf8")) as {
+      offset?: unknown;
+    };
+    if (!Number.isInteger(parsed.offset) || Number(parsed.offset) < 0) return 0;
+    return Number(parsed.offset);
+  } catch {
+    return 0;
+  }
+}

--- a/src/a2a/types.ts
+++ b/src/a2a/types.ts
@@ -1,0 +1,119 @@
+import type { Message } from "@a2a-js/sdk";
+
+export const AXINT_A2A_REQUEST_SCHEMA =
+  "https://axint.ai/schemas/a2a-request.v1.json" as const;
+export const AXINT_A2A_RESULT_SCHEMA =
+  "https://axint.ai/schemas/a2a-result.v1.json" as const;
+export const AXINT_A2A_INPUT_MEDIA_TYPE =
+  "application/vnd.axint.a2a-request+json" as const;
+export const AXINT_A2A_RESULT_MEDIA_TYPE =
+  "application/vnd.axint.a2a-result+json" as const;
+
+export const AXINT_A2A_SKILL_IDS = [
+  "check_apple_code",
+  "diagnose_apple_failure",
+  "prove_apple_project",
+  "plan_apple_repair",
+] as const;
+
+export type AxintA2ASkillId = (typeof AXINT_A2A_SKILL_IDS)[number];
+
+export interface AxintA2ARequestInput {
+  projectPath?: string;
+  source?: string;
+  sourcePath?: string;
+  fileName?: string;
+  issue?: string;
+  platform?: "iOS" | "macOS" | "watchOS" | "visionOS" | "all";
+  scheme?: string;
+  workspace?: string;
+  project?: string;
+  destination?: string;
+  configuration?: string;
+  testPlan?: string;
+  onlyTesting?: string[];
+  modifiedFiles?: string[];
+  skipBuild?: boolean;
+  skipTests?: boolean;
+  runtime?: boolean;
+  timeoutSeconds?: number;
+  xcodeBuildLog?: string;
+  testFailure?: string;
+  runtimeFailure?: string;
+  expectedBehavior?: string;
+  actualBehavior?: string;
+}
+
+export interface AxintA2ARequest {
+  schema: typeof AXINT_A2A_REQUEST_SCHEMA;
+  skill: AxintA2ASkillId;
+  input: AxintA2ARequestInput;
+}
+
+export type AxintA2AVerdict = "pass" | "needs_review" | "fail";
+
+export interface AxintA2AResult {
+  schema: typeof AXINT_A2A_RESULT_SCHEMA;
+  skill: AxintA2ASkillId;
+  verdict: AxintA2AVerdict;
+  summary: string;
+  createdAt: string;
+  data: Record<string, unknown>;
+  privacy: {
+    sourceIncluded: false;
+    absolutePathsIncluded: false;
+    rawLogsIncluded: false;
+  };
+}
+
+export interface ParsedAxintA2ARequest extends AxintA2ARequest {
+  projectRoot: string;
+  projectDirectory: string;
+}
+
+export interface ParseAxintA2ARequestOptions {
+  projectRoot: string;
+}
+
+export class AxintA2AInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AxintA2AInputError";
+  }
+}
+
+export class AxintA2APolicyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AxintA2APolicyError";
+  }
+}
+
+export interface AxintA2AExecutionRequest {
+  request: ParsedAxintA2ARequest;
+  signal: AbortSignal;
+}
+
+export interface AxintA2AExecutionResult {
+  result: AxintA2AResult;
+  markdown: string;
+}
+
+export type AxintA2ARunner = (
+  input: AxintA2AExecutionRequest
+) => Promise<AxintA2AExecutionResult>;
+
+export function isAxintA2ASkillId(value: unknown): value is AxintA2ASkillId {
+  return (
+    typeof value === "string" &&
+    (AXINT_A2A_SKILL_IDS as readonly string[]).includes(value)
+  );
+}
+
+export function messageText(message: Message): string {
+  return message.parts
+    .filter((part) => part.content?.$case === "text")
+    .map((part) => (part.content?.$case === "text" ? part.content.value : ""))
+    .join("\n")
+    .trim();
+}

--- a/src/proof/prove.ts
+++ b/src/proof/prove.ts
@@ -42,6 +42,7 @@ export interface AxintProveInput {
   dryRun?: boolean;
   fix?: boolean;
   outputDir?: string;
+  signal?: AbortSignal;
 }
 
 export interface AxintProveReport {
@@ -95,6 +96,7 @@ export async function proveAxintProject(
     advisory: true,
     fix: false,
     outputDir: outputDirectory,
+    signal: input.signal,
   };
 
   let run = await runAxintProject(runInput);

--- a/src/run/project-runner.ts
+++ b/src/run/project-runner.ts
@@ -102,6 +102,7 @@ export interface AxintRunInput {
   localOnly?: boolean;
   fix?: boolean;
   outputDir?: string;
+  signal?: AbortSignal;
 }
 
 const DEFAULT_CLOUD_SWEEP_LIMIT = 8;
@@ -432,6 +433,7 @@ export async function runAxintProject(
       dryRun: input.dryRun,
       job,
       artifactRoot: minimal ? (outputDirectory ?? false) : undefined,
+      signal: input.signal,
     });
     steps.push(stepFromCommand("Xcode build", commands.build));
   } else if (input.skipBuild) {
@@ -455,6 +457,7 @@ export async function runAxintProject(
       dryRun: input.dryRun,
       job,
       artifactRoot: minimal ? (outputDirectory ?? false) : undefined,
+      signal: input.signal,
     });
     steps.push(stepFromCommand("Xcode test", commands.test));
   } else if (input.skipTests) {
@@ -1420,10 +1423,41 @@ async function runCommand(
     dryRun?: boolean;
     job?: AxintRunJobRecord;
     artifactRoot?: string | false;
+    signal?: AbortSignal;
   }
 ): Promise<AxintRunCommandResult> {
   const started = Date.now();
   const commandId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  if (options.signal?.aborted) {
+    const resultBundlePath = expectedResultBundlePath(args);
+    markRunJobCommandStarted(options.job, {
+      id: commandId,
+      label,
+      command,
+      args,
+      cwd: options.cwd,
+      expectedResultBundlePath: resultBundlePath,
+    });
+    markRunJobCommandFinished(options.job, commandId, {
+      exitCode: null,
+      signal: "SIGTERM",
+      timedOut: false,
+      cancelled: true,
+    });
+    return {
+      command,
+      args,
+      cwd: options.cwd,
+      exitCode: null,
+      signal: "SIGTERM",
+      timedOut: false,
+      stdout: "",
+      stderr: "Execution canceled before the command started.",
+      durationMs: 0,
+      resultBundlePath,
+      cancelled: true,
+    };
+  }
   if (options.dryRun) {
     const resultBundlePath = expectedResultBundlePath(args);
     markRunJobCommandStarted(options.job, {
@@ -1458,7 +1492,9 @@ async function runCommand(
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let aborted = false;
     let settled = false;
+    let forceKillTimer: NodeJS.Timeout | undefined;
     let spawnError: Error | undefined;
     const resultBundlePath = expectedResultBundlePath(args);
     const logPath = commandLogPath(
@@ -1489,6 +1525,14 @@ async function runCommand(
       stdio: ["ignore", "pipe", "pipe"],
     });
 
+    const abort = () => {
+      aborted = true;
+      appendToCommandLog(
+        logPath,
+        "\n[axint] Cancellation requested; stopping command.\n"
+      );
+      stopProcessGroup(child.pid);
+    };
     markRunJobCommandStarted(options.job, {
       id: commandId,
       label,
@@ -1499,6 +1543,10 @@ async function runCommand(
       logPath,
       expectedResultBundlePath: resultBundlePath,
     });
+
+    options.signal?.addEventListener("abort", abort, { once: true });
+    // Close the gap between the pre-spawn check and listener registration.
+    if (options.signal?.aborted) abort();
 
     child.stdout?.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf-8");
@@ -1517,7 +1565,7 @@ async function runCommand(
         logPath,
         `\n[axint] Command timed out after ${options.timeoutSeconds}s; sending SIGTERM to child process group.\n`
       );
-      if (child.pid) killProcessGroup(child.pid, "SIGTERM");
+      stopProcessGroup(child.pid);
     }, options.timeoutSeconds * 1000);
 
     child.once("error", (error) => {
@@ -1536,7 +1584,9 @@ async function runCommand(
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
-      const cancelled = signal === "SIGTERM" && !timedOut;
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+      options.signal?.removeEventListener("abort", abort);
+      const cancelled = aborted || (signal === "SIGTERM" && !timedOut);
       markRunJobCommandFinished(options.job, commandId, {
         exitCode: code,
         signal,
@@ -1559,6 +1609,22 @@ async function runCommand(
         resultBundlePath,
         cancelled,
       });
+    }
+
+    function stopProcessGroup(pid: number | undefined) {
+      if (!pid) return;
+      killProcessGroup(pid, "SIGTERM");
+      if (forceKillTimer) return;
+      forceKillTimer = setTimeout(() => {
+        if (!settled) {
+          appendToCommandLog(
+            logPath,
+            "\n[axint] Command did not exit after SIGTERM; sending SIGKILL.\n"
+          );
+          killProcessGroup(pid, "SIGKILL");
+        }
+      }, 5_000);
+      forceKillTimer.unref();
     }
   });
 }
@@ -1583,6 +1649,7 @@ async function runMacRuntimeProbe(
       timeoutSeconds: 90,
       job,
       artifactRoot: options.artifactRoot,
+      signal: input.signal,
     }
   );
   if (settings.exitCode !== 0) {
@@ -1603,7 +1670,8 @@ async function runMacRuntimeProbe(
     appPath,
     input.runtimeTimeoutSeconds ?? 8,
     job,
-    options
+    options,
+    input.signal
   );
   return {
     buildSettings: settings,
@@ -1617,7 +1685,8 @@ async function runRuntimeLaunchProbe(
   appPath: string,
   waitSeconds: number,
   job?: AxintRunJobRecord,
-  options: { artifactRoot?: string | false } = {}
+  options: { artifactRoot?: string | false } = {},
+  signal?: AbortSignal
 ): Promise<AxintRunCommandResult> {
   const started = Date.now();
   const appName = basename(appPath, ".app");
@@ -1626,11 +1695,12 @@ async function runRuntimeLaunchProbe(
     timeoutSeconds: 15,
     job,
     artifactRoot: options.artifactRoot,
+    signal,
   });
   if (openResult.exitCode !== 0) return openResult;
 
   const boundedWait = String(Math.min(Math.max(Math.round(waitSeconds), 1), 60));
-  await delay(Number(boundedWait) * 1000);
+  await delay(Number(boundedWait) * 1000, signal);
   const processCheck = await runCommand(
     "Runtime process check",
     "pgrep",
@@ -1640,6 +1710,7 @@ async function runRuntimeLaunchProbe(
       timeoutSeconds: 5,
       job,
       artifactRoot: options.artifactRoot,
+      signal,
     }
   );
   return {
@@ -2764,8 +2835,18 @@ function killProcessGroup(pid: number, signal: NodeJS.Signals): void {
   }
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timeout = setTimeout(finish, ms);
+    const abort = () => finish();
+    signal?.addEventListener("abort", abort, { once: true });
+    function finish() {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    }
+  });
 }
 
 function summarizeStatus(

--- a/tests/a2a/a2a.test.ts
+++ b/tests/a2a/a2a.test.ts
@@ -1,0 +1,382 @@
+import { createServer, type Server } from "node:http";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  Role,
+  TaskState,
+  type ListTasksRequest,
+  type Message,
+  type Task,
+} from "@a2a-js/sdk";
+import {
+  DefaultExecutionEventBus,
+  RequestContext,
+  ServerCallContext,
+  type AgentExecutionEvent,
+} from "@a2a-js/sdk/server";
+import { afterEach, describe, expect, it } from "vitest";
+import { createAxintAgentCard } from "../../src/a2a/agent-card.js";
+import { AxintA2AUser, parseTokens } from "../../src/a2a/auth.js";
+import { AxintA2AExecutor } from "../../src/a2a/executor.js";
+import { parseAxintA2ARequest } from "../../src/a2a/request.js";
+import { createAxintA2AApp } from "../../src/a2a/server.js";
+import { AxintA2ACancelledError } from "../../src/a2a/service.js";
+import { AxintA2ATaskStore } from "../../src/a2a/task-store.js";
+import { AXINT_A2A_REQUEST_SCHEMA } from "../../src/a2a/types.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("Axint A2A", () => {
+  it("publishes a v1 Agent Card with bounded skills and bearer security", () => {
+    const card = createAxintAgentCard({
+      endpointUrl: "https://example.test/a2a",
+      authenticationRequired: true,
+    });
+
+    expect(card.supportedInterfaces).toEqual([
+      expect.objectContaining({
+        url: "https://example.test/a2a",
+        protocolBinding: "JSONRPC",
+        protocolVersion: "1.0",
+      }),
+    ]);
+    expect(card.skills.map((skill) => skill.id)).toEqual([
+      "check_apple_code",
+      "diagnose_apple_failure",
+      "prove_apple_project",
+      "plan_apple_repair",
+    ]);
+    expect(card.capabilities).toMatchObject({
+      streaming: true,
+      pushNotifications: false,
+    });
+    expect(card.securitySchemes).toHaveProperty("Bearer");
+  });
+
+  it("validates token configuration without retaining plaintext secrets", () => {
+    const tokens = parseTokens("team-a=0123456789abcdef,team-b=fedcba9876543210");
+    expect(tokens.map((token) => token.id)).toEqual(["team-a", "team-b"]);
+    expect(tokens[0].digest).toHaveLength(32);
+    expect(String(tokens[0].digest)).not.toContain("0123456789abcdef");
+    expect(() => parseTokens("weak=short")).toThrow(/at least 16/);
+    expect(() => parseTokens("same=0123456789abcdef,same=fedcba9876543210")).toThrow(
+      /Duplicate/
+    );
+  });
+
+  it("parses structured input and rejects paths outside the project root", () => {
+    const projectRoot = temporaryDirectory("axint-a2a-request-");
+    writeFileSync(join(projectRoot, "Example.swift"), "import SwiftUI\n", "utf8");
+    const parsed = parseAxintA2ARequest(
+      userMessage({
+        skill: "check_apple_code",
+        input: { sourcePath: "Example.swift" },
+      }),
+      { projectRoot }
+    );
+    expect(parsed.input.sourcePath).toBe(
+      realpathSync(join(projectRoot, "Example.swift"))
+    );
+
+    expect(() =>
+      parseAxintA2ARequest(
+        userMessage({
+          skill: "check_apple_code",
+          input: { sourcePath: "../outside.swift" },
+        }),
+        { projectRoot }
+      )
+    ).toThrow(/inside the project/);
+    expect(() =>
+      parseAxintA2ARequest(
+        userMessage({ skill: "prove_apple_project", input: { timeoutSeconds: 9_999 } }),
+        { projectRoot }
+      )
+    ).toThrow(/1 through 3600/);
+
+    const outside = temporaryDirectory("axint-a2a-outside-");
+    writeFileSync(join(outside, "Outside.swift"), "struct Outside {}\n", "utf8");
+    symlinkSync(join(outside, "Outside.swift"), join(projectRoot, "Linked.swift"));
+    expect(() =>
+      parseAxintA2ARequest(
+        userMessage({
+          skill: "prove_apple_project",
+          input: { modifiedFiles: ["Linked.swift"] },
+        }),
+        { projectRoot }
+      )
+    ).toThrow(/configured project root/);
+  });
+
+  it("persists tasks atomically and isolates them by tenant and authenticated owner", async () => {
+    const root = temporaryDirectory("axint-a2a-store-");
+    const store = new AxintA2ATaskStore({ stateDirectory: root });
+    const ownerA = context("tenant-a", "owner-a");
+    const ownerB = context("tenant-a", "owner-b");
+    const otherTenant = context("tenant-b", "owner-a");
+    const task = sampleTask("task-1", "context-1");
+    await store.save(task, ownerA);
+
+    expect(await store.load(task.id, ownerA)).toEqual(task);
+    expect(await store.load(task.id, ownerB)).toBeUndefined();
+    expect(await store.load(task.id, otherTenant)).toBeUndefined();
+
+    const listed = await store.list(listRequest(), ownerA);
+    expect(listed.totalSize).toBe(1);
+    expect(listed.tasks[0].artifacts).toEqual([]);
+    expect((await store.list(listRequest(), ownerB)).totalSize).toBe(0);
+  });
+
+  it("propagates cancellation to a running execution and emits one canceled terminal state", async () => {
+    const root = temporaryDirectory("axint-a2a-cancel-");
+    let started!: () => void;
+    const didStart = new Promise<void>((resolveStart) => {
+      started = resolveStart;
+    });
+    const executor = new AxintA2AExecutor({
+      projectRoot: root,
+      runner: async ({ signal }) => {
+        started();
+        await new Promise<void>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new AxintA2ACancelledError()), {
+            once: true,
+          });
+        });
+        throw new Error("unreachable");
+      },
+      heartbeatMs: 60_000,
+    });
+    const eventBus = new DefaultExecutionEventBus();
+    const events: AgentExecutionEvent[] = [];
+    eventBus.on("event", (event) => events.push(event));
+    const request = new RequestContext(
+      {
+        tenant: "",
+        message: userMessage({ skill: "prove_apple_project", input: {} }),
+        configuration: undefined,
+        metadata: undefined,
+      },
+      "task-cancel",
+      "context-cancel",
+      context("", "owner-a")
+    );
+
+    const execution = executor.execute(request, eventBus);
+    await didStart;
+    await executor.cancelTask("task-cancel", eventBus);
+    await execution;
+    const canceled = events.filter(
+      (event) =>
+        event.kind === "statusUpdate" &&
+        event.data.status?.state === TaskState.TASK_STATE_CANCELED
+    );
+    expect(canceled).toHaveLength(1);
+  });
+
+  it("serves authenticated JSON-RPC and never persists or returns the input source", async () => {
+    const root = temporaryDirectory("axint-a2a-http-");
+    const stateDirectory = temporaryDirectory("axint-a2a-http-state-");
+    const secret = "0123456789abcdef0123456789abcdef";
+    const source =
+      "struct PrivateSourceMarker: View { var body: some View { EmptyView() } }";
+    const created = createAxintA2AApp({
+      projectRoot: root,
+      stateDirectory,
+      tokens: `test=${secret}`,
+      publicUrl: "http://127.0.0.1:41242",
+    });
+    const server = createServer(created.app);
+    const url = await listen(server);
+    try {
+      const cardResponse = await fetch(`${url}/.well-known/agent-card.json`);
+      expect(cardResponse.status).toBe(200);
+      expect((await cardResponse.json()) as object).toMatchObject({
+        name: "Axint Apple Proof and Repair",
+      });
+
+      const unauthorized = await fetch(`${url}/a2a`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "a2a-version": "1.0" },
+        body: JSON.stringify(sendMessageBody(source)),
+      });
+      expect(unauthorized.status).toBe(401);
+
+      const unsupportedVersion = await fetch(`${url}/a2a`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${secret}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(sendMessageBody(source)),
+      });
+      expect(unsupportedVersion.status).toBe(400);
+      expect(await unsupportedVersion.text()).toMatch(/version.*supported/i);
+
+      const response = await fetch(`${url}/a2a`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${secret}`,
+          "content-type": "application/json",
+          "a2a-version": "1.0",
+        },
+        body: JSON.stringify(sendMessageBody(source)),
+      });
+      expect(response.status).toBe(200);
+      const text = await response.text();
+      expect(text).toContain("TASK_STATE_COMPLETED");
+      expect(text).toContain("input_not_persisted");
+      expect(text).not.toContain("PrivateSourceMarker");
+
+      const persisted = persistedTaskContents(stateDirectory);
+      expect(persisted).toContain("input_not_persisted");
+      expect(persisted).not.toContain("PrivateSourceMarker");
+    } finally {
+      await close(server);
+    }
+  });
+});
+
+function userMessage(payload: Record<string, unknown>): Message {
+  return {
+    messageId: "message-1",
+    contextId: "",
+    taskId: "",
+    role: Role.ROLE_USER,
+    parts: [
+      {
+        content: {
+          $case: "data",
+          value: { schema: AXINT_A2A_REQUEST_SCHEMA, ...payload },
+        },
+        metadata: undefined,
+        filename: "",
+        mediaType: "application/vnd.axint.a2a-request+json",
+      },
+    ],
+    metadata: undefined,
+    extensions: [],
+    referenceTaskIds: [],
+  };
+}
+
+function context(tenant: string, owner: string): ServerCallContext {
+  return new ServerCallContext({
+    tenant,
+    requestedVersion: "1.0",
+    user: new AxintA2AUser(owner, true),
+  });
+}
+
+function sampleTask(id: string, contextId: string): Task {
+  return {
+    id,
+    contextId,
+    status: {
+      state: TaskState.TASK_STATE_COMPLETED,
+      message: undefined,
+      timestamp: "2026-08-03T00:00:00.000Z",
+    },
+    artifacts: [
+      {
+        artifactId: "artifact-1",
+        name: "result",
+        description: "",
+        parts: [],
+        metadata: undefined,
+        extensions: [],
+      },
+    ],
+    history: [],
+    metadata: undefined,
+  };
+}
+
+function listRequest(): ListTasksRequest {
+  return {
+    tenant: "tenant-a",
+    contextId: "",
+    status: TaskState.TASK_STATE_UNSPECIFIED,
+    pageToken: "",
+    statusTimestampAfter: undefined,
+    includeArtifacts: false,
+  };
+}
+
+function sendMessageBody(source: string): object {
+  return {
+    jsonrpc: "2.0",
+    id: "request-1",
+    method: "SendMessage",
+    params: {
+      message: {
+        messageId: "message-http-1",
+        contextId: "",
+        taskId: "",
+        role: "ROLE_USER",
+        parts: [
+          {
+            data: {
+              schema: AXINT_A2A_REQUEST_SCHEMA,
+              skill: "check_apple_code",
+              input: { source, fileName: "Private.swift", platform: "iOS" },
+            },
+            mediaType: "application/vnd.axint.a2a-request+json",
+          },
+        ],
+        metadata: {},
+        extensions: [],
+        referenceTaskIds: [],
+      },
+      configuration: {
+        acceptedOutputModes: ["application/json"],
+        returnImmediately: false,
+      },
+      metadata: {},
+    },
+  };
+}
+
+function temporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function persistedTaskContents(stateDirectory: string): string {
+  const taskRoot = join(stateDirectory, "tasks");
+  const scope = readdirSync(taskRoot)[0];
+  const file = readdirSync(join(taskRoot, scope))[0];
+  return readFileSync(join(taskRoot, scope, file), "utf8");
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolveListen());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("Server did not bind TCP.");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolveClose, reject) => {
+    server.close((error) => (error ? reject(error) : resolveClose()));
+  });
+}

--- a/tests/run/project-runner.test.ts
+++ b/tests/run/project-runner.test.ts
@@ -162,6 +162,48 @@ describe("runAxintProject", () => {
     }
   });
 
+  it("propagates AbortSignal cancellation to the active Xcode process group", async () => {
+    const dir = makeFakeXcodeProject();
+    const binDir = join(dir, "bin");
+    const startedMarker = join(dir, "xcodebuild.started");
+    mkdirSync(binDir, { recursive: true });
+    const xcodebuild = join(binDir, "xcodebuild");
+    writeFileSync(
+      xcodebuild,
+      [
+        "#!/bin/sh",
+        'trap "exit 143" TERM',
+        `touch ${JSON.stringify(startedMarker)}`,
+        "sleep 30",
+        "",
+      ].join("\n")
+    );
+    chmodSync(xcodebuild, 0o755);
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    try {
+      const controller = new AbortController();
+      const execution = runAxintProject({
+        cwd: dir,
+        writeReport: false,
+        signal: controller.signal,
+      });
+      for (let attempt = 0; attempt < 200 && !existsSync(startedMarker); attempt++) {
+        await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+      }
+      expect(existsSync(startedMarker)).toBe(true);
+      controller.abort();
+      const report = await execution;
+
+      expect(report.commands.build?.cancelled).toBe(true);
+      expect(report.commands.test?.cancelled).toBe(true);
+      expect(getRunJobStatus({ cwd: dir, id: report.id }).activePids).toEqual([]);
+    } finally {
+      process.env.PATH = previousPath;
+    }
+  }, 10_000);
+
   it("renders a repair prompt for agents", async () => {
     const dir = makeFakeXcodeProject();
     const report = await runAxintProject({

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -43,6 +43,20 @@ export default defineConfig([
     target: "node22",
     noExternal: bundledMcpDependencies,
   },
+  // Importable A2A adapter and direct axint-a2a executable
+  {
+    entry: {
+      "a2a/index": "src/a2a/index.ts",
+    },
+    format: ["esm"],
+    dts: true,
+    splitting: false,
+    sourcemap: false,
+    target: "node22",
+    banner: {
+      js: "#!/usr/bin/env node",
+    },
+  },
   // MCP stdio binary (side-effectful axint-mcp entrypoint)
   {
     entry: {


### PR DESCRIPTION
## Summary

- add a production A2A server with Agent Card discovery and JSON-RPC task lifecycle support
- expose Apple code checks, failure diagnosis, project proof, and repair planning as four focused skills
- add authenticated tenant-scoped task storage, path confinement, source redaction, cancellation, rate limits, and security headers
- publish the `axint-a2a` executable and `@axint/compiler/a2a` export with complete operator documentation
- refresh npm and pnpm dependency locks with zero known npm vulnerabilities and supply-chain policy compliance

## Validation

- `npm run quality:local`
- 111 test files, 1,402 tests
- `npm run install:gauntlet`
- packed executable and package import smoke tests
- npm audit: 0 vulnerabilities
